### PR TITLE
refactor(orchestrator): extract AuthCooldownManager (0020)

### DIFF
--- a/apps/gridbot/src/gridbot/auth_cooldown_manager.py
+++ b/apps/gridbot/src/gridbot/auth_cooldown_manager.py
@@ -68,7 +68,7 @@ class AuthCooldownManager:
         """
         if threading.current_thread() is not threading.main_thread():
             raise RuntimeError(
-                "_on_auth_cooldown_entered must run on the main thread; "
+                "AuthCooldownManager.enter() must run on the main thread; "
                 "see docstring for the locking required before relaxing "
                 f"this. Called from: {threading.current_thread().name}"
             )

--- a/apps/gridbot/src/gridbot/auth_cooldown_manager.py
+++ b/apps/gridbot/src/gridbot/auth_cooldown_manager.py
@@ -1,0 +1,121 @@
+"""Auth-cooldown state machine extracted from Orchestrator.
+
+Owns the per-strategy cooldown expiry map and the cumulative cycle
+counter. Callers (Orchestrator) hand in collaborators via constructor
+injection — this class holds no back-reference to Orchestrator.
+
+Thread model: main-thread-only. ``enter`` mutates ``_auth_cooldown_cycles``
+(read-then-write — NOT atomic) and ``_auth_cooldown_until``, and calls
+``retry_queue.clear()`` which runs in parallel with ``process_due()``
+only if the main-thread assumption holds. All current callers satisfy
+this: executor entry points (``execute_place`` / ``execute_cancel`` /
+``execute_amend``) are invoked from ``StrategyRunner`` (main-thread
+ticker cycle) and ``RetryQueue.process_due()`` (main-thread retry-drain
+tick). ``enter`` enforces the invariant at runtime with a fail-loud
+``RuntimeError``.
+
+Design note: the fail-loud thread guard is deliberate — not a missing
+lock. Adding one here would signal "safe from any thread" and invite
+callers that deadlock against ``process_due`` or push us into a
+drain-pattern that delays cooldown activation. Enforcing the invariant
+at runtime keeps the design simple and makes any violation impossible
+to miss.
+"""
+
+import logging
+import threading
+from datetime import datetime, timedelta, UTC
+
+from gridbot.executor import IntentExecutor
+from gridbot.notifier import Notifier
+from gridbot.retry_queue import RetryQueue
+
+logger = logging.getLogger(__name__)
+
+
+class AuthCooldownManager:
+    """Per-strategy auth-cooldown lifecycle (entry + expiry sweep).
+
+    Owns two pieces of state: ``_auth_cooldown_until`` (expiry timestamp
+    per strat_id) and ``_auth_cooldown_cycles`` (cumulative cooldown
+    count per strat_id).
+    """
+
+    def __init__(
+        self,
+        *,
+        strategy_executors: dict[str, IntentExecutor],
+        retry_queues: dict[str, RetryQueue],
+        notifier: Notifier,
+        cooldown_minutes: int,
+    ):
+        # Dicts held by reference; Orchestrator mutates them in place
+        # during _init_strategy, and those updates are visible here.
+        self._strategy_executors = strategy_executors
+        self._retry_queues = retry_queues
+        self._notifier = notifier
+        self._cooldown_minutes = cooldown_minutes
+
+        self._auth_cooldown_until: dict[str, datetime] = {}  # strat_id -> expiry
+        self._auth_cooldown_cycles: dict[str, int] = {}  # strat_id -> cumulative cycle count
+
+    def enter(self, strat_id: str) -> None:
+        """Called by executor when auth cooldown activates.
+
+        Works regardless of whether the failure came from the ticker path
+        or the retry queue path. See module docstring for the thread-model
+        rationale and the fail-loud guard's role.
+        """
+        if threading.current_thread() is not threading.main_thread():
+            raise RuntimeError(
+                "_on_auth_cooldown_entered must run on the main thread; "
+                "see docstring for the locking required before relaxing "
+                f"this. Called from: {threading.current_thread().name}"
+            )
+        cycle = self._auth_cooldown_cycles.get(strat_id, 0) + 1
+        self._auth_cooldown_cycles[strat_id] = cycle
+
+        expiry = datetime.now(UTC) + timedelta(minutes=self._cooldown_minutes)
+        self._auth_cooldown_until[strat_id] = expiry
+
+        executor = self._strategy_executors.get(strat_id)
+        failure_count = executor.auth_failure_count if executor else "?"
+
+        # Clear retry queue — stale intents would fail with the same auth error,
+        # and fresh intents at current prices will be generated after cooldown.
+        retry_queue = self._retry_queues.get(strat_id)
+        if retry_queue:
+            cleared = retry_queue.clear()
+            if cleared:
+                logger.info(f"Cleared {cleared} items from retry queue for {strat_id}")
+
+        msg = (
+            f"Strategy {strat_id}: {failure_count} consecutive auth errors, "
+            f"entering {self._cooldown_minutes}-min cooldown (cycle {cycle})"
+        )
+        logger.error(msg)
+        self._notifier.alert(msg, error_key=f"auth_cooldown_{strat_id}")
+
+    def sweep_expired(self, now: datetime) -> None:
+        """Reset any strategies whose cooldown window has elapsed.
+
+        Iterates over a ``list(keys())`` snapshot so ``del`` during the
+        loop cannot raise ``RuntimeError: dict changed size during
+        iteration``.
+        """
+        for strat_id in list(self._auth_cooldown_until.keys()):
+            expiry = self._auth_cooldown_until[strat_id]
+            if now >= expiry:
+                executor = self._strategy_executors.get(strat_id)
+                cycle = self._auth_cooldown_cycles.get(strat_id, 1)
+                if executor:
+                    executor.reset_auth_cooldown()
+                    msg = (
+                        f"Strategy {strat_id}: cooldown expired (cycle {cycle}), "
+                        f"resuming order execution"
+                    )
+                    logger.info(msg)
+                    self._notifier.alert(
+                        msg, error_key=f"auth_cooldown_resume_{strat_id}",
+                    )
+                del self._auth_cooldown_until[strat_id]

--- a/apps/gridbot/src/gridbot/orchestrator.py
+++ b/apps/gridbot/src/gridbot/orchestrator.py
@@ -9,10 +9,9 @@ The orchestrator is the main entry point for the gridbot. It:
 """
 
 import logging
-import threading
 import time
 from collections import deque
-from datetime import datetime, timedelta, UTC
+from datetime import datetime, UTC
 from typing import Optional
 from uuid import UUID, uuid5
 
@@ -37,6 +36,7 @@ from gridbot.runner import StrategyRunner
 from gridbot.reconciler import Reconciler
 from gridbot.retry_queue import RetryQueue
 from gridbot.position_fetcher import PositionFetcher, _POSITION_TICK_BASE
+from gridbot.auth_cooldown_manager import AuthCooldownManager
 
 _HEALTH_CHECK_INTERVAL = 10  # seconds
 _CHECK_INTERVAL = 0.1  # 100 ms main loop tick (bbu2 value)
@@ -138,6 +138,18 @@ class Orchestrator:
             position_check_interval=self._config.position_check_interval,
         )
 
+        # Auth-cooldown subsystem. Constructed eagerly for the same reason
+        # as _position_fetcher — _init_strategy registers an executor
+        # callback bound to this instance, and _strategy_executors /
+        # _retry_queues are held by reference (empty now, populated in
+        # place by _init_strategy).
+        self._auth_cooldown = AuthCooldownManager(
+            strategy_executors=self._strategy_executors,
+            retry_queues=self._retry_queues,
+            notifier=self._notifier,
+            cooldown_minutes=self._config.auth_cooldown_minutes,
+        )
+
         # WS → main-thread buffers.
         #
         # Memory model: CPython's GIL serialises bytecode execution, so a
@@ -166,10 +178,6 @@ class Orchestrator:
         # Debounce window for WS-triggered fast-track order syncs. Bursts of
         # untracked-order WS events coalesce into a single reconciliation sweep.
         self._unknown_order_debounce_until: float = 0.0
-
-        # Auth cooldown tracking
-        self._auth_cooldown_until: dict[str, datetime] = {}  # strat_id -> expiry
-        self._auth_cooldown_cycles: dict[str, int] = {}  # strat_id -> cumulative cycle count
 
     @property
     def running(self) -> bool:
@@ -536,7 +544,7 @@ class Orchestrator:
         executor = IntentExecutor(
             base_executor._client,
             shadow_mode=strategy_config.shadow_mode,
-            on_cooldown_entered=lambda sid=strat_id: self._on_auth_cooldown_entered(sid),
+            on_cooldown_entered=lambda sid=strat_id: self._auth_cooldown.enter(sid),
         )
 
         # Create retry queue with dispatcher that routes by intent type
@@ -626,62 +634,6 @@ class Orchestrator:
             self._latest_ticker[symbol] = event
         except Exception as e:
             self._notifier.alert_exception("_on_ticker", e, error_key="ws_on_ticker")
-
-    def _on_auth_cooldown_entered(self, strat_id: str) -> None:
-        """Called by executor when auth cooldown activates.
-
-        Works regardless of whether the failure came from the ticker path
-        or the retry queue path.
-
-        Thread-safety: this callback is main-thread only. It mutates
-        ``_auth_cooldown_cycles`` (read-then-write — NOT atomic) and
-        ``_auth_cooldown_until``, and calls ``retry_queue.clear()`` which
-        runs in parallel with ``process_due()`` only if the main-thread
-        assumption holds. All current callers satisfy this: executor
-        entry points (`execute_place`/`execute_cancel`/`execute_amend`)
-        are invoked from `StrategyRunner` (main-thread ticker cycle) and
-        `RetryQueue.process_due()` (main-thread retry-drain tick). If a
-        future change wires this callback to a WebSocket handler or any
-        other thread, the cycle-counter update and the retry-queue clear
-        must be serialized with a lock (and with `process_due`).
-
-        Design note: fail-loud thread guard is deliberate — not a missing
-        lock. Adding one here would signal "safe from any thread" and
-        invite callers that deadlock against `process_due` or push us
-        into a drain-pattern that delays cooldown activation. Enforcing
-        the invariant at runtime keeps the design simple and makes any
-        violation impossible to miss.
-        """
-        if threading.current_thread() is not threading.main_thread():
-            raise RuntimeError(
-                "_on_auth_cooldown_entered must run on the main thread; "
-                "see docstring for the locking required before relaxing "
-                f"this. Called from: {threading.current_thread().name}"
-            )
-        cycle = self._auth_cooldown_cycles.get(strat_id, 0) + 1
-        self._auth_cooldown_cycles[strat_id] = cycle
-
-        cooldown_minutes = self._config.auth_cooldown_minutes
-        expiry = datetime.now(UTC) + timedelta(minutes=cooldown_minutes)
-        self._auth_cooldown_until[strat_id] = expiry
-
-        executor = self._strategy_executors.get(strat_id)
-        failure_count = executor.auth_failure_count if executor else "?"
-
-        # Clear retry queue — stale intents would fail with the same auth error,
-        # and fresh intents at current prices will be generated after cooldown.
-        retry_queue = self._retry_queues.get(strat_id)
-        if retry_queue:
-            cleared = retry_queue.clear()
-            if cleared:
-                logger.info(f"Cleared {cleared} items from retry queue for {strat_id}")
-
-        msg = (
-            f"Strategy {strat_id}: {failure_count} consecutive auth errors, "
-            f"entering {cooldown_minutes}-min cooldown (cycle {cycle})"
-        )
-        logger.error(msg)
-        self._notifier.alert(msg, error_key=f"auth_cooldown_{strat_id}")
 
     def _on_order(self, account_name: str, message: dict) -> None:
         """Handle order WebSocket message (runs in pybit WS thread).
@@ -785,24 +737,7 @@ class Orchestrator:
         seconds.
         """
         try:
-            # Check auth cooldown expiry
-            now = datetime.now(UTC)
-            for strat_id in list(self._auth_cooldown_until.keys()):
-                expiry = self._auth_cooldown_until[strat_id]
-                if now >= expiry:
-                    executor = self._strategy_executors.get(strat_id)
-                    cycle = self._auth_cooldown_cycles.get(strat_id, 1)
-                    if executor:
-                        executor.reset_auth_cooldown()
-                        msg = (
-                            f"Strategy {strat_id}: cooldown expired (cycle {cycle}), "
-                            f"resuming order execution"
-                        )
-                        logger.info(msg)
-                        self._notifier.alert(
-                            msg, error_key=f"auth_cooldown_resume_{strat_id}",
-                        )
-                    del self._auth_cooldown_until[strat_id]
+            self._auth_cooldown.sweep_expired(datetime.now(UTC))
 
             for account_name in list(self._public_ws.keys()):
                 # Check public WS

--- a/apps/gridbot/tests/test_auth_cooldown_manager.py
+++ b/apps/gridbot/tests/test_auth_cooldown_manager.py
@@ -107,7 +107,7 @@ class TestEnter:
         # Documented prefix — guards against accidental message drift that
         # would otherwise slip through looser substring checks.
         assert str(captured[0]).startswith(
-            "_on_auth_cooldown_entered must run on the main thread"
+            "AuthCooldownManager.enter() must run on the main thread"
         )
         assert "worker-42" in str(captured[0])
         assert "s1" not in manager._auth_cooldown_until

--- a/apps/gridbot/tests/test_auth_cooldown_manager.py
+++ b/apps/gridbot/tests/test_auth_cooldown_manager.py
@@ -1,0 +1,190 @@
+"""Isolated unit tests for AuthCooldownManager.
+
+These tests exercise AuthCooldownManager directly, without spinning up
+an Orchestrator. They complement the integration-style tests in
+test_orchestrator.py (which go through the Orchestrator and assert the
+callback and health-check wiring).
+"""
+
+import threading
+from datetime import datetime, timedelta, UTC
+from unittest.mock import Mock
+
+from gridbot.auth_cooldown_manager import AuthCooldownManager
+from gridbot.notifier import Notifier
+
+
+def _make_manager(
+    *,
+    strategy_executors=None,
+    retry_queues=None,
+    notifier=None,
+    cooldown_minutes=5,
+):
+    return AuthCooldownManager(
+        strategy_executors=strategy_executors if strategy_executors is not None else {},
+        retry_queues=retry_queues if retry_queues is not None else {},
+        notifier=notifier if notifier is not None else Mock(spec=Notifier),
+        cooldown_minutes=cooldown_minutes,
+    )
+
+
+class TestEnter:
+    def test_increments_cycle_counter(self):
+        executor = Mock()
+        executor.auth_failure_count = 5
+        manager = _make_manager(strategy_executors={"s1": executor})
+
+        manager.enter("s1")
+        assert manager._auth_cooldown_cycles["s1"] == 1
+
+        manager.enter("s1")
+        assert manager._auth_cooldown_cycles["s1"] == 2
+
+    def test_sets_expiry_based_on_cooldown_minutes(self):
+        manager = _make_manager(cooldown_minutes=10)
+
+        before = datetime.now(UTC)
+        manager.enter("s1")
+        after = datetime.now(UTC)
+
+        expiry = manager._auth_cooldown_until["s1"]
+        assert expiry >= before + timedelta(minutes=10)
+        assert expiry <= after + timedelta(minutes=10)
+
+    def test_clears_retry_queue(self):
+        retry_queue = Mock()
+        retry_queue.clear.return_value = 2
+        manager = _make_manager(retry_queues={"s1": retry_queue})
+
+        manager.enter("s1")
+
+        retry_queue.clear.assert_called_once()
+
+    def test_alerts_notifier_with_cycle_number_and_key(self):
+        notifier = Mock(spec=Notifier)
+        executor = Mock()
+        executor.auth_failure_count = 3
+        manager = _make_manager(
+            strategy_executors={"s1": executor}, notifier=notifier,
+        )
+
+        manager.enter("s1")
+
+        notifier.alert.assert_called_once()
+        body = notifier.alert.call_args[0][0]
+        assert "cycle 1" in body
+        assert "3 consecutive auth errors" in body
+        assert notifier.alert.call_args.kwargs["error_key"] == "auth_cooldown_s1"
+
+    def test_missing_executor_falls_back_to_question_mark(self):
+        notifier = Mock(spec=Notifier)
+        manager = _make_manager(notifier=notifier)  # empty executor dict
+
+        manager.enter("s1")
+
+        body = notifier.alert.call_args[0][0]
+        assert "? consecutive auth errors" in body
+
+    def test_raises_when_called_from_non_main_thread(self):
+        """Fail-loud guard: touching state off the main thread must raise."""
+        manager = _make_manager()
+
+        captured: list[BaseException] = []
+
+        def run() -> None:
+            try:
+                manager.enter("s1")
+            except BaseException as exc:
+                captured.append(exc)
+
+        t = threading.Thread(target=run, name="worker-42")
+        t.start()
+        t.join()
+
+        assert len(captured) == 1
+        assert isinstance(captured[0], RuntimeError)
+        # Documented prefix — guards against accidental message drift that
+        # would otherwise slip through looser substring checks.
+        assert str(captured[0]).startswith(
+            "_on_auth_cooldown_entered must run on the main thread"
+        )
+        assert "worker-42" in str(captured[0])
+        assert "s1" not in manager._auth_cooldown_until
+        assert "s1" not in manager._auth_cooldown_cycles
+
+
+class TestSweepExpired:
+    def test_removes_past_expiries_and_keeps_future(self):
+        executor_a = Mock()
+        executor_b = Mock()
+        manager = _make_manager(
+            strategy_executors={"a": executor_a, "b": executor_b},
+        )
+        now = datetime.now(UTC)
+        manager._auth_cooldown_until["a"] = now - timedelta(seconds=1)
+        manager._auth_cooldown_until["b"] = now + timedelta(minutes=5)
+        manager._auth_cooldown_cycles["a"] = 1
+        manager._auth_cooldown_cycles["b"] = 1
+
+        manager.sweep_expired(now)
+
+        assert "a" not in manager._auth_cooldown_until
+        assert "b" in manager._auth_cooldown_until
+        # Cycle history is cumulative — not cleared on expiry.
+        assert manager._auth_cooldown_cycles["a"] == 1
+
+    def test_calls_reset_on_executor(self):
+        executor = Mock()
+        manager = _make_manager(strategy_executors={"s1": executor})
+        now = datetime.now(UTC)
+        manager._auth_cooldown_until["s1"] = now - timedelta(seconds=1)
+        manager._auth_cooldown_cycles["s1"] = 2
+
+        manager.sweep_expired(now)
+
+        executor.reset_auth_cooldown.assert_called_once()
+
+    def test_missing_executor_still_deletes_entry(self):
+        # Defensive: dynamic strategy removal could drop the executor
+        # mid-flight. Expiry sweep must still reclaim the entry.
+        manager = _make_manager()  # empty executor dict
+        now = datetime.now(UTC)
+        manager._auth_cooldown_until["s1"] = now - timedelta(seconds=1)
+
+        manager.sweep_expired(now)
+
+        assert "s1" not in manager._auth_cooldown_until
+
+    def test_alerts_with_resume_message_and_key(self):
+        notifier = Mock(spec=Notifier)
+        executor = Mock()
+        manager = _make_manager(
+            strategy_executors={"s1": executor}, notifier=notifier,
+        )
+        now = datetime.now(UTC)
+        manager._auth_cooldown_until["s1"] = now - timedelta(seconds=1)
+        manager._auth_cooldown_cycles["s1"] = 3
+
+        manager.sweep_expired(now)
+
+        notifier.alert.assert_called_once()
+        body = notifier.alert.call_args[0][0]
+        assert "cooldown expired" in body
+        assert "cycle 3" in body
+        assert notifier.alert.call_args.kwargs["error_key"] == "auth_cooldown_resume_s1"
+
+    def test_skips_entries_not_yet_expired(self):
+        executor = Mock()
+        notifier = Mock(spec=Notifier)
+        manager = _make_manager(
+            strategy_executors={"s1": executor}, notifier=notifier,
+        )
+        now = datetime.now(UTC)
+        manager._auth_cooldown_until["s1"] = now + timedelta(minutes=5)
+
+        manager.sweep_expired(now)
+
+        executor.reset_auth_cooldown.assert_not_called()
+        notifier.alert.assert_not_called()
+        assert "s1" in manager._auth_cooldown_until

--- a/apps/gridbot/tests/test_orchestrator.py
+++ b/apps/gridbot/tests/test_orchestrator.py
@@ -1671,7 +1671,7 @@ class TestOrchestratorHealthCheckOnce:
         priv_ws.is_connected.return_value = True
 
         # Cooldown sweep at top of _health_check_once is a no-op
-        orchestrator._auth_cooldown_until = {}
+        orchestrator._auth_cooldown._auth_cooldown_until = {}
 
         with patch(
             "gridbot.orchestrator.time.monotonic",
@@ -1716,7 +1716,7 @@ class TestOrchestratorHealthCheckOnce:
         priv_ws.connect = Mock()
         priv_ws.disconnect = Mock()
 
-        orchestrator._auth_cooldown_until = {}
+        orchestrator._auth_cooldown._auth_cooldown_until = {}
 
         with patch(
             "gridbot.orchestrator.time.monotonic",
@@ -1759,7 +1759,7 @@ class TestOrchestratorHealthCheckOnce:
         priv_ws = orchestrator._private_ws["test_account"]
         priv_ws.is_connected.return_value = True
 
-        orchestrator._auth_cooldown_until = {}
+        orchestrator._auth_cooldown._auth_cooldown_until = {}
 
         with patch(
             "gridbot.orchestrator.time.monotonic",
@@ -2028,16 +2028,16 @@ class TestOrchestratorAuthCooldown:
         self, mock_private_ws, mock_public_ws, mock_rest_client,
         gridbot_config, account_config, strategy_config,
     ):
-        """_on_auth_cooldown_entered sets expiry timer and sends alert."""
+        """AuthCooldownManager.enter sets expiry timer and sends alert."""
         notifier = Mock(spec=Notifier)
         orchestrator = Orchestrator(gridbot_config, notifier=notifier)
         orchestrator._init_account(account_config)
         orchestrator._init_strategy(strategy_config)
 
-        orchestrator._on_auth_cooldown_entered("btcusdt_test")
+        orchestrator._auth_cooldown.enter("btcusdt_test")
 
-        assert "btcusdt_test" in orchestrator._auth_cooldown_until
-        assert orchestrator._auth_cooldown_cycles["btcusdt_test"] == 1
+        assert "btcusdt_test" in orchestrator._auth_cooldown._auth_cooldown_until
+        assert orchestrator._auth_cooldown._auth_cooldown_cycles["btcusdt_test"] == 1
         notifier.alert.assert_called_once()
         assert "cycle 1" in notifier.alert.call_args[0][0]
 
@@ -2054,13 +2054,13 @@ class TestOrchestratorAuthCooldown:
         orchestrator._init_account(account_config)
         orchestrator._init_strategy(strategy_config)
 
-        orchestrator._on_auth_cooldown_entered("btcusdt_test")
-        assert orchestrator._auth_cooldown_cycles["btcusdt_test"] == 1
+        orchestrator._auth_cooldown.enter("btcusdt_test")
+        assert orchestrator._auth_cooldown._auth_cooldown_cycles["btcusdt_test"] == 1
 
-        del orchestrator._auth_cooldown_until["btcusdt_test"]
+        del orchestrator._auth_cooldown._auth_cooldown_until["btcusdt_test"]
 
-        orchestrator._on_auth_cooldown_entered("btcusdt_test")
-        assert orchestrator._auth_cooldown_cycles["btcusdt_test"] == 2
+        orchestrator._auth_cooldown.enter("btcusdt_test")
+        assert orchestrator._auth_cooldown._auth_cooldown_cycles["btcusdt_test"] == 2
         assert "cycle 2" in notifier.alert.call_args[0][0]
 
     @patch("gridbot.orchestrator.BybitRestClient")
@@ -2082,8 +2082,8 @@ class TestOrchestratorAuthCooldown:
         executor = orchestrator._strategy_executors["btcusdt_test"]
         executor._auth_cooldown = True
         executor._auth_failure_count = 5
-        orchestrator._auth_cooldown_until["btcusdt_test"] = datetime.now(UTC) - timedelta(seconds=1)
-        orchestrator._auth_cooldown_cycles["btcusdt_test"] = 2
+        orchestrator._auth_cooldown._auth_cooldown_until["btcusdt_test"] = datetime.now(UTC) - timedelta(seconds=1)
+        orchestrator._auth_cooldown._auth_cooldown_cycles["btcusdt_test"] = 2
 
         pub_ws = orchestrator._public_ws["test_account"]
         pub_ws.is_connected.return_value = True
@@ -2094,8 +2094,8 @@ class TestOrchestratorAuthCooldown:
 
         assert executor.auth_cooldown is False
         assert executor.auth_failure_count == 0
-        assert "btcusdt_test" not in orchestrator._auth_cooldown_until
-        assert orchestrator._auth_cooldown_cycles["btcusdt_test"] == 2
+        assert "btcusdt_test" not in orchestrator._auth_cooldown._auth_cooldown_until
+        assert orchestrator._auth_cooldown._auth_cooldown_cycles["btcusdt_test"] == 2
         assert any("cooldown expired" in str(c) for c in notifier.alert.call_args_list)
 
     @patch("gridbot.orchestrator.BybitRestClient")
@@ -2118,10 +2118,10 @@ class TestOrchestratorAuthCooldown:
         orchestrator._init_strategy(strategy_config)
 
         before = datetime.now(UTC)
-        orchestrator._on_auth_cooldown_entered("btcusdt_test")
+        orchestrator._auth_cooldown.enter("btcusdt_test")
         after = datetime.now(UTC)
 
-        expiry = orchestrator._auth_cooldown_until["btcusdt_test"]
+        expiry = orchestrator._auth_cooldown._auth_cooldown_until["btcusdt_test"]
         assert expiry >= before + timedelta(minutes=10)
         assert expiry <= after + timedelta(minutes=10)
 
@@ -2147,7 +2147,7 @@ class TestOrchestratorAuthCooldown:
         retry_queue.add(intent, "auth error")
         assert retry_queue.size == 2
 
-        orchestrator._on_auth_cooldown_entered("btcusdt_test")
+        orchestrator._auth_cooldown.enter("btcusdt_test")
 
         assert retry_queue.size == 0
 

--- a/docs/features/0020_PLAN.md
+++ b/docs/features/0020_PLAN.md
@@ -109,12 +109,13 @@ a couple of mock executors and a fake notifier, no orchestrator needed.
 - **Imports**: add `from gridbot.auth_cooldown_manager import AuthCooldownManager`.
 - **`__init__` changes**:
   - Remove fields `_auth_cooldown_until` and `_auth_cooldown_cycles`.
-  - Add field `self._auth_cooldown: Optional[AuthCooldownManager] = None`
-    (instantiated in `start()` once `_strategy_executors` and
-    `_retry_queues` are populated).
-- **`start()`**:
-  - After `_strategy_executors` and `_retry_queues` are fully populated
-    (end of the runner-init loop), instantiate:
+  - Instantiate `AuthCooldownManager` eagerly in `__init__`, just after
+    the `PositionFetcher` block. The constructor takes
+    `_strategy_executors` and `_retry_queues` by reference; the dicts
+    are declared empty here (lines 103, 105) and populated by
+    `_init_strategy` later, so reads through the manager always see
+    the latest entries. Mirrors the 0019 `PositionFetcher` pattern at
+    `orchestrator.py:133–139`.
     ```
     self._auth_cooldown = AuthCooldownManager(
         strategy_executors=self._strategy_executors,
@@ -123,18 +124,12 @@ a couple of mock executors and a fake notifier, no orchestrator needed.
         cooldown_minutes=self._config.auth_cooldown_minutes,
     )
     ```
-  - **Ordering caveat**: the `on_cooldown_entered` executor callback
-    is registered at `_init_strategy` time (`orchestrator.py:491`),
-    which runs inside `start()` **before** `_strategy_executors` /
-    `_retry_queues` are fully populated. Options:
-      - **Option A (preferred)**: instantiate `AuthCooldownManager` at
-        the top of `start()` (like `PositionFetcher` in 0019), before
-        any `_init_strategy` runs. Its constructor takes the two dicts
-        by reference; they get filled in afterwards, and the first
-        cooldown-entry callback (if any) fires well after init is done.
-      - **Option B**: register a thunk that lazily resolves the
-        manager. Rejected — adds indirection without benefit.
-  - Go with Option A.
+- **`start()`**: no changes needed. Because the manager is constructed
+  in `__init__`, the `on_cooldown_entered` callback registered by
+  `_init_strategy` resolves against the already-built
+  `self._auth_cooldown`. The executor and retry-queue dicts are held
+  by reference and fill in naturally as `_init_strategy` runs, so no
+  ordering caveat applies.
 - **Callback registration (`_init_strategy`, line 491)**:
   ```
   on_cooldown_entered=lambda sid=strat_id: self._on_auth_cooldown_entered(sid),

--- a/docs/features/0020_REVIEW.md
+++ b/docs/features/0020_REVIEW.md
@@ -1,0 +1,46 @@
+# 0020 Review
+
+Scope reviewed: implementation of `docs/features/0020_PLAN.md` in
+`apps/gridbot/src/gridbot/orchestrator.py`,
+`apps/gridbot/src/gridbot/auth_cooldown_manager.py`,
+`apps/gridbot/tests/test_orchestrator.py`, and
+`apps/gridbot/tests/test_auth_cooldown_manager.py`, with focus on plan
+fidelity, runtime behavior, data-shape assumptions, style consistency,
+and test quality.
+
+## Findings
+
+No actionable implementation findings for 0020 at this point.
+
+## Plan Fidelity
+
+Implemented as planned:
+
+- New manager module extracted:
+  `apps/gridbot/src/gridbot/auth_cooldown_manager.py`.
+- Main-thread fail-loud guard, cycle counting, retry-queue clear, and
+  notifier keys are preserved.
+- `_on_auth_cooldown_entered` was removed from orchestrator and executor
+  callback now targets manager `enter()`.
+- `_health_check_once` delegates expiry handling to
+  `self._auth_cooldown.sweep_expired(datetime.now(UTC))`.
+- Manager is instantiated eagerly in `Orchestrator.__init__` (by-reference
+  dict injection pattern), matching the updated plan text.
+- Isolated unit tests for `AuthCooldownManager` exist and cover happy
+  paths and edge cases from the plan.
+
+## Verification
+
+Executed checks:
+
+- `uv run pytest -q apps/gridbot/tests/test_auth_cooldown_manager.py apps/gridbot/tests/test_orchestrator.py`
+  - Result: `103 passed`
+- `uv run pytest -q apps/gridbot/tests`
+  - Result: `336 passed`
+- `git diff --name-only -- packages/gridcore apps/backtest apps/comparator apps/gridbot/src/gridbot/executor.py apps/event_saver`
+  - Result: empty (no cross-boundary edits)
+- `uv run ruff check apps/gridbot/src/gridbot/auth_cooldown_manager.py apps/gridbot/src/gridbot/orchestrator.py apps/gridbot/tests/test_auth_cooldown_manager.py apps/gridbot/tests/test_orchestrator.py`
+  - Result: 2 `F401` warnings in `orchestrator.py` only:
+    - unused `ExecutionEvent`
+    - unused `OrderUpdateEvent`
+  - These appear pre-existing and are unrelated to plan 0020 changes.


### PR DESCRIPTION
## Summary
- Extract auth-cooldown state machine from `Orchestrator` into a dedicated `AuthCooldownManager` (`apps/gridbot/src/gridbot/auth_cooldown_manager.py`). Sibling refactor to #52 (0019 PositionFetcher); same DI pattern, no behaviour change.
- Preserves fail-loud main-thread guard, cycle counter, retry-queue clear, and notifier alert keys (`auth_cooldown_{sid}` / `auth_cooldown_resume_{sid}`) byte-identically.
- Adds `apps/gridbot/tests/test_auth_cooldown_manager.py` (11 isolated unit tests) covering entry, expiry, missing-executor fallback, and the non-main-thread `RuntimeError` (asserts the documented message prefix).
- Path-patches existing `TestOrchestratorAuthCooldown` integration tests through `orchestrator._auth_cooldown`.
- Aligns `docs/features/0020_PLAN.md` with the chosen `__init__` placement (matches 0019 precedent at `orchestrator.py:133–139`; resolves the plan's earlier "ordering caveat" without a two-phase init).
- Includes `docs/features/0020_REVIEW.md`.

## Test plan
- [x] `uv run pytest apps/gridbot/tests/test_auth_cooldown_manager.py -v` — 11 passed
- [x] `uv run pytest apps/gridbot/tests/test_orchestrator.py -v` — 92 passed
- [x] `uv run pytest apps/gridbot/tests` — 336 passed
- [x] `git diff main -- packages/gridcore apps/backtest apps/comparator apps/gridbot/src/gridbot/executor.py apps/event_saver` is empty (no cross-boundary edits)
- [x] `uv run ruff check` clean on new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)