### PR TITLE
Update allowed-tools for claude-code-review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -81,5 +81,5 @@ jobs:
           # or https://code.claude.com/docs/en/cli-reference for available options
           claude_args: |
             --model claude-sonnet-4-5-20250929
-            --allowed-tools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowed-tools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*)"
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **ci/workflows**: Narrow the Claude Code Review action’s tool permissions.
> 
> - Updates `claude_args` in `.github/workflows/claude-code-review.yml` to restrict `--allowed-tools` from `Bash(*)` to specific `gh pr` subcommands: `gh pr comment`, `gh pr diff`, `gh pr view`, and `gh pr review`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e31c302e624ddaddb08886a59606ab8d32274a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->