### PR TITLE
Change allowed tools to all Bash commands

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -81,5 +81,5 @@ jobs:
           # or https://code.claude.com/docs/en/cli-reference for available options
           claude_args: |
             --model claude-4-5-sonnet-latest
-            --allowed-tools "Bash(ls:*),Bash(cat:*),Bash(find:*),Bash(git:*),Bash(grep:*),Bash(gh pr:*),Bash(gh issue:*)"
+            --allowed-tools "Bash(*)"
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Update GitHub Actions workflow**
> 
> - Broadens `--allowed-tools` in `claude_args` to `"Bash(*)"`, enabling all Bash commands for the Claude code review action in `claude-code-review.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f3175ec71a56d6a0a930496c4602e251aa0b14e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->