### PR TITLE
Fix float/Decimal type mismatch in position ratio calculation

### DIFF
--- a/apps/gridbot/src/gridbot/runner.py
+++ b/apps/gridbot/src/gridbot/runner.py
@@ -423,9 +423,9 @@ class StrategyRunner:
             self._long_position.size = long_state.size if long_state else Decimal('0')
             self._short_position.size = short_state.size if short_state else Decimal('0')
 
-            # Calculate position ratio
-            long_size = long_state.size if long_state else 0.0
-            short_size = short_state.size if short_state else 0.0
+            # Calculate position ratio (use float for ratio arithmetic)
+            long_size = float(long_state.size) if long_state else 0.0
+            short_size = float(short_state.size) if short_state else 0.0
 
             if short_size > 0:
                 position_ratio = long_size / short_size

--- a/apps/gridbot/src/gridbot/runner.py
+++ b/apps/gridbot/src/gridbot/runner.py
@@ -423,7 +423,8 @@ class StrategyRunner:
             self._long_position.size = long_state.size if long_state else Decimal('0')
             self._short_position.size = short_state.size if short_state else Decimal('0')
 
-            # Calculate position ratio (use float for ratio arithmetic)
+            # Convert Decimal sizes to float: position_ratio is stored as float (position.py:98)
+            # and mixing Decimal/float in division raises TypeError
             long_size = float(long_state.size) if long_state else 0.0
             short_size = float(short_state.size) if short_state else 0.0
 

--- a/apps/gridbot/tests/test_runner.py
+++ b/apps/gridbot/tests/test_runner.py
@@ -349,6 +349,35 @@ class TestStrategyRunnerPositionUpdate:
         assert "Sell" in short_mult
 
     @pytest.mark.asyncio
+    async def test_on_position_update_decimal_float_type_safety(self, runner):
+        """Regression: ratio calculation must not raise TypeError when mixing Decimal/float.
+
+        PositionState.size is Decimal but the None-fallback was float 0.0,
+        causing 'unsupported operand type(s) for /: float and Decimal'.
+        Test all three combos: both exist, only long, only short.
+        """
+        long_pos = {"size": "1.0", "avgPrice": "50000", "liqPrice": "40000"}
+        short_pos = {"size": "0.5", "avgPrice": "50000", "liqPrice": "60000"}
+
+        # Both positions present (Decimal / Decimal)
+        await runner.on_position_update(
+            long_position=long_pos, short_position=short_pos,
+            wallet_balance=10000.0, last_close=50000.0,
+        )
+
+        # Only long (Decimal / float-fallback)
+        await runner.on_position_update(
+            long_position=long_pos, short_position=None,
+            wallet_balance=10000.0, last_close=50000.0,
+        )
+
+        # Only short (float-fallback / Decimal)
+        await runner.on_position_update(
+            long_position=None, short_position=short_pos,
+            wallet_balance=10000.0, last_close=50000.0,
+        )
+
+    @pytest.mark.asyncio
     async def test_on_position_update_no_positions_keeps_default_multipliers(self, runner):
         """Test multipliers stay at defaults when no positions exist."""
         await runner.on_position_update(

--- a/apps/gridbot/tests/test_runner.py
+++ b/apps/gridbot/tests/test_runner.py
@@ -364,18 +364,25 @@ class TestStrategyRunnerPositionUpdate:
             long_position=long_pos, short_position=short_pos,
             wallet_balance=10000.0, last_close=50000.0,
         )
+        # Long ratio survives; short's is overwritten by calculate_amount_multiplier
+        assert runner._long_position.position_ratio == 2.0  # 1.0 / 0.5
 
         # Only long (Decimal / float-fallback)
         await runner.on_position_update(
             long_position=long_pos, short_position=None,
             wallet_balance=10000.0, last_close=50000.0,
         )
+        # Short's ratio survives since calculate is not called (short_state is None)
+        assert runner._short_position.position_ratio == float("inf")
 
         # Only short (float-fallback / Decimal)
         await runner.on_position_update(
             long_position=None, short_position=short_pos,
             wallet_balance=10000.0, last_close=50000.0,
         )
+        # Long's ratio survives since calculate is not called (long_state is None)
+        # long_size=0.0 / short_size=0.5 = 0.0
+        assert runner._long_position.position_ratio == 0.0
 
     @pytest.mark.asyncio
     async def test_on_position_update_no_positions_keeps_default_multipliers(self, runner):


### PR DESCRIPTION
## Summary
- Fix pre-existing `TypeError: unsupported operand type(s) for /: 'float' and 'decimal.Decimal'` in `on_position_update` when one position exists (Decimal size) and the other is None (float 0.0 fallback)
- Cast `long_state.size` / `short_state.size` to `float` for ratio arithmetic

## Test plan
- [x] All 598 tests pass
- [ ] Manual: run bot with open positions, verify no TypeError in position update logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)