### PR TITLE
Fix pull-requests permission in Claude code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -73,11 +73,12 @@ jobs:
 
             Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
 
-            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
+            Use `gh pr review` with your Bash tool to leave inline comments on specific code lines.
+            Use `gh pr comment` with your Bash tool to leave top-level comments on the PR.
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           claude_args: |
             --model claude-4-5-sonnet-latest
-            --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"
+            --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr review:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"
 


### PR DESCRIPTION
Fixed permission issue where the workflow had `pull-requests: read` but needed `pull-requests: write` to use `gh pr comment` command. Also enhanced the review prompt with more comprehensive focus areas.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves the Claude code review GitHub Action for better automation and feedback.
> 
> - Updates workflow permissions: `pull-requests: write` (was `read`) and adds `actions: read` for CI visibility
> - Expands the review `prompt` with structured focus areas (Code Quality, Security, Performance, Testing, Documentation) and clarifies use of `gh pr review` for inline and `gh pr comment` for top-level feedback
> - Specifies model via `claude_args` (`--model claude-4-5-sonnet-latest`) and adds allowed tool `Bash(gh pr review:*)`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c66791890455b4a87df5f78a47056e750aecc69d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->