### PR TITLE
Enhance is_grid_correct method to support BUY→SELL pattern

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -19,6 +19,7 @@ Successfully extracted pure strategy logic from `bbu2-master` into `packages/gri
    - **IMPORTANT**: `tick_size` must be passed as `Decimal` parameter, not looked up from exchange
    - Removed: `read_from_db()`, `write_to_db()`, `strat` dependency
    - Added: `is_price_sorted()`, `is_greed_correct()` validation methods
+   - **is_grid_correct() Pattern Support (2026-01-10)**: Method accepts both BUY→WAIT→SELL and BUY→SELL patterns. Sometimes there's no WAIT state between BUY and SELL levels, which is now considered valid.
    - File: `packages/gridcore/src/gridcore/grid.py`
 
 3. **Engine Module (`engine.py`)**


### PR DESCRIPTION
Updated the is_grid_correct method to validate both BUY→WAIT→SELL and BUY→SELL sequences. Adjusted logic to ensure direct transitions from BUY to SELL are accepted when no WAIT state is present. Added corresponding unit tests to verify the new behavior and ensure correctness of grid sequences.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Grid validation expanded**
> 
> - Updates `is_grid_correct()` to accept both `BUY→WAIT→SELL` and `BUY→SELL` (no WAIT) patterns; adds state tracking to permit direct BUY→SELL transitions while maintaining sorted-price check
> - Extends tests in `test_grid.py` to cover valid `BUY→SELL`, `BUY→WAIT→SELL`, and invalid `SELL→BUY` sequences; adjusts prior test expectations
> - Documents new pattern support in `RULES.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ce4c186c3f93e1716100a1943a989b576e8ca1f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->