### PR TITLE
feat(persistence): persist full grid state across restarts (0021)

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -114,12 +114,12 @@ Successfully extracted pure strategy logic from `bbu2-master` into `packages/gri
    │   ├── engine.py            # GridEngine (from strat.py)
    │   ├── position.py          # Position risk management
    │   ├── pnl.py               # Pure PnL formulas + MMTiers + parse_risk_limit_tiers
-   │   └── persistence.py       # Grid anchor persistence
+   │   └── persistence.py       # Full grid state persistence (GridStateStore)
    └── tests/
        ├── test_grid.py         # Grid calculation tests
        ├── test_engine.py       # Engine event processing tests
        ├── test_position.py     # Position risk tests
-       ├── test_persistence.py  # Anchor persistence tests
+       ├── test_persistence.py  # Grid state persistence tests
        └── test_comparison.py   # Comparison with original (optional)
    ```
 
@@ -243,6 +243,62 @@ make test-integration
   - See `docs/features/ORDER_IDENTITY_DESIGN.md`
 
 ### PnL Calculations (`pnl.py`)
+
+### Grid State Persistence (`persistence.py`)
+
+`GridStateStore` (renamed from the legacy `GridAnchorStore` in feature 0021) persists the **full** ordered grid per strategy across restarts, replacing the old anchor-only scheme. This restores per-fill WAIT zones, side reassignments, and `__center_grid` drift that were previously lost.
+
+**Usage**
+
+- File location: `db/grid_anchor.json` (filename preserved for deploy-config compatibility — orchestrator constructor still accepts `anchor_store_path`).
+- Wired by `Orchestrator → StrategyRunner` (`apps/gridbot/src/gridbot/orchestrator.py`, `apps/gridbot/src/gridbot/runner.py`). Runner registers `_on_grid_change` as a callback into `Grid` via `GridEngine(on_grid_change=...)`.
+- `Grid.build_grid()` and `Grid.update_grid()` invoke the callback at the end of every mutation; `Grid.restore_grid()` does NOT (loading is not a mutation worth re-persisting).
+
+**Schema**
+
+```json
+{
+  "ltcusdt_test": {
+    "grid": [
+      {"side": "Buy",  "price": 53.4},
+      {"side": "Wait", "price": 55.4},
+      {"side": "Sell", "price": 57.4}
+    ],
+    "grid_step": 0.3,
+    "grid_count": 20
+  }
+}
+```
+
+`side` values are `GridSideType` enum values (`"Buy"`, `"Sell"`, `"Wait"`). `grid_step` and `grid_count` are kept alongside the grid only for config-mismatch invalidation (see below).
+
+**Thread-safety + atomic write**
+
+- `save()` is a **sync API but non-blocking**. It computes a cheap fingerprint (tuple of `(side, price)` pairs + grid_step + grid_count), short-circuits if equal to the last-enqueued payload (dedupe BEFORE deepcopy), then dispatches via a per-strat pending slot.
+- **Single-writer-per-strat**: each `strat_id` has at most one daemon `threading.Thread` writing at a time. A new save while a writer is in flight overwrites the slot; the in-flight writer drains it on its next loop iteration. Coalesces rapid bursts into one final disk write per strat with **latest-wins ordering** (a naive `threading.Lock`-per-write would not be FIFO and could write older payloads after newer ones).
+- **Atomic on disk**: every write goes through tmp file + `f.flush()` + `os.fsync()` + `os.replace()`. A `kill -9` mid-write cannot leave a corrupted half-written file. Failed writes (disk full, permission denied) clean up the `.tmp` file before propagating the exception, so stale tmp files do not accumulate.
+- **Two locks**: `_io_lock` (`threading.Lock`) serializes disk I/O across strats — the file is shared. `_cv` (`threading.Condition`) gates dedupe state, the active-writer set, and `flush()` wait/notify.
+- **Failure semantics**: a write failure inside the writer is logged (`logger.error("Save failed for %s: %s", ...)`) and the dedupe fingerprint is rolled back (only if no newer payload arrived since), so the next identical save can retry. The writer thread continues to drain any newer pending payload — failures do not crash strategy logic.
+
+**Legacy format migration**
+
+Pre-0021 files contain `{anchor_price, grid_step, grid_count}` per strat (no `grid` key). On `load()`, missing-`grid` is detected and treated as no-saved-state; one info log fires (`"Legacy anchor format ignored, building fresh grid at market price"`) and the engine builds a fresh grid from market price on the first ticker. **No data-preserving conversion** is needed (a converter would produce the same result as building fresh from the anchor).
+
+**Config-mismatch invalidation**
+
+If the saved `grid_step` or `grid_count` differs from the current strategy config, the runner discards the saved grid and logs `"Config changed, will build fresh grid"`. Done in `runner._load_grid_state()` before passing `restored_grid` to `GridEngine`.
+
+**Self-healing on corruption**
+
+`_read_all_data()` returns `{}` on any error: missing file, JSON parse failure, or **non-dict root** (e.g. hand-edited `[]` / `"x"` / `1`). The next `save()` silently overwrites a corrupt file. Per-entry corruption (entry that isn't a dict, or grid that fails `is_grid_correct()`) also returns None / fresh build — the bot never crashes on a bad persistence file.
+
+**Pitfalls**
+
+- **Why threads, not asyncio?** Gridbot's `Orchestrator.run()` is a synchronous main loop using `time.sleep` — there is no event loop in the live runtime. `asyncio.create_task()` would always raise `RuntimeError` and fall through to synchronous fsync, blocking the main loop. Daemon threads work in both sync and async caller contexts. **Do not "modernize" to asyncio** without first making the orchestrator async end-to-end.
+- **`GridStateStore.flush()`** blocks until all pending writes complete. Use it in tests (deterministic instead of `time.sleep`) and in graceful shutdown. Production callers do not need it — daemon threads either complete or die with the process, and the next save retries.
+- **Drift guard on restore**: `engine._handle_ticker_event` rebuilds if `last_close` is outside `[grid.min_grid, grid.max_grid]`. Uses `Grid.bounds` (single-pass min+max) for the per-tick check — do not call `min_grid` and `max_grid` separately in hot paths.
+- **`anchor_price` parameter on `GridEngine` is retained for backtest compatibility**, separate from `restored_grid`. Backtest pins grid origin via `anchor_price`; live runner uses `restored_grid` for full-state restore. They serve different use cases.
+- **Known limitation**: an in-flight writer thread that has already popped a payload from `_pending_payload` and is waiting on `_io_lock` cannot be cancelled by a concurrent `delete()`. The writer will eventually re-persist the entry after the delete. Acceptable for current usage (delete is for "strat removed from config" — no concurrent saves expected); not currently fixed.
 
 ## Logging Configuration
 

--- a/apps/gridbot/src/gridbot/orchestrator.py
+++ b/apps/gridbot/src/gridbot/orchestrator.py
@@ -21,7 +21,7 @@ from bybit_adapter.normalizer import BybitNormalizer
 from grid_db import DatabaseFactory
 from grid_db import Run, Strategy, BybitAccount, User
 from gridcore import (
-    GridAnchorStore,
+    GridStateStore,
     InstrumentInfo,
     TickerEvent,
 )
@@ -81,12 +81,14 @@ class Orchestrator:
         Args:
             config: Gridbot configuration.
             db: Database factory for persistence (optional).
-            anchor_store_path: Path to grid anchor JSON file.
+            anchor_store_path: Path to grid state JSON file. Name preserved
+                for deploy-config compatibility; the file now holds full grid
+                state, not just anchor prices.
             notifier: Alert notifier (optional, log-only if None).
         """
         self._config = config
         self._db = db
-        self._anchor_store = GridAnchorStore(anchor_store_path)
+        self._state_store = GridStateStore(anchor_store_path)
         self._notifier = notifier or Notifier()
 
         # Per-account resources
@@ -569,7 +571,7 @@ class Orchestrator:
             strategy_config=strategy_config,
             executor=executor,
             instrument_info=instrument_info,
-            anchor_store=self._anchor_store,
+            state_store=self._state_store,
             on_intent_failed=lambda intent, error: retry_queue.add(intent, error),
             on_unknown_order=self._request_immediate_order_sync,
             notifier=self._notifier,

--- a/apps/gridbot/src/gridbot/runner.py
+++ b/apps/gridbot/src/gridbot/runner.py
@@ -28,7 +28,7 @@ from gridcore import (
     OrderUpdateEvent,
     PlaceLimitIntent,
     CancelIntent,
-    GridAnchorStore,
+    GridStateStore,
     DirectionType,
     calc_position_value,
     calc_margin_ratio,
@@ -108,7 +108,7 @@ class StrategyRunner:
         strategy_config: StrategyConfig,
         executor: IntentExecutor,
         instrument_info: Optional[InstrumentInfo] = None,
-        anchor_store: Optional[GridAnchorStore] = None,
+        state_store: Optional[GridStateStore] = None,
         on_intent_failed: Optional[Callable[[PlaceLimitIntent | CancelIntent, str], None]] = None,
         on_unknown_order: Optional[Callable[[str], None]] = None,
         notifier: Optional[Notifier] = None,
@@ -119,7 +119,7 @@ class StrategyRunner:
             strategy_config: Strategy configuration.
             executor: Intent executor for API calls.
             instrument_info: Instrument info for qty rounding (None uses no rounding).
-            anchor_store: Optional anchor store for grid persistence.
+            state_store: Optional grid state store for persistence.
             on_intent_failed: Callback when intent execution fails (for retry queue).
             on_unknown_order: Callback when WS reports a New order we don't track
                 (for fast-tracking the next order-sync sweep).
@@ -127,7 +127,7 @@ class StrategyRunner:
         """
         self._config = strategy_config
         self._executor = executor
-        self._anchor_store = anchor_store
+        self._state_store = state_store
         self._on_intent_failed = on_intent_failed
         self._on_unknown_order = on_unknown_order
         self._notifier = notifier
@@ -139,8 +139,8 @@ class StrategyRunner:
         )
         self._wallet_balance: Decimal = Decimal("0")
 
-        # Load anchor if available and config matches
-        anchor_price = self._load_anchor()
+        # Restore full grid if available and config matches
+        restored_grid = self._load_grid_state()
 
         # Create GridEngine
         grid_config = GridConfig(
@@ -152,7 +152,8 @@ class StrategyRunner:
             tick_size=strategy_config.tick_size,
             config=grid_config,
             strat_id=strategy_config.strat_id,
-            anchor_price=anchor_price,
+            restored_grid=restored_grid,
+            on_grid_change=self._on_grid_change,
         )
 
         # Create linked Position managers
@@ -217,46 +218,51 @@ class StrategyRunner:
         self._recent_executions_long.clear()
         self._recent_executions_short.clear()
 
-    def _load_anchor(self) -> Optional[float]:
-        """Load anchor price if config matches."""
-        if self._anchor_store is None:
+    def _load_grid_state(self) -> Optional[list[dict]]:
+        """Load saved grid if config matches.
+
+        Returns the saved `grid` list, or None if no store configured, no entry
+        for this strat_id, the entry is in the legacy anchor-only format, or
+        the saved grid_step/grid_count differ from the current config.
+        """
+        if self._state_store is None:
             return None
 
-        anchor_data = self._anchor_store.load(self._config.strat_id)
-        if anchor_data is None:
+        saved = self._state_store.load(self._config.strat_id)
+        if saved is None:
             return None
 
-        # Check if config matches
         if (
-            anchor_data.get("grid_step") == self._config.grid_step
-            and anchor_data.get("grid_count") == self._config.grid_count
+            saved.get("grid_step") == self._config.grid_step
+            and saved.get("grid_count") == self._config.grid_count
         ):
             logger.info(
-                f"{self.strat_id}: Loaded anchor price {anchor_data['anchor_price']} "
-                f"(grid_step={anchor_data['grid_step']}, grid_count={anchor_data['grid_count']})"
+                f"{self.strat_id}: Loaded saved grid ({len(saved['grid'])} levels, "
+                f"grid_step={saved['grid_step']}, grid_count={saved['grid_count']})"
             )
-            return anchor_data["anchor_price"]
+            return saved["grid"]
         else:
             logger.info(
                 f"{self.strat_id}: Config changed, will build fresh grid "
-                f"(saved: step={anchor_data.get('grid_step')}, count={anchor_data.get('grid_count')}; "
+                f"(saved: step={saved.get('grid_step')}, count={saved.get('grid_count')}; "
                 f"current: step={self._config.grid_step}, count={self._config.grid_count})"
             )
             return None
 
-    def _save_anchor(self) -> None:
-        """Save current anchor price."""
-        if self._anchor_store is None:
+    def _on_grid_change(self, grid: list[dict]) -> None:
+        """Persist grid mutations triggered from inside Grid.build_grid /
+        Grid.update_grid. Skips writes for the just-built single-WAIT case
+        and for empty grids (a restored grid that failed validation)."""
+        if self._state_store is None:
             return
-
-        anchor_price = self._engine.get_anchor_price()
-        if anchor_price is not None:
-            self._anchor_store.save(
-                strat_id=self._config.strat_id,
-                anchor_price=anchor_price,
-                grid_step=self._config.grid_step,
-                grid_count=self._config.grid_count,
-            )
+        if len(grid) <= 1:
+            return
+        self._state_store.save(
+            strat_id=self._config.strat_id,
+            grid=grid,
+            grid_step=self._config.grid_step,
+            grid_count=self._config.grid_count,
+        )
 
     def get_limit_orders(self) -> dict[str, list[dict]]:
         """Get current limit orders in format expected by GridEngine.
@@ -314,10 +320,6 @@ class StrategyRunner:
 
             if intents:
                 self._execute_intents(intents, limit_orders)
-
-                # Save anchor after grid changes
-                if self._anchor_store and len(self._engine.grid.grid) > 1:
-                    self._save_anchor()
 
             return intents
         except Exception as e:

--- a/apps/gridbot/tests/test_runner.py
+++ b/apps/gridbot/tests/test_runner.py
@@ -2142,3 +2142,75 @@ class TestIsGoodToPlace:
         )
         runner._execute_place_intent(intent, EMPTY_LIMITS)
         mock_executor.execute_place.assert_not_called()
+
+
+class TestStateStoreWiring:
+    """Tests for the GridStateStore wiring on the runner."""
+
+    def test_no_store_means_no_save_no_restore(self, strategy_config, mock_executor):
+        """state_store=None must not crash on construction or grid mutation."""
+        runner = StrategyRunner(strategy_config=strategy_config, executor=mock_executor)
+        runner._engine.grid.build_grid(50000.0)
+        assert len(runner._engine.grid.grid) > 0
+
+    def test_load_grid_state_returns_none_when_no_store(self, strategy_config, mock_executor):
+        runner = StrategyRunner(strategy_config=strategy_config, executor=mock_executor)
+        assert runner._load_grid_state() is None
+
+    def test_load_grid_state_config_match(self, strategy_config, mock_executor):
+        """Saved grid with matching grid_step + grid_count is loaded."""
+        store = Mock()
+        store.load.return_value = {
+            "grid": [{"side": "Buy", "price": 49000.0}, {"side": "Wait", "price": 50000.0}],
+            "grid_step": strategy_config.grid_step,
+            "grid_count": strategy_config.grid_count,
+        }
+        StrategyRunner(
+            strategy_config=strategy_config, executor=mock_executor, state_store=store,
+        )
+        store.load.assert_called_once_with(strategy_config.strat_id)
+
+    def test_load_grid_state_config_mismatch_returns_none(self, strategy_config, mock_executor):
+        """Saved grid with different grid_step is discarded — engine starts empty."""
+        store = Mock()
+        store.load.return_value = {
+            "grid": [{"side": "Buy", "price": 49000.0}],
+            "grid_step": strategy_config.grid_step + 0.1,
+            "grid_count": strategy_config.grid_count,
+        }
+        runner = StrategyRunner(
+            strategy_config=strategy_config, executor=mock_executor, state_store=store,
+        )
+        assert runner._engine.grid.grid == []
+
+    def test_on_grid_change_persists_full_grid(self, strategy_config, mock_executor):
+        """Grid mutations flow through the on_change callback into store.save."""
+        store = Mock()
+        store.load.return_value = None
+        runner = StrategyRunner(
+            strategy_config=strategy_config, executor=mock_executor, state_store=store,
+        )
+        runner._engine.grid.build_grid(50000.0)
+
+        store.save.assert_called_once()
+        call = store.save.call_args
+        assert call.kwargs["strat_id"] == strategy_config.strat_id
+        assert call.kwargs["grid_step"] == strategy_config.grid_step
+        assert call.kwargs["grid_count"] == strategy_config.grid_count
+        assert len(call.kwargs["grid"]) == strategy_config.grid_count + 1
+
+    def test_on_grid_change_skips_empty_grid(self, strategy_config, mock_executor):
+        """Empty / single-WAIT intermediate states are not persisted."""
+        store = Mock()
+        store.load.return_value = None
+        runner = StrategyRunner(
+            strategy_config=strategy_config, executor=mock_executor, state_store=store,
+        )
+        runner._on_grid_change([])
+        runner._on_grid_change([{"side": "Wait", "price": 100.0}])
+        store.save.assert_not_called()
+
+    def test_on_grid_change_no_store_is_noop(self, strategy_config, mock_executor):
+        runner = StrategyRunner(strategy_config=strategy_config, executor=mock_executor)
+        runner._on_grid_change([{"side": "Wait", "price": 100.0}] * 5)
+

--- a/docs/features/0021_PLAN.md
+++ b/docs/features/0021_PLAN.md
@@ -61,29 +61,76 @@ Keep gridbot's current dict-per-`strat_id` shape (not bbu2's array) — simpler 
 
 ## Algorithm
 
-### Save (runner)
+### Save (event-driven via Grid callback, async fire-and-forget)
 
-1. On every execution cycle that mutates state (existing trigger at `apps/gridbot/src/gridbot/runner.py:319-320`), if `engine.grid.grid` is non-empty:
-2. Serialize `engine.grid.grid` → list of `{side: side.value, price}` dicts.
-3. Persist `{grid, grid_step, grid_count}` keyed by `strat_id`.
+The save trigger moves out of `runner.on_ticker` into the `Grid` itself, mirroring bbu2's `write_to_db()` calls inside `build_greed`/`update_greed` (`bbu_reference/bbu2-master/greed.py:41,66`):
+
+1. `Grid.__init__` accepts `on_change: Optional[Callable[[list[dict]], None]] = None`, stored as `self._on_change`.
+2. At the end of `Grid.build_grid()` and `Grid.update_grid()`: `if self._on_change: self._on_change(self.grid)`.
+3. Runner registers `self._on_grid_change` as the callback when constructing `GridEngine` (passed through to `Grid`).
+4. `Runner._on_grid_change` calls `self._state_store.save(strat_id, grid, grid_step, grid_count)`.
+
+`GridStateStore.save()` is sync but non-blocking — it dedupes and schedules an async write:
+
+```python
+def save(self, strat_id, grid, grid_step, grid_count):
+    payload = {"grid": grid, "grid_step": grid_step, "grid_count": grid_count}
+    if self._last_payload.get(strat_id) == payload:
+        return  # dedupe — skip identical writes
+    self._last_payload[strat_id] = payload
+    asyncio.create_task(self._async_write(strat_id, payload))
+
+async def _async_write(self, strat_id, payload):
+    async with self._lock:
+        try:
+            await asyncio.to_thread(self._sync_write_to_disk, strat_id, payload)
+        except Exception as e:
+            logger.error(f"Save failed for {strat_id}: {e}")
+```
+
+- `asyncio.Lock` serializes writes (the file is shared across all `strat_id`s — read-modify-write race without a lock).
+- `asyncio.to_thread` offloads disk I/O so the event loop never blocks.
+- Dedupe compares against `_last_payload` (latest intent), so if a new payload arrives while a write is in flight, it queues a follow-up `create_task` — the latest state always wins.
+- Errors are logged but never propagate.
+
+`_sync_write_to_disk` does an atomic write (tmp + `os.replace`):
+
+```python
+def _sync_write_to_disk(self, strat_id, payload):
+    all_data = self._read_existing()
+    all_data[strat_id] = payload
+    tmp_path = self.file_path + ".tmp"
+    with open(tmp_path, "w") as f:
+        json.dump(all_data, f, indent=2)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp_path, self.file_path)
+```
+
+`os.replace` is atomic on POSIX — either the new file fully replaces the old one or nothing happens. Without this, a kill -9 / power loss between `open('w')` (which truncates) and `json.dump` could leave a corrupted file (a real risk now that the payload is ~2KB instead of ~50 bytes).
 
 ### Load (runner init)
 
 1. `store.load(strat_id)` → returns saved entry or `None`.
-2. Config-match: if `saved.grid_step != config.grid_step` or `saved.grid_count != config.grid_count`, discard (return `None`). Existing behavior carried over from `runner.py:229-244`.
-3. If valid, pass the grid list into `GridEngine`; engine calls `Grid.restore_grid(saved_grid)` during construction.
-4. `_handle_ticker_event`: change the empty-grid guard from `len(self.grid.grid) <= 1` (`engine.py:122`) to `len(self.grid.grid) == 0` so a restored grid skips `build_grid`.
-5. Downstream `_check_and_place` proceeds against the restored grid; existing order-placement / reconciliation logic is unchanged.
+2. **Detect legacy:** if the entry has no `grid` key (old `{anchor_price, ...}` format) → log info `"{strat_id}: Legacy anchor format ignored, building fresh grid at market price"`, return `None`. See Migration section.
+3. **Config-match:** if `saved.grid_step != config.grid_step` or `saved.grid_count != config.grid_count` → log existing `"Config changed, will build fresh grid"`, return `None`. Existing behavior from `runner.py:229-244`.
+4. If valid, pass the grid list into `GridEngine` via new param `restored_grid: Optional[list[dict]]`.
+5. `GridEngine.__init__` calls `Grid.restore_grid(saved_grid)`.
+6. `_handle_ticker_event` (`engine.py:122`): change empty-grid guard from `len(self.grid.grid) <= 1` to `len(self.grid.grid) == 0` so a restored grid skips `build_grid`.
+7. **New drift guard in `_handle_ticker_event`:** if grid is non-empty AND `last_close` is outside `[Grid.__min_grid, Grid.__max_grid]` → log `"{symbol}: Restored grid out of range (last_close={x}), rebuilding"` + `build_grid(last_close)`. Covers long downtimes where the saved grid is far from the current price. Existing `update_grid` (`grid.py:157`) already does this on fill events; this adds the same safety on the tick path.
+8. Downstream `_check_and_place` proceeds against the restored grid; existing order-placement / reconciliation logic is unchanged.
 
-### `Grid.restore_grid(grid_list)`
+### `Grid.restore_grid(grid_list) -> bool`
 
-1. Convert each `{side, price}` dict into in-memory form (string → `GridSideType`).
-2. Assign `self.grid = [...restored...]`.
-3. Derive `_original_anchor_price` from the restored grid:
+1. Convert each `{side, price}` dict into in-memory form (string → `GridSideType`). Catch `ValueError` from unknown side strings → return `False`.
+2. Tentatively assign `self.grid = [...restored...]`.
+3. Run existing `is_grid_correct()` (`grid.py:251`) to validate the BUY→WAIT→SELL pattern.
+4. **On validation failure** (malformed `side`, broken pattern): log warning `"Restored grid failed validation, building fresh grid"`, reset `self.grid = []`, return `False`. The engine's `_handle_ticker_event` will then build fresh on the first ticker (because `len == 0`).
+5. On success: derive `_original_anchor_price` from the restored grid:
    - If exactly one `WAIT` level: use its price.
    - If multiple consecutive `WAIT`s (allowed per `grid.py:290`): use the middle element's price.
    - If no `WAIT`s (possible after heavy drift): use the median-indexed level.
-4. Run existing `_validate_grid_pattern` (`grid.py:253`) to reject malformed persisted state; on failure, treat as no saved state.
+6. Return `True`.
 
 ## Files to change
 
@@ -91,8 +138,11 @@ Keep gridbot's current dict-per-`strat_id` shape (not bbu2's array) — simpler 
 
 - `packages/gridcore/src/gridcore/persistence.py`
   - Rename `GridAnchorStore` → `GridStateStore`.
-  - `load()` returns `{grid: list[dict], grid_step: float, grid_count: int}` or `None`.
-  - `save(strat_id, grid: list[dict], grid_step, grid_count)` writes the full grid list.
+  - `__init__`: add `self._last_payload: dict[str, dict] = {}`, `self._lock = asyncio.Lock()`.
+  - `load()` returns the saved dict or `None` (with detect-legacy + corruption handling).
+  - `save(strat_id, grid, grid_step, grid_count)` — sync wrapper: dedupe + `asyncio.create_task(self._async_write(...))`.
+  - `_async_write()` — async: `await asyncio.to_thread(self._sync_write_to_disk, ...)` inside `self._lock`.
+  - `_sync_write_to_disk()` — atomic write via tmp + `os.replace` + `fsync`.
   - Preserve existing corruption handling (return `None` on bad JSON / IO).
   - Keep `delete()` unchanged.
 - `packages/gridcore/src/gridcore/__init__.py`
@@ -101,25 +151,29 @@ Keep gridbot's current dict-per-`strat_id` shape (not bbu2's array) — simpler 
 ### Grid / engine
 
 - `packages/gridcore/src/gridcore/grid.py`
-  - Add `restore_grid(grid_list: list[dict]) -> None` (algorithm above).
-  - Add `serialize() -> list[dict]` helper, or inline in runner.
+  - `__init__`: add `on_change: Optional[Callable[[list[dict]], None]] = None`, store as `self._on_change`.
+  - At end of `build_grid()` and `update_grid()`: `if self._on_change: self._on_change(self.grid)`.
+  - Add `restore_grid(grid_list: list[dict]) -> bool` (algorithm above; returns `False` on validation failure).
 - `packages/gridcore/src/gridcore/engine.py`
-  - Constructor: replace `anchor_price: Optional[float]` param with `restored_grid: Optional[list[dict]]`.
+  - Constructor: replace `anchor_price: Optional[float]` param with `restored_grid: Optional[list[dict]] = None`.
+  - Constructor: add `on_grid_change: Optional[Callable] = None`, passed through to `Grid(on_change=...)`.
   - If `restored_grid` passed, call `self.grid.restore_grid(restored_grid)` in `__init__`.
   - `_handle_ticker_event` (`engine.py:122`): guard change `<= 1` → `== 0`.
+  - `_handle_ticker_event`: add drift guard — if `last_close` outside `[Grid.__min_grid, Grid.__max_grid]` → log + `build_grid(last_close)`.
   - `get_anchor_price()` (`engine.py:177-187`): semantics change to "current WAIT center of the grid" (via the restore-derived `_original_anchor_price`). Used only in tests today; adjust tests accordingly.
 
 ### Runner / orchestrator
 
 - `apps/gridbot/src/gridbot/runner.py`
   - Rename `_load_anchor` → `_load_grid_state`; returns `Optional[list[dict]]` after config-match check.
-  - Rename `_save_anchor` → `_save_grid_state`; serializes `self._engine.grid.grid`.
+  - **Remove `_save_anchor` entirely** and **remove the save call from `on_ticker`** (`runner.py:319-320`) — saves are now event-driven from `Grid` via the callback.
+  - Add `_on_grid_change(grid: list[dict]) -> None`: calls `self._state_store.save(strat_id, grid, grid_step, grid_count)`.
   - Constructor param `anchor_store: Optional[GridAnchorStore]` → `state_store: Optional[GridStateStore]`; attribute `_anchor_store` → `_state_store`.
-  - Engine construction (`runner.py:143-156`): pass `restored_grid=` instead of `anchor_price=`.
-  - Save trigger (`runner.py:319-320`): same condition (`len(self._engine.grid.grid) > 1`) — keep the `> 1` gate to avoid writing a just-WAIT grid.
+  - Engine construction (`runner.py:143-156`): pass `restored_grid=` instead of `anchor_price=`, and `on_grid_change=self._on_grid_change`.
 - `apps/gridbot/src/gridbot/orchestrator.py`
-  - Constructor param `anchor_store_path` → `state_store_path`.
+  - Keep config param name `anchor_store_path` to avoid breaking deploy (rename file/key is out of scope).
   - `GridAnchorStore(...)` → `GridStateStore(...)` (`orchestrator.py:93`).
+  - Attribute: `_anchor_store` → `_state_store`.
   - Runner wiring (`orchestrator.py:523`): `state_store=self._state_store`.
 
 ### Tests
@@ -127,15 +181,22 @@ Keep gridbot's current dict-per-`strat_id` shape (not bbu2's array) — simpler 
 - `packages/gridcore/tests/test_persistence.py` — full rewrite for the new schema:
   - save/load round-trip of a concrete grid list
   - config-mismatch invalidation
-  - corruption handling (bad JSON, bad `side` strings, missing keys)
+  - detect-legacy: entry without `grid` key → `load()` returns `None`
+  - corruption handling (bad JSON, bad `side` strings, missing keys) — no exception
   - multiple strat_ids sharing the file
+  - atomic write: simulate exception mid-`_sync_write_to_disk`, verify old file still readable
+  - dedupe: two identical `save()` calls → only one disk write
+  - async: verify `asyncio.create_task` only fires when payload changed; flush via `await asyncio.sleep(0)` in tests
 - `packages/gridcore/tests/test_engine.py` — update tests that reference `get_anchor_price()` and the `anchor_price=` constructor param; add:
   - engine constructed with `restored_grid` does not call `build_grid` on first ticker
   - restored grid with multi-WAIT band derives correct anchor
   - restored grid after simulated `__center_grid` drift survives round-trip
+  - drift guard: restored grid + `last_close` outside `[min, max]` → rebuild on first ticker
 - `packages/gridcore/tests/test_grid.py` (existing or new) — add:
-  - `restore_grid` validation rejects malformed patterns
-  - `serialize` round-trip equals identity
+  - `restore_grid` with valid grid → `is_grid_correct()` is True, returns `True`
+  - `restore_grid` with malformed pattern / bad `side` → returns `False`, leaves `self.grid = []`
+  - `on_change` callback fires after `build_grid` and after `update_grid`
+  - round-trip identity: `Grid(...).build_grid() → grid; new Grid(...).restore_grid(grid)` produces identical structure
 
 ## Migration
 
@@ -147,23 +208,27 @@ No data-preserving conversion is necessary because a converter would produce the
 
 ## Save-trigger coverage
 
-Current behavior already saves at `runner.py:319-320` after `_execute_intents`. Every mutation that changes `self.grid.grid` flows through the tick path and gets persisted on the next save. Specifically:
+Saves are now event-driven from inside `Grid` (matching bbu2's pattern in `bbu_reference/bbu2-master/greed.py:41,66`):
 
-- `build_grid` (first ticker) → save on first save-trigger after.
-- `update_grid` / `__center_grid` / `__rebuild_grid` (on fills) → same.
+- `build_grid` (first ticker, drift-guard rebuild, or `_check_and_place` "too many orders" rebuild) → save fires from inside the method.
+- `update_grid` / `__center_grid` / `__rebuild_grid` (on fills) → save fires from inside `update_grid`.
 
-No new save points are needed. If in practice this proves insufficient (e.g., crash between mutation and save), an optional follow-up is to add a save call inside `Grid` methods themselves. Out of scope here.
+No save calls remain in `runner.on_ticker`. Dedupe in `GridStateStore.save()` skips no-op writes. Async fire-and-forget via `asyncio.to_thread` keeps the event loop unblocked.
 
 ## Out of scope
 
-- Detection/action for "current price > 1 grid_step from WAIT center" — separate design.
+- Detection/action for "current price > 1 grid_step from WAIT center" — beyond the simple `[min_grid, max_grid]` guard added here.
 - Live-run drift speed (one level per tick via `__center_grid`) — unchanged.
 - Persisting `last_filled_price` or fetching it on startup — unchanged. The gap-gated `update_grid` path is a separate issue that this plan does not resolve on its own, but it DOES restore the pre-stop drift and fill-WAIT state that was previously lost, matching the user's stated concern.
-- File-path / class renames beyond what is listed above.
+- File-path / class renames beyond what is listed above (file stays `db/grid_anchor.json`, orchestrator config key stays `anchor_store_path`).
+- Schema versioning field — detect-by-missing-`grid`-key is sufficient for the one-time legacy → new-format transition.
 
 ## Verification
 
 1. Unit tests pass: `uv run pytest packages/gridcore/tests/test_persistence.py packages/gridcore/tests/test_engine.py packages/gridcore/tests/test_grid.py`
 2. Integration: stop bot mid-run after observing `__center_grid` drift (tail `/tmp/gridbot.log` for `update_grid` activity), inspect `db/grid_anchor.json` to confirm full grid list is present, restart and verify grid is restored verbatim (no `Building grid from ...` log line on first ticker).
-3. Config-change invalidation: edit `grid_step` or `grid_count` in the strategy config, restart, confirm `Config changed, will build fresh grid` log line and a new grid built at `last_close`.
-4. Legacy migration: place an old-format `grid_anchor.json` in `db/`, start bot, confirm `Legacy anchor format ignored` log line and a fresh grid.
+3. Atomic write: `kill -9` the process during a write window (or mock `os.replace` to raise after `json.dump`), restart, confirm the old file remains readable (not a corrupted zero-byte file).
+4. Config-change invalidation: edit `grid_step` or `grid_count` in the strategy config, restart, confirm `Config changed, will build fresh grid` log line and a new grid built at `last_close`.
+5. Legacy migration: place an old-format `grid_anchor.json` in `db/`, start bot, confirm `Legacy anchor format ignored` log line and a fresh grid.
+6. Drift-on-restore: stop the bot, wait for significant price move (or hand-edit the saved grid in the file far from current price), restart, confirm `Restored grid out of range, rebuilding` log + fresh grid.
+7. Validation failure: hand-place a file with `"side": "Garbage"`, restart, confirm `Restored grid failed validation` log + fresh grid (bot continues, doesn't crash).

--- a/docs/features/0021_REVIEW.md
+++ b/docs/features/0021_REVIEW.md
@@ -1,0 +1,34 @@
+# 0021 Review — Persist full grid state across restarts
+
+## Verdict
+
+No actionable findings in the current implementation.
+
+The previously reported persistence issues are resolved:
+
+- failed-write dedupe retry bug: fixed
+- non-dict per-strategy entry crash: fixed
+- non-dict JSON root crash/recovery gap: fixed
+
+## Plan Alignment Check
+
+- `GridStateStore` replacement is implemented.
+- Full grid schema (`grid`, `grid_step`, `grid_count`) is implemented.
+- Event-driven persistence via grid callback is implemented.
+- Runner/orchestrator wiring to state store is implemented.
+- Restore flow and config mismatch invalidation are implemented.
+- Drift guard on ticker path is implemented.
+
+Note: implementation uses threaded async persistence instead of the plan’s asyncio sketch. This is a valid adaptation for the current synchronous orchestrator loop.
+
+## Tests Review
+
+Executed:
+
+```bash
+uv run pytest packages/gridcore/tests/test_persistence.py packages/gridcore/tests/test_grid.py packages/gridcore/tests/test_engine.py apps/gridbot/tests/test_runner.py -q
+```
+
+Result: `243 passed`.
+
+Also verified malformed-but-valid JSON root recovery manually (`[]`, `"x"`, `1`, `true`, `null`): `load()` no longer crashes and subsequent `save()` self-heals the file.

--- a/packages/gridcore/src/gridcore/__init__.py
+++ b/packages/gridcore/src/gridcore/__init__.py
@@ -12,7 +12,7 @@ from gridcore.config import GridConfig
 from gridcore.grid import Grid, GridSideType
 from gridcore.engine import GridEngine
 from gridcore.position import PositionState, Position, PositionRiskManager, RiskConfig, DirectionType, SideType
-from gridcore.persistence import GridAnchorStore
+from gridcore.persistence import GridStateStore
 from gridcore.instrument_info import InstrumentInfo
 from gridcore.qty import create_qty_calculator
 from gridcore.pnl import (
@@ -50,7 +50,7 @@ __all__ = [
     "RiskConfig",
     "DirectionType",
     "SideType",
-    "GridAnchorStore",
+    "GridStateStore",
     "InstrumentInfo",
     "create_qty_calculator",
     "calc_unrealised_pnl",

--- a/packages/gridcore/src/gridcore/engine.py
+++ b/packages/gridcore/src/gridcore/engine.py
@@ -72,7 +72,11 @@ class GridEngine:
         self.grid = Grid(tick_size, config.grid_count, config.grid_step, config.rebalance_threshold,
                          on_change=on_grid_change)
         if restored_grid is not None:
-            self.grid.restore_grid(restored_grid)
+            if not self.grid.restore_grid(restored_grid):
+                logger.warning(
+                    "%s (%s): Restored grid failed validation, will build fresh grid on first ticker",
+                    self.strat_id, self.symbol,
+                )
         self.last_close: Optional[float] = None
         self.last_filled_price: Optional[float] = None
 

--- a/packages/gridcore/src/gridcore/engine.py
+++ b/packages/gridcore/src/gridcore/engine.py
@@ -10,7 +10,7 @@ Extracted from bbu2-master/strat.py Strat50 class with the following transformat
 
 import logging
 from decimal import Decimal
-from typing import Optional
+from typing import Callable, Optional
 
 from gridcore.config import GridConfig
 
@@ -43,7 +43,9 @@ class GridEngine:
     }
 
     def __init__(self, symbol: str, tick_size: Decimal, config: GridConfig,
-                 strat_id: str, anchor_price: Optional[float] = None):
+                 strat_id: str, anchor_price: Optional[float] = None,
+                 restored_grid: Optional[list[dict]] = None,
+                 on_grid_change: Optional[Callable[[list[dict]], None]] = None):
         """
         Initialize grid trading engine.
 
@@ -52,15 +54,25 @@ class GridEngine:
             tick_size: Minimum price increment for the symbol
             config: Grid configuration parameters
             strat_id: Strategy identifier for this engine instance
-            anchor_price: Optional anchor price to build grid from instead of market price.
-                         Used to restore grid levels after restart.
+            anchor_price: Optional starting price for build_grid on the first ticker
+                         (overrides last_close). Used by backtests to pin grid origin.
+            restored_grid: Optional serialized grid (list of {side, price}) to restore
+                         on construction. Used by the live runner to resume after restart.
+                         If validation fails the engine falls back to a fresh build on
+                         the first ticker.
+            on_grid_change: Optional callback invoked with the current grid after every
+                         build_grid / update_grid mutation. Used by the live runner to
+                         persist grid state.
         """
         self.symbol = symbol
         self.config = config
         self.tick_size = tick_size
         self.strat_id = strat_id
         self._anchor_price = anchor_price
-        self.grid = Grid(tick_size, config.grid_count, config.grid_step, config.rebalance_threshold)
+        self.grid = Grid(tick_size, config.grid_count, config.grid_step, config.rebalance_threshold,
+                         on_change=on_grid_change)
+        if restored_grid is not None:
+            self.grid.restore_grid(restored_grid)
         self.last_close: Optional[float] = None
         self.last_filled_price: Optional[float] = None
 
@@ -118,16 +130,27 @@ class GridEngine:
         # Update last close price
         self.last_close = float(event.last_price)
 
-        # Build grid if empty
-        if len(self.grid.grid) <= 1:
-            # Use anchor price if provided (for grid restoration after restart)
-            # Otherwise use current market price
+        # Build grid if empty (a restored grid skips this branch)
+        if len(self.grid.grid) == 0:
             build_price = self._anchor_price if self._anchor_price else self.last_close
             if self._anchor_price:
                 logger.info('%s: Building grid from anchor price %s', self.symbol, build_price)
             else:
                 logger.info('%s: Building grid from market price %s', self.symbol, build_price)
             self.grid.build_grid(build_price)
+        else:
+            # Drift guard: if restored (or stale) grid is far from the current
+            # price, rebuild around last_close. Mirrors update_grid's bounds
+            # check (grid.py:157) but applies on the tick path so a restored
+            # grid does not need a fill event to re-anchor. Single-pass bounds
+            # to keep the per-tick cost low.
+            min_p, max_p = self.grid.bounds
+            if not (min_p <= self.last_close <= max_p):
+                logger.info(
+                    '%s: Restored grid out of range (last_close=%s, range=[%s, %s]), rebuilding',
+                    self.symbol, self.last_close, min_p, max_p,
+                )
+                self.grid.build_grid(self.last_close)
 
         # Check and place orders for both directions
         intents.extend(self._check_and_place('long', limit_orders.get('long', [])))

--- a/packages/gridcore/src/gridcore/grid.py
+++ b/packages/gridcore/src/gridcore/grid.py
@@ -12,7 +12,7 @@ Extracted from bbu2-master/greed.py with the following key transformations:
 import logging
 from decimal import Decimal
 from enum import StrEnum
-from typing import Optional
+from typing import Callable, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +33,8 @@ class Grid:
     the original greed.py when given the same inputs.
     """
 
-    def __init__(self, tick_size: Decimal, grid_count: int = 50, grid_step: float = 0.2, rebalance_threshold: float = 0.3):
+    def __init__(self, tick_size: Decimal, grid_count: int = 50, grid_step: float = 0.2, rebalance_threshold: float = 0.3,
+                 on_change: Optional[Callable[[list[dict]], None]] = None):
         """
         Initialize Grid calculator.
 
@@ -42,6 +43,9 @@ class Grid:
             grid_count: Number of grid levels (default 50 = 25 buy + 1 wait + 25 sell)
             grid_step: Step size in percentage (default 0.2 = 0.2% between levels)
             rebalance_threshold: Threshold for rebalancing grid when imbalanced (default 0.3 = 30%)
+            on_change: Optional callback fired after build_grid/update_grid mutates self.grid.
+                Used by callers (e.g. live runner) to persist grid state. Grid stays pure —
+                the callback is just a function reference, no I/O knowledge here.
         """
         self.grid: list[dict] = []
         self.tick_size = tick_size
@@ -49,6 +53,17 @@ class Grid:
         self.grid_step = grid_step
         self.REBALANCE_THRESHOLD = rebalance_threshold
         self._original_anchor_price: Optional[float] = None
+        self._on_change = on_change
+
+    def _notify_change(self) -> None:
+        """Invoke on_change callback. Errors are logged but never propagate —
+        persistence failures must not crash strategy logic."""
+        if self._on_change is None:
+            return
+        try:
+            self._on_change(self.grid)
+        except Exception as e:
+            logger.error("Grid on_change callback failed: %s", e, exc_info=True)
 
     def _round_price(self, price: float) -> float:
         """
@@ -124,6 +139,8 @@ class Grid:
                 f"Check tick_size={self.tick_size} and grid_step={self.grid_step}."
             )
 
+        self._notify_change()
+
     def __rebuild_grid(self, last_close: float) -> None:
         """
         Rebuild grid from scratch.
@@ -132,6 +149,75 @@ class Grid:
         """
         self.grid = []
         self.build_grid(last_close)
+
+    def restore_grid(self, grid_list: list[dict]) -> bool:
+        """
+        Restore grid state from a serialized list of {side, price} dicts.
+
+        Validates the restored structure via is_grid_correct(); on failure
+        the grid is left empty so the engine will rebuild from market price
+        on the first ticker. Does NOT fire on_change — restoration is not a
+        mutation worth persisting (we just loaded what was already on disk).
+
+        Args:
+            grid_list: Serialized grid (list of {'side': str, 'price': float}).
+
+        Returns:
+            True if the grid was restored and validated, False otherwise.
+        """
+        try:
+            restored = [
+                {'side': GridSideType(item['side']), 'price': float(item['price'])}
+                for item in grid_list
+            ]
+        except (KeyError, ValueError, TypeError) as e:
+            logger.warning("Restored grid failed parsing (%s), building fresh grid", e)
+            self.grid = []
+            return False
+
+        self.grid = restored
+
+        if not self.is_grid_correct():
+            logger.warning("Restored grid failed validation, building fresh grid")
+            self.grid = []
+            return False
+
+        # Derive _original_anchor_price from the WAIT center so anchor_price
+        # property continues to reflect a meaningful "center" value.
+        wait_indices = [i for i, g in enumerate(self.grid) if g['side'] == GridSideType.WAIT]
+        if wait_indices:
+            center = (wait_indices[0] + wait_indices[-1]) // 2
+        else:
+            center = len(self.grid) // 2
+        self._original_anchor_price = self.grid[center]['price']
+
+        return True
+
+    @property
+    def bounds(self) -> tuple[float, float]:
+        """(min_price, max_price) computed in one pass. Raises ValueError if
+        the grid is empty. Prefer this over min_grid + max_grid in hot paths
+        (e.g. per-tick drift guard) — saves one full iteration over the grid."""
+        if not self.grid:
+            raise ValueError("Cannot get bounds from empty grid")
+        lo = hi = self.grid[0]['price']
+        for step in self.grid[1:]:
+            p = step['price']
+            if p < lo:
+                lo = p
+            elif p > hi:
+                hi = p
+        return lo, hi
+
+    @property
+    def min_grid(self) -> float:
+        """Lowest grid price. Raises ValueError if grid is empty."""
+        return self.bounds[0]
+
+    @property
+    def max_grid(self) -> float:
+        """Highest grid price. Raises ValueError if grid is empty."""
+        return self.bounds[1]
 
     def update_grid(self, last_filled_price: Optional[float], last_close: Optional[float]) -> None:
         """
@@ -169,6 +255,8 @@ class Grid:
                 grid['side'] = GridSideType.BUY
 
         self.__center_grid()
+
+        self._notify_change()
 
     def __center_grid(self) -> None:
         """

--- a/packages/gridcore/src/gridcore/grid.py
+++ b/packages/gridcore/src/gridcore/grid.py
@@ -159,6 +159,10 @@ class Grid:
         on the first ticker. Does NOT fire on_change — restoration is not a
         mutation worth persisting (we just loaded what was already on disk).
 
+        Failures are NOT logged here — the caller has the business-level
+        context (strat_id, symbol) needed to make the warning useful, so
+        logging is delegated upstream to the engine.
+
         Args:
             grid_list: Serialized grid (list of {'side': str, 'price': float}).
 
@@ -170,15 +174,13 @@ class Grid:
                 {'side': GridSideType(item['side']), 'price': float(item['price'])}
                 for item in grid_list
             ]
-        except (KeyError, ValueError, TypeError) as e:
-            logger.warning("Restored grid failed parsing (%s), building fresh grid", e)
+        except (KeyError, ValueError, TypeError):
             self.grid = []
             return False
 
         self.grid = restored
 
         if not self.is_grid_correct():
-            logger.warning("Restored grid failed validation, building fresh grid")
             self.grid = []
             return False
 

--- a/packages/gridcore/src/gridcore/persistence.py
+++ b/packages/gridcore/src/gridcore/persistence.py
@@ -1,121 +1,286 @@
 """
-Grid anchor persistence for maintaining grid levels across restarts.
+Grid state persistence for maintaining full grid levels across restarts.
 
-This module provides file-based persistence for grid anchor data,
-keyed by strat_id to support multiple strategy instances.
+This module provides file-based persistence for grid state, keyed by strat_id
+to support multiple strategy instances.
+
+Save semantics:
+- Sync API, non-blocking: cheap-fingerprint dedupe + a daemon
+  threading.Thread for the actual disk I/O. Atomic writes via tmp +
+  os.replace + fsync.
+- Single-writer-per-strat: a per-strat pending slot holds the latest payload;
+  if a writer is already running for that strat, save() just updates the slot
+  and the in-flight writer drains it. This guarantees latest-wins ordering
+  per strat (threading.Lock by itself is not FIFO, so a naive "spawn-a-thread-
+  per-save" design can write payloads out of order).
+
+Threads (rather than asyncio) are used because the live gridbot orchestrator
+runs a synchronous main loop (time.sleep), so asyncio.create_task would
+always fall through to the sync path and block the loop on fsync.
 """
 
+import copy
 import json
+import logging
 import os
+import threading
 from typing import Optional
 
+logger = logging.getLogger(__name__)
 
-class GridAnchorStore:
+
+class GridStateStore:
     """
-    File-based storage for grid anchor data.
+    File-based storage for full grid state.
 
-    Stores anchor_price, grid_step, and grid_count per strat_id
-    to enable grid restoration after restarts.
+    Stores the full ordered grid (list of {side, price}) per strat_id along with
+    grid_step and grid_count for config-mismatch invalidation.
 
-    Reference: Similar pattern to bbu2-master/db_files.py
+    Reference: bbu2-master/db_files.py greed.json schema (array form);
+    we use a dict-per-strat_id shape (carried over from the legacy format).
     """
 
     def __init__(self, file_path: str = 'db/grid_anchor.json'):
         """
-        Initialize anchor store.
+        Initialize state store.
 
         Args:
-            file_path: Path to JSON file for storing anchor data
+            file_path: Path to JSON file for storing grid state. The default
+                       name is preserved from the legacy GridAnchorStore to
+                       avoid disturbing deploy configs.
         """
         self.file_path = file_path
+        # Cheap fingerprint of the last-enqueued payload per strat_id, used to
+        # short-circuit identical save() calls without paying for deepcopy.
+        self._last_fingerprint: dict[str, tuple] = {}
+        # The latest payload waiting to be written, per strat_id. A new save()
+        # overwrites the slot — the in-flight writer (if any) will pick up the
+        # newer value the next time it loops, so a burst of saves coalesces
+        # into one final disk write per strat.
+        self._pending_payload: dict[str, dict] = {}
+        # State + condition variable for: serializing slot access, dedupe
+        # bookkeeping, the active-writer set, and flush() wait/notify.
+        self._cv = threading.Condition()
+        # strat_ids that currently have a writer thread running.
+        self._active_writers: set[str] = set()
+        # Serializes concurrent disk I/O across strats (the file is shared).
+        self._io_lock = threading.Lock()
 
     def _validate_strat_id(self, strat_id: str) -> None:
         if strat_id == "":
             raise ValueError("strat_id must be a non-empty string")
 
+    @staticmethod
+    def _fingerprint(grid: list[dict], grid_step: float, grid_count: int) -> tuple:
+        """Cheap structural identity of a payload — comparable, hashable,
+        and ~50x cheaper than deepcopy + dict equality."""
+        return (
+            tuple((g['side'], g['price']) for g in grid),
+            grid_step,
+            grid_count,
+        )
+
+    def _read_all_data(self) -> dict:
+        """Read the full JSON file, returning {} on any error or if the root
+        is not a JSON object. A hand-edited file with a list/string/number
+        root would otherwise crash load()/save()/delete() with AttributeError
+        or TypeError; this helper makes the persistence layer self-healing."""
+        if not os.path.exists(self.file_path):
+            return {}
+        try:
+            with open(self.file_path, 'r') as f:
+                data = json.load(f)
+        except (json.JSONDecodeError, IOError):
+            return {}
+        if not isinstance(data, dict):
+            return {}
+        return data
+
     def load(self, strat_id: str) -> Optional[dict]:
         """
-        Load anchor data for a strategy.
+        Load grid state for a strategy.
+
+        Returns the full saved entry (with `grid`, `grid_step`, `grid_count`)
+        or None if not found, corrupted, or in the legacy anchor-only format.
+
+        Legacy format detection: if the entry has no `grid` key it is treated
+        as no saved state and a one-time info log is emitted; the engine will
+        rebuild from market price on the first ticker.
 
         Args:
             strat_id: Strategy identifier
 
         Returns:
-            Dict with anchor_price, grid_step, grid_count or None if not found
+            Saved entry dict (with `grid`, `grid_step`, `grid_count`) or None.
         """
         self._validate_strat_id(strat_id)
-        if not os.path.exists(self.file_path):
+        all_data = self._read_all_data()
+
+        entry = all_data.get(strat_id)
+        if entry is None:
             return None
 
-        try:
-            with open(self.file_path, 'r') as f:
-                all_anchors = json.load(f)
-            return all_anchors.get(strat_id)
-        except (json.JSONDecodeError, IOError):
+        # Defensive: a hand-edited or otherwise malformed file may have an
+        # entry that isn't a dict (e.g. {"strat_id": 1}). Treat it the same
+        # as corruption — fall back to a fresh grid instead of crashing.
+        if not isinstance(entry, dict):
             return None
 
-    def save(self, strat_id: str, anchor_price: float, grid_step: float, grid_count: int) -> None:
+        if 'grid' not in entry:
+            logger.info(
+                "%s: Legacy anchor format ignored, building fresh grid at market price",
+                strat_id,
+            )
+            return None
+
+        return entry
+
+    def save(self, strat_id: str, grid: list[dict], grid_step: float, grid_count: int) -> None:
         """
-        Save anchor data for a strategy.
+        Save grid state for a strategy.
+
+        Sync wrapper: cheap-fingerprint dedupe and then dispatch via a per-strat
+        pending slot. Returns immediately; does not block on fsync.
+
+        If a writer thread is already running for this strat_id, this call just
+        updates the slot — the in-flight writer drains it. Otherwise a fresh
+        writer thread is spawned. Net effect: latest-wins per strat, no write
+        reordering across rapid bursts.
 
         Args:
             strat_id: Strategy identifier
-            anchor_price: Center price the grid was built around
-            grid_step: Grid step size in percentage
-            grid_count: Number of grid levels
+            grid: Full grid as list of {side, price} dicts
+            grid_step: Grid step size (for config-mismatch invalidation)
+            grid_count: Number of grid levels (for config-mismatch invalidation)
         """
         self._validate_strat_id(strat_id)
-        # Load existing data
-        all_anchors = {}
-        if os.path.exists(self.file_path):
-            try:
-                with open(self.file_path, 'r') as f:
-                    all_anchors = json.load(f)
-            except (json.JSONDecodeError, IOError):
-                all_anchors = {}
 
-        # Update with new data
-        all_anchors[strat_id] = {
-            'anchor_price': anchor_price,
-            'grid_step': grid_step,
-            'grid_count': grid_count
-        }
+        fingerprint = self._fingerprint(grid, grid_step, grid_count)
+        # Deep-copy lazily, only after the dedupe check decides we'll persist.
+        spawn = False
+        with self._cv:
+            if self._last_fingerprint.get(strat_id) == fingerprint:
+                return
+            self._last_fingerprint[strat_id] = fingerprint
 
-        # Ensure directory exists
+            payload = {
+                'grid': copy.deepcopy(grid),
+                'grid_step': grid_step,
+                'grid_count': grid_count,
+            }
+            # Pair the fingerprint with the payload so the writer can roll
+            # back the dedupe key on failure without clobbering a newer
+            # enqueued payload that arrived in the meantime.
+            self._pending_payload[strat_id] = (fingerprint, payload)
+
+            if strat_id not in self._active_writers:
+                self._active_writers.add(strat_id)
+                spawn = True
+
+        if spawn:
+            threading.Thread(
+                target=self._writer_loop,
+                args=(strat_id,),
+                daemon=True,
+            ).start()
+
+    def _writer_loop(self, strat_id: str) -> None:
+        """Drain the per-strat pending slot until empty, then exit. Each
+        iteration writes the latest payload; concurrent saves arriving while
+        the previous write is in flight just overwrite the slot and the next
+        loop iteration picks them up. Errors are logged, never propagated —
+        persistence failures must not crash strategy logic."""
+        try:
+            while True:
+                with self._cv:
+                    item = self._pending_payload.pop(strat_id, None)
+                    if item is None:
+                        self._active_writers.discard(strat_id)
+                        self._cv.notify_all()
+                        return
+                fingerprint, payload = item
+                try:
+                    with self._io_lock:
+                        self._sync_write_to_disk(strat_id, payload)
+                except Exception as e:
+                    logger.error("Save failed for %s: %s", strat_id, e)
+                    # Roll back the dedupe key so the next identical save()
+                    # is not silently skipped — but only if no newer payload
+                    # has been enqueued in the meantime (whose fingerprint
+                    # would have replaced ours in _last_fingerprint).
+                    with self._cv:
+                        if self._last_fingerprint.get(strat_id) == fingerprint:
+                            self._last_fingerprint.pop(strat_id, None)
+        except BaseException:
+            # Defensive: even on unexpected failure, release the active-writer
+            # slot so future saves can spawn a new thread.
+            with self._cv:
+                self._active_writers.discard(strat_id)
+                self._cv.notify_all()
+            raise
+
+    def flush(self, timeout: Optional[float] = None) -> None:
+        """Block until all in-flight background writes have completed.
+
+        Useful in tests and for graceful shutdown. Production callers do not
+        need to invoke this — daemon threads either complete or die with the
+        process, and the next save() will retry (the write itself is atomic).
+        """
+        with self._cv:
+            self._cv.wait_for(lambda: not self._active_writers, timeout=timeout)
+
+    def _sync_write_to_disk(self, strat_id: str, payload: dict) -> None:
+        """Atomic write: tmp file + fsync + os.replace. Either the new file
+        fully replaces the old one or nothing happens — a kill -9 mid-write
+        cannot leave a corrupted half-written file in place. A corrupt or
+        non-dict-root file is silently overwritten with a fresh dict."""
+        all_data = self._read_all_data()
+        all_data[strat_id] = payload
+
         dir_path = os.path.dirname(self.file_path)
         if dir_path and not os.path.exists(dir_path):
             os.makedirs(dir_path)
 
-        # Write to file
-        with open(self.file_path, 'w') as f:
-            json.dump(all_anchors, f, indent=2)
+        tmp_path = self.file_path + '.tmp'
+        with open(tmp_path, 'w') as f:
+            json.dump(all_data, f, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, self.file_path)
 
     def delete(self, strat_id: str) -> bool:
         """
-        Delete anchor data for a strategy.
+        Delete grid state for a strategy.
 
-        Args:
-            strat_id: Strategy identifier
+        Atomic (uses the same tmp + os.replace pattern as save) and serialized
+        through the same I/O lock that gates background writes, so it cannot
+        race with an in-flight write to the shared file.
 
-        Returns:
-            True if deleted, False if not found
+        Returns True if deleted, False if not found.
         """
         self._validate_strat_id(strat_id)
         if not os.path.exists(self.file_path):
             return False
 
-        try:
-            with open(self.file_path, 'r') as f:
-                all_anchors = json.load(f)
-
-            if strat_id not in all_anchors:
+        with self._io_lock:
+            all_data = self._read_all_data()
+            if strat_id not in all_data:
                 return False
 
-            del all_anchors[strat_id]
+            del all_data[strat_id]
 
-            with open(self.file_path, 'w') as f:
-                json.dump(all_anchors, f, indent=2)
+            tmp_path = self.file_path + '.tmp'
+            try:
+                with open(tmp_path, 'w') as f:
+                    json.dump(all_data, f, indent=2)
+                    f.flush()
+                    os.fsync(f.fileno())
+                os.replace(tmp_path, self.file_path)
+            except (IOError, OSError):
+                return False
 
-            return True
-        except (json.JSONDecodeError, IOError):
-            return False
+        with self._cv:
+            self._last_fingerprint.pop(strat_id, None)
+            self._pending_payload.pop(strat_id, None)
+
+        return True

--- a/packages/gridcore/src/gridcore/persistence.py
+++ b/packages/gridcore/src/gridcore/persistence.py
@@ -19,7 +19,6 @@ runs a synchronous main loop (time.sleep), so asyncio.create_task would
 always fall through to the sync path and block the loop on fsync.
 """
 
-import copy
 import json
 import logging
 import os
@@ -163,8 +162,12 @@ class GridStateStore:
                 return
             self._last_fingerprint[strat_id] = fingerprint
 
+            # Shallow per-dict copy is safe (and ~50-100x faster than
+            # copy.deepcopy under this lock) because each entry is a flat
+            # dict of an immutable StrEnum side and an immutable float
+            # price — no nested mutable state to share with the caller.
             payload = {
-                'grid': copy.deepcopy(grid),
+                'grid': [{'side': g['side'], 'price': g['price']} for g in grid],
                 'grid_step': grid_step,
                 'grid_count': grid_count,
             }

--- a/packages/gridcore/src/gridcore/persistence.py
+++ b/packages/gridcore/src/gridcore/persistence.py
@@ -57,7 +57,7 @@ class GridStateStore:
         # overwrites the slot — the in-flight writer (if any) will pick up the
         # newer value the next time it loops, so a burst of saves coalesces
         # into one final disk write per strat.
-        self._pending_payload: dict[str, dict] = {}
+        self._pending_payload: dict[str, tuple[tuple, dict]] = {}
         # State + condition variable for: serializing slot access, dedupe
         # bookkeeping, the active-writer set, and flush() wait/notify.
         self._cv = threading.Condition()

--- a/packages/gridcore/src/gridcore/persistence.py
+++ b/packages/gridcore/src/gridcore/persistence.py
@@ -236,17 +236,31 @@ class GridStateStore:
         non-dict-root file is silently overwritten with a fresh dict."""
         all_data = self._read_all_data()
         all_data[strat_id] = payload
+        self._atomic_write(all_data)
 
+    def _atomic_write(self, all_data: dict) -> None:
+        """Write the full data dict to self.file_path atomically. On any
+        failure (json.dump, fsync, or os.replace) the half-written .tmp file
+        is removed so failed writes do not leave garbage behind. After a
+        successful os.replace the .tmp path no longer exists, so the cleanup
+        branch only runs on real failure."""
         dir_path = os.path.dirname(self.file_path)
         if dir_path and not os.path.exists(dir_path):
             os.makedirs(dir_path)
 
         tmp_path = self.file_path + '.tmp'
-        with open(tmp_path, 'w') as f:
-            json.dump(all_data, f, indent=2)
-            f.flush()
-            os.fsync(f.fileno())
-        os.replace(tmp_path, self.file_path)
+        try:
+            with open(tmp_path, 'w') as f:
+                json.dump(all_data, f, indent=2)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, self.file_path)
+        except BaseException:
+            try:
+                os.remove(tmp_path)
+            except FileNotFoundError:
+                pass
+            raise
 
     def delete(self, strat_id: str) -> bool:
         """
@@ -267,20 +281,22 @@ class GridStateStore:
             if strat_id not in all_data:
                 return False
 
+            # Clear dedupe state BEFORE the disk write. Otherwise a concurrent
+            # save() with the same payload could slip in between the file
+            # write and the cleanup, see a stale _last_fingerprint match, and
+            # silently dedupe-skip — losing the caller's save with no error.
+            # A save() racing AFTER the cleanup will set its own fingerprint
+            # and queue a writer that waits on _io_lock; once we release it,
+            # the writer persists the new payload — caller intent honored.
+            with self._cv:
+                self._last_fingerprint.pop(strat_id, None)
+                self._pending_payload.pop(strat_id, None)
+
             del all_data[strat_id]
 
-            tmp_path = self.file_path + '.tmp'
             try:
-                with open(tmp_path, 'w') as f:
-                    json.dump(all_data, f, indent=2)
-                    f.flush()
-                    os.fsync(f.fileno())
-                os.replace(tmp_path, self.file_path)
+                self._atomic_write(all_data)
             except (IOError, OSError):
                 return False
-
-        with self._cv:
-            self._last_fingerprint.pop(strat_id, None)
-            self._pending_payload.pop(strat_id, None)
 
         return True

--- a/packages/gridcore/src/gridcore/persistence.py
+++ b/packages/gridcore/src/gridcore/persistence.py
@@ -189,7 +189,20 @@ class GridStateStore:
         iteration writes the latest payload; concurrent saves arriving while
         the previous write is in flight just overwrite the slot and the next
         loop iteration picks them up. Errors are logged, never propagated —
-        persistence failures must not crash strategy logic."""
+        persistence failures must not crash strategy logic.
+
+        Exception strategy is two-level:
+          - inner `except Exception` (around _sync_write_to_disk): catches
+            recoverable per-write failures (disk full, permission denied,
+            fsync errors, JSON serialization errors). Logs, rolls back the
+            dedupe fingerprint so a retry with the same payload reaches
+            disk, and CONTINUES the loop to drain any newer pending payload.
+          - outer `except BaseException`: catches non-Exception signals
+            (KeyboardInterrupt, SystemExit, MemoryError) that the inner
+            handler intentionally lets through. Releases the _active_writers
+            slot before re-raising so a concurrent flush() does not deadlock
+            waiting for a thread that is about to die.
+        """
         try:
             while True:
                 with self._cv:
@@ -203,17 +216,18 @@ class GridStateStore:
                     with self._io_lock:
                         self._sync_write_to_disk(strat_id, payload)
                 except Exception as e:
+                    # Recoverable failure: log, rebrand dedupe, keep draining.
                     logger.error("Save failed for %s: %s", strat_id, e)
-                    # Roll back the dedupe key so the next identical save()
-                    # is not silently skipped — but only if no newer payload
-                    # has been enqueued in the meantime (whose fingerprint
-                    # would have replaced ours in _last_fingerprint).
+                    # Roll back the dedupe key only if no newer payload has
+                    # arrived since (a newer payload would have already
+                    # replaced our fingerprint in _last_fingerprint).
                     with self._cv:
                         if self._last_fingerprint.get(strat_id) == fingerprint:
                             self._last_fingerprint.pop(strat_id, None)
         except BaseException:
-            # Defensive: even on unexpected failure, release the active-writer
-            # slot so future saves can spawn a new thread.
+            # KeyboardInterrupt / SystemExit / other BaseException — release
+            # the writer slot so flush() can return, then let the signal
+            # propagate normally to terminate the thread (and the process).
             with self._cv:
                 self._active_writers.discard(strat_id)
                 self._cv.notify_all()

--- a/packages/gridcore/tests/test_engine.py
+++ b/packages/gridcore/tests/test_engine.py
@@ -932,6 +932,129 @@ class TestAnchorPricePersistence:
             f"Original center should be SELL after price moved below it, got {center_after_fill['side']}"
 
 
+class TestRestoredGrid:
+    """Tests for restoring grid state on engine construction."""
+
+    def _ticker(self, price: float) -> TickerEvent:
+        return TickerEvent(
+            event_type=EventType.TICKER,
+            symbol='BTCUSDT',
+            exchange_ts=datetime.now(UTC),
+            local_ts=datetime.now(UTC),
+            last_price=Decimal(str(price)),
+            mark_price=Decimal(str(price)),
+            bid1_price=Decimal(str(price - 1)),
+            ask1_price=Decimal(str(price + 1)),
+            funding_rate=Decimal('0.0001'),
+        )
+
+    def test_restored_grid_skips_build_on_first_ticker(self):
+        """Engine constructed with restored_grid does not call build_grid on
+        the first ticker (the saved grid is preserved verbatim)."""
+        config = GridConfig(grid_count=10, grid_step=0.2)
+        restored = [
+            {'side': 'Buy', 'price': 99000.0},
+            {'side': 'Buy', 'price': 99500.0},
+            {'side': 'Wait', 'price': 100000.0},
+            {'side': 'Sell', 'price': 100500.0},
+            {'side': 'Sell', 'price': 101000.0},
+        ]
+        engine = GridEngine(
+            symbol='BTCUSDT',
+            tick_size=Decimal('0.1'),
+            config=config,
+            strat_id='btcusdt_test',
+            restored_grid=restored,
+        )
+
+        # First ticker within the restored grid range — must not rebuild.
+        engine.on_event(self._ticker(100100.0), {'long': [], 'short': []})
+
+        prices = [g['price'] for g in engine.grid.grid]
+        assert prices == [99000.0, 99500.0, 100000.0, 100500.0, 101000.0]
+
+    def test_restored_grid_with_invalid_pattern_falls_back_to_fresh_build(self):
+        """Restored grid that fails validation leaves the engine empty so the
+        first ticker triggers a fresh build_grid at market price."""
+        config = GridConfig(grid_count=50, grid_step=0.2)
+        bad = [
+            {'side': 'Sell', 'price': 99.0},  # SELL before BUY — invalid
+            {'side': 'Buy', 'price': 99.5},
+        ]
+        engine = GridEngine(
+            symbol='BTCUSDT',
+            tick_size=Decimal('0.1'),
+            config=config,
+            strat_id='btcusdt_test',
+            restored_grid=bad,
+        )
+        assert engine.grid.grid == []
+
+        engine.on_event(self._ticker(100000.0), {'long': [], 'short': []})
+
+        # Fresh grid built at market price.
+        assert engine.grid.anchor_price == 100000.0
+
+    def test_drift_guard_rebuilds_when_price_outside_grid(self, caplog):
+        """If last_close is outside [min_grid, max_grid] for the restored grid,
+        the drift guard rebuilds at the current price on the first ticker."""
+        config = GridConfig(grid_count=10, grid_step=0.2)
+        restored = [
+            {'side': 'Buy', 'price': 99.0},
+            {'side': 'Wait', 'price': 100.0},
+            {'side': 'Sell', 'price': 101.0},
+        ]
+        engine = GridEngine(
+            symbol='BTCUSDT',
+            tick_size=Decimal('0.1'),
+            config=config,
+            strat_id='btcusdt_test',
+            restored_grid=restored,
+        )
+
+        with caplog.at_level('INFO'):
+            engine.on_event(self._ticker(150.0), {'long': [], 'short': []})
+
+        assert any('Restored grid out of range' in r.message for r in caplog.records)
+        # Rebuild centered at the current price.
+        assert engine.grid.anchor_price == 150.0
+
+    def test_drift_guard_does_not_fire_when_price_inside_grid(self):
+        config = GridConfig(grid_count=10, grid_step=0.2)
+        restored = [
+            {'side': 'Buy', 'price': 99.0},
+            {'side': 'Buy', 'price': 99.5},
+            {'side': 'Wait', 'price': 100.0},
+            {'side': 'Sell', 'price': 100.5},
+            {'side': 'Sell', 'price': 101.0},
+        ]
+        engine = GridEngine(
+            symbol='BTCUSDT',
+            tick_size=Decimal('0.1'),
+            config=config,
+            strat_id='btcusdt_test',
+            restored_grid=restored,
+        )
+        engine.on_event(self._ticker(100.5), {'long': [], 'short': []})
+
+        prices = [g['price'] for g in engine.grid.grid]
+        assert prices == [99.0, 99.5, 100.0, 100.5, 101.0]
+
+    def test_on_grid_change_callback_fires_on_build(self):
+        """on_grid_change is invoked when the engine builds a fresh grid."""
+        captured = []
+        config = GridConfig(grid_count=10, grid_step=0.2)
+        engine = GridEngine(
+            symbol='BTCUSDT',
+            tick_size=Decimal('0.1'),
+            config=config,
+            strat_id='btcusdt_test',
+            on_grid_change=lambda g: captured.append(len(g)),
+        )
+        engine.on_event(self._ticker(100.0), {'long': [], 'short': []})
+        assert captured == [11]
+
+
 class TestGridConfigValidation:
     """Tests for GridConfig validation in __post_init__."""
 

--- a/packages/gridcore/tests/test_engine.py
+++ b/packages/gridcore/tests/test_engine.py
@@ -973,27 +973,58 @@ class TestRestoredGrid:
         prices = [g['price'] for g in engine.grid.grid]
         assert prices == [99000.0, 99500.0, 100000.0, 100500.0, 101000.0]
 
-    def test_restored_grid_with_invalid_pattern_falls_back_to_fresh_build(self):
+    def test_restored_grid_with_invalid_pattern_falls_back_to_fresh_build(self, caplog):
         """Restored grid that fails validation leaves the engine empty so the
-        first ticker triggers a fresh build_grid at market price."""
+        first ticker triggers a fresh build_grid at market price. The engine
+        must log a warning that includes strat_id and symbol so operators can
+        identify which strategy hit the bad-state path."""
         config = GridConfig(grid_count=50, grid_step=0.2)
         bad = [
             {'side': 'Sell', 'price': 99.0},  # SELL before BUY — invalid
             {'side': 'Buy', 'price': 99.5},
         ]
-        engine = GridEngine(
-            symbol='BTCUSDT',
-            tick_size=Decimal('0.1'),
-            config=config,
-            strat_id='btcusdt_test',
-            restored_grid=bad,
-        )
+        with caplog.at_level('WARNING'):
+            engine = GridEngine(
+                symbol='BTCUSDT',
+                tick_size=Decimal('0.1'),
+                config=config,
+                strat_id='btcusdt_test',
+                restored_grid=bad,
+            )
         assert engine.grid.grid == []
+
+        # Warning identifies strat_id AND symbol — the kernel of the original
+        # review feedback was that failures were hard to attribute under load.
+        warnings = [r.message for r in caplog.records if r.levelname == 'WARNING']
+        assert any(
+            'btcusdt_test' in m and 'BTCUSDT' in m and 'Restored grid failed' in m
+            for m in warnings
+        ), f"Expected contextual restore-failure warning, got: {warnings}"
 
         engine.on_event(self._ticker(100000.0), {'long': [], 'short': []})
 
         # Fresh grid built at market price.
         assert engine.grid.anchor_price == 100000.0
+
+    def test_restored_grid_success_does_not_warn(self, caplog):
+        """Successful restoration must NOT emit the failure warning — would
+        be alert-spam noise."""
+        config = GridConfig(grid_count=10, grid_step=0.2)
+        good = [
+            {'side': 'Buy', 'price': 99.0},
+            {'side': 'Wait', 'price': 100.0},
+            {'side': 'Sell', 'price': 101.0},
+        ]
+        with caplog.at_level('WARNING'):
+            GridEngine(
+                symbol='BTCUSDT',
+                tick_size=Decimal('0.1'),
+                config=config,
+                strat_id='btcusdt_test',
+                restored_grid=good,
+            )
+        warnings = [r.message for r in caplog.records if r.levelname == 'WARNING']
+        assert not any('Restored grid failed' in m for m in warnings)
 
     def test_drift_guard_rebuilds_when_price_outside_grid(self, caplog):
         """If last_close is outside [min_grid, max_grid] for the restored grid,

--- a/packages/gridcore/tests/test_grid.py
+++ b/packages/gridcore/tests/test_grid.py
@@ -566,3 +566,143 @@ class TestGridAnchorPrice:
 
         # Anchor should remain the same
         assert grid.anchor_price == original_anchor
+
+
+class TestGridOnChangeCallback:
+    """Tests for the on_change callback wiring."""
+
+    def test_callback_fires_after_build_grid(self):
+        calls = []
+        grid = Grid(tick_size=Decimal('0.1'), grid_count=10, grid_step=0.2,
+                    on_change=lambda g: calls.append(list(g)))
+        grid.build_grid(100.0)
+        assert len(calls) == 1
+        assert len(calls[0]) == 11  # 5 buy + 1 wait + 5 sell
+
+    def test_callback_fires_after_update_grid(self):
+        calls = []
+        grid = Grid(tick_size=Decimal('0.1'), grid_count=10, grid_step=0.2,
+                    on_change=lambda g: calls.append(list(g)))
+        grid.build_grid(100.0)
+        calls.clear()
+        grid.update_grid(last_filled_price=100.2, last_close=100.0)
+        assert len(calls) == 1
+
+    def test_callback_does_not_fire_for_restore_grid(self):
+        """Restoration is not a mutation worth persisting (we just loaded
+        what was already on disk)."""
+        calls = []
+        grid = Grid(tick_size=Decimal('0.1'), grid_count=10, grid_step=0.2,
+                    on_change=lambda g: calls.append(list(g)))
+        serialized = [
+            {'side': 'Buy', 'price': 99.0},
+            {'side': 'Buy', 'price': 99.5},
+            {'side': 'Wait', 'price': 100.0},
+            {'side': 'Sell', 'price': 100.5},
+            {'side': 'Sell', 'price': 101.0},
+        ]
+        grid.restore_grid(serialized)
+        assert calls == []
+
+    def test_callback_errors_do_not_break_grid(self):
+        """Callback failures are logged but never propagate — persistence
+        failures must not crash strategy logic."""
+        def raise_callback(g):
+            raise RuntimeError("boom")
+
+        grid = Grid(tick_size=Decimal('0.1'), grid_count=10, grid_step=0.2,
+                    on_change=raise_callback)
+        grid.build_grid(100.0)  # Should not raise.
+        assert len(grid.grid) == 11
+
+
+class TestGridRestoreGrid:
+    """Tests for restore_grid()."""
+
+    def test_restore_valid_grid(self):
+        grid = Grid(tick_size=Decimal('0.1'), grid_count=10, grid_step=0.2)
+        serialized = [
+            {'side': 'Buy', 'price': 99.0},
+            {'side': 'Buy', 'price': 99.5},
+            {'side': 'Wait', 'price': 100.0},
+            {'side': 'Sell', 'price': 100.5},
+            {'side': 'Sell', 'price': 101.0},
+        ]
+        assert grid.restore_grid(serialized) is True
+        assert len(grid.grid) == 5
+        assert grid.grid[2]['side'] == GridSideType.WAIT
+
+    def test_restore_invalid_pattern_returns_false(self):
+        """Grid that violates BUY→WAIT→SELL pattern is rejected."""
+        grid = Grid(tick_size=Decimal('0.1'), grid_count=10, grid_step=0.2)
+        bad = [
+            {'side': 'Sell', 'price': 99.0},  # SELL before BUY — invalid
+            {'side': 'Buy', 'price': 99.5},
+            {'side': 'Wait', 'price': 100.0},
+        ]
+        assert grid.restore_grid(bad) is False
+        assert grid.grid == []
+
+    def test_restore_unknown_side_returns_false(self):
+        grid = Grid(tick_size=Decimal('0.1'), grid_count=10, grid_step=0.2)
+        bad = [{'side': 'Garbage', 'price': 100.0}]
+        assert grid.restore_grid(bad) is False
+        assert grid.grid == []
+
+    def test_restore_missing_keys_returns_false(self):
+        grid = Grid(tick_size=Decimal('0.1'), grid_count=10, grid_step=0.2)
+        bad = [{'side': 'Wait'}]  # missing 'price'
+        assert grid.restore_grid(bad) is False
+        assert grid.grid == []
+
+    def test_restore_derives_anchor_from_wait(self):
+        """anchor_price is derived from the WAIT center after restore."""
+        grid = Grid(tick_size=Decimal('0.1'), grid_count=10, grid_step=0.2)
+        serialized = [
+            {'side': 'Buy', 'price': 99.0},
+            {'side': 'Wait', 'price': 100.0},
+            {'side': 'Sell', 'price': 101.0},
+        ]
+        grid.restore_grid(serialized)
+        assert grid.anchor_price == 100.0
+
+    def test_restore_derives_anchor_with_multi_wait(self):
+        """When restored grid has multiple consecutive WAITs (allowed by
+        is_grid_correct), anchor_price uses the middle WAIT."""
+        grid = Grid(tick_size=Decimal('0.1'), grid_count=10, grid_step=0.2)
+        serialized = [
+            {'side': 'Buy', 'price': 99.0},
+            {'side': 'Wait', 'price': 99.5},
+            {'side': 'Wait', 'price': 100.0},
+            {'side': 'Wait', 'price': 100.5},
+            {'side': 'Sell', 'price': 101.0},
+        ]
+        grid.restore_grid(serialized)
+        # WAIT indices are [1, 2, 3], middle = 2 → price 100.0
+        assert grid.anchor_price == 100.0
+
+    def test_round_trip_identity(self):
+        """build_grid → serialize → restore_grid produces identical grid."""
+        grid_a = Grid(tick_size=Decimal('0.1'), grid_count=20, grid_step=0.3)
+        grid_a.build_grid(50.0)
+
+        serialized = [{'side': str(g['side']), 'price': g['price']} for g in grid_a.grid]
+
+        grid_b = Grid(tick_size=Decimal('0.1'), grid_count=20, grid_step=0.3)
+        assert grid_b.restore_grid(serialized) is True
+        assert grid_b.grid == grid_a.grid
+
+
+class TestGridMinMaxAccessors:
+    def test_min_max_grid_after_build(self):
+        grid = Grid(tick_size=Decimal('0.1'), grid_count=10, grid_step=0.2)
+        grid.build_grid(100.0)
+        assert grid.min_grid == grid.grid[0]['price']
+        assert grid.max_grid == grid.grid[-1]['price']
+
+    def test_min_max_grid_raises_when_empty(self):
+        grid = Grid(tick_size=Decimal('0.1'), grid_count=10, grid_step=0.2)
+        with pytest.raises(ValueError):
+            _ = grid.min_grid
+        with pytest.raises(ValueError):
+            _ = grid.max_grid

--- a/packages/gridcore/tests/test_persistence.py
+++ b/packages/gridcore/tests/test_persistence.py
@@ -1,559 +1,447 @@
 """
-Tests for GridAnchorStore persistence functionality.
+Tests for GridStateStore persistence functionality.
 """
 
 import json
-import math
 import os
-import tempfile
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
 import pytest
-from unittest.mock import patch, mock_open, MagicMock
 
-from gridcore.persistence import GridAnchorStore
+from gridcore.persistence import GridStateStore
 
 
-class TestGridAnchorStore:
-    """Tests for GridAnchorStore."""
+def _sample_grid() -> list[dict]:
+    return [
+        {"side": "Buy", "price": 100.0},
+        {"side": "Buy", "price": 101.0},
+        {"side": "Wait", "price": 102.0},
+        {"side": "Sell", "price": 103.0},
+        {"side": "Sell", "price": 104.0},
+    ]
 
-    def test_save_and_load(self, tmp_path):
-        """Test basic save and load functionality."""
-        file_path = str(tmp_path / "grid_anchor.json")
-        store = GridAnchorStore(file_path)
 
-        # Save anchor data
-        store.save(
-            strat_id="btcusdt_main",
-            anchor_price=100000.0,
-            grid_step=0.2,
-            grid_count=50
-        )
+class TestGridStateStoreRoundtrip:
+    def test_save_and_load_roundtrip(self, tmp_path):
+        file_path = str(tmp_path / "grid_state.json")
+        store = GridStateStore(file_path)
+        grid = _sample_grid()
 
-        # Load and verify
-        data = store.load("btcusdt_main")
-        assert data is not None
-        assert data['anchor_price'] == 100000.0
-        assert data['grid_step'] == 0.2
-        assert data['grid_count'] == 50
+        store.save(strat_id="strat1", grid=grid, grid_step=0.2, grid_count=20)
+        store.flush()
 
-    def test_load_nonexistent_strat_id(self, tmp_path):
-        """Test loading non-existent strat_id returns None."""
-        file_path = str(tmp_path / "grid_anchor.json")
-        store = GridAnchorStore(file_path)
+        loaded = store.load("strat1")
+        assert loaded is not None
+        assert loaded["grid"] == grid
+        assert loaded["grid_step"] == 0.2
+        assert loaded["grid_count"] == 20
 
-        # Save one strat
-        store.save("btcusdt_main", 100000.0, 0.2, 50)
+    def test_save_overwrites_existing_entry(self, tmp_path):
+        file_path = str(tmp_path / "grid_state.json")
+        store = GridStateStore(file_path)
+        store.save("strat1", _sample_grid(), grid_step=0.2, grid_count=20)
 
-        # Try to load different strat
-        data = store.load("ethusdt_main")
-        assert data is None
+        new_grid = [{"side": "Wait", "price": 200.0}, {"side": "Sell", "price": 201.0}]
+        store.save("strat1", new_grid, grid_step=0.3, grid_count=10)
+        store.flush()
 
-    def test_load_nonexistent_file(self, tmp_path):
-        """Test loading from non-existent file returns None."""
-        file_path = str(tmp_path / "nonexistent.json")
-        store = GridAnchorStore(file_path)
+        loaded = store.load("strat1")
+        assert loaded["grid"] == new_grid
+        assert loaded["grid_step"] == 0.3
+        assert loaded["grid_count"] == 10
 
-        data = store.load("btcusdt_main")
-        assert data is None
+    def test_multiple_strats_share_file(self, tmp_path):
+        file_path = str(tmp_path / "grid_state.json")
+        store = GridStateStore(file_path)
 
-    def test_multiple_strategies(self, tmp_path):
-        """Test saving and loading multiple strategies."""
-        file_path = str(tmp_path / "grid_anchor.json")
-        store = GridAnchorStore(file_path)
+        grid1 = _sample_grid()
+        grid2 = [{"side": "Buy", "price": 50.0}, {"side": "Wait", "price": 51.0}]
 
-        # Save multiple strategies
-        store.save("btcusdt_main", 100000.0, 0.2, 50)
-        store.save("ethusdt_main", 3500.0, 0.3, 40)
-        store.save("solusdt_main", 150.0, 0.5, 30)
+        store.save("strat_a", grid1, grid_step=0.2, grid_count=20)
+        store.save("strat_b", grid2, grid_step=0.5, grid_count=10)
+        store.flush()
 
-        # Load and verify each
-        btc_data = store.load("btcusdt_main")
-        assert btc_data['anchor_price'] == 100000.0
-        assert btc_data['grid_step'] == 0.2
-        assert btc_data['grid_count'] == 50
+        assert store.load("strat_a")["grid"] == grid1
+        assert store.load("strat_b")["grid"] == grid2
 
-        eth_data = store.load("ethusdt_main")
-        assert eth_data['anchor_price'] == 3500.0
-        assert eth_data['grid_step'] == 0.3
-        assert eth_data['grid_count'] == 40
+    def test_load_missing_file_returns_none(self, tmp_path):
+        file_path = str(tmp_path / "missing.json")
+        store = GridStateStore(file_path)
+        assert store.load("strat1") is None
 
-        sol_data = store.load("solusdt_main")
-        assert sol_data['anchor_price'] == 150.0
-        assert sol_data['grid_step'] == 0.5
-        assert sol_data['grid_count'] == 30
+    def test_load_unknown_strat_id_returns_none(self, tmp_path):
+        file_path = str(tmp_path / "grid_state.json")
+        store = GridStateStore(file_path)
+        store.save("strat1", _sample_grid(), grid_step=0.2, grid_count=20)
+        store.flush()
+        assert store.load("strat_other") is None
 
-    def test_multiple_stores_same_file(self, tmp_path):
-        """Test multiple GridAnchorStore instances accessing same file."""
-        file_path = str(tmp_path / "grid_anchor.json")
+    def test_load_empty_strat_id_raises(self, tmp_path):
+        store = GridStateStore(str(tmp_path / "grid_state.json"))
+        with pytest.raises(ValueError):
+            store.load("")
 
-        # First store saves data
-        store1 = GridAnchorStore(file_path)
-        store1.save("btcusdt_main", 100000.0, 0.2, 50)
+    def test_save_empty_strat_id_raises(self, tmp_path):
+        store = GridStateStore(str(tmp_path / "grid_state.json"))
+        with pytest.raises(ValueError):
+            store.save("", _sample_grid(), 0.2, 20)
 
-        # Second store can read it
-        store2 = GridAnchorStore(file_path)
-        data = store2.load("btcusdt_main")
-        assert data['anchor_price'] == 100000.0
 
-        # Second store updates
-        store2.save("ethusdt_main", 3500.0, 0.3, 40)
+class TestLegacyDetection:
+    def test_legacy_anchor_format_returns_none(self, tmp_path, caplog):
+        """Legacy entry (no `grid` key) is treated as no saved state."""
+        file_path = str(tmp_path / "grid_state.json")
+        legacy_data = {
+            "strat1": {
+                "anchor_price": 100.0,
+                "grid_step": 0.2,
+                "grid_count": 20,
+            }
+        }
+        Path(file_path).write_text(json.dumps(legacy_data))
 
-        # First store can see updates
-        eth_data = store1.load("ethusdt_main")
-        assert eth_data['anchor_price'] == 3500.0
+        store = GridStateStore(file_path)
+        with caplog.at_level("INFO"):
+            result = store.load("strat1")
 
-    def test_update_existing_strategy(self, tmp_path):
-        """Test updating existing strategy overwrites old data."""
-        file_path = str(tmp_path / "grid_anchor.json")
-        store = GridAnchorStore(file_path)
+        assert result is None
+        assert any("Legacy anchor format ignored" in r.message for r in caplog.records)
 
-        # Save initial data
-        store.save("btcusdt_main", 100000.0, 0.2, 50)
+    def test_new_format_loads_normally(self, tmp_path):
+        """Entries with `grid` key load normally — does not trigger legacy path."""
+        file_path = str(tmp_path / "grid_state.json")
+        store = GridStateStore(file_path)
+        store.save("strat1", _sample_grid(), grid_step=0.2, grid_count=20)
+        store.flush()
 
-        # Update with new data
-        store.save("btcusdt_main", 105000.0, 0.25, 60)
+        loaded = store.load("strat1")
+        assert loaded is not None
+        assert "grid" in loaded
 
-        # Verify updated data
-        data = store.load("btcusdt_main")
-        assert data['anchor_price'] == 105000.0
-        assert data['grid_step'] == 0.25
-        assert data['grid_count'] == 60
 
-    def test_delete_strategy(self, tmp_path):
-        """Test deleting a strategy."""
-        file_path = str(tmp_path / "grid_anchor.json")
-        store = GridAnchorStore(file_path)
+class TestCorruption:
+    def test_corrupt_json_returns_none(self, tmp_path):
+        file_path = str(tmp_path / "grid_state.json")
+        Path(file_path).write_text("not json at all")
 
-        # Save and then delete
-        store.save("btcusdt_main", 100000.0, 0.2, 50)
-        result = store.delete("btcusdt_main")
+        store = GridStateStore(file_path)
+        assert store.load("strat1") is None
 
-        assert result is True
-        assert store.load("btcusdt_main") is None
+    def test_partial_json_returns_none(self, tmp_path):
+        file_path = str(tmp_path / "grid_state.json")
+        Path(file_path).write_text('{"strat1": {"grid":')
 
-    def test_delete_nonexistent_strategy(self, tmp_path):
-        """Test deleting non-existent strategy returns False."""
-        file_path = str(tmp_path / "grid_anchor.json")
-        store = GridAnchorStore(file_path)
+        store = GridStateStore(file_path)
+        assert store.load("strat1") is None
 
-        # Save one strategy
-        store.save("btcusdt_main", 100000.0, 0.2, 50)
+    def test_non_dict_entry_returns_none(self, tmp_path):
+        """Hand-edited file with a non-dict entry must not crash load() —
+        regression for `'grid' not in entry` raising TypeError on int/str/list."""
+        file_path = str(tmp_path / "grid_state.json")
+        Path(file_path).write_text(json.dumps({
+            "int_entry": 1,
+            "str_entry": "garbage",
+            "list_entry": [1, 2, 3],
+        }))
 
-        # Try to delete different strategy
-        result = store.delete("ethusdt_main")
-        assert result is False
+        store = GridStateStore(file_path)
+        assert store.load("int_entry") is None
+        assert store.load("str_entry") is None
+        assert store.load("list_entry") is None
 
-    def test_delete_from_nonexistent_file(self, tmp_path):
-        """Test deleting from non-existent file returns False."""
-        file_path = str(tmp_path / "nonexistent.json")
-        store = GridAnchorStore(file_path)
+    @pytest.mark.parametrize("root_value", ["[]", '"x"', "1", "true", "null"])
+    def test_non_dict_root_does_not_crash_load(self, tmp_path, root_value):
+        """Hand-edited file with valid JSON but non-object root (e.g. `[]`)
+        must not crash load() — regression for AttributeError on
+        `all_data.get(...)` when root is a list/string/number."""
+        file_path = str(tmp_path / "grid_state.json")
+        Path(file_path).write_text(root_value)
 
-        result = store.delete("btcusdt_main")
-        assert result is False
+        store = GridStateStore(file_path)
+        assert store.load("any_strat") is None
 
-    def test_creates_directory_if_not_exists(self, tmp_path):
-        """Test that save creates parent directories if they don't exist."""
-        file_path = str(tmp_path / "nested" / "dir" / "grid_anchor.json")
-        store = GridAnchorStore(file_path)
+    def test_save_self_heals_non_dict_root(self, tmp_path):
+        """A file whose root was hand-edited to a non-dict must be silently
+        overwritten on the next save(), not crash with TypeError. Persistence
+        layer should be self-healing without manual file cleanup."""
+        file_path = str(tmp_path / "grid_state.json")
+        Path(file_path).write_text("[]")
 
-        store.save("btcusdt_main", 100000.0, 0.2, 50)
+        store = GridStateStore(file_path)
+        grid = _sample_grid()
+        store.save("strat1", grid, 0.2, 20)
+        store.flush()
 
-        # Verify file was created
+        loaded = store.load("strat1")
+        assert loaded is not None
+        assert loaded["grid"] == grid
+
+    def test_delete_non_dict_root_returns_false(self, tmp_path):
+        """delete() on a file with non-dict root must not crash — returns
+        False (nothing to delete) since the per-strat entry can't exist."""
+        file_path = str(tmp_path / "grid_state.json")
+        Path(file_path).write_text("[]")
+
+        store = GridStateStore(file_path)
+        assert store.delete("strat1") is False
+
+    def test_save_recovers_from_corrupt_existing_file(self, tmp_path):
+        """Corrupt existing file is silently overwritten on save (matches legacy behavior)."""
+        file_path = str(tmp_path / "grid_state.json")
+        Path(file_path).write_text("garbage")
+
+        store = GridStateStore(file_path)
+        grid = _sample_grid()
+        store.save("strat1", grid, grid_step=0.2, grid_count=20)
+        store.flush()
+
+        loaded = store.load("strat1")
+        assert loaded["grid"] == grid
+
+
+class TestAtomicWrite:
+    def test_old_file_survives_failed_write(self, tmp_path):
+        """If os.replace fails after the tmp file is written, the original file
+        must remain intact (atomicity guarantee)."""
+        file_path = str(tmp_path / "grid_state.json")
+        store = GridStateStore(file_path)
+
+        # First write succeeds.
+        original_grid = _sample_grid()
+        store.save("strat1", original_grid, grid_step=0.2, grid_count=20)
+        store.flush()
+        original_content = Path(file_path).read_text()
+
+        # Second write fails at os.replace step.
+        new_grid = [{"side": "Wait", "price": 999.0}]
+        with patch("os.replace", side_effect=OSError("simulated failure")):
+            with pytest.raises(OSError):
+                store._sync_write_to_disk(
+                    "strat1",
+                    {"grid": new_grid, "grid_step": 0.2, "grid_count": 20},
+                )
+
+        # Original file is untouched.
+        assert Path(file_path).read_text() == original_content
         assert os.path.exists(file_path)
-        data = store.load("btcusdt_main")
-        assert data['anchor_price'] == 100000.0
-
-    def test_handles_corrupted_json(self, tmp_path):
-        """Test that load handles corrupted JSON gracefully."""
-        file_path = str(tmp_path / "grid_anchor.json")
-
-        # Write corrupted JSON
-        with open(file_path, 'w') as f:
-            f.write("not valid json {{{")
-
-        store = GridAnchorStore(file_path)
-        data = store.load("btcusdt_main")
-        assert data is None
-
-    def test_json_format(self, tmp_path):
-        """Test that saved JSON has expected format."""
-        file_path = str(tmp_path / "grid_anchor.json")
-        store = GridAnchorStore(file_path)
-
-        store.save("btcusdt_main", 100000.0, 0.2, 50)
-        store.save("ethusdt_main", 3500.0, 0.3, 40)
-
-        # Read raw JSON and verify structure
-        with open(file_path, 'r') as f:
-            raw_data = json.load(f)
-
-        assert "btcusdt_main" in raw_data
-        assert "ethusdt_main" in raw_data
-        assert raw_data["btcusdt_main"]["anchor_price"] == 100000.0
-        assert raw_data["ethusdt_main"]["grid_step"] == 0.3
-
-    def test_default_file_path(self):
-        """Test default file path is db/grid_anchor.json."""
-        store = GridAnchorStore()
-        assert store.file_path == 'db/grid_anchor.json'
-
-
-class TestGridAnchorStoreIOErrors:
-    """Tests for IOError handling in GridAnchorStore."""
-
-    def test_load_with_permission_error(self, tmp_path):
-        """Test load handles permission errors gracefully."""
-        file_path = str(tmp_path / "grid_anchor.json")
-        store = GridAnchorStore(file_path)
-
-        # Save valid data first
-        store.save("btcusdt_main", 100000.0, 0.2, 50)
 
-        # Mock open to raise PermissionError
-        with patch("builtins.open", side_effect=PermissionError("Permission denied")):
-            data = store.load("btcusdt_main")
-            assert data is None
-
-    def test_save_with_permission_error(self, tmp_path):
-        """Test save handles permission errors when writing."""
-        file_path = str(tmp_path / "restricted" / "grid_anchor.json")
-        store = GridAnchorStore(file_path)
-
-        # Mock os.makedirs to succeed but open to fail with PermissionError
-        with patch("os.makedirs"):
-            with patch("builtins.open", side_effect=PermissionError("Permission denied")):
-                # Should raise the PermissionError
-                with pytest.raises(PermissionError):
-                    store.save("btcusdt_main", 100000.0, 0.2, 50)
-
-    def test_delete_with_read_permission_error(self, tmp_path):
-        """Test delete returns False when file cannot be read due to permissions."""
-        file_path = str(tmp_path / "grid_anchor.json")
-        store = GridAnchorStore(file_path)
-
-        # Save data first
-        store.save("btcusdt_main", 100000.0, 0.2, 50)
-
-        # Mock open to raise PermissionError on read
-        with patch("builtins.open", side_effect=PermissionError("Permission denied")):
-            result = store.delete("btcusdt_main")
-            assert result is False
-
-    def test_delete_preserves_other_strategies(self, tmp_path):
-        """Test delete only removes target strategy, preserves others."""
-        file_path = str(tmp_path / "grid_anchor.json")
-        store = GridAnchorStore(file_path)
-
-        # Save multiple strategies
-        store.save("btcusdt_main", 100000.0, 0.2, 50)
-        store.save("ethusdt_main", 3500.0, 0.3, 40)
-        store.save("solusdt_main", 150.0, 0.5, 30)
-
-        # Delete one strategy
-        result = store.delete("ethusdt_main")
-        assert result is True
-
-        # Verify others are preserved
-        btc_data = store.load("btcusdt_main")
-        assert btc_data is not None
-        assert btc_data['anchor_price'] == 100000.0
-
-        sol_data = store.load("solusdt_main")
-        assert sol_data is not None
-        assert sol_data['anchor_price'] == 150.0
 
-        # Verify deleted strategy is gone
-        eth_data = store.load("ethusdt_main")
-        assert eth_data is None
-
-
-class TestGridAnchorStoreCorruption:
-    """Tests for handling corrupted data scenarios."""
-
-    def test_delete_with_corrupted_json(self, tmp_path):
-        """Test delete returns False when JSON is corrupted."""
-        file_path = str(tmp_path / "grid_anchor.json")
-
-        # Write corrupted JSON
-        with open(file_path, 'w') as f:
-            f.write("not valid json {{{")
-
-        store = GridAnchorStore(file_path)
-        result = store.delete("btcusdt_main")
-        assert result is False
-
-    def test_save_overwrites_corrupted_data(self, tmp_path):
-        """Test save succeeds even when existing file has corrupted JSON."""
-        file_path = str(tmp_path / "grid_anchor.json")
-        store = GridAnchorStore(file_path)
-
-        # Save initial valid data
-        store.save("btcusdt_main", 100000.0, 0.2, 50)
-
-        # Corrupt the file
-        with open(file_path, 'w') as f:
-            f.write("corrupted json {{{")
-
-        # Save should succeed and overwrite corrupted data
-        store.save("ethusdt_main", 3500.0, 0.3, 40)
-
-        # Verify new data is saved
-        data = store.load("ethusdt_main")
-        assert data is not None
-        assert data['anchor_price'] == 3500.0
-
-        # Original data should be lost (corrupted file was overwritten with empty dict)
-        btc_data = store.load("btcusdt_main")
-        assert btc_data is None
-
-
-class TestGridAnchorStoreEdgeFilePaths:
-    """Tests for edge cases with file paths."""
-
-    def test_save_with_no_parent_directory(self, tmp_path):
-        """Test save works with file path that has no parent directory."""
-        # Change to tmp_path to test relative path
-        original_cwd = os.getcwd()
-        try:
-            os.chdir(tmp_path)
-            store = GridAnchorStore("grid_anchor.json")
-
-            store.save("btcusdt_main", 100000.0, 0.2, 50)
-
-            # Verify file was created in current directory
-            assert os.path.exists("grid_anchor.json")
-            data = store.load("btcusdt_main")
-            assert data['anchor_price'] == 100000.0
-        finally:
-            os.chdir(original_cwd)
-
-    def test_empty_file_after_deleting_last_strategy(self, tmp_path):
-        """Test that deleting the last strategy leaves an empty JSON object."""
-        file_path = str(tmp_path / "grid_anchor.json")
-        store = GridAnchorStore(file_path)
-
-        # Save single strategy
-        store.save("btcusdt_main", 100000.0, 0.2, 50)
-
-        # Delete it
-        result = store.delete("btcusdt_main")
-        assert result is True
-
-        # File should contain empty JSON object
-        with open(file_path, 'r') as f:
-            data = json.load(f)
-        assert data == {}
-
-    def test_very_long_file_path(self, tmp_path):
-        """Test save and load work with very long file paths."""
-        # Create a deeply nested directory structure
-        long_path = tmp_path
-        for i in range(10):
-            long_path = long_path / f"nested_directory_{i}"
-
-        file_path = str(long_path / "grid_anchor.json")
-        store = GridAnchorStore(file_path)
-
-        # Should create all directories and save
-        store.save("btcusdt_main", 100000.0, 0.2, 50)
-
-        assert os.path.exists(file_path)
-        data = store.load("btcusdt_main")
-        assert data['anchor_price'] == 100000.0
-
-
-class TestGridAnchorStoreEdgeValues:
-    """Tests for edge case data values."""
-
-    def test_save_with_negative_values(self, tmp_path):
-        """Test save works with negative values."""
-        file_path = str(tmp_path / "grid_anchor.json")
-        store = GridAnchorStore(file_path)
-
-        # Negative values (may not make sense for trading but should persist)
-        store.save("test_strat", -100.0, -0.5, -10)
-
-        data = store.load("test_strat")
-        assert data['anchor_price'] == -100.0
-        assert data['grid_step'] == -0.5
-        assert data['grid_count'] == -10
-
-    def test_save_with_zero_values(self, tmp_path):
-        """Test save works with zero values."""
-        file_path = str(tmp_path / "grid_anchor.json")
-        store = GridAnchorStore(file_path)
-
-        store.save("test_strat", 0.0, 0.0, 0)
-
-        data = store.load("test_strat")
-        assert data['anchor_price'] == 0.0
-        assert data['grid_step'] == 0.0
-        assert data['grid_count'] == 0
-
-    def test_save_with_very_large_numbers(self, tmp_path):
-        """Test save works with very large float values."""
-        file_path = str(tmp_path / "grid_anchor.json")
-        store = GridAnchorStore(file_path)
-
-        # Very large but valid float values
-        large_price = 1e100
-        large_step = 1e50
-        large_count = 999999999
-
-        store.save("test_strat", large_price, large_step, large_count)
-
-        data = store.load("test_strat")
-        assert data['anchor_price'] == large_price 
-        assert data['grid_step'] == large_step
-        assert data['grid_count'] == large_count
-
-    def test_save_with_nan_values(self, tmp_path):
-        """Test save with NaN values (Python json allows NaN by default)."""
-        file_path = str(tmp_path / "grid_anchor.json")
-        store = GridAnchorStore(file_path)
-
-        # Python's json.dump() allows NaN by default (writes as JavaScript literal)
-        store.save("test_strat", float('nan'), 0.2, 50)
-
-        # Verify it was saved and can be loaded
-        data = store.load("test_strat")
-        assert data is not None
-        # NaN != NaN, so use math.isnan()
-        assert math.isnan(data['anchor_price'])
-        assert data['grid_step'] == 0.2
-        assert data['grid_count'] == 50
-
-    def test_save_with_infinity_values(self, tmp_path):
-        """Test save with infinity values (Python json allows Infinity by default)."""
-        file_path = str(tmp_path / "grid_anchor.json")
-        store = GridAnchorStore(file_path)
-
-        # Python's json.dump() allows Infinity by default (writes as JavaScript literal)
-        store.save("test_strat", float('inf'), 0.2, 50)
-
-        # Verify it was saved and can be loaded
-        data = store.load("test_strat")
-        assert data is not None
-        assert math.isinf(data['anchor_price'])
-        assert data['anchor_price'] > 0  # Positive infinity
-        assert data['grid_step'] == 0.2
-        assert data['grid_count'] == 50
-
-    def test_load_returns_correct_types(self, tmp_path):
-        """Test that loaded data has correct Python types."""
-        file_path = str(tmp_path / "grid_anchor.json")
-        store = GridAnchorStore(file_path)
-
-        store.save("btcusdt_main", 100000.0, 0.2, 50)
-
-        data = store.load("btcusdt_main")
-        assert isinstance(data, dict)
-        assert isinstance(data['anchor_price'], (int, float))
-        assert isinstance(data['grid_step'], (int, float))
-        assert isinstance(data['grid_count'], int)
-
-
-class TestGridAnchorStoreSpecialStratIds:
-    """Tests for special characters in strat_id."""
-
-    def test_strat_id_with_spaces(self, tmp_path):
-        """Test strat_id with spaces works correctly."""
-        file_path = str(tmp_path / "grid_anchor.json")
-        store = GridAnchorStore(file_path)
-
-        strat_id = "btc usdt main strategy"
-        store.save(strat_id, 100000.0, 0.2, 50)
-
-        data = store.load(strat_id)
-        assert data is not None
-        assert data['anchor_price'] == 100000.0
-
-    def test_strat_id_with_unicode(self, tmp_path):
-        """Test strat_id with unicode characters."""
-        file_path = str(tmp_path / "grid_anchor.json")
-        store = GridAnchorStore(file_path)
-
-        # Unicode: emoji, Chinese, Arabic
-        strat_id = "策略_🚀_استراتيجية"
-        store.save(strat_id, 100000.0, 0.2, 50)
-
-        data = store.load(strat_id)
-        assert data is not None
-        assert data['anchor_price'] == 100000.0
-
-    def test_strat_id_with_special_chars(self, tmp_path):
-        """Test strat_id with special characters."""
-        file_path = str(tmp_path / "grid_anchor.json")
-        store = GridAnchorStore(file_path)
-
-        strat_id = "btc@usdt#main$strategy%^&*()"
-        store.save(strat_id, 100000.0, 0.2, 50)
-
-        data = store.load(strat_id)
-        assert data is not None
-        assert data['anchor_price'] == 100000.0
-
-    def test_empty_strat_id(self, tmp_path):
-        """Test empty string as strat_id."""
-        file_path = str(tmp_path / "grid_anchor.json")
-        store = GridAnchorStore(file_path)
-
-        strat_id = ""
-        with pytest.raises(ValueError, match="strat_id must be a non-empty string"):
-            store.save(strat_id, 100000.0, 0.2, 50)
-        with pytest.raises(ValueError, match="strat_id must be a non-empty string"):
-            store.load(strat_id)
-        with pytest.raises(ValueError, match="strat_id must be a non-empty string"):
-            store.delete(strat_id)
-
-
-class TestGridAnchorStoreMiscEdgeCases:
-    """Tests for miscellaneous edge cases."""
-
-    def test_save_creates_valid_json_format(self, tmp_path):
-        """Test that save creates properly formatted JSON with indentation."""
-        file_path = str(tmp_path / "grid_anchor.json")
-        store = GridAnchorStore(file_path)
-
-        store.save("btcusdt_main", 100000.0, 0.2, 50)
-
-        # Read raw file content
-        with open(file_path, 'r') as f:
-            content = f.read()
-
-        # Should have indentation (indent=2)
-        assert '\n' in content
-        assert '  ' in content  # 2-space indent
-
-        # Should be valid JSON
-        parsed = json.loads(content)
-        assert parsed["btcusdt_main"]["anchor_price"] == 100000.0
-
-    def test_file_path_property_accessible(self):
-        """Test that file_path attribute is accessible."""
-        store = GridAnchorStore("custom/path/grid_anchor.json")
-        assert store.file_path == "custom/path/grid_anchor.json"
-
-        # Should be able to read it
-        path = store.file_path
-        assert isinstance(path, str)
-        assert "grid_anchor.json" in path
-
-    def test_multiple_stores_same_file(self, tmp_path):
-        """Test multiple GridAnchorStore instances accessing same file."""
-        file_path = str(tmp_path / "grid_anchor.json")
-
-        # First store saves data
-        store1 = GridAnchorStore(file_path)
-        store1.save("btcusdt_main", 100000.0, 0.2, 50)
-
-        # Second store can read it
-        store2 = GridAnchorStore(file_path)
-        data = store2.load("btcusdt_main")
-        assert data['anchor_price'] == 100000.0
-
-        # Second store updates
-        store2.save("ethusdt_main", 3500.0, 0.3, 40)
-
-        # First store can see updates
-        eth_data = store1.load("ethusdt_main")
-        assert eth_data['anchor_price'] == 3500.0
+class TestDedupe:
+    def test_identical_payload_skips_thread_spawn(self, tmp_path):
+        """Two identical save() calls — the second must short-circuit before
+        even spawning a background thread (no work, no deepcopy)."""
+        file_path = str(tmp_path / "grid_state.json")
+        store = GridStateStore(file_path)
+        grid = _sample_grid()
+
+        store.save("strat1", grid, grid_step=0.2, grid_count=20)
+        store.flush()
+
+        with patch("threading.Thread") as mock_thread:
+            store.save("strat1", grid, grid_step=0.2, grid_count=20)
+
+        mock_thread.assert_not_called()
+
+    def test_changed_payload_triggers_write(self, tmp_path):
+        file_path = str(tmp_path / "grid_state.json")
+        store = GridStateStore(file_path)
+        grid_a = _sample_grid()
+        grid_b = list(grid_a) + [{"side": "Sell", "price": 105.0}]
+
+        store.save("strat1", grid_a, grid_step=0.2, grid_count=20)
+        store.save("strat1", grid_b, grid_step=0.2, grid_count=20)
+        store.flush()
+
+        loaded = store.load("strat1")
+        assert loaded["grid"] == grid_b
+
+    def test_dedupe_baseline_unaffected_by_in_place_mutation(self, tmp_path):
+        """The store fingerprints by structural identity at save() time. If
+        the caller later mutates the same list in place, the next save() must
+        still detect the difference and trigger a write — i.e. the fingerprint
+        must reflect the snapshot at the moment of the prior save, not a live
+        reference."""
+        file_path = str(tmp_path / "grid_state.json")
+        store = GridStateStore(file_path)
+        grid = _sample_grid()
+
+        store.save("strat1", grid, grid_step=0.2, grid_count=20)
+        store.flush()
+
+        grid[0]["side"] = "Wait"  # In-place mutation by caller.
+
+        with patch("threading.Thread") as mock_thread:
+            store.save("strat1", grid, grid_step=0.2, grid_count=20)
+            assert mock_thread.call_count == 1
+
+
+class TestFlush:
+    def test_flush_waits_for_pending_writes(self, tmp_path):
+        """flush() must block until all in-flight writes have completed —
+        used by tests and graceful shutdown."""
+        file_path = str(tmp_path / "grid_state.json")
+        store = GridStateStore(file_path)
+        store.save("strat1", _sample_grid(), grid_step=0.2, grid_count=20)
+        store.flush()
+        # File exists immediately after flush returns.
+        assert Path(file_path).exists()
+        loaded = store.load("strat1")
+        assert loaded is not None
+
+    def test_flush_with_no_pending_writes_is_noop(self, tmp_path):
+        store = GridStateStore(str(tmp_path / "grid_state.json"))
+        store.flush()  # Should not raise.
+
+
+class TestBackgroundWrite:
+    def test_save_does_not_block_caller(self, tmp_path):
+        """save() returns immediately; disk I/O happens in a background thread."""
+        file_path = str(tmp_path / "grid_state.json")
+        store = GridStateStore(file_path)
+        store.save("strat1", _sample_grid(), grid_step=0.2, grid_count=20)
+        # If save() were blocking on fsync, this assertion would race with
+        # the actual disk write. flush() makes the test deterministic.
+        store.flush()
+        assert store.load("strat1") is not None
+
+    def test_concurrent_writes_serialized_by_lock(self, tmp_path):
+        """Two strats writing back-to-back both end up on disk (the lock
+        serializes; nothing is dropped)."""
+        file_path = str(tmp_path / "grid_state.json")
+        store = GridStateStore(file_path)
+
+        store.save("a", [{"side": "Wait", "price": 1.0}, {"side": "Sell", "price": 2.0}], 0.2, 10)
+        store.save("b", [{"side": "Buy", "price": 3.0}, {"side": "Wait", "price": 4.0}], 0.2, 10)
+        store.flush()
+
+        assert store.load("a") is not None
+        assert store.load("b") is not None
+
+    def test_burst_saves_persist_latest_payload(self, tmp_path):
+        """Five rapid distinct saves for the same strat_id must end with the
+        last payload on disk — verifies the single-writer-per-strat coalescing
+        does not reorder writes (the original threading.Lock approach was not
+        FIFO and could write older payloads after newer ones)."""
+        file_path = str(tmp_path / "grid_state.json")
+        store = GridStateStore(file_path)
+
+        for i in range(5):
+            grid = [{"side": "Wait", "price": 100.0 + i}, {"side": "Sell", "price": 200.0 + i}]
+            store.save("strat1", grid, 0.2, 10)
+        store.flush()
+
+        loaded = store.load("strat1")
+        # Last payload (i=4) must win.
+        assert loaded["grid"][0]["price"] == 104.0
+        assert loaded["grid"][1]["price"] == 204.0
+
+    def test_save_during_in_flight_write_is_coalesced(self, tmp_path):
+        """A save() that arrives while an earlier write is in flight must NOT
+        spawn a second writer thread — the in-flight writer drains the slot."""
+        file_path = str(tmp_path / "grid_state.json")
+        store = GridStateStore(file_path)
+
+        spawn_count = 0
+        original_thread = threading.Thread
+
+        def counting_thread(*args, **kwargs):
+            nonlocal spawn_count
+            spawn_count += 1
+            return original_thread(*args, **kwargs)
+
+        with patch("threading.Thread", side_effect=counting_thread):
+            store.save("strat1", _sample_grid(), 0.2, 20)
+            grid_b = _sample_grid() + [{"side": "Sell", "price": 999.0}]
+            store.save("strat1", grid_b, 0.2, 20)
+
+        store.flush()
+        # At most 2 thread spawns (in the worst case the first finished before
+        # the second save), but importantly the disk has the latest payload.
+        assert spawn_count <= 2
+        assert store.load("strat1")["grid"] == grid_b
+
+    def test_write_failure_logged_not_raised(self, tmp_path, caplog):
+        """A disk-write failure inside the background thread is logged but
+        never propagates — persistence failures must not crash the bot."""
+        file_path = str(tmp_path / "grid_state.json")
+        store = GridStateStore(file_path)
+
+        with patch.object(store, "_sync_write_to_disk", side_effect=OSError("boom")):
+            with caplog.at_level("ERROR"):
+                store.save("strat1", _sample_grid(), 0.2, 20)
+                store.flush()
+
+        assert any("Save failed for strat1" in r.message for r in caplog.records)
+
+    def test_failed_write_allows_retry_with_same_payload(self, tmp_path):
+        """After a transient write failure the same payload must persist on
+        the next save() — regression for stale-dedupe (the failed payload's
+        fingerprint stayed in _last_fingerprint and silently skipped retries
+        until the grid happened to mutate to a different fingerprint)."""
+        file_path = str(tmp_path / "grid_state.json")
+        store = GridStateStore(file_path)
+        grid = _sample_grid()
+
+        # First save fails at the disk layer.
+        with patch.object(store, "_sync_write_to_disk", side_effect=OSError("transient")):
+            store.save("strat1", grid, 0.2, 20)
+            store.flush()
+        assert store.load("strat1") is None  # nothing on disk
+
+        # Retry with the SAME payload — must reach disk now that the writer
+        # rolled back the dedupe fingerprint on failure.
+        store.save("strat1", grid, 0.2, 20)
+        store.flush()
+
+        loaded = store.load("strat1")
+        assert loaded is not None
+        assert loaded["grid"] == grid
+
+    def test_failed_write_does_not_overwrite_newer_payload_dedupe(self, tmp_path):
+        """If a newer payload was enqueued between a save() and its writer's
+        failure, the rollback must NOT clear the newer payload's fingerprint
+        (it's still valid and pending)."""
+        file_path = str(tmp_path / "grid_state.json")
+        store = GridStateStore(file_path)
+        grid_a = _sample_grid()
+        grid_b = list(grid_a) + [{"side": "Sell", "price": 999.0}]
+
+        # Both writes fail. After flush, neither is on disk and dedupe is
+        # cleared so a retry of either succeeds.
+        with patch.object(store, "_sync_write_to_disk", side_effect=OSError("boom")):
+            store.save("strat1", grid_a, 0.2, 20)
+            store.save("strat1", grid_b, 0.2, 20)
+            store.flush()
+
+        # Without the rollback, the second save's fingerprint would persist
+        # in _last_fingerprint even after the failure, and a retry would
+        # silently skip. Verify retry works.
+        store.save("strat1", grid_b, 0.2, 20)
+        store.flush()
+        loaded = store.load("strat1")
+        assert loaded is not None
+        assert loaded["grid"] == grid_b
+
+
+class TestDelete:
+    def test_delete_existing_strat(self, tmp_path):
+        file_path = str(tmp_path / "grid_state.json")
+        store = GridStateStore(file_path)
+        store.save("strat1", _sample_grid(), 0.2, 20)
+        store.flush()
+
+        assert store.delete("strat1") is True
+        assert store.load("strat1") is None
+
+    def test_delete_unknown_strat_returns_false(self, tmp_path):
+        file_path = str(tmp_path / "grid_state.json")
+        store = GridStateStore(file_path)
+        store.save("strat1", _sample_grid(), 0.2, 20)
+        store.flush()
+        assert store.delete("strat_other") is False
+
+    def test_delete_missing_file_returns_false(self, tmp_path):
+        store = GridStateStore(str(tmp_path / "missing.json"))
+        assert store.delete("strat1") is False

--- a/packages/gridcore/tests/test_persistence.py
+++ b/packages/gridcore/tests/test_persistence.py
@@ -227,6 +227,56 @@ class TestAtomicWrite:
         assert Path(file_path).read_text() == original_content
         assert os.path.exists(file_path)
 
+    def test_failed_save_cleans_up_tmp_file(self, tmp_path):
+        """A write that fails at os.replace must remove its .tmp file before
+        propagating — otherwise stale tmp files accumulate (especially on
+        disk-full / permission errors that prevent the next save from
+        succeeding either)."""
+        file_path = str(tmp_path / "grid_state.json")
+        tmp_file = file_path + ".tmp"
+        store = GridStateStore(file_path)
+
+        with patch("os.replace", side_effect=OSError("simulated failure")):
+            with pytest.raises(OSError):
+                store._sync_write_to_disk(
+                    "strat1",
+                    {"grid": _sample_grid(), "grid_step": 0.2, "grid_count": 20},
+                )
+
+        assert not os.path.exists(tmp_file), (
+            "Failed atomic write left a stale .tmp file behind"
+        )
+
+    def test_failed_delete_cleans_up_tmp_file(self, tmp_path):
+        """delete()'s atomic write must also clean up its tmp file on failure
+        (delete uses the same _atomic_write helper)."""
+        file_path = str(tmp_path / "grid_state.json")
+        tmp_file = file_path + ".tmp"
+        store = GridStateStore(file_path)
+        store.save("strat1", _sample_grid(), 0.2, 20)
+        store.flush()
+
+        with patch("os.replace", side_effect=OSError("simulated failure")):
+            # delete catches OSError and returns False; the tmp cleanup must
+            # still run before the catch swallows the error.
+            assert store.delete("strat1") is False
+
+        assert not os.path.exists(tmp_file), (
+            "Failed delete left a stale .tmp file behind"
+        )
+
+    def test_successful_write_leaves_no_tmp(self, tmp_path):
+        """Sanity check: after a successful save the .tmp file does not exist
+        (os.replace moved it to the final destination)."""
+        file_path = str(tmp_path / "grid_state.json")
+        tmp_file = file_path + ".tmp"
+        store = GridStateStore(file_path)
+        store.save("strat1", _sample_grid(), 0.2, 20)
+        store.flush()
+
+        assert os.path.exists(file_path)
+        assert not os.path.exists(tmp_file)
+
 
 class TestDedupe:
     def test_identical_payload_skips_thread_spawn(self, tmp_path):
@@ -445,3 +495,56 @@ class TestDelete:
     def test_delete_missing_file_returns_false(self, tmp_path):
         store = GridStateStore(str(tmp_path / "missing.json"))
         assert store.delete("strat1") is False
+
+    def test_delete_does_not_silently_drop_concurrent_save(self, tmp_path):
+        """Regression: with cleanup happening AFTER the file write, a
+        concurrent save() with the same payload would dedupe-hit on the
+        stale _last_fingerprint and be silently lost. Force the race via
+        os.replace blocked on a threading.Event, fire save() in that window,
+        then resume delete() and verify the save still landed on disk."""
+        import time
+
+        file_path = str(tmp_path / "grid_state.json")
+        store = GridStateStore(file_path)
+        grid = _sample_grid()
+
+        # Seed the store so the entry exists and _last_fingerprint is set.
+        store.save("strat1", grid, 0.2, 20)
+        store.flush()
+
+        proceed = threading.Event()
+        original_replace = os.replace
+
+        def slow_replace(src, dst):
+            proceed.wait(timeout=2.0)
+            return original_replace(src, dst)
+
+        def concurrent_save():
+            store.save("strat1", grid, 0.2, 20)
+
+        with patch("os.replace", side_effect=slow_replace):
+            delete_thread = threading.Thread(
+                target=lambda: store.delete("strat1"), daemon=True,
+            )
+            delete_thread.start()
+            time.sleep(0.05)  # let delete() reach os.replace and pause
+
+            save_thread = threading.Thread(target=concurrent_save, daemon=True)
+            save_thread.start()
+            time.sleep(0.05)  # let save() race in while delete is paused
+
+            proceed.set()
+            delete_thread.join(timeout=2.0)
+            save_thread.join(timeout=2.0)
+
+        store.flush()
+
+        # With the fix (cleanup BEFORE the write), the concurrent save sees
+        # a cleared fingerprint and re-persists. Without the fix it would
+        # dedupe-hit on stale _last_fingerprint and the entry would be gone.
+        loaded = store.load("strat1")
+        assert loaded is not None, (
+            "Concurrent save() during delete() was silently dropped — "
+            "delete()'s dedupe cleanup happened too late."
+        )
+        assert loaded["grid"] == grid


### PR DESCRIPTION
## Summary

- Replace anchor-only persistence with full grid storage (matches bbu2's `db/greed.json`). Restores per-fill WAIT zones, side reassignments, and `__center_grid` drift that were previously lost on restart.
- New `GridStateStore` (renamed from `GridAnchorStore`): atomic writes (tmp + `os.replace` + `fsync`), single-writer-per-strat coalescing for latest-wins under bursts, fingerprint-before-deepcopy dedupe, retry-after-failure rollback, self-healing on corrupt files.
- `Grid` callback fires from `build_grid`/`update_grid` so `gridcore` stays I/O-free; runner registers a save callback. Drift guard rebuilds when `last_close` is outside the restored grid bounds.
- Legacy `{anchor_price, ...}` files are auto-detected and treated as no-saved-state (one-time info log, falls back to fresh build).

## Test plan

- [x] `uv run pytest packages/gridcore/tests/ apps/gridbot/tests/ apps/backtest/tests/` — 1038 passed, 1 skipped (3 unrelated `test_risk_limit_info` failures pre-existing on main)
- [x] New regression coverage for: atomic write under simulated failure, burst-coalescing latest-wins, dedupe rollback after transient I/O error, non-dict-root JSON self-healing, restore validation fallback
- [ ] Manual: stop bot mid-run after observing `__center_grid` drift, restart, verify grid restored verbatim (no `Building grid from ...` log on first ticker)
- [ ] Manual: legacy migration — place old-format file, verify `Legacy anchor format ignored` log + fresh build
- [ ] Manual: drift on restore — restart with stale grid far from current price, verify `Restored grid out of range, rebuilding` log

## Notes

- One design deviation from `0021_PLAN.md`: persistence uses **threaded** background writes (daemon `threading.Thread` + `threading.Lock`) rather than `asyncio.create_task`/`to_thread`. Reason: gridbot's main loop is synchronous (`time.sleep`), so the asyncio path always falls through to the sync branch and blocks the loop on `fsync`. Threads work in both sync and async caller contexts.
- `anchor_price` parameter retained on `GridEngine` for backtest compatibility (backtest uses it to pin grid origin); `restored_grid` added alongside.
- Orchestrator config key `anchor_store_path` preserved for deploy compatibility; only the class name and file *contents* change.
- Three review iterations addressed before merge — see `docs/features/0021_REVIEW.md` for the audit trail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)