### PR TITLE
chore(orchestrator): drop unused ExecutionEvent / OrderUpdateEvent imports

### DIFF
--- a/apps/gridbot/src/gridbot/orchestrator.py
+++ b/apps/gridbot/src/gridbot/orchestrator.py
@@ -24,8 +24,6 @@ from gridcore import (
     GridAnchorStore,
     InstrumentInfo,
     TickerEvent,
-    ExecutionEvent,
-    OrderUpdateEvent,
 )
 from gridcore.intents import CancelIntent
 


### PR DESCRIPTION
## Summary
- Remove two unused imports (`ExecutionEvent`, `OrderUpdateEvent`) from `apps/gridbot/src/gridbot/orchestrator.py`. Pre-existing F401 surfaced by ruff during the PR #54 review; deferred to this follow-up to keep #54 scope-focused.

## Test plan
- [x] `uv run ruff check apps/gridbot/src/gridbot/orchestrator.py` — All checks passed
- [x] `uv run pytest apps/gridbot/tests` — 336 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)