### PR TITLE
feat(orchestrator): instrument WS reconnect elapsed time (0018)

### DIFF
--- a/apps/gridbot/src/gridbot/orchestrator.py
+++ b/apps/gridbot/src/gridbot/orchestrator.py
@@ -41,6 +41,7 @@ _HEALTH_CHECK_INTERVAL = 10  # seconds
 _CHECK_INTERVAL = 0.1  # 100 ms main loop tick (bbu2 value)
 _RETRY_TICK_INTERVAL = 1.0  # seconds between retry-queue drains
 _POSITION_FETCH_SLOW_THRESHOLD = 2.0  # log a warning if REST position fetch takes longer
+_WS_RECONNECT_SLOW_THRESHOLD = 5.0  # log a warning if a single WS disconnect+connect takes longer
 _POSITION_TICK_BASE = 15.0  # base cadence for the steady-state position-fetch rotation tick (seconds)
 _POSITION_STARTUP_HARD_CAP = 60.0  # hard ceiling on the startup batch; exceeding aborts startup
 _MAX_TICK_BACKOFF = 30.0  # cap (s) on main-loop backoff after consecutive _tick() failures
@@ -1142,6 +1143,7 @@ class Orchestrator:
                         f"Public WS disconnected for {account_name}, reconnecting",
                         error_key=f"ws_pub_disconnect_{account_name}",
                     )
+                    reconnect_start = time.monotonic()
                     try:
                         pub_ws.disconnect()
                         pub_ws.connect()  # re-subscribes automatically via callbacks
@@ -1151,6 +1153,14 @@ class Orchestrator:
                             f"Public WS reconnect {account_name}", e,
                             error_key=f"ws_pub_reconnect_{account_name}",
                         )
+                    finally:
+                        elapsed = time.monotonic() - reconnect_start
+                        if elapsed > _WS_RECONNECT_SLOW_THRESHOLD:
+                            logger.warning(
+                                "Public WS reconnect for %s took %.1fs "
+                                "(threshold=%.1fs) — blocking main polling loop",
+                                account_name, elapsed, _WS_RECONNECT_SLOW_THRESHOLD,
+                            )
 
                 # Check private WS
                 priv_ws = self._private_ws.get(account_name)
@@ -1159,6 +1169,7 @@ class Orchestrator:
                         f"Private WS disconnected for {account_name}, reconnecting",
                         error_key=f"ws_priv_disconnect_{account_name}",
                     )
+                    reconnect_start = time.monotonic()
                     try:
                         priv_ws.disconnect()
                         priv_ws.connect()  # re-subscribes automatically via callbacks
@@ -1168,6 +1179,14 @@ class Orchestrator:
                             f"Private WS reconnect {account_name}", e,
                             error_key=f"ws_priv_reconnect_{account_name}",
                         )
+                    finally:
+                        elapsed = time.monotonic() - reconnect_start
+                        if elapsed > _WS_RECONNECT_SLOW_THRESHOLD:
+                            logger.warning(
+                                "Private WS reconnect for %s took %.1fs "
+                                "(threshold=%.1fs) — blocking main polling loop",
+                                account_name, elapsed, _WS_RECONNECT_SLOW_THRESHOLD,
+                            )
         except Exception as e:
             self._notifier.alert_exception(
                 "_health_check_once", e, error_key="health_check_loop",

--- a/apps/gridbot/tests/test_orchestrator.py
+++ b/apps/gridbot/tests/test_orchestrator.py
@@ -1632,6 +1632,139 @@ class TestOrchestratorHealthCheckOnce:
         assert notifier.alert.call_count >= 1
         assert notifier.alert_exception.call_count >= 1
 
+    @patch("gridbot.orchestrator.BybitRestClient")
+    @patch("gridbot.orchestrator.PublicWebSocketClient")
+    @patch("gridbot.orchestrator.PrivateWebSocketClient")
+    def test_health_check_warns_on_slow_reconnect(
+        self, mock_private_ws_cls, mock_public_ws_cls, mock_rest_client,
+        gridbot_config, account_config, strategy_config, caplog,
+    ):
+        """A reconnect exceeding the threshold emits a WARNING."""
+        notifier = Mock(spec=Notifier)
+        orchestrator = Orchestrator(gridbot_config, notifier=notifier)
+        orchestrator._init_account(account_config)
+        orchestrator._init_strategy(strategy_config)
+        orchestrator._build_routing_maps()
+
+        # Public branch enters reconnect and consumes both time.monotonic calls
+        pub_ws = orchestrator._public_ws["test_account"]
+        pub_ws.is_connected.return_value = False
+        pub_ws.connect = Mock()
+        pub_ws.disconnect = Mock()
+
+        # Private branch skipped so the iterator is not drained further
+        priv_ws = orchestrator._private_ws["test_account"]
+        priv_ws.is_connected.return_value = True
+
+        # Cooldown sweep at top of _health_check_once is a no-op
+        orchestrator._auth_cooldown_until = {}
+
+        with patch(
+            "gridbot.orchestrator.time.monotonic",
+            side_effect=iter([0.0, 6.0]),
+        ):
+            with caplog.at_level("WARNING", logger="gridbot.orchestrator"):
+                orchestrator._health_check_once()
+
+        matching = [
+            r for r in caplog.records
+            if r.levelname == "WARNING"
+            and "Public WS reconnect" in r.getMessage()
+            and "took" in r.getMessage()
+            and "blocking main polling loop" in r.getMessage()
+        ]
+        assert len(matching) == 1, (
+            f"Expected one slow-reconnect WARNING, got {len(matching)}: "
+            f"{[r.getMessage() for r in caplog.records]}"
+        )
+
+    @patch("gridbot.orchestrator.BybitRestClient")
+    @patch("gridbot.orchestrator.PublicWebSocketClient")
+    @patch("gridbot.orchestrator.PrivateWebSocketClient")
+    def test_health_check_warns_on_slow_private_reconnect(
+        self, mock_private_ws_cls, mock_public_ws_cls, mock_rest_client,
+        gridbot_config, account_config, strategy_config, caplog,
+    ):
+        """Private-branch slow reconnect emits its own distinct WARNING."""
+        notifier = Mock(spec=Notifier)
+        orchestrator = Orchestrator(gridbot_config, notifier=notifier)
+        orchestrator._init_account(account_config)
+        orchestrator._init_strategy(strategy_config)
+        orchestrator._build_routing_maps()
+
+        # Public branch skipped so the monotonic iterator is only consumed
+        # by the private branch (start + finally = exactly 2 calls).
+        pub_ws = orchestrator._public_ws["test_account"]
+        pub_ws.is_connected.return_value = True
+
+        priv_ws = orchestrator._private_ws["test_account"]
+        priv_ws.is_connected.return_value = False
+        priv_ws.connect = Mock()
+        priv_ws.disconnect = Mock()
+
+        orchestrator._auth_cooldown_until = {}
+
+        with patch(
+            "gridbot.orchestrator.time.monotonic",
+            side_effect=iter([0.0, 6.0]),
+        ):
+            with caplog.at_level("WARNING", logger="gridbot.orchestrator"):
+                orchestrator._health_check_once()
+
+        matching = [
+            r for r in caplog.records
+            if r.levelname == "WARNING"
+            and "Private WS reconnect" in r.getMessage()
+            and "took" in r.getMessage()
+            and "blocking main polling loop" in r.getMessage()
+        ]
+        assert len(matching) == 1, (
+            f"Expected one slow-reconnect WARNING, got {len(matching)}: "
+            f"{[r.getMessage() for r in caplog.records]}"
+        )
+
+    @patch("gridbot.orchestrator.BybitRestClient")
+    @patch("gridbot.orchestrator.PublicWebSocketClient")
+    @patch("gridbot.orchestrator.PrivateWebSocketClient")
+    def test_health_check_no_warn_on_fast_reconnect(
+        self, mock_private_ws_cls, mock_public_ws_cls, mock_rest_client,
+        gridbot_config, account_config, strategy_config, caplog,
+    ):
+        """A reconnect under the threshold must NOT emit the warning."""
+        notifier = Mock(spec=Notifier)
+        orchestrator = Orchestrator(gridbot_config, notifier=notifier)
+        orchestrator._init_account(account_config)
+        orchestrator._init_strategy(strategy_config)
+        orchestrator._build_routing_maps()
+
+        pub_ws = orchestrator._public_ws["test_account"]
+        pub_ws.is_connected.return_value = False
+        pub_ws.connect = Mock()
+        pub_ws.disconnect = Mock()
+
+        priv_ws = orchestrator._private_ws["test_account"]
+        priv_ws.is_connected.return_value = True
+
+        orchestrator._auth_cooldown_until = {}
+
+        with patch(
+            "gridbot.orchestrator.time.monotonic",
+            side_effect=iter([0.0, 0.5]),
+        ):
+            with caplog.at_level("WARNING", logger="gridbot.orchestrator"):
+                orchestrator._health_check_once()
+
+        matching = [
+            r for r in caplog.records
+            if r.levelname == "WARNING"
+            and "WS reconnect" in r.getMessage()
+            and "blocking main polling loop" in r.getMessage()
+        ]
+        assert matching == [], (
+            f"Unexpected slow-reconnect WARNING on fast path: "
+            f"{[r.getMessage() for r in matching]}"
+        )
+
 
 class TestOrchestratorOrderSyncOnce:
     """Tests for _order_sync_once (single-shot, called from _tick)."""

--- a/docs/features/0018_REVIEW.md
+++ b/docs/features/0018_REVIEW.md
@@ -1,0 +1,41 @@
+# 0018 Review
+
+Scope reviewed: implementation of `0018_PLAN.md` in
+`apps/gridbot/src/gridbot/orchestrator.py` and
+`apps/gridbot/tests/test_orchestrator.py`, with focus on plan fidelity,
+runtime safety, data-shape assumptions, style consistency, and test coverage.
+
+## Findings
+
+No findings.
+
+## Verification
+
+Plan-to-code checks:
+
+- `_WS_RECONNECT_SLOW_THRESHOLD = 5.0` exists next to the existing REST timing
+  threshold at `apps/gridbot/src/gridbot/orchestrator.py:40-45`.
+- Both reconnect blocks in `_health_check_once` now measure elapsed time with
+  `time.monotonic()` and emit `%`-formatted `logger.warning(...)` in `finally`
+  when above threshold at `apps/gridbot/src/gridbot/orchestrator.py:1146-1189`.
+- Existing reconnect behavior (disconnect alert, reconnect attempts, success
+  info log, failure `alert_exception`) is preserved.
+- Added tests:
+  - `test_health_check_warns_on_slow_reconnect`
+  - `test_health_check_warns_on_slow_private_reconnect`
+  - `test_health_check_no_warn_on_fast_reconnect`
+  at `apps/gridbot/tests/test_orchestrator.py:1638-1764`.
+
+Executed checks:
+
+- `uv run pytest -q apps/gridbot/tests/test_orchestrator.py -k health_check`
+  - Result: `9 passed, 83 deselected`
+- `uv run pytest -q apps/gridbot/tests/test_orchestrator.py`
+  - Result: `92 passed`
+
+Additional note:
+
+- `uv run ruff check apps/gridbot/src/gridbot/orchestrator.py apps/gridbot/tests/test_orchestrator.py`
+  reports two pre-existing unused-import warnings in
+  `apps/gridbot/src/gridbot/orchestrator.py` (`ExecutionEvent`, `OrderUpdateEvent`);
+  these are unrelated to feature 0018 changes.


### PR DESCRIPTION
## Summary
- Add `_WS_RECONNECT_SLOW_THRESHOLD = 5.0` and wrap both public + private WS reconnect blocks in `_health_check_once` with `time.monotonic()` measurement; emit `logger.warning` in `finally` when elapsed exceeds threshold. No behaviour change.
- Purpose: collect empirical data on how long `disconnect()`/`connect()` actually takes in production before committing to a deeper fix (pybit timeout plumbing or background reconnect). See `docs/features/0018_PLAN.md` for escalation criteria and review cadence.
- 3 new tests in `TestOrchestratorHealthCheckOnce` cover slow-public, slow-private, and fast (no-warning) paths; existing tests unchanged.

## Test plan
- [x] `uv run pytest apps/gridbot/tests/test_orchestrator.py::TestOrchestratorHealthCheckOnce -v` — 7/7 pass (4 existing + 3 new)
- [x] `uv run pytest apps/gridbot/tests/test_orchestrator.py` — 92/92 pass
- [ ] Post-deploy smoke: force-disconnect a WS in test env and confirm WARNING appears in `--log-file=<path>` JSON output
- [ ] T+7 days: grep production logs for `"WS reconnect for .* took"` and compare to escalation trigger table in `0018_PLAN.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)