### PR TITLE
feat(gridcore): per-tick grid drift detector (0022) @codex

### DIFF
--- a/docs/features/0022_PLAN.md
+++ b/docs/features/0022_PLAN.md
@@ -4,6 +4,8 @@
 
 Add an ungated per-tick drift detector. When the current market price has moved more than one `grid_step` away from the current WAIT band center, walk the grid by `N = floor(deviation_pct / grid_step)` levels toward the price. Works identically on cold restart, during live run, and after WS reconnect — it does not depend on `last_filled_price` (which is what causes the existing `update_grid`/`__center_grid` machinery to stay silent on a fresh start, per `/tmp/gridbot.log` evidence at 2026-04-22 13:51).
 
+Note: feature 0021 (full grid persistence) is shipped — the grid is restored verbatim across restarts, but `last_filled_price` is NOT persisted, so the gating bug remains.
+
 User selections:
 - **Q1 = current.** Reference point is the center of the current WAIT band in `self.grid.grid`, not the original build-time anchor (`_original_anchor_price`), so the detector self-adjusts as the grid walks.
 - **Q2 = walk by N steps.** Generalization of `__center_grid` (one-step) to shift by multiple levels in a single tick, not a full rebuild (option a) nor log-only (option c).
@@ -32,7 +34,7 @@ User selections:
 1. Collect prices of all levels with `side == GridSideType.WAIT` from `self.grid.grid`.
 2. If one WAIT level exists: `wait_center = its price`.
 3. If multiple consecutive WAIT levels exist (allowed — see `grid.py:290`): `wait_center = (min_wait_price + max_wait_price) / 2`.
-4. If zero WAIT levels (possible after heavy drift or after fill-based relabeling): fall back to the price at the median index of `self.grid.grid` (`self.grid.grid[len // 2]['price']`).
+4. If zero WAIT levels (possible after heavy drift or after fill-based relabeling): let `n = len(self.grid.grid)` and fall back to the **mean of the two middle levels** for even-length grids: `(self.grid.grid[n//2 - 1]['price'] + self.grid.grid[n//2]['price']) / 2`. For odd-length: the single middle level `self.grid.grid[n // 2]['price']`. (Edge case is rare post-0021 since the persisted grid carries its WAIT band.)
 
 ### Step 2 — trigger check
 
@@ -42,7 +44,7 @@ User selections:
 
 ### Step 3 — safety cap / fallback
 
-1. If `n_steps >= grid_count // 2`: the walk would push the entire grid past one side. Fall back to a **full rebuild** at `last_close` by calling the private rebuild path (equivalent to `__rebuild_grid(last_close)` at `grid.py:127-134`). Log a `Grid drift exceeds half-grid; rebuilding at market` line.
+1. If `n_steps >= grid_count // 2`: the walk would push the entire grid past one side. Fall back to a **full rebuild** at `last_close` by calling the private rebuild path (equivalent to `__rebuild_grid(last_close)` at `grid.py:127-134`). Use the same INFO log line as the walk path (see engine.py section below) — `n_steps` reflects how far the drift was even though the action is rebuild.
 2. Otherwise, proceed to Step 4.
 
 ### Step 4 — walk `n_steps` toward `last_close`
@@ -59,28 +61,36 @@ Direction derived from `sign(last_close - wait_center)`.
 2. Compute new bottom: `new_bot = _round_price(self.grid[0]['price'] * (1 - grid_step / 100))`.
 3. Prepend: `self.grid.insert(0, {'side': BUY, 'price': new_bot})`.
 
+The grid level schema is `{side, price}` only (verified in `grid.py:112-121, 296`); no other fields to carry across pop/append.
+
 ### Step 5 — side reassignment (no fill required)
 
 Loop over `self.grid.grid` and assign sides relative to `last_close` only:
 - `last_close > grid['price']` → `BUY`
 - `last_close < grid['price']` → `SELL`
-- `abs(grid['price'] - last_close) / grid['price'] * 100 < grid_step / 2` → `WAIT` (use the same too-close rule as `__is_too_close` but compared against `last_close` rather than `last_filled_price`).
+- `__is_too_close(grid['price'], last_close)` → `WAIT` (the same `< grid_step / 4` rule used post-fill in `update_grid`, but referenced against `last_close` instead of `last_filled_price`). Typically yields 0–1 WAIT levels (occasionally 2 in rare alignment).
 
 This replaces the need to call `update_grid` (which is gated on `last_filled_price`). After Step 5 the grid has a WAIT band centered near `last_close`, and BUY/SELL sides assigned correctly.
 
+**Full overwrite is intentional.** Any `WAIT` mark that was set by a recent fill via `update_grid` (`grid.py:252-253`) will be reassigned relative to `last_close` here. The next fill triggers `update_grid` again and re-applies fill-based WAIT marking.
+
+### Step 5.5 — update `_original_anchor_price`
+
+Set `self._original_anchor_price = self._wait_center()` (recomputed after the side reassignment). Keeps the invariant "anchor ≈ current WAIT center" so any consumer reading the anchor for diagnostics or logging sees a value consistent with the actual grid center. Lives inside `recenter_if_drifted`, not engine.
+
 ### Step 6 — persist
 
-No explicit save call is needed here: the existing save trigger at `apps/gridbot/src/gridbot/runner.py:319-320` runs on every execution cycle and will pick up the mutated grid. If feature 0021 (full grid persistence) is shipped first, this plan benefits automatically.
+No explicit save call is needed here: feature 0021 (full grid persistence) is shipped — the existing save trigger at `apps/gridbot/src/gridbot/runner.py:319-320` runs on every execution cycle and will pick up the mutated grid.
 
 ## Files to change
 
 ### Core
 
 - `packages/gridcore/src/gridcore/grid.py`
-  - Add `recenter_if_drifted(last_close: float) -> bool` — orchestrates steps 1-5; returns `True` if any action taken. Called by engine on every ticker.
-  - Add private `_wait_center() -> float | None` — returns the center per Step 1.
+  - Add `recenter_if_drifted(last_close: float) -> bool` — orchestrates steps 1–5.5; returns `True` if any action taken. Called by engine on every ticker. Updates `_original_anchor_price` to the post-walk WAIT center.
+  - Add private `_wait_center() -> float` — returns the center per Step 1. Always returns a float for non-empty grids (median fallback covers the zero-WAIT case). Caller must guard against empty grid (already done via the `len(grid) == 0` branch in `_handle_ticker_event`).
   - Add private `_shift_grid(n_steps: int, direction: str)` — executes Step 4 for `'up'` / `'down'`.
-  - Add private `_assign_sides(last_close: float)` — Step 5 side reassignment. (Extracted from the existing inline logic in `update_grid` lines 162-169 so it can be reused; `update_grid` keeps calling it too.)
+  - Add private `_assign_sides(last_close: float)` — Step 5 side reassignment, full overwrite by `last_close`. Used by both `update_grid` and `recenter_if_drifted` (extracted from the existing inline logic in `update_grid` lines 162-169).
 
 - `packages/gridcore/src/gridcore/engine.py`
   - In `_handle_ticker_event`, after `self.last_close = float(event.last_price)` (`engine.py:119`) and after the `len(grid) == 0` initial-build branch, call `self.grid.recenter_if_drifted(self.last_close)` before the `_check_and_place` calls at lines 133-134.
@@ -89,12 +99,14 @@ No explicit save call is needed here: the existing save trigger at `apps/gridbot
 ### Tests
 
 - `packages/gridcore/tests/test_grid.py` — new tests:
-  - `_wait_center`: single WAIT, multi-WAIT band, zero-WAIT fallback to median.
-  - `recenter_if_drifted`: no action when deviation ≤ grid_step; walks N steps up when price > wait_center + N*step; walks N steps down when price < wait_center − N*step; falls back to full rebuild when `n_steps >= grid_count // 2`.
-  - Side reassignment: after walk, levels below last_close are BUY, above are SELL, within grid_step/2 are WAIT.
+  - `_wait_center`: single WAIT, multi-WAIT band, zero-WAIT fallback uses **mean of two middle prices** for even-length grids and the single middle for odd-length.
+  - `recenter_if_drifted`: no action when deviation ≤ grid_step; walks N steps up when price > wait_center + N*step; walks N steps down when price < wait_center − N*step.
+  - `recenter_if_drifted` falls back to full rebuild (does not walk) when `n_steps >= grid_count // 2`. Assert grid is fully replaced and not just shifted by N.
+  - `recenter_if_drifted` updates `_original_anchor_price` to the new wait_center after walk.
+  - Side reassignment: after walk, levels below last_close are BUY, above are SELL, within `grid_step/4` of last_close (`__is_too_close` rule) are WAIT.
   - Round-trip: original grid prices are preserved outside the walked region (same prices end up at new indices, not re-derived from `last_close`).
 - `packages/gridcore/tests/test_engine.py` — new tests:
-  - Cold-start repro (from `/tmp/gridbot.log`): construct engine with a pre-built grid anchored at 55.4, drive ticker event with `last_price=55.9`, assert grid walked ~3 steps up and orders are now placed in the 55.6–56.2 strip.
+  - Cold-start repro (motivated by `/tmp/gridbot.log` 2026-04-22 13:51, but self-contained): load a fixture grid through `GridStateStore` with explicit anchor/grid_step, drive a ticker event with explicit `last_price`, assert the grid walked exactly `floor((|last_price - anchor| / anchor * 100) / grid_step)` steps up and orders are placed in the new WAIT-band strip. Do not read the actual log file.
   - Mid-run repro: fast price move within bounds — verify recenter fires and covers the gap in one tick.
   - Idempotency: calling `_handle_ticker_event` twice in a row with the same `last_close` produces no second walk.
 
@@ -112,14 +124,14 @@ User's condition is verbatim "more than one grid distance": trigger when `deviat
 ## Out of scope
 
 - Changing `__center_grid` behavior (kept as-is).
-- Persisting `last_filled_price` or fetching it on startup.
-- Full grid persistence — covered by feature 0021.
+- Persisting `last_filled_price` or fetching it on startup (could be a follow-up extension to 0021).
+- Full grid persistence — covered by feature 0021 (already shipped).
 - Configurable threshold / hysteresis.
 
 ## Verification
 
 1. Unit tests: `uv run pytest packages/gridcore/tests/test_grid.py packages/gridcore/tests/test_engine.py`.
-2. Cold-restart repro matching `/tmp/gridbot.log`: start bot with stored anchor 55.4, market at ~55.9, confirm on the first ticker a `Grid drift ... recentering` log line appears and orders are placed in the previously-empty 55.6–56.2 strip (no orders stranded at old anchor).
+2. Cold-restart repro matching `/tmp/gridbot.log`: start bot with grid loaded via `GridStateStore` (post-0021), market at the recorded `last_price`, confirm on the first ticker a `Grid drift ... recentering` log line appears, `_original_anchor_price` was updated, and orders are placed in the new WAIT-band strip (no orders stranded at old anchor).
 3. Mid-run fast move: during a live run, synthesize a ticker event that jumps price by 3 × grid_step, confirm the grid recenters in one tick instead of over many `__center_grid` ticks.
 4. Below-threshold stability: confirm no recenter fires for deviations ≤ 1 `grid_step` — verify with a jitter-style ticker sequence that the grid does not thrash.
 5. Safety cap: artificially construct `last_close` far outside the grid (deviation ≥ half the grid width) and confirm the full-rebuild fallback path runs and logs accordingly.

--- a/docs/features/0022_REVIEW.md
+++ b/docs/features/0022_REVIEW.md
@@ -1,0 +1,80 @@
+# 0022 Review — Detect grid drift every tick, walk grid by N steps
+
+## Verdict
+
+No blocking findings found. The current implementation matches the plan's core behavior: drift is measured from the current WAIT-band center, below-threshold ticks are true no-ops, stale fills do not cause repeated walks, pending fills are consumed on the first ticker, and a pending fill consumed during a fresh-build tick can now participate in same-tick recentering before order placement.
+
+The prior P2 finding is resolved. `_handle_ticker_event()` now tracks `fill_consumed_this_tick` and permits `recenter_if_drifted()` when a fresh build also consumes a deferred fill.
+
+Verification run:
+
+```bash
+uv run pytest packages/gridcore/tests/test_grid.py packages/gridcore/tests/test_engine.py -q
+# 130 passed in 0.06s
+
+uv run pytest packages/gridcore/tests -q
+# 379 passed, 1 skipped in 0.28s
+
+uv run ruff check packages/gridcore/src/gridcore/grid.py packages/gridcore/src/gridcore/engine.py
+# All checks passed
+```
+
+Additional manual repro for the previous fresh-build edge also passes:
+
+```text
+ExecutionEvent before first ticker: fill at 98.01
+First ticker: last_close=100.0
+Pending fill consumed: True -> False
+WAIT center after recenter: 100.0
+Grid prices: [96.06, 97.03, 98.01, 99.0, 100.0, 101.0, 102.01, 103.03, 104.06, 105.1, 106.15]
+```
+
+The wider lint command including the touched tests still fails on four pre-existing unused locals in `packages/gridcore/tests/test_grid.py` (`min_price_before`, `imbalance_after`, `max_price_before`, `imbalance_after`). Those are outside this feature's changed test block and are not a 0022 blocker.
+
+## Findings
+
+No blocking findings found.
+
+## Resolved Since Prior Review
+
+- `recenter_if_drifted()` uses `wait_center = self._wait_center()`, matching plan Q1.
+- Below-threshold ticks preserve both prices and sides, so cumulative sub-step drift is still detected against a stable WAIT band.
+- `_fill_pending` is consumed on the first ticker for both restored-grid and empty-grid builds.
+- Pending fills consumed during a fresh build now allow same-tick recentering before `_check_and_place()`.
+- Stale `last_filled_price` no longer causes repeated grid walks on identical ticker events.
+- `RecenterResult.__bool__` is falsy on no-op and truthy on walk/rebuild.
+- Out-of-bounds restored grids emit the planned `Grid drift ... N=...` log line before rebuild.
+- `restore_grid()` derives `_original_anchor_price` from `_wait_center()`.
+
+## Plan Alignment
+
+Implemented correctly:
+
+- WAIT-center helper behavior for single WAIT, multi-WAIT, and zero-WAIT fallback.
+- Trigger boundary: no action at `deviation_pct <= grid_step`; walk when greater.
+- Drift reference is the current WAIT-band center, not the original build-time anchor.
+- `n_steps = int(deviation_pct / grid_step)`.
+- Multi-step walk up/down and safety-cap rebuild.
+- Side reassignment only after actual walk/rebuild.
+- `_original_anchor_price` refresh after incremental walks.
+- Engine drift logging for walk and rebuild paths.
+- Order placement remains downstream of the recentered grid state.
+
+No snake_case/camelCase or `{data: ...}` nesting mismatch was found. `TickerEvent.last_price` remains a `Decimal` at the event boundary and is converted to `float` inside the engine. Persisted grid entries remain flat `{side, price}` dicts, and `GridSideType` remains a `StrEnum`, so JSON serialization stays string-compatible.
+
+## Test Review
+
+Coverage strengths:
+
+- Focused grid tests cover WAIT-center calculation, threshold behavior, up/down walks, safety-cap rebuild, side reassignment, round-trip preservation outside the walked region, anchor refresh, notify behavior, and update-grid side assignment compatibility.
+- Engine tests cover cold-start drift, mid-run fast moves, idempotency, below-threshold side stability, cumulative sub-step drift, pending fill consumption for restored and empty grids, current-WAIT-band reference after fill, same-tick recenter after fresh-build fill consumption, stale-fill idempotency, out-of-bounds drift logging, and full rebuild fallback.
+
+Residual non-blocking gaps:
+
+- Engine tests still inject `restored_grid` directly instead of exercising the full `GridStateStore` cold-restart path requested in the plan. This is acceptable for unit scope, but it is not a full persistence-path repro.
+- There is no explicit even-sized multi-WAIT restore test. The implementation uses `_wait_center()`, so it should behave correctly, but a dedicated regression would lock it down.
+- A few test comments around `TestAnchorPricePersistence` still describe the drift reference as an "original" or "persisted" anchor. The implementation now uses the current WAIT center; the comments should be cleaned up when convenient, but they do not affect behavior.
+
+## Structure / Style
+
+`RecenterResult`, `_wait_center()`, `_assign_sides()`, `_shift_grid()`, and `_fill_pending` are small, locally scoped additions that fit the existing engine/grid split. The feature does not introduce a large abstraction or move unrelated behavior. The only style nit is the stale wording in a few comments noted above.

--- a/packages/gridcore/src/gridcore/engine.py
+++ b/packages/gridcore/src/gridcore/engine.py
@@ -79,6 +79,12 @@ class GridEngine:
                 )
         self.last_close: Optional[float] = None
         self.last_filled_price: Optional[float] = None
+        # True if a fill arrived before last_close was known. Consumed by the
+        # next _handle_ticker_event so the fill's WAIT marking and __center_grid
+        # pass aren't lost (P2 fix). Once _check_and_place stopped calling
+        # update_grid on every tick, this became necessary to avoid dropping
+        # the fill permanently.
+        self._fill_pending: bool = False
 
         # Track pending orders to avoid duplicates
         # client_order_id → order_id mapping
@@ -135,6 +141,7 @@ class GridEngine:
         self.last_close = float(event.last_price)
 
         # Build grid if empty (a restored grid skips this branch)
+        grid_just_built = False
         if len(self.grid.grid) == 0:
             build_price = self._anchor_price if self._anchor_price else self.last_close
             if self._anchor_price:
@@ -142,6 +149,7 @@ class GridEngine:
             else:
                 logger.info('%s: Building grid from market price %s', self.symbol, build_price)
             self.grid.build_grid(build_price)
+            grid_just_built = True
         else:
             # Drift guard: if restored (or stale) grid is far from the current
             # price, rebuild around last_close. Mirrors update_grid's bounds
@@ -150,11 +158,53 @@ class GridEngine:
             # to keep the per-tick cost low.
             min_p, max_p = self.grid.bounds
             if not (min_p <= self.last_close <= max_p):
+                # Emit the same Grid-drift INFO line that recenter's safety-cap
+                # path uses, so out-of-bounds rebuilds are observable through
+                # the same telemetry hook (per 0022 Step 3).
+                wait_center = self.grid._wait_center()
+                deviation_pct = abs(self.last_close - wait_center) / wait_center * 100
+                n_steps = int(deviation_pct / self.grid.grid_step) if self.grid.grid_step > 0 else 0
+                logger.info(
+                    '%s: Grid drift %.2f%% (N=%d steps) — recentering at %s',
+                    self.symbol, deviation_pct, n_steps, self.last_close,
+                )
                 logger.info(
                     '%s: Restored grid out of range (last_close=%s, range=[%s, %s]), rebuilding',
                     self.symbol, self.last_close, min_p, max_p,
                 )
                 self.grid.build_grid(self.last_close)
+                grid_just_built = True
+
+        # Consume any deferred fill (one that arrived before last_close was set).
+        # Apply it before recenter so __center_grid and post-fill WAIT marking
+        # both get a chance to run before drift detection sees the grid state.
+        # Runs even on the same tick as build_grid so a fill that arrived first
+        # is applied to the freshly-built grid, not deferred to the next ticker.
+        fill_consumed_this_tick = False
+        if (
+            self._fill_pending
+            and self.last_filled_price is not None
+            and len(self.grid.grid) > 0
+        ):
+            self.grid.update_grid(self.last_filled_price, self.last_close)
+            self._fill_pending = False
+            fill_consumed_this_tick = True
+
+        # Per-tick drift detector (feature 0022). Independent of last_filled_price,
+        # so it fires on cold start and after WS reconnect even before the first
+        # fill. Skipped on a plain fresh-build tick — the freshly built grid
+        # reflects an explicit anchor or market-price choice that recenter would
+        # otherwise immediately overwrite. BUT: if a pending fill was consumed
+        # this tick, the consumed fill may have shifted the WAIT band far enough
+        # that drift now legitimately exceeds one grid_step; allow recenter in
+        # that case so order placement isn't done against a stale grid.
+        if not grid_just_built or fill_consumed_this_tick:
+            walked, deviation_pct, n_steps = self.grid.recenter_if_drifted(self.last_close)
+            if walked:
+                logger.info(
+                    '%s: Grid drift %.2f%% (N=%d steps) — recentering at %s',
+                    self.symbol, deviation_pct, n_steps, self.last_close,
+                )
 
         # Check and place orders for both directions
         intents.extend(self._check_and_place('long', limit_orders.get('long', [])))
@@ -180,6 +230,10 @@ class GridEngine:
         # Update grid based on fill
         if self.last_close is not None:
             self.grid.update_grid(self.last_filled_price, self.last_close)
+        else:
+            # Defer: no last_close yet, so update_grid would early-return.
+            # Consume on first ticker event.
+            self._fill_pending = True
 
         return []
 
@@ -269,10 +323,12 @@ class GridEngine:
             intents.extend(self._cancel_all_limits(limits, 'rebuild'))
             return intents
 
-        # Update grid if we have some fills
-        if 0 < len(limits) < self.grid.grid_count:
-            if self.last_filled_price is not None and self.last_close is not None:
-                self.grid.update_grid(self.last_filled_price, self.last_close)
+        # NOTE: Pre-0022 this path also called update_grid(last_filled_price,
+        # last_close) every tick. After 0022 added recenter_if_drifted on the
+        # tick path, that call would re-mark WAIT around a stale last_filled_price
+        # and undo recenter's side assignment, causing repeated walks on identical
+        # ticks. update_grid is now driven only by _handle_execution_event (where
+        # fills actually happen); recenter handles per-tick side assignment.
 
         # Place grid orders
         intents.extend(self._place_grid_orders(limits, direction))

--- a/packages/gridcore/src/gridcore/engine.py
+++ b/packages/gridcore/src/gridcore/engine.py
@@ -162,13 +162,17 @@ class GridEngine:
                 # path uses, so out-of-bounds rebuilds are observable through
                 # the same telemetry hook (per 0022 Step 3).
                 wait_center = self.grid.wait_center()
-                # No zero-guard on wait_center — same invariants as grid.py recenter_if_drifted (see comment there).
-                deviation_pct = abs(self.last_close - wait_center) / wait_center * 100
-                n_steps = int(deviation_pct / self.grid.grid_step) if self.grid.grid_step > 0 else 0
-                logger.info(
-                    '%s: Grid drift %.2f%% (N=%d steps) — recentering at %s',
-                    self.symbol, deviation_pct, n_steps, self.last_close,
-                )
+                if wait_center == 0:
+                    logger.warning(
+                        '%s: wait_center is zero, cannot calculate drift metrics',
+                        self.symbol,
+                    )
+                    deviation_pct = 0.0
+                    n_steps = 0
+                else:
+                    deviation_pct = abs(self.last_close - wait_center) / wait_center * 100
+                    n_steps = int(deviation_pct / self.grid.grid_step) if self.grid.grid_step > 0 else 0
+                self._log_drift(deviation_pct, n_steps, self.last_close)
                 logger.info(
                     '%s: Restored grid out of range (last_close=%s, range=[%s, %s]), rebuilding',
                     self.symbol, self.last_close, min_p, max_p,
@@ -202,16 +206,20 @@ class GridEngine:
         if not grid_just_built or fill_consumed_this_tick:
             walked, deviation_pct, n_steps = self.grid.recenter_if_drifted(self.last_close)
             if walked:
-                logger.info(
-                    '%s: Grid drift %.2f%% (N=%d steps) — recentering at %s',
-                    self.symbol, deviation_pct, n_steps, self.last_close,
-                )
+                self._log_drift(deviation_pct, n_steps, self.last_close)
 
         # Check and place orders for both directions
         intents.extend(self._check_and_place('long', limit_orders.get('long', [])))
         intents.extend(self._check_and_place('short', limit_orders.get('short', [])))
 
         return intents
+
+    def _log_drift(self, deviation_pct: float, n_steps: int, last_close: float) -> None:
+        """Log grid drift recentering event."""
+        logger.info(
+            '%s: Grid drift %.2f%% (N=%d steps) — recentering at %s',
+            self.symbol, deviation_pct, n_steps, last_close,
+        )
 
     def _handle_execution_event(self, event: ExecutionEvent) -> list[PlaceLimitIntent | CancelIntent]:
         """

--- a/packages/gridcore/src/gridcore/engine.py
+++ b/packages/gridcore/src/gridcore/engine.py
@@ -161,7 +161,7 @@ class GridEngine:
                 # Emit the same Grid-drift INFO line that recenter's safety-cap
                 # path uses, so out-of-bounds rebuilds are observable through
                 # the same telemetry hook (per 0022 Step 3).
-                wait_center = self.grid._wait_center()
+                wait_center = self.grid.wait_center()
                 # No zero-guard on wait_center — same invariants as grid.py recenter_if_drifted (see comment there).
                 deviation_pct = abs(self.last_close - wait_center) / wait_center * 100
                 n_steps = int(deviation_pct / self.grid.grid_step) if self.grid.grid_step > 0 else 0

--- a/packages/gridcore/src/gridcore/engine.py
+++ b/packages/gridcore/src/gridcore/engine.py
@@ -162,6 +162,7 @@ class GridEngine:
                 # path uses, so out-of-bounds rebuilds are observable through
                 # the same telemetry hook (per 0022 Step 3).
                 wait_center = self.grid._wait_center()
+                # No zero-guard on wait_center — same invariants as grid.py recenter_if_drifted (see comment there).
                 deviation_pct = abs(self.last_close - wait_center) / wait_center * 100
                 n_steps = int(deviation_pct / self.grid.grid_step) if self.grid.grid_step > 0 else 0
                 logger.info(

--- a/packages/gridcore/src/gridcore/grid.py
+++ b/packages/gridcore/src/gridcore/grid.py
@@ -265,7 +265,13 @@ class Grid:
 
     def wait_center(self) -> float:
         """Center price of the current WAIT band, with a median fallback when
-        no WAIT levels exist. Caller must guard against empty grid."""
+        no WAIT levels exist.
+
+        Raises:
+            ValueError: If called on an empty grid
+        """
+        if not self.grid:
+            raise ValueError("wait_center() called on empty grid")
         wait_prices = [g['price'] for g in self.grid if g['side'] == GridSideType.WAIT]
         if wait_prices:
             return (min(wait_prices) + max(wait_prices)) / 2
@@ -330,12 +336,16 @@ class Grid:
             return RecenterResult(False, 0.0, 0)
 
         wait_center = self.wait_center()
-        # No zero-guard: wait_center > 0 by invariants (positive traded prices, strictly-ascending sort, falsy last_close rejected by build_grid). Same in __is_too_close / _create_place_intent.
+        if wait_center == 0:
+            logger.warning('wait_center is zero, cannot calculate drift')
+            return RecenterResult(False, 0.0, 0)
         deviation_pct = abs(last_close - wait_center) / wait_center * 100
         if deviation_pct <= self.grid_step:
             return RecenterResult(False, deviation_pct, 0)
 
-        # No zero-guard on grid_step: GridConfig.__post_init__ enforces grid_step > 0.
+        if self.grid_step == 0:
+            logger.warning('grid_step is zero, cannot compute n_steps')
+            return RecenterResult(False, deviation_pct, 0)
         n_steps = int(deviation_pct / self.grid_step)
 
         if n_steps >= self.grid_count // 2:
@@ -408,7 +418,8 @@ class Grid:
         Returns:
             True if prices are within grid_step/4 of each other
         """
-        # No zero-guard: price1 > 0 by grid invariants (positive traded prices, strictly-ascending sort), grid_step > 0 enforced by GridConfig.__post_init__.
+        if price1 == 0 or self.grid_step == 0:
+            return False
         return abs(price1 - price2) / price1 * 100 < self.grid_step / 4
 
     def __is_price_sorted(self) -> bool:

--- a/packages/gridcore/src/gridcore/grid.py
+++ b/packages/gridcore/src/gridcore/grid.py
@@ -335,6 +335,7 @@ class Grid:
         if deviation_pct <= self.grid_step:
             return RecenterResult(False, deviation_pct, 0)
 
+        # No zero-guard on grid_step: GridConfig.__post_init__ enforces grid_step > 0.
         n_steps = int(deviation_pct / self.grid_step)
 
         if n_steps >= self.grid_count // 2:

--- a/packages/gridcore/src/gridcore/grid.py
+++ b/packages/gridcore/src/gridcore/grid.py
@@ -330,12 +330,7 @@ class Grid:
             return RecenterResult(False, 0.0, 0)
 
         wait_center = self._wait_center()
-        # Zero-division on `wait_center` is theoretically possible but ruled out
-        # in practice: build_grid() rejects falsy last_close, __is_price_sorted
-        # enforces strictly-ascending prices, and traded-symbol prices are
-        # always positive — so wait_center is always > 0. Same assumption holds
-        # for __is_too_close and _create_place_intent (engine.py); if a future
-        # change ever loosens those invariants, add a zero-guard here too.
+        # No zero-guard: wait_center > 0 by invariants (positive traded prices, strictly-ascending sort, falsy last_close rejected by build_grid). Same in __is_too_close / _create_place_intent.
         deviation_pct = abs(last_close - wait_center) / wait_center * 100
         if deviation_pct <= self.grid_step:
             return RecenterResult(False, deviation_pct, 0)

--- a/packages/gridcore/src/gridcore/grid.py
+++ b/packages/gridcore/src/gridcore/grid.py
@@ -199,9 +199,9 @@ class Grid:
 
         # Derive _original_anchor_price from the WAIT center so anchor_price
         # property continues to reflect a meaningful "center" value. Uses
-        # _wait_center() to keep the post-restore anchor consistent with the
+        # wait_center() to keep the post-restore anchor consistent with the
         # post-recenter-walk anchor (feature 0022, Step 5.5).
-        self._original_anchor_price = self._wait_center()
+        self._original_anchor_price = self.wait_center()
 
         return True
 
@@ -263,7 +263,7 @@ class Grid:
 
         self._notify_change()
 
-    def _wait_center(self) -> float:
+    def wait_center(self) -> float:
         """Center price of the current WAIT band, with a median fallback when
         no WAIT levels exist. Caller must guard against empty grid."""
         wait_prices = [g['price'] for g in self.grid if g['side'] == GridSideType.WAIT]
@@ -321,7 +321,7 @@ class Grid:
         a walk once cumulative drift from the current WAIT center exceeds the
         threshold.
 
-        Drift is measured against the current `_wait_center()` per plan Q1
+        Drift is measured against the current `wait_center()` per plan Q1
         (the detector self-adjusts as the grid walks or as `update_grid()`
         expands the WAIT band after a fill).
 
@@ -329,7 +329,7 @@ class Grid:
         if not self.grid:
             return RecenterResult(False, 0.0, 0)
 
-        wait_center = self._wait_center()
+        wait_center = self.wait_center()
         # No zero-guard: wait_center > 0 by invariants (positive traded prices, strictly-ascending sort, falsy last_close rejected by build_grid). Same in __is_too_close / _create_place_intent.
         deviation_pct = abs(last_close - wait_center) / wait_center * 100
         if deviation_pct <= self.grid_step:
@@ -347,7 +347,7 @@ class Grid:
         direction = 'up' if last_close > wait_center else 'down'
         self._shift_grid(n_steps, direction)
         self._assign_sides(last_close)
-        self._original_anchor_price = self._wait_center()
+        self._original_anchor_price = self.wait_center()
         self._notify_change()
         return RecenterResult(True, deviation_pct, n_steps)
 

--- a/packages/gridcore/src/gridcore/grid.py
+++ b/packages/gridcore/src/gridcore/grid.py
@@ -330,6 +330,12 @@ class Grid:
             return RecenterResult(False, 0.0, 0)
 
         wait_center = self._wait_center()
+        # Zero-division on `wait_center` is theoretically possible but ruled out
+        # in practice: build_grid() rejects falsy last_close, __is_price_sorted
+        # enforces strictly-ascending prices, and traded-symbol prices are
+        # always positive — so wait_center is always > 0. Same assumption holds
+        # for __is_too_close and _create_place_intent (engine.py); if a future
+        # change ever loosens those invariants, add a zero-guard here too.
         deviation_pct = abs(last_close - wait_center) / wait_center * 100
         if deviation_pct <= self.grid_step:
             return RecenterResult(False, deviation_pct, 0)

--- a/packages/gridcore/src/gridcore/grid.py
+++ b/packages/gridcore/src/gridcore/grid.py
@@ -408,6 +408,7 @@ class Grid:
         Returns:
             True if prices are within grid_step/4 of each other
         """
+        # No zero-guard: price1 > 0 by grid invariants (positive traded prices, strictly-ascending sort), grid_step > 0 enforced by GridConfig.__post_init__.
         return abs(price1 - price2) / price1 * 100 < self.grid_step / 4
 
     def __is_price_sorted(self) -> bool:

--- a/packages/gridcore/src/gridcore/grid.py
+++ b/packages/gridcore/src/gridcore/grid.py
@@ -12,7 +12,7 @@ Extracted from bbu2-master/greed.py with the following key transformations:
 import logging
 from decimal import Decimal
 from enum import StrEnum
-from typing import Callable, Optional
+from typing import Callable, NamedTuple, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +22,19 @@ class GridSideType(StrEnum):
     BUY = 'Buy'
     SELL = 'Sell'
     WAIT = 'Wait'
+
+
+class RecenterResult(NamedTuple):
+    """Outcome of a recenter_if_drifted() call.
+
+    Truthy when (and only when) the grid was actually mutated. Tuple-compatible
+    so callers can also destructure as `walked, dev, n = grid.recenter_if_drifted(...)`."""
+    walked: bool
+    deviation_pct: float
+    n_steps: int
+
+    def __bool__(self) -> bool:
+        return self.walked
 
 
 class Grid:
@@ -185,13 +198,10 @@ class Grid:
             return False
 
         # Derive _original_anchor_price from the WAIT center so anchor_price
-        # property continues to reflect a meaningful "center" value.
-        wait_indices = [i for i, g in enumerate(self.grid) if g['side'] == GridSideType.WAIT]
-        if wait_indices:
-            center = (wait_indices[0] + wait_indices[-1]) // 2
-        else:
-            center = len(self.grid) // 2
-        self._original_anchor_price = self.grid[center]['price']
+        # property continues to reflect a meaningful "center" value. Uses
+        # _wait_center() to keep the post-restore anchor consistent with the
+        # post-recenter-walk anchor (feature 0022, Step 5.5).
+        self._original_anchor_price = self._wait_center()
 
         return True
 
@@ -247,18 +257,97 @@ class Grid:
             self.__rebuild_grid(last_close)
             # Continue to apply side assignment logic after rebuild (matches original behavior)
 
-        # Update grid sides
-        for grid in self.grid:
-            if self.__is_too_close(grid['price'], last_filled_price):
-                grid['side'] = GridSideType.WAIT
-            elif last_close < grid['price']:
-                grid['side'] = GridSideType.SELL
-            elif last_close > grid['price']:
-                grid['side'] = GridSideType.BUY
+        self._assign_sides(last_close, fill_price=last_filled_price)
 
         self.__center_grid()
 
         self._notify_change()
+
+    def _wait_center(self) -> float:
+        """Center price of the current WAIT band, with a median fallback when
+        no WAIT levels exist. Caller must guard against empty grid."""
+        wait_prices = [g['price'] for g in self.grid if g['side'] == GridSideType.WAIT]
+        if wait_prices:
+            return (min(wait_prices) + max(wait_prices)) / 2
+        n = len(self.grid)
+        if n % 2 == 0:
+            return (self.grid[n // 2 - 1]['price'] + self.grid[n // 2]['price']) / 2
+        return self.grid[n // 2]['price']
+
+    def _assign_sides(self, last_close: float, *, fill_price: Optional[float] = None) -> None:
+        """Assign side (BUY/SELL/WAIT) to every level relative to last_close.
+
+        WAIT marking uses __is_too_close against fill_price when given (post-fill
+        path used by update_grid), or against last_close otherwise (drift-recenter
+        path used by recenter_if_drifted)."""
+        too_close_ref = fill_price if fill_price is not None else last_close
+        for level in self.grid:
+            if self.__is_too_close(level['price'], too_close_ref):
+                level['side'] = GridSideType.WAIT
+            elif last_close < level['price']:
+                level['side'] = GridSideType.SELL
+            elif last_close > level['price']:
+                level['side'] = GridSideType.BUY
+
+    def _shift_grid(self, n_steps: int, direction: str) -> None:
+        """Walk the grid by n_steps levels. Side placeholder is not meaningful;
+        the caller must follow up with _assign_sides()."""
+        step = self.grid_step / 100
+        if direction == 'up':
+            for _ in range(n_steps):
+                self.grid.pop(0)
+                new_top = self._round_price(self.grid[-1]['price'] * (1 + step))
+                self.grid.append({'side': GridSideType.SELL, 'price': new_top})
+        elif direction == 'down':
+            for _ in range(n_steps):
+                self.grid.pop()
+                new_bot = self._round_price(self.grid[0]['price'] * (1 - step))
+                self.grid.insert(0, {'side': GridSideType.BUY, 'price': new_bot})
+        else:
+            raise ValueError(f"direction must be 'up' or 'down', got {direction!r}")
+
+    def recenter_if_drifted(self, last_close: float) -> RecenterResult:
+        """Per-tick drift detector: walk the grid by N steps toward last_close
+        when it has moved more than one grid_step from the current WAIT-band
+        center. Falls back to a full rebuild when N >= grid_count // 2.
+
+        Independent of last_filled_price, so it fires on cold restart and after
+        WS reconnect even before the first fill of the session.
+
+        Below-threshold ticks are TRUE no-ops: no side reassignment, no anchor
+        update. This preserves the plan's Step 2 contract and prevents the
+        WAIT band from silently migrating when last_close drifts within one
+        grid_step per tick — a sequence of sub-step ticks must still trigger
+        a walk once cumulative drift from the current WAIT center exceeds the
+        threshold.
+
+        Drift is measured against the current `_wait_center()` per plan Q1
+        (the detector self-adjusts as the grid walks or as `update_grid()`
+        expands the WAIT band after a fill).
+
+        Returns a RecenterResult that is truthy only when the grid was mutated."""
+        if not self.grid:
+            return RecenterResult(False, 0.0, 0)
+
+        wait_center = self._wait_center()
+        deviation_pct = abs(last_close - wait_center) / wait_center * 100
+        if deviation_pct <= self.grid_step:
+            return RecenterResult(False, deviation_pct, 0)
+
+        n_steps = int(deviation_pct / self.grid_step)
+
+        if n_steps >= self.grid_count // 2:
+            # Walk would push the entire grid past one side — rebuild instead.
+            self.__rebuild_grid(last_close)
+            # __rebuild_grid -> build_grid already fires _notify_change.
+            return RecenterResult(True, deviation_pct, n_steps)
+
+        direction = 'up' if last_close > wait_center else 'down'
+        self._shift_grid(n_steps, direction)
+        self._assign_sides(last_close)
+        self._original_anchor_price = self._wait_center()
+        self._notify_change()
+        return RecenterResult(True, deviation_pct, n_steps)
 
     def __center_grid(self) -> None:
         """
@@ -456,11 +545,13 @@ class Grid:
         """
         Get anchor price (WAIT zone center price).
 
-        The anchor price is the price around which the grid was built.
-        This is the original center WAIT zone price, not any WAIT zones
-        created after order fills.
+        Tracks the build-time center until a drift walk updates it: a fill via
+        `update_grid` does NOT mutate the anchor (post-fill WAIT marks are not
+        reflected here), but `recenter_if_drifted` DOES re-seed it to the new
+        WAIT-band center after an incremental walk (feature 0022, Step 5.5).
+        On `restore_grid`, the anchor is derived from the restored WAIT center.
 
         Returns:
-            The original WAIT zone center price, or None if grid was never built
+            Current anchor price, or None if grid was never built
         """
         return self._original_anchor_price

--- a/packages/gridcore/tests/test_engine.py
+++ b/packages/gridcore/tests/test_engine.py
@@ -1606,6 +1606,32 @@ class TestRecenterIntegration:
         filled_level = next(g for g in engine.grid.grid if g['price'] == 99.0)
         assert filled_level['side'] == GridSideType.WAIT
 
+    def test_bounds_rebuild_handles_zero_wait_center(self, caplog):
+        """Defensive: if the bounds-guard rebuild path encounters wait_center==0
+        (degenerate restored grid), it must emit a WARNING and the consolidated
+        drift INFO line with deterministic zeros — and proceed to rebuild."""
+        config = GridConfig(grid_count=10, grid_step=1.0)
+        # Build a symmetric ±X grid where wait_center() returns 0. This needs to
+        # both (a) make wait_center == 0 and (b) trigger the bounds-guard so
+        # last_close is OUTSIDE [min_grid, max_grid] (last_close > 1.0 here).
+        engine = GridEngine(
+            symbol='BTCUSDT',
+            tick_size=Decimal('0.01'),
+            config=config,
+            strat_id='btcusdt_test',
+        )
+        engine.grid.grid = [
+            {'side': GridSideType.WAIT, 'price': -1.0},
+            {'side': GridSideType.WAIT, 'price': 1.0},
+        ]
+
+        with caplog.at_level('WARNING'):
+            engine.on_event(self._ticker(100.0), {'long': [], 'short': []})
+
+        assert any('wait_center is zero' in r.message for r in caplog.records)
+        # Rebuild still happens — anchor lands at last_close.
+        assert engine.grid.anchor_price == 100.0
+
     def test_fresh_build_with_consumed_fill_runs_recenter(self, caplog):
         """If a pending fill consumed on the same tick as build_grid shifts
         the WAIT band far enough from last_close to exceed one grid_step,

--- a/packages/gridcore/tests/test_engine.py
+++ b/packages/gridcore/tests/test_engine.py
@@ -914,22 +914,23 @@ class TestAnchorPricePersistence:
         }
         engine.on_event(ticker_after_fill, existing_limits)
 
-        # Verify anchor_price still returns original center (100k), not filled price (99800)
+        # Verify anchor_price still returns original center (100k), not filled price (99800).
+        # The drift between last_close (99850) and original anchor (100000) is below
+        # one grid_step, so recenter does not walk and anchor stays put.
         anchor_after_fill = engine.get_anchor_price()
         assert anchor_after_fill == 100000.0, \
             f"Expected anchor_price to remain 100000.0 after fill, got {anchor_after_fill}"
 
-        # Only the filled level should be WAIT (price moved away from original center)
-        wait_items = [g for g in engine.grid.grid if g['side'] == GridSideType.WAIT]
-        assert len(wait_items) == 1, \
-            f"Should have only 1 WAIT item (filled level), got {len(wait_items)}: {[g['price'] for g in wait_items]}"
-        assert wait_items[0]['price'] == 99800.0, \
-            f"WAIT should be at filled price 99800, got {wait_items[0]['price']}"
-
-        # Original center should now be SELL (since price 99850 < 100000)
-        center_after_fill = next(g for g in engine.grid.grid if g['price'] == 100000.0)
-        assert center_after_fill['side'] == GridSideType.SELL, \
-            f"Original center should be SELL after price moved below it, got {center_after_fill['side']}"
+        # Filled level is marked WAIT by update_grid post-fill.
+        filled_level = next(g for g in engine.grid.grid if g['price'] == 99800.0)
+        assert filled_level['side'] == GridSideType.WAIT, \
+            f"Filled level should be WAIT, got {filled_level['side']}"
+        # Note: pre-0022 the per-tick update_grid call in _check_and_place would
+        # have reassigned the original center 100000.0 from WAIT to SELL on the
+        # ticker after the fill. Post-0022 below-threshold ticks are true no-ops
+        # (Step 2), so 100000.0 retains its build-time WAIT status until a walk
+        # rewrites the grid. This is by design — drift is measured against the
+        # persisted anchor, and side reassignment only happens on walks.
 
 
 class TestRestoredGrid:
@@ -1066,7 +1067,9 @@ class TestRestoredGrid:
             strat_id='btcusdt_test',
             restored_grid=restored,
         )
-        engine.on_event(self._ticker(100.5), {'long': [], 'short': []})
+        # Price within grid_step of WAIT center → neither bounds-based drift
+        # guard NOR feature-0022 recenter fires.
+        engine.on_event(self._ticker(100.1), {'long': [], 'short': []})
 
         prices = [g['price'] for g in engine.grid.grid]
         assert prices == [99.0, 99.5, 100.0, 100.5, 101.0]
@@ -1358,3 +1361,346 @@ class TestReduceOnlyMap:
                 f"direction={intent.direction}, side={intent.side}: "
                 f"expected reduce_only={expected}, got {intent.reduce_only}"
             )
+
+
+class TestRecenterIntegration:
+    """Engine-level tests for feature 0022 (per-tick grid drift detector)."""
+
+    def _ticker(self, price: float) -> TickerEvent:
+        return TickerEvent(
+            event_type=EventType.TICKER,
+            symbol='BTCUSDT',
+            exchange_ts=datetime.now(UTC),
+            local_ts=datetime.now(UTC),
+            last_price=Decimal(str(price)),
+            mark_price=Decimal(str(price)),
+            bid1_price=Decimal(str(price - 0.01)),
+            ask1_price=Decimal(str(price + 0.01)),
+            funding_rate=Decimal('0.0001'),
+        )
+
+    def _restored_grid_around_100(self) -> list[dict]:
+        """11-level grid centered at 100 with 1.0% step:
+        BUY 95..99, WAIT 100, SELL 101..105."""
+        return [
+            {'side': 'Buy', 'price': 95.0},
+            {'side': 'Buy', 'price': 96.0},
+            {'side': 'Buy', 'price': 97.0},
+            {'side': 'Buy', 'price': 98.0},
+            {'side': 'Buy', 'price': 99.0},
+            {'side': 'Wait', 'price': 100.0},
+            {'side': 'Sell', 'price': 101.0},
+            {'side': 'Sell', 'price': 102.0},
+            {'side': 'Sell', 'price': 103.0},
+            {'side': 'Sell', 'price': 104.0},
+            {'side': 'Sell', 'price': 105.0},
+        ]
+
+    def _make_engine(self, restored=True):
+        config = GridConfig(grid_count=10, grid_step=1.0)
+        kwargs = {
+            'symbol': 'BTCUSDT',
+            'tick_size': Decimal('0.01'),
+            'config': config,
+            'strat_id': 'btcusdt_test',
+        }
+        if restored:
+            kwargs['restored_grid'] = self._restored_grid_around_100()
+        return GridEngine(**kwargs)
+
+    def test_cold_start_drift_walks_grid(self, caplog):
+        """Restored grid centered at 100, ticker at 103.5 (within bounds, dev=3.5% > 1*step).
+        Expected n_steps = 3."""
+        engine = self._make_engine()
+        with caplog.at_level('INFO'):
+            engine.on_event(self._ticker(103.5), {'long': [], 'short': []})
+
+        # Grid walked: bottom three BUYs dropped, three SELLs added on top.
+        prices = [g['price'] for g in engine.grid.grid]
+        assert 95.0 not in prices
+        assert 96.0 not in prices
+        assert 97.0 not in prices
+        # Length preserved
+        assert len(prices) == 11
+        # New top is roughly 105 * (1.01)^3 ≈ 108.18 (after rounding)
+        assert prices[-1] > 105.0
+
+        drift_logs = [r.message for r in caplog.records if 'Grid drift' in r.message]
+        assert len(drift_logs) == 1
+        assert 'N=3' in drift_logs[0]
+        assert 'BTCUSDT' in drift_logs[0]
+
+    def test_mid_run_fast_move_recenters_in_one_tick(self, caplog):
+        """3 * grid_step jump triggers an N=3 walk in a single tick."""
+        engine = self._make_engine()
+        # Warm up with an in-band ticker first (no drift)
+        engine.on_event(self._ticker(100.2), {'long': [], 'short': []})
+        caplog.clear()
+        # Now jump 3% above WAIT center
+        with caplog.at_level('INFO'):
+            engine.on_event(self._ticker(103.2), {'long': [], 'short': []})
+
+        drift_logs = [r.message for r in caplog.records if 'Grid drift' in r.message]
+        assert len(drift_logs) == 1
+        assert 'N=3' in drift_logs[0]
+
+    def test_idempotent_no_second_walk(self, caplog):
+        """Two ticker events with the same last_close → only one walk."""
+        engine = self._make_engine()
+        with caplog.at_level('INFO'):
+            engine.on_event(self._ticker(103.5), {'long': [], 'short': []})
+            engine.on_event(self._ticker(103.5), {'long': [], 'short': []})
+        drift_logs = [r.message for r in caplog.records if 'Grid drift' in r.message]
+        assert len(drift_logs) == 1
+
+    def test_below_threshold_does_not_walk(self, caplog):
+        """Deviation = 0.5 * grid_step → no recenter, no log line."""
+        engine = self._make_engine()
+        with caplog.at_level('INFO'):
+            engine.on_event(self._ticker(100.5), {'long': [], 'short': []})
+        drift_logs = [r.message for r in caplog.records if 'Grid drift' in r.message]
+        assert drift_logs == []
+        # Grid prices unchanged
+        prices = [g['price'] for g in engine.grid.grid]
+        assert prices == [g['price'] for g in self._restored_grid_around_100()]
+
+    def test_below_threshold_does_not_migrate_wait_band(self):
+        """Sub-step drift must NOT migrate the WAIT band — that would let
+        cumulative drift hide indefinitely. Below-threshold ticks are true
+        no-ops: prices AND sides unchanged."""
+        engine = self._make_engine()
+        original_grid = self._restored_grid_around_100()
+        # Drift 0.9% (< 1.0 grid_step) — should be no-op
+        engine.on_event(self._ticker(100.9), {'long': [], 'short': []})
+
+        for actual, expected in zip(engine.grid.grid, original_grid):
+            assert actual['price'] == expected['price']
+            # Side must match restored (no migration of WAIT mark)
+            assert str(actual['side']) == expected['side'], (
+                f"side at {actual['price']} migrated: "
+                f"expected {expected['side']}, got {actual['side']}"
+            )
+
+    def test_cumulative_sub_step_drift_eventually_walks(self, caplog):
+        """A sequence of below-threshold ticks must eventually trigger a walk
+        once cumulative drift from the persisted anchor exceeds grid_step."""
+        engine = self._make_engine()
+        with caplog.at_level('INFO'):
+            for price in [100.5, 100.9, 100.99]:
+                engine.on_event(self._ticker(price), {'long': [], 'short': []})
+            drift_logs = [r.message for r in caplog.records if 'Grid drift' in r.message]
+            assert drift_logs == [], "no walk expected yet (all sub-step)"
+            # Now cross the threshold against fixed anchor=100
+            engine.on_event(self._ticker(101.5), {'long': [], 'short': []})
+
+        drift_logs = [r.message for r in caplog.records if 'Grid drift' in r.message]
+        assert len(drift_logs) == 1, f"expected exactly one walk, got {drift_logs}"
+
+    def test_fill_before_first_ticker_is_consumed_once(self):
+        """ExecutionEvent that arrives before any TickerEvent (last_close=None)
+        must be applied on the first ticker. Pre-0022 the per-tick update_grid
+        in _check_and_place would always re-apply it; post-0022 we use a
+        _fill_pending flag for one-shot consumption."""
+        engine = self._make_engine()
+        # Fill arrives before any ticker — last_close is still None.
+        fill_event = ExecutionEvent(
+            event_type=EventType.EXECUTION,
+            symbol='BTCUSDT',
+            exchange_ts=datetime.now(UTC),
+            local_ts=datetime.now(UTC),
+            price=Decimal('99.0'),
+            qty=Decimal('0.01'),
+            side='Buy',
+        )
+        engine.on_event(fill_event)
+        assert engine._fill_pending is True
+
+        # First ticker — must consume the pending fill exactly once.
+        engine.on_event(self._ticker(100.0), {'long': [], 'short': []})
+        assert engine._fill_pending is False
+        # Filled level (99) is WAIT; level 100 is still the anchor (WAIT from build).
+        filled_level = next(g for g in engine.grid.grid if g['price'] == 99.0)
+        assert filled_level['side'] == GridSideType.WAIT
+
+    def test_recenter_result_truthy_only_on_walk(self):
+        """RecenterResult must be falsy on no-op so callers using
+        `if grid.recenter_if_drifted(...):` see only real walks."""
+        engine = self._make_engine()
+        result_no_walk = engine.grid.recenter_if_drifted(100.5)
+        assert bool(result_no_walk) is False
+        result_walk = engine.grid.recenter_if_drifted(103.5)
+        assert bool(result_walk) is True
+
+    def test_drift_measured_against_current_wait_band_after_fill(self, caplog):
+        """Plan Q1: drift reference is the CURRENT WAIT band, not the original
+        anchor. After a fill expands the WAIT band, recenter must measure
+        against the new wait_center so a tick that crosses one grid_step from
+        the new center triggers a walk even when it would not have crossed
+        from the original anchor."""
+        config = GridConfig(grid_count=10, grid_step=1.0)
+        engine = GridEngine(
+            symbol='BTCUSDT',
+            tick_size=Decimal('0.01'),
+            config=config,
+            strat_id='btcusdt_test',
+        )
+        # Build at 100.0; original anchor and wait_center both = 100.0.
+        engine.on_event(self._ticker(100.0), {'long': [], 'short': []})
+        assert engine.grid.anchor_price == 100.0
+
+        # Fill at 99.0 (last_close still 100.0 at fill time). update_grid
+        # marks 99.0 as WAIT and the equality keeps 100.0 as WAIT, so the
+        # WAIT band becomes [99.0, 100.0] and wait_center becomes 99.5.
+        fill = ExecutionEvent(
+            event_type=EventType.EXECUTION,
+            symbol='BTCUSDT',
+            exchange_ts=datetime.now(UTC),
+            local_ts=datetime.now(UTC),
+            price=Decimal('99.0'),
+            qty=Decimal('0.01'),
+            side='Buy',
+        )
+        engine.on_event(fill)
+
+        # last_close = 100.6:
+        #   - drift from anchor=100.0: 0.6% → would NOT walk if anchor was the reference
+        #   - drift from wait_center=99.5: ≈1.106% > 1% → MUST walk per plan
+        with caplog.at_level('INFO'):
+            engine.on_event(self._ticker(100.6), {'long': [], 'short': []})
+
+        drift_logs = [r.message for r in caplog.records if 'Grid drift' in r.message]
+        assert len(drift_logs) == 1, (
+            f"expected one walk (drift > 1*step from current WAIT center 99.5), "
+            f"got {drift_logs}"
+        )
+
+    def test_fill_before_first_ticker_with_empty_grid(self):
+        """P2: pending fill must be consumed on the first ticker that builds
+        the grid (empty-engine path). Pre-fix the consume gate was skipped on
+        grid_just_built=True ticks, leaving the fill stranded for one cycle."""
+        config = GridConfig(grid_count=10, grid_step=1.0)
+        engine = GridEngine(
+            symbol='BTCUSDT',
+            tick_size=Decimal('0.01'),
+            config=config,
+            strat_id='btcusdt_test',
+        )
+        # No restored_grid, no anchor — engine starts truly empty.
+        assert len(engine.grid.grid) == 0
+
+        fill = ExecutionEvent(
+            event_type=EventType.EXECUTION,
+            symbol='BTCUSDT',
+            exchange_ts=datetime.now(UTC),
+            local_ts=datetime.now(UTC),
+            price=Decimal('99.0'),
+            qty=Decimal('0.01'),
+            side='Buy',
+        )
+        engine.on_event(fill)
+        assert engine._fill_pending is True
+
+        # First ticker builds the grid AND consumes the pending fill.
+        engine.on_event(self._ticker(100.0), {'long': [], 'short': []})
+        assert engine._fill_pending is False, "pending fill must be consumed on first build tick"
+        filled_level = next(g for g in engine.grid.grid if g['price'] == 99.0)
+        assert filled_level['side'] == GridSideType.WAIT
+
+    def test_fresh_build_with_consumed_fill_runs_recenter(self, caplog):
+        """If a pending fill consumed on the same tick as build_grid shifts
+        the WAIT band far enough from last_close to exceed one grid_step,
+        recenter must run before order placement instead of being skipped
+        by the grid_just_built guard."""
+        config = GridConfig(grid_count=10, grid_step=1.0)
+        engine = GridEngine(
+            symbol='BTCUSDT',
+            tick_size=Decimal('0.01'),
+            config=config,
+            strat_id='btcusdt_test',
+        )
+
+        # Fill at 98.01 — this is a grid level 2 steps below the build anchor
+        # (100 * 0.99^2 = 98.01). After build at 100 and post-fill update_grid,
+        # WAIT band becomes [98.01, 100.0] → wait_center=99.005. Deviation
+        # |100 - 99.005| / 99.005 ≈ 1.005% > 1*grid_step → walk should fire.
+        fill = ExecutionEvent(
+            event_type=EventType.EXECUTION,
+            symbol='BTCUSDT',
+            exchange_ts=datetime.now(UTC),
+            local_ts=datetime.now(UTC),
+            price=Decimal('98.01'),
+            qty=Decimal('0.01'),
+            side='Buy',
+        )
+        engine.on_event(fill)
+        assert engine._fill_pending is True
+
+        with caplog.at_level('INFO'):
+            engine.on_event(self._ticker(100.0), {'long': [], 'short': []})
+
+        drift_logs = [r.message for r in caplog.records if 'Grid drift' in r.message]
+        assert len(drift_logs) == 1, (
+            "fresh-build tick that consumed a pending fill must still run recenter "
+            "when the post-fill WAIT center diverges from last_close beyond one step; "
+            f"got {drift_logs}"
+        )
+
+    def test_stale_fill_does_not_cause_repeated_walks(self, caplog):
+        """P1 regression: a stale last_filled_price + existing limits used to
+        cause _check_and_place's update_grid to overwrite recenter's WAIT
+        assignment, so two identical ticks each triggered a fresh walk.
+        After fix, a stale fill must not re-trigger the walk on the second
+        identical ticker."""
+        engine = self._make_engine()
+        # Stale fill from a prior session — last_filled_price set, no fresh fill.
+        engine.last_filled_price = 99.0
+        existing_limits = {
+            'long': [{'orderId': '1', 'price': '99.0', 'side': 'Buy'}],
+            'short': [],
+        }
+        with caplog.at_level('INFO'):
+            engine.on_event(self._ticker(103.5), existing_limits)
+            grid_after_first = [g['price'] for g in engine.grid.grid]
+            engine.on_event(self._ticker(103.5), existing_limits)
+            grid_after_second = [g['price'] for g in engine.grid.grid]
+
+        drift_logs = [r.message for r in caplog.records if 'Grid drift' in r.message]
+        assert len(drift_logs) == 1, f"expected 1 drift log, got {len(drift_logs)}: {drift_logs}"
+        assert grid_after_first == grid_after_second, "second identical ticker must not mutate grid"
+
+    def test_out_of_bounds_rebuild_emits_drift_log(self, caplog):
+        """P3: when the bounds-guard rebuilds at last_close because price is
+        outside the restored grid, the planned 'Grid drift ... N=...' INFO line
+        is emitted alongside the existing 'Restored grid out of range' line."""
+        engine = self._make_engine()
+        # 200 is far outside the restored grid [95..105].
+        with caplog.at_level('INFO'):
+            engine.on_event(self._ticker(200.0), {'long': [], 'short': []})
+
+        msgs = [r.message for r in caplog.records]
+        assert any('Grid drift' in m and 'N=' in m for m in msgs)
+        assert any('Restored grid out of range' in m for m in msgs)
+        assert engine.grid.anchor_price == 200.0
+
+    def test_full_rebuild_fallback_via_engine(self, caplog):
+        """deviation that yields n_steps >= grid_count // 2 → full rebuild via fallback.
+        With grid_count=10, threshold = 5. A 6% deviation (last_close=106 inside bounds
+        of [95..105]? No — 106 is outside max, would trigger engine's own out-of-bounds
+        rebuild. Use a wider grid for this case."""
+        # Use grid_count=10 still but pick last_close close to upper bound but inside.
+        engine = self._make_engine()
+        # last_close = 104.99 → deviation ≈ 4.99% → n_steps = 4 → walk path (NOT fallback).
+        # Need n_steps >= 5 while staying in [95, 105]. With 1% step and centre=100,
+        # max in-bounds last_close ≈ 105 → max deviation ≈ 5%. n_steps = int(5/1) = 5,
+        # which equals grid_count // 2 = 5 → fallback triggers.
+        # Use last_close = 105.0 exactly (still inside bounds inclusive).
+        with caplog.at_level('INFO'):
+            engine.on_event(self._ticker(105.0), {'long': [], 'short': []})
+
+        drift_logs = [r.message for r in caplog.records if 'Grid drift' in r.message]
+        assert len(drift_logs) == 1
+        # Grid is fully rebuilt around 105.0 — anchor must equal 105.0.
+        assert engine.grid.anchor_price == 105.0
+        # Original prices like 95.0, 96.0 should not survive the rebuild.
+        prices = [g['price'] for g in engine.grid.grid]
+        assert 95.0 not in prices

--- a/packages/gridcore/tests/test_grid.py
+++ b/packages/gridcore/tests/test_grid.py
@@ -706,3 +706,191 @@ class TestGridMinMaxAccessors:
             _ = grid.min_grid
         with pytest.raises(ValueError):
             _ = grid.max_grid
+
+
+class TestWaitCenter:
+    """Tests for Grid._wait_center()."""
+
+    def test_single_wait_level_returns_its_price(self):
+        grid = Grid(tick_size=Decimal('0.01'), grid_count=10, grid_step=1.0)
+        grid.build_grid(100.0)
+        # build_grid produces exactly one WAIT level
+        assert grid._wait_center() == 100.0
+
+    def test_multi_wait_band_returns_midpoint(self):
+        grid = Grid(tick_size=Decimal('0.01'), grid_count=10, grid_step=1.0)
+        grid.build_grid(100.0)
+        # Manually expand the WAIT band: relabel a few levels around center as WAIT
+        center_idx = next(i for i, g in enumerate(grid.grid) if g['side'] == GridSideType.WAIT)
+        grid.grid[center_idx - 1]['side'] = GridSideType.WAIT
+        grid.grid[center_idx + 1]['side'] = GridSideType.WAIT
+        wait_prices = [g['price'] for g in grid.grid if g['side'] == GridSideType.WAIT]
+        expected = (min(wait_prices) + max(wait_prices)) / 2
+        assert grid._wait_center() == expected
+
+    def test_zero_wait_even_length_uses_mean_of_two_middles(self):
+        grid = Grid(tick_size=Decimal('0.01'), grid_count=10, grid_step=1.0)
+        grid.build_grid(100.0)
+        # Force even length
+        grid.grid.pop()
+        # Strip every WAIT mark
+        for level in grid.grid:
+            if level['side'] == GridSideType.WAIT:
+                level['side'] = GridSideType.BUY
+        n = len(grid.grid)
+        assert n % 2 == 0
+        expected = (grid.grid[n // 2 - 1]['price'] + grid.grid[n // 2]['price']) / 2
+        assert grid._wait_center() == expected
+
+    def test_zero_wait_odd_length_uses_single_middle(self):
+        grid = Grid(tick_size=Decimal('0.01'), grid_count=10, grid_step=1.0)
+        grid.build_grid(100.0)
+        n = len(grid.grid)
+        assert n % 2 == 1  # build_grid yields 11 levels for grid_count=10
+        for level in grid.grid:
+            if level['side'] == GridSideType.WAIT:
+                level['side'] = GridSideType.BUY
+        assert grid._wait_center() == grid.grid[n // 2]['price']
+
+
+class TestRecenterIfDrifted:
+    """Tests for Grid.recenter_if_drifted (feature 0022)."""
+
+    def _make_grid(self, anchor=100.0, grid_count=20, grid_step=1.0):
+        grid = Grid(tick_size=Decimal('0.01'), grid_count=grid_count, grid_step=grid_step)
+        grid.build_grid(anchor)
+        return grid
+
+    def test_no_action_when_grid_empty(self):
+        grid = Grid(tick_size=Decimal('0.01'), grid_count=10, grid_step=1.0)
+        walked, dev, n = grid.recenter_if_drifted(100.0)
+        assert walked is False
+        assert n == 0
+
+    def test_no_action_when_deviation_below_grid_step(self):
+        grid = self._make_grid(anchor=100.0, grid_step=1.0)
+        # 0.5% deviation < 1.0% grid_step
+        walked, dev, n = grid.recenter_if_drifted(100.5)
+        assert walked is False
+        assert n == 0
+        assert dev < 1.0
+
+    def test_no_action_at_exact_grid_step(self):
+        grid = self._make_grid(anchor=100.0, grid_step=1.0)
+        # exactly at threshold; trigger uses '>', not '>='
+        walked, dev, n = grid.recenter_if_drifted(101.0)
+        assert walked is False
+        assert n == 0
+
+    def test_walks_n_steps_up_when_price_above_band(self):
+        grid = self._make_grid(anchor=100.0, grid_count=20, grid_step=1.0)
+        original_min = grid.grid[0]['price']
+        original_max = grid.grid[-1]['price']
+        original_len = len(grid.grid)
+        # 3.5% deviation → n_steps = 3
+        walked, dev, n = grid.recenter_if_drifted(103.5)
+        assert walked is True
+        assert n == 3
+        assert len(grid.grid) == original_len  # length preserved
+        assert grid.grid[0]['price'] > original_min  # bottom raised
+        assert grid.grid[-1]['price'] > original_max  # top raised
+
+    def test_walks_n_steps_down_when_price_below_band(self):
+        grid = self._make_grid(anchor=100.0, grid_count=20, grid_step=1.0)
+        original_min = grid.grid[0]['price']
+        original_max = grid.grid[-1]['price']
+        original_len = len(grid.grid)
+        # -2.5% deviation → n_steps = 2 (deviation_pct ≈ 2.439, floor = 2)
+        walked, dev, n = grid.recenter_if_drifted(97.5)
+        assert walked is True
+        assert n == 2
+        assert len(grid.grid) == original_len
+        assert grid.grid[0]['price'] < original_min
+        assert grid.grid[-1]['price'] < original_max
+
+    def test_round_trip_outside_walked_region(self):
+        """Walk-up by N: levels at indices [0..len-N-1] post-walk == levels at [N..len-1] pre-walk."""
+        grid = self._make_grid(anchor=100.0, grid_count=20, grid_step=1.0)
+        pre_prices = [g['price'] for g in grid.grid]
+        walked, _, n = grid.recenter_if_drifted(103.5)
+        assert walked is True
+        post_prices = [g['price'] for g in grid.grid]
+        assert post_prices[: len(pre_prices) - n] == pre_prices[n:]
+
+    def test_full_rebuild_fallback_when_n_steps_exceeds_half(self):
+        grid = self._make_grid(anchor=100.0, grid_count=20, grid_step=1.0)
+        original_prices = {g['price'] for g in grid.grid}
+        # 15% deviation → n_steps = 15 > grid_count // 2 = 10 → fallback
+        walked, dev, n = grid.recenter_if_drifted(115.0)
+        assert walked is True
+        assert n >= grid.grid_count // 2
+        # Grid is rebuilt around 115.0; very few (if any) shared prices with original
+        new_prices = {g['price'] for g in grid.grid}
+        # Rebuilt grid is centered far from original — bulk of prices differ.
+        overlap = original_prices & new_prices
+        assert len(overlap) <= 1
+
+    def test_anchor_updated_to_wait_center_after_walk(self):
+        grid = self._make_grid(anchor=100.0, grid_count=20, grid_step=1.0)
+        walked, _, _ = grid.recenter_if_drifted(103.5)
+        assert walked is True
+        # _original_anchor_price should now equal new wait_center (close to 103.5)
+        assert grid._original_anchor_price == grid._wait_center()
+        assert abs(grid._original_anchor_price - 103.5) < 1.0
+
+    def test_assign_sides_post_walk(self):
+        grid = self._make_grid(anchor=100.0, grid_count=20, grid_step=1.0)
+        walked, _, _ = grid.recenter_if_drifted(103.5)
+        assert walked is True
+        last_close = 103.5
+        for level in grid.grid:
+            diff_pct = abs(level['price'] - last_close) / level['price'] * 100
+            if diff_pct < grid.grid_step / 4:
+                assert level['side'] == GridSideType.WAIT
+            elif level['price'] > last_close:
+                assert level['side'] == GridSideType.SELL
+            elif level['price'] < last_close:
+                assert level['side'] == GridSideType.BUY
+
+    def test_notify_change_called_on_walk(self):
+        calls = []
+        grid = Grid(
+            tick_size=Decimal('0.01'),
+            grid_count=20,
+            grid_step=1.0,
+            on_change=lambda g: calls.append(len(g)),
+        )
+        grid.build_grid(100.0)
+        calls_after_build = len(calls)
+        walked, _, _ = grid.recenter_if_drifted(103.5)
+        assert walked is True
+        assert len(calls) == calls_after_build + 1
+
+    def test_notify_change_not_called_when_no_action(self):
+        calls = []
+        grid = Grid(
+            tick_size=Decimal('0.01'),
+            grid_count=20,
+            grid_step=1.0,
+            on_change=lambda g: calls.append(len(g)),
+        )
+        grid.build_grid(100.0)
+        calls_after_build = len(calls)
+        walked, _, _ = grid.recenter_if_drifted(100.2)
+        assert walked is False
+        assert len(calls) == calls_after_build  # no extra notify
+
+    def test_assign_sides_with_fill_price_preserves_legacy(self):
+        """_assign_sides(last_close, fill_price=fp) preserves update_grid semantics:
+        WAIT marking is driven by proximity to fp, not last_close."""
+        grid = self._make_grid(anchor=100.0, grid_count=20, grid_step=1.0)
+        target_idx = 5
+        fp = grid.grid[target_idx]['price']
+        last_close = grid.grid[12]['price']  # well separated from fp (different level)
+        grid._assign_sides(last_close, fill_price=fp)
+        # Level at fp must be WAIT (driven by fill_price proximity)
+        assert grid.grid[target_idx]['side'] == GridSideType.WAIT
+        # The level at last_close must NOT be WAIT, because the WAIT rule uses
+        # fill_price as reference, not last_close. (If it were last_close, this
+        # level would also be WAIT.)
+        assert grid.grid[12]['side'] != GridSideType.WAIT

--- a/packages/gridcore/tests/test_grid.py
+++ b/packages/gridcore/tests/test_grid.py
@@ -709,13 +709,13 @@ class TestGridMinMaxAccessors:
 
 
 class TestWaitCenter:
-    """Tests for Grid._wait_center()."""
+    """Tests for Grid.wait_center()."""
 
     def test_single_wait_level_returns_its_price(self):
         grid = Grid(tick_size=Decimal('0.01'), grid_count=10, grid_step=1.0)
         grid.build_grid(100.0)
         # build_grid produces exactly one WAIT level
-        assert grid._wait_center() == 100.0
+        assert grid.wait_center() == 100.0
 
     def test_multi_wait_band_returns_midpoint(self):
         grid = Grid(tick_size=Decimal('0.01'), grid_count=10, grid_step=1.0)
@@ -726,7 +726,7 @@ class TestWaitCenter:
         grid.grid[center_idx + 1]['side'] = GridSideType.WAIT
         wait_prices = [g['price'] for g in grid.grid if g['side'] == GridSideType.WAIT]
         expected = (min(wait_prices) + max(wait_prices)) / 2
-        assert grid._wait_center() == expected
+        assert grid.wait_center() == expected
 
     def test_zero_wait_even_length_uses_mean_of_two_middles(self):
         grid = Grid(tick_size=Decimal('0.01'), grid_count=10, grid_step=1.0)
@@ -740,7 +740,7 @@ class TestWaitCenter:
         n = len(grid.grid)
         assert n % 2 == 0
         expected = (grid.grid[n // 2 - 1]['price'] + grid.grid[n // 2]['price']) / 2
-        assert grid._wait_center() == expected
+        assert grid.wait_center() == expected
 
     def test_zero_wait_odd_length_uses_single_middle(self):
         grid = Grid(tick_size=Decimal('0.01'), grid_count=10, grid_step=1.0)
@@ -750,7 +750,7 @@ class TestWaitCenter:
         for level in grid.grid:
             if level['side'] == GridSideType.WAIT:
                 level['side'] = GridSideType.BUY
-        assert grid._wait_center() == grid.grid[n // 2]['price']
+        assert grid.wait_center() == grid.grid[n // 2]['price']
 
 
 class TestRecenterIfDrifted:
@@ -835,7 +835,7 @@ class TestRecenterIfDrifted:
         walked, _, _ = grid.recenter_if_drifted(103.5)
         assert walked is True
         # _original_anchor_price should now equal new wait_center (close to 103.5)
-        assert grid._original_anchor_price == grid._wait_center()
+        assert grid._original_anchor_price == grid.wait_center()
         assert abs(grid._original_anchor_price - 103.5) < 1.0
 
     def test_assign_sides_post_walk(self):

--- a/packages/gridcore/tests/test_grid.py
+++ b/packages/gridcore/tests/test_grid.py
@@ -752,6 +752,65 @@ class TestWaitCenter:
                 level['side'] = GridSideType.BUY
         assert grid.wait_center() == grid.grid[n // 2]['price']
 
+    def test_wait_center_raises_on_empty_grid(self):
+        """Defensive contract: wait_center() must raise ValueError on empty grid
+        rather than IndexError or returning a meaningless value."""
+        grid = Grid(tick_size=Decimal('0.01'), grid_count=10, grid_step=1.0)
+        assert grid.grid == []
+        with pytest.raises(ValueError, match="empty grid"):
+            grid.wait_center()
+
+
+class TestZeroDivisionGuards:
+    """Defensive guards against division-by-zero in degenerate states.
+    The grid invariants (positive traded prices, GridConfig.grid_step > 0)
+    make these unreachable in production, but the guards are exercised here
+    to lock in the contract."""
+
+    def test_recenter_no_op_when_wait_center_is_zero(self, caplog):
+        """If the WAIT band is symmetric around zero (e.g. [-1, 1]), wait_center
+        returns 0. recenter_if_drifted must early-return rather than divide."""
+        grid = Grid(tick_size=Decimal('0.01'), grid_count=10, grid_step=1.0)
+        # Bypass build_grid validation by setting grid directly.
+        grid.grid = [
+            {'side': GridSideType.WAIT, 'price': -1.0},
+            {'side': GridSideType.WAIT, 'price': 1.0},
+        ]
+        assert grid.wait_center() == 0.0
+
+        with caplog.at_level('WARNING'):
+            result = grid.recenter_if_drifted(5.0)
+
+        assert bool(result) is False
+        assert result.n_steps == 0
+        assert any('wait_center is zero' in r.message for r in caplog.records)
+
+    def test_recenter_no_op_when_grid_step_is_zero(self, caplog):
+        """grid_step == 0 would crash int(deviation_pct / 0). Guard returns
+        a no-op RecenterResult."""
+        grid = Grid(tick_size=Decimal('0.01'), grid_count=10, grid_step=1.0)
+        grid.build_grid(100.0)
+        grid.grid_step = 0  # break GridConfig invariant for the test
+
+        with caplog.at_level('WARNING'):
+            result = grid.recenter_if_drifted(105.0)
+
+        assert bool(result) is False
+        assert result.n_steps == 0
+        assert any('grid_step is zero' in r.message for r in caplog.records)
+
+    def test_is_too_close_returns_false_on_zero_price(self):
+        """__is_too_close divides by price1 — guard short-circuits on zero."""
+        grid = Grid(tick_size=Decimal('0.01'), grid_count=10, grid_step=1.0)
+        # Name-mangled access for the private method
+        assert grid._Grid__is_too_close(0.0, 1.0) is False
+
+    def test_is_too_close_returns_false_on_zero_grid_step(self):
+        """grid_step == 0 makes the threshold 0; guard returns False."""
+        grid = Grid(tick_size=Decimal('0.01'), grid_count=10, grid_step=1.0)
+        grid.grid_step = 0
+        assert grid._Grid__is_too_close(100.0, 100.0) is False
+
 
 class TestRecenterIfDrifted:
     """Tests for Grid.recenter_if_drifted (feature 0022)."""


### PR DESCRIPTION
Adds an ungated drift detector that walks the grid by N steps toward last_close when it has moved more than one grid_step from the current WAIT-band center. Falls back to a full rebuild when N >= grid_count // 2. Independent of last_filled_price, so it fires on cold restart and after WS reconnect even before the first fill of the session.

Key design decisions (settled across four review rounds):
- Drift reference is the current WAIT-band midpoint (plan Q1) so the detector self-adjusts as the grid walks or as update_grid expands the WAIT band after a fill.
- Below-threshold ticks are TRUE no-ops: no side reassignment, no anchor update. Prevents silent WAIT-band migration on sub-step ticks.
- update_grid is no longer called per-tick from _check_and_place; its former side-refresh role is covered by recenter's _assign_sides on walks. Eliminates the stale-fill repeated-walk loop.
- _fill_pending consumes fills that arrived before last_close was set (including the empty-grid first-build path) and runs recenter on the same tick when the fill shifted the WAIT band beyond one grid_step.
- recenter_if_drifted returns RecenterResult (NamedTuple with __bool__) so `if grid.recenter_if_drifted(...)` is falsy on no-op.
- Engine emits the planned `Grid drift %.2f%% (N=%d steps)` INFO line for walk, in-bounds rebuild, and out-of-bounds rebuild paths.
- restore_grid derives _original_anchor_price via _wait_center() so the post-restore anchor matches post-recenter anchor for even-sized bands.

@codex 