### PR TITLE
feat(gridbot): WS position updates drained from main loop (0023)

### DIFF
--- a/apps/gridbot/src/gridbot/orchestrator.py
+++ b/apps/gridbot/src/gridbot/orchestrator.py
@@ -122,6 +122,16 @@ class Orchestrator:
         self._started = False
         self._running = False
 
+        # Coalesced WS position snapshot (feature 0023).
+        # Outer key = account_name, inner key = symbol, value = dict with
+        # "long" / "short" position dicts and a monotonic "seq". The WS
+        # callback (`_on_position`) writes the latest snapshot here; the
+        # main-loop tick drains it once per (account, symbol). Seq lives
+        # in `_position_seq` and is bumped under the WS thread.
+        self._latest_position: dict[str, dict[str, dict]] = {}
+        self._last_processed_position_seq: dict[tuple[str, str], int] = {}
+        self._position_seq: int = 0
+
         # Position-fetch subsystem (WS cache + REST fallback + wallet cache
         # + startup batch + rotation tick). Constructed eagerly so that
         # _init_account — which registers WS callbacks bound to
@@ -130,12 +140,19 @@ class Orchestrator:
         # fetcher holds _rest_clients / _account_to_runners by reference
         # (they are empty dicts at this point and get populated in place
         # by _init_account / _init_strategy).
+        #
+        # `on_position_changed=self._on_position` rewires the WS-thread
+        # callback so a snapshot lands in `_latest_position` for the next
+        # main-loop drain (feature 0023). Method-bound reference is fine —
+        # `_on_position` is defined on the class, available before any WS
+        # message can fire (sockets only connect inside start()).
         self._position_fetcher = PositionFetcher(
             rest_clients=self._rest_clients,
             account_to_runners=self._account_to_runners,
             notifier=self._notifier,
             wallet_cache_interval=self._config.wallet_cache_interval,
             position_check_interval=self._config.position_check_interval,
+            on_position_changed=self._on_position,
         )
 
         # Auth-cooldown subsystem. Constructed eagerly for the same reason
@@ -244,6 +261,11 @@ class Orchestrator:
         logger.info("Fetching initial positions before entering main loop")
         self._position_fetcher.fetch_and_update(startup=True)
 
+        # Prime the coalesced-position seq map so the first main-loop tick
+        # does not redispatch snapshots already covered by the startup
+        # REST batch (feature 0023).
+        self._prime_position_seq()
+
         # Prime periodic-tick schedulers so the first main loop iteration
         # does not immediately re-run expensive checks.
         now = time.monotonic()
@@ -338,6 +360,43 @@ class Orchestrator:
                     self._notifier.alert_exception(
                         "runner.on_order_update", e,
                         error_key=f"on_order_update_{runner.strat_id}",
+                    )
+
+        # 2.5 Drain coalesced WS position snapshots (feature 0023).
+        #     One dispatch per (account, symbol) per tick, deduped via the
+        #     monotonic seq counter set in `_on_position`. Older snapshots
+        #     overwrite each other in `_latest_position`; only the freshest
+        #     is dispatched. Runs BEFORE the ticker drain so `_check_and_place`
+        #     reasons over fresh position size on the same tick.
+        for account_name, runners in self._account_to_runners.items():
+            account_slot = self._latest_position.get(account_name)
+            if not account_slot:
+                continue
+            wallet_balance = self._position_fetcher.get_wallet_balance(account_name)
+            for runner in runners:
+                snapshot = account_slot.get(runner.symbol)
+                if snapshot is None:
+                    continue
+                seq = snapshot["seq"]
+                key = (account_name, runner.symbol)
+                if self._last_processed_position_seq.get(key) == seq:
+                    continue
+                self._last_processed_position_seq[key] = seq
+                try:
+                    runner.on_position_update(
+                        long_position=snapshot["long"],
+                        short_position=snapshot["short"],
+                        wallet_balance=wallet_balance,
+                        last_close=runner.engine.last_close or 0.0,
+                    )
+                except Exception as e:
+                    logger.error(
+                        "%s: on_position_update error (WS drain): %s",
+                        runner.strat_id, e, exc_info=True,
+                    )
+                    self._notifier.alert_exception(
+                        "runner.on_position_update", e,
+                        error_key=f"on_position_update_{runner.strat_id}",
                     )
 
         # 3. Process latest ticker per symbol (coalesced — WS callback
@@ -611,6 +670,85 @@ class Orchestrator:
         self._private_ws[account_name].connect()
 
         logger.info(f"Connected WebSockets for account: {account_name}")
+
+    def _prime_position_seq(self) -> None:
+        """Prime `_last_processed_position_seq` from `_latest_position`.
+
+        Called from `start()` AFTER `fetch_and_update(startup=True)` has
+        pushed initial state through `runner.on_position_update`. Without
+        this priming, the first `_tick()` would redispatch any WS-cached
+        snapshot that the startup REST batch already covered.
+
+        Snapshot via list(...) before iterating: pybit WS threads are
+        already running by this point and `_on_position` can insert new
+        entries into `_latest_position` (or its inner dicts) concurrently.
+        Iterating the live dict could otherwise raise
+        `RuntimeError: dictionary changed size during iteration`. Worst
+        case with the snapshot: a WS-thread insert that lands AFTER we
+        took the list() but BEFORE the first `_tick()` runs is correctly
+        NOT primed here, so the first tick will dispatch it — that's
+        acceptable because it represents data the startup REST batch
+        didn't see.
+        """
+        for account_name, account_slot in list(self._latest_position.items()):
+            for symbol, snapshot in list(account_slot.items()):
+                self._last_processed_position_seq[(account_name, symbol)] = snapshot["seq"]
+
+    def _on_position(self, account_name: str, symbol: str) -> None:
+        """Handle WS position notification (runs in pybit WS thread).
+
+        Called by `PositionFetcher.on_position_message` AFTER its cache
+        write completes, so `get_position_from_ws` returns the freshest
+        per-side data here. Builds a paired snapshot (long + short +
+        monotonic seq) into `_latest_position[account_name][symbol]`
+        for the main-loop drain to pick up — feature 0023.
+
+        Incomplete-cache guard: skips publishing the snapshot if either
+        side is missing from the WS cache. Bybit may push an update for
+        only the changed side; the opposite side's cache slot can be
+        absent until the first push for that side ever lands. Without
+        this guard, the drain would call `runner.on_position_update`
+        with `long_position=None` (or `short=None`), and runner.py:443-448
+        would coerce that to `Decimal('0')`, erroneously zeroing the
+        opposite-side size that REST already knew was nonzero. The
+        periodic REST cycle keeps working in the meantime — it has its
+        own REST fallback for missing WS sides and updates the runner
+        directly without going through this drain.
+
+        Thread-safety: per-`(account, symbol)` writes have at most one
+        WS-thread writer, since pybit dispatches private-socket callbacks
+        from a single thread per account, and `(account, symbol)` is
+        partitioned by account. `_position_seq += 1` is shared across
+        all private WS threads; with multiple accounts, two concurrent
+        increments can collide and produce a duplicate seq value, but
+        the resulting snapshots land in different `_latest_position`
+        slots and are dispatched independently against per-key entries
+        in `_last_processed_position_seq`, so no update is lost. Within
+        the same `(account, symbol)`, only one writer exists, so the
+        seq comparison in the drain is a clean single-writer monotonic
+        check. Reads on the main thread are GIL-atomic.
+        """
+        try:
+            long_pos = self._position_fetcher.get_position_from_ws(
+                account_name, symbol, "Buy"
+            )
+            short_pos = self._position_fetcher.get_position_from_ws(
+                account_name, symbol, "Sell"
+            )
+            if long_pos is None or short_pos is None:
+                # Wait for the opposite side to arrive (or for the next
+                # periodic REST cycle to refresh runner state). See
+                # incomplete-cache guard rationale above.
+                return
+            self._position_seq += 1
+            account_slot = self._latest_position.setdefault(account_name, {})
+            account_slot[symbol] = {
+                "long": long_pos,
+                "short": short_pos,
+                "seq": self._position_seq,
+            }
+        except Exception as e:
+            self._notifier.alert_exception("_on_position", e, error_key="ws_on_position")
 
     def _on_ticker(self, account_name: str, symbol: str, message: dict) -> None:
         """Handle ticker WebSocket message (runs in pybit WS thread).

--- a/apps/gridbot/src/gridbot/position_fetcher.py
+++ b/apps/gridbot/src/gridbot/position_fetcher.py
@@ -19,7 +19,7 @@ import logging
 import threading
 import time
 from datetime import datetime, UTC
-from typing import Optional
+from typing import Callable, Optional
 
 from bybit_adapter.rest_client import BybitRestClient
 
@@ -58,6 +58,7 @@ class PositionFetcher:
         notifier: Notifier,
         wallet_cache_interval: float,
         position_check_interval: float,
+        on_position_changed: Optional[Callable[[str, str], None]] = None,
     ):
         # Dicts are held by reference; Orchestrator mutates them in place
         # during _init_account, and those updates are visible here.
@@ -66,6 +67,10 @@ class PositionFetcher:
         self._notifier = notifier
         self._wallet_cache_interval = wallet_cache_interval
         self._position_check_interval = position_check_interval
+        # Optional WS-thread notification: called once per (account, symbol)
+        # after on_position_message has written the cache. Orchestrator uses
+        # this to coalesce a snapshot for the main-loop drain (feature 0023).
+        self._on_position_changed = on_position_changed
 
         # WebSocket position data cache: account_name -> symbol -> side -> position_data
         # Follows original bbu2 pattern: WebSocket provides real-time updates,
@@ -128,6 +133,7 @@ class PositionFetcher:
             ]
         }
         """
+        changed_symbols: set[str] = set()
         try:
             # Initialize account cache if needed. setdefault is a single
             # C-level call and is GIL-atomic (unlike check-then-assign,
@@ -152,6 +158,7 @@ class PositionFetcher:
 
                 # Store position data by side — atomic dict-set under GIL.
                 symbol_cache[side] = pos
+                changed_symbols.add(symbol)
 
                 logger.debug(
                     f"Position WS update: {account_name}/{symbol}/{side} "
@@ -160,6 +167,21 @@ class PositionFetcher:
 
         except Exception as e:
             self._notifier.alert_exception("_on_position", e, error_key="ws_on_position")
+            return
+
+        # Notify orchestrator (feature 0023). Done after the cache writes so
+        # the callback can read the freshest snapshot via get_position_from_ws.
+        # Deduped to one call per (account, symbol) regardless of how many
+        # sides arrived in this message. Wrapped so a misbehaving callback
+        # cannot wedge the WS thread.
+        if self._on_position_changed is not None:
+            for symbol in changed_symbols:
+                try:
+                    self._on_position_changed(account_name, symbol)
+                except Exception as e:
+                    self._notifier.alert_exception(
+                        "_on_position_changed", e, error_key="ws_on_position_changed",
+                    )
 
     def get_position_from_ws(
         self, account_name: str, symbol: str, side: str

--- a/apps/gridbot/tests/test_orchestrator.py
+++ b/apps/gridbot/tests/test_orchestrator.py
@@ -811,6 +811,262 @@ class TestOrchestratorTick:
         notifier.alert_exception.assert_called_once()
 
 
+class TestOrchestratorWsPositionDrain:
+    """Feature 0023 — coalesced WS position snapshot drained from main loop.
+
+    `_on_position(account, symbol)` runs in WS thread and writes a snapshot
+    + monotonic seq into `_latest_position`. `_tick()` dispatches the
+    latest snapshot per (account, symbol) once via `runner.on_position_update`.
+    """
+
+    def _make_orch(self, gridbot_config, account_config, strategy_config):
+        """Build a fully-routed orchestrator with a mock runner stand-in.
+
+        Real PositionFetcher is left in place (we want its WS-cache reads
+        through `get_position_from_ws`). The runner is mocked because we
+        only assert on `on_position_update` calls.
+        """
+        with patch("gridbot.orchestrator.BybitRestClient"), \
+             patch("gridbot.orchestrator.PublicWebSocketClient"), \
+             patch("gridbot.orchestrator.PrivateWebSocketClient"):
+            orchestrator = Orchestrator(gridbot_config)
+            orchestrator._init_account(account_config)
+            orchestrator._init_strategy(strategy_config)
+            orchestrator._build_routing_maps()
+
+        from collections import deque
+        orchestrator._pending_executions["btcusdt_test"] = deque()
+        orchestrator._pending_orders["btcusdt_test"] = deque()
+
+        mock_runner = Mock()
+        mock_runner.strat_id = "btcusdt_test"
+        mock_runner.symbol = "BTCUSDT"
+        mock_runner.engine.last_close = 42500.0
+        orchestrator._runners = {"btcusdt_test": mock_runner}
+        orchestrator._account_to_runners = {"test_account": [mock_runner]}
+        orchestrator._symbol_to_runners = {"BTCUSDT": [mock_runner]}
+
+        # Stub wallet fetch — real impl raises from non-main thread guards
+        # in some paths and we want a deterministic value here.
+        orchestrator._position_fetcher.get_wallet_balance = Mock(return_value=1000.0)
+        return orchestrator, mock_runner
+
+    @staticmethod
+    def _push_ws(orchestrator, symbol, *, long_size, short_size):
+        """Simulate a WS message arriving and `_on_position` firing."""
+        msg = {"data": []}
+        if long_size is not None:
+            msg["data"].append({
+                "category": "linear", "symbol": symbol, "side": "Buy",
+                "size": str(long_size),
+            })
+        if short_size is not None:
+            msg["data"].append({
+                "category": "linear", "symbol": symbol, "side": "Sell",
+                "size": str(short_size),
+            })
+        orchestrator._position_fetcher.on_position_message("test_account", msg)
+
+    def test_drain_dispatches_snapshot(self, gridbot_config, account_config, strategy_config):
+        """A WS push lands in _latest_position; the next tick dispatches
+        it through runner.on_position_update with paired long/short data.
+        """
+        orch, runner = self._make_orch(gridbot_config, account_config, strategy_config)
+
+        self._push_ws(orch, "BTCUSDT", long_size="0.3", short_size="0.2")
+        orch._tick()
+
+        runner.on_position_update.assert_called_once()
+        kwargs = runner.on_position_update.call_args.kwargs
+        assert kwargs["long_position"]["size"] == "0.3"
+        assert kwargs["short_position"]["size"] == "0.2"
+        assert kwargs["wallet_balance"] == 1000.0
+        assert kwargs["last_close"] == 42500.0
+
+    def test_drain_idempotent_on_unchanged_seq(self, gridbot_config, account_config, strategy_config):
+        """Two consecutive ticks with no new WS push → dispatch fires once."""
+        orch, runner = self._make_orch(gridbot_config, account_config, strategy_config)
+
+        self._push_ws(orch, "BTCUSDT", long_size="0.3", short_size="0.2")
+        orch._tick()
+        orch._tick()
+
+        runner.on_position_update.assert_called_once()
+
+    def test_drain_coalesces_to_latest(self, gridbot_config, account_config, strategy_config):
+        """Multiple WS pushes between ticks collapse to one dispatch with
+        the latest snapshot — older sizes are never seen by the runner.
+        """
+        orch, runner = self._make_orch(gridbot_config, account_config, strategy_config)
+
+        self._push_ws(orch, "BTCUSDT", long_size="0.1", short_size="0.0")
+        self._push_ws(orch, "BTCUSDT", long_size="0.2", short_size="0.0")
+        self._push_ws(orch, "BTCUSDT", long_size="0.3", short_size="0.0")
+        orch._tick()
+
+        runner.on_position_update.assert_called_once()
+        kwargs = runner.on_position_update.call_args.kwargs
+        assert kwargs["long_position"]["size"] == "0.3"
+
+    def test_new_push_after_first_tick_dispatches_again(self, gridbot_config, account_config, strategy_config):
+        """A fresh WS push after a previous tick triggers a second dispatch."""
+        orch, runner = self._make_orch(gridbot_config, account_config, strategy_config)
+
+        self._push_ws(orch, "BTCUSDT", long_size="0.2", short_size="0.2")
+        orch._tick()
+        self._push_ws(orch, "BTCUSDT", long_size="0.3", short_size="0.2")
+        orch._tick()
+
+        assert runner.on_position_update.call_count == 2
+        last_kwargs = runner.on_position_update.call_args_list[-1].kwargs
+        assert last_kwargs["long_position"]["size"] == "0.3"
+
+    def test_drain_skips_runners_without_snapshot(self, gridbot_config, account_config, strategy_config):
+        """If `_latest_position[account][symbol]` is absent, the runner
+        for that symbol is not dispatched — no exception, no spurious call.
+        """
+        orch, runner = self._make_orch(gridbot_config, account_config, strategy_config)
+
+        # No WS push for BTCUSDT.
+        orch._tick()
+        runner.on_position_update.assert_not_called()
+
+    def test_drain_only_dispatches_matching_runner(self, gridbot_config, account_config, strategy_config):
+        """A WS snapshot for ETHUSDT must NOT reach a BTCUSDT runner."""
+        orch, runner = self._make_orch(gridbot_config, account_config, strategy_config)
+
+        self._push_ws(orch, "ETHUSDT", long_size="1.0", short_size="0.0")
+        orch._tick()
+
+        runner.on_position_update.assert_not_called()
+
+    def test_drain_isolates_runner_exceptions(self, gridbot_config, account_config, strategy_config):
+        """If runner.on_position_update raises, the tick keeps running and
+        the notifier is alerted (matches existing exec/order conventions).
+        """
+        notifier = Mock(spec=Notifier)
+        with patch("gridbot.orchestrator.BybitRestClient"), \
+             patch("gridbot.orchestrator.PublicWebSocketClient"), \
+             patch("gridbot.orchestrator.PrivateWebSocketClient"):
+            orch = Orchestrator(gridbot_config, notifier=notifier)
+            orch._init_account(account_config)
+            orch._init_strategy(strategy_config)
+            orch._build_routing_maps()
+        from collections import deque
+        orch._pending_executions["btcusdt_test"] = deque()
+        orch._pending_orders["btcusdt_test"] = deque()
+        mock_runner = Mock()
+        mock_runner.strat_id = "btcusdt_test"
+        mock_runner.symbol = "BTCUSDT"
+        mock_runner.engine.last_close = 42500.0
+        mock_runner.on_position_update.side_effect = ValueError("boom")
+        orch._runners = {"btcusdt_test": mock_runner}
+        orch._account_to_runners = {"test_account": [mock_runner]}
+        orch._symbol_to_runners = {"BTCUSDT": [mock_runner]}
+        orch._position_fetcher.get_wallet_balance = Mock(return_value=1000.0)
+
+        self._push_ws(orch, "BTCUSDT", long_size="0.3", short_size="0.2")
+        orch._tick()  # must not raise
+
+        notifier.alert_exception.assert_called_once()
+        assert "on_position_update" in notifier.alert_exception.call_args[0][0]
+
+    def test_drain_skips_when_ws_cache_incomplete(self, gridbot_config, account_config, strategy_config):
+        """P1 regression: a one-sided WS message must NOT cause the drain
+        to call `runner.on_position_update` with `short_position=None`.
+
+        Previously the drain would dispatch a snapshot like
+        `{long: <fresh>, short: None}` and runner.py:443-448 would coerce
+        the missing side to Decimal('0'), erroneously zeroing the
+        opposite-side size that REST already knew was nonzero. The fix
+        is to skip publishing the snapshot until both sides are present
+        in the WS cache; the periodic REST cycle handles the gap.
+        """
+        orch, runner = self._make_orch(gridbot_config, account_config, strategy_config)
+
+        # Only Buy side ever cached (Sell never WS-pushed for this symbol).
+        self._push_ws(orch, "BTCUSDT", long_size="0.3", short_size=None)
+        orch._tick()
+
+        # Drain must NOT dispatch — the snapshot would be incomplete.
+        runner.on_position_update.assert_not_called()
+        # And `_latest_position` must not carry a half-snapshot.
+        assert "BTCUSDT" not in orch._latest_position.get("test_account", {})
+
+    def test_drain_dispatches_after_second_side_arrives(self, gridbot_config, account_config, strategy_config):
+        """Companion to the incomplete-cache guard: once the opposite
+        side lands in the cache, the next WS push (with either side)
+        produces a complete snapshot and the drain dispatches.
+        """
+        orch, runner = self._make_orch(gridbot_config, account_config, strategy_config)
+
+        # Step 1: only Buy in cache → drain skips.
+        self._push_ws(orch, "BTCUSDT", long_size="0.3", short_size=None)
+        orch._tick()
+        runner.on_position_update.assert_not_called()
+
+        # Step 2: Sell now arrives. Now both sides cached.
+        self._push_ws(orch, "BTCUSDT", long_size=None, short_size="0.2")
+        orch._tick()
+
+        runner.on_position_update.assert_called_once()
+        kwargs = runner.on_position_update.call_args.kwargs
+        assert kwargs["long_position"]["size"] == "0.3"
+        assert kwargs["short_position"]["size"] == "0.2"
+
+    def test_prime_position_seq_survives_concurrent_mutation(self, gridbot_config, account_config, strategy_config):
+        """P2 regression: `_prime_position_seq` must not raise
+        `RuntimeError: dictionary changed size during iteration` when a
+        WS thread inserts into `_latest_position` (or its inner dicts)
+        mid-iteration. The fix is to snapshot via list(...) before
+        iterating.
+        """
+        orch, _runner = self._make_orch(gridbot_config, account_config, strategy_config)
+
+        # Custom dict that mutates itself when items() is called, simulating
+        # a WS-thread insertion landing during the priming iteration. With
+        # the bare `for ... in dict.items()` pattern this raises RuntimeError;
+        # the list(...) snapshot is immune.
+        class _MutatingDict(dict):
+            def items(self_inner):
+                snapshot = list(super().items())
+                # Mutate AFTER the view is requested. Without list(), the
+                # subsequent iteration would observe the mutation and raise.
+                self_inner["LATE_INSERT"] = {"long": {"size": "0.5"},
+                                              "short": {"size": "0.5"},
+                                              "seq": 999}
+                return snapshot
+
+        orch._latest_position = {"test_account": _MutatingDict({
+            "BTCUSDT": {"long": {"size": "0.3"}, "short": {"size": "0.2"}, "seq": 1},
+        })}
+
+        # Must not raise.
+        orch._prime_position_seq()
+
+        # The originally-seen entry was primed.
+        assert orch._last_processed_position_seq[("test_account", "BTCUSDT")] == 1
+
+    def test_startup_prime_skips_first_tick(self, gridbot_config, account_config, strategy_config):
+        """Mimic start()'s priming: simulate a WS-populated `_latest_position`
+        already drained by startup REST, prime `_last_processed_position_seq`,
+        and verify the first tick does NOT redispatch the snapshot.
+        """
+        orch, runner = self._make_orch(gridbot_config, account_config, strategy_config)
+
+        self._push_ws(orch, "BTCUSDT", long_size="0.2", short_size="0.2")
+        # Mimic the priming step in start() right after fetch_and_update(startup=True).
+        orch._prime_position_seq()
+
+        orch._tick()
+        runner.on_position_update.assert_not_called()
+
+        # New push after startup priming — should now dispatch.
+        self._push_ws(orch, "BTCUSDT", long_size="0.3", short_size="0.2")
+        orch._tick()
+        runner.on_position_update.assert_called_once()
+
+
 class TestOrchestratorTickPeriodicCheckIsolation:
     """Each periodic REST check is isolated so one failure doesn't wedge
     WS-event drain via the outer backoff path."""

--- a/apps/gridbot/tests/test_position_fetcher.py
+++ b/apps/gridbot/tests/test_position_fetcher.py
@@ -29,6 +29,7 @@ def _make_fetcher(
     notifier=None,
     wallet_cache_interval=300.0,
     position_check_interval=60.0,
+    on_position_changed=None,
 ):
     return PositionFetcher(
         rest_clients=rest_clients if rest_clients is not None else {},
@@ -36,6 +37,7 @@ def _make_fetcher(
         notifier=notifier if notifier is not None else Mock(spec=Notifier),
         wallet_cache_interval=wallet_cache_interval,
         position_check_interval=position_check_interval,
+        on_position_changed=on_position_changed,
     )
 
 
@@ -101,6 +103,85 @@ class TestOnPositionMessage:
         fetcher.on_position_message("acct", {"data": 12345})
         notifier.alert_exception.assert_called_once()
         assert "on_position" in notifier.alert_exception.call_args[0][0]
+
+    def test_callback_fires_once_per_symbol(self):
+        """Feature 0023: callback invoked once per (account, symbol),
+        deduped across sides arriving in the same message.
+        """
+        callback = Mock()
+        fetcher = _make_fetcher(on_position_changed=callback)
+        msg = {
+            "data": [
+                {"category": "linear", "symbol": "BTCUSDT", "side": "Buy", "size": "0.1"},
+                {"category": "linear", "symbol": "BTCUSDT", "side": "Sell", "size": "0.05"},
+                {"category": "linear", "symbol": "ETHUSDT", "side": "Buy", "size": "1.0"},
+            ]
+        }
+        fetcher.on_position_message("acct", msg)
+        # BTCUSDT once (despite Buy+Sell), ETHUSDT once.
+        assert callback.call_count == 2
+        symbols_called = {call.args[1] for call in callback.call_args_list}
+        assert symbols_called == {"BTCUSDT", "ETHUSDT"}
+        for call in callback.call_args_list:
+            assert call.args[0] == "acct"
+
+    def test_callback_not_fired_when_unregistered(self):
+        """Backward compat: when on_position_changed is None,
+        on_position_message behaves exactly as before.
+        """
+        # No callback wired — must not raise.
+        fetcher = _make_fetcher()
+        msg = {
+            "data": [
+                {"category": "linear", "symbol": "BTCUSDT", "side": "Buy", "size": "0.1"},
+            ]
+        }
+        fetcher.on_position_message("acct", msg)
+        # Cache write still happened.
+        assert fetcher._position_ws_data["acct"]["BTCUSDT"]["Buy"]["size"] == "0.1"
+
+    def test_callback_not_fired_for_filtered_messages(self):
+        """Non-linear / empty-symbol entries don't store and don't notify."""
+        callback = Mock()
+        fetcher = _make_fetcher(on_position_changed=callback)
+        msg = {
+            "data": [
+                {"category": "spot", "symbol": "BTCUSDT", "side": "Buy", "size": "1.0"},
+                {"category": "linear", "symbol": "", "side": "Buy", "size": "0.1"},
+            ]
+        }
+        fetcher.on_position_message("acct", msg)
+        callback.assert_not_called()
+
+    def test_callback_exception_isolated(self):
+        """A misbehaving callback must not wedge the WS thread —
+        cache writes succeed, exception is alerted via notifier.
+        """
+        notifier = Mock(spec=Notifier)
+        callback = Mock(side_effect=RuntimeError("boom"))
+        fetcher = _make_fetcher(notifier=notifier, on_position_changed=callback)
+        msg = {
+            "data": [
+                {"category": "linear", "symbol": "BTCUSDT", "side": "Buy", "size": "0.1"},
+            ]
+        }
+        # Must not raise.
+        fetcher.on_position_message("acct", msg)
+        # Cache write still happened.
+        assert fetcher._position_ws_data["acct"]["BTCUSDT"]["Buy"]["size"] == "0.1"
+        # Notifier was alerted.
+        notifier.alert_exception.assert_called_once()
+        assert "on_position_changed" in notifier.alert_exception.call_args[0][0]
+
+    def test_callback_skipped_when_message_raises(self):
+        """If on_position_message hits an exception during cache writes,
+        the callback must NOT fire — partial state should not leak.
+        """
+        callback = Mock()
+        fetcher = _make_fetcher(on_position_changed=callback)
+        # data=int triggers TypeError before any cache write.
+        fetcher.on_position_message("acct", {"data": 12345})
+        callback.assert_not_called()
 
 
 class TestGetPositionFromWs:

--- a/docs/features/0023_PLAN.md
+++ b/docs/features/0023_PLAN.md
@@ -1,0 +1,135 @@
+# 0023_PLAN — Push WS position updates to runner via main-loop drain
+
+## Description
+
+Today, `position_fetcher.on_position_message` (WS thread) only writes the latest position into the `_position_ws_data` cache. The runner's local position state (`_long_position.size`, `_short_position.size`) is updated **only** by the main-thread periodic `fetch_and_update`, gated by `per_account_floor = max(config.position_check_interval, N * _POSITION_TICK_BASE)` — default **63 s**. Between two periodic fetches the runner's position is stale, so `_is_good_to_place` rejects new reduce-only orders that would actually fit the freshly-grown position.
+
+Live evidence (`/tmp/gridbot.log` 2026-05-02 16:35:53 → 16:36:48): two manual market fills (long 0.2→0.3 at 16:36:09, short 0.2→0.3 at 16:36:28) arrived as `Position WS update` DEBUG lines, the runner's `Position update` INFO never re-fired, and every reduce-only intent past the existing book was rejected by `_is_good_to_place` with stale `position_size = 0.2`. Bot was killed at 16:36:48 — 14 s before the next periodic 63 s fetch was due.
+
+This feature closes that gap by **adding a third coalescing event channel to the orchestrator main loop** (alongside ticker, order, execution): on every WS position push, store the latest snapshot per `(account, symbol)` and let the main-loop tick (~100 ms) call `runner.on_position_update` with that snapshot. The existing 63 s REST-backed cycle stays as fallback for WS gaps.
+
+User selections from prior conversation (verbatim):
+- Latency target: "сразу же" — within ~100 ms (one main-loop tick) of the WS push.
+- Single source of truth: keep `runner._long_position.size` as the only read site for position size; do NOT introduce a parallel direct-from-cache read in `_is_good_to_place` (rejected option 3).
+- Coalesce pushes: Bybit emits position events on every PnL tick, so the new channel must follow the **ticker pattern** (`_latest_ticker[symbol] = event` — overwrite, latest wins), not the order/execution pattern (FIFO deque).
+
+## Context
+
+- WS callback today: `apps/gridbot/src/gridbot/position_fetcher.py:97-162` (`on_position_message`) — pure cache write, no propagation.
+- WS-thread → main-thread coalescing pattern already exists for tickers: `apps/gridbot/src/gridbot/orchestrator.py:615-636` (`_on_ticker` writes `_latest_ticker[symbol] = event`) and the consumer at `orchestrator.py:349-365` (`is`-identity check + dispatch). This is the precedent to mirror.
+- WS-thread → main-thread queueing pattern for orders/executions (NOT used here, kept for reference): `orchestrator.py:638-667` (`_on_order`), `orchestrator.py:669-...` (`_on_execution`), drained at `orchestrator.py:300-341`.
+- The single existing `runner.on_position_update` call site is `position_fetcher.py:378` inside `_fetch_one_account`; the new path adds a second call site from the main-loop drain.
+- Default `position_check_interval = 63.0` (`apps/gridbot/src/gridbot/config.py:89-97`). Not changed by this feature — REST cycle stays as fallback.
+- `_POSITION_TICK_BASE = 15.0` (`position_fetcher.py:32`) — also unchanged.
+
+## Reference
+
+- Ticker coalescing field: `orchestrator.py:_latest_ticker` (declaration in `__init__`), the consumer loop at `_tick()` step 3 (`orchestrator.py:343-365`).
+- WS-thread atomicity rationale (used verbatim for the new field's docstring): `orchestrator.py:630-633` and `position_fetcher.py:104-111`.
+- `runner.on_position_update` signature: `apps/gridbot/src/gridbot/runner.py:420-426` — params `long_position`, `short_position`, `wallet_balance`, `last_close`.
+- `position_fetcher.get_position_from_ws`: `position_fetcher.py:164-187` — already implemented, used to read the cache slot for a `(account, symbol, side)`.
+- `position_fetcher.get_wallet_balance`: `position_fetcher.py:189-...` — main-thread cache; safe to read from the drain.
+- `runner.engine.last_close`: same source `_fetch_one_account` already uses (`position_fetcher.py:375`).
+
+## Algorithm
+
+### Step 1 — register a new coalescing slot in the orchestrator
+
+Add `self._latest_position: dict[str, dict[str, dict]] = {}` to `Orchestrator.__init__`. Outer key = `account_name`, inner key = `symbol`, value = an opaque "position snapshot" object that pairs `long_pos` and `short_pos` dicts plus a monotonic seq counter.
+
+Use a seq counter (not `is`-identity) because the WS callback writes `long` and `short` sides into separate slots in `_position_ws_data` (`position_fetcher.py:151-154`); the orchestrator must dispatch on either-side change without missing the other. Pair-snapshot + seq is simpler than tracking per-side identity.
+
+### Step 2 — WS-thread write site
+
+Modify `position_fetcher.on_position_message` (`position_fetcher.py:97-162`):
+1. Keep the existing `_position_ws_data` write as-is (it remains primary cache for `get_position_from_ws`).
+2. After writing, invoke a registered orchestrator callback `notify_position_changed(account_name, symbol)` (passed in via constructor, optional / nullable for tests).
+3. The orchestrator callback rebuilds the snapshot from `get_position_from_ws(account, symbol, "Buy")` and `get_position_from_ws(account, symbol, "Sell")`, increments the seq, and writes `_latest_position[account][symbol] = {"long": ..., "short": ..., "seq": N}`.
+
+Why the callback indirection: `position_fetcher` already owns the cache; orchestrator owns the main-loop snapshot. Keeps the dependency arrow `position_fetcher → orchestrator`, matching how ticker and order callbacks are wired (orchestrator passes `_on_ticker` / `_on_order` to `WSClient` constructor).
+
+### Step 3 — main-loop drain
+
+In `Orchestrator._tick()`, between the existing "drain pending order-update events" (`orchestrator.py:322-341`) and "process latest ticker per symbol" (`orchestrator.py:349-365`), insert a new section:
+
+1. For each `account_name` in `_account_to_runners`:
+   1. For each `symbol` mapped to runners under that account:
+      1. Read `snapshot = self._latest_position.get(account, {}).get(symbol)`.
+      2. If `snapshot is None`: skip.
+      3. If `snapshot["seq"] == self._last_processed_position_seq.get((account, symbol))`: skip (already dispatched).
+      4. Mark `self._last_processed_position_seq[(account, symbol)] = snapshot["seq"]`.
+      5. For each runner whose `(account, symbol)` matches: call `runner.on_position_update(long_position=snapshot["long"], short_position=snapshot["short"], wallet_balance=self._position_fetcher.get_wallet_balance(account), last_close=runner.engine.last_close or 0.0)`.
+
+Wallet read uses the existing main-thread cache (`get_wallet_balance` is GIL-atomic and main-thread-only per `position_fetcher.py:80-83` invariant — the cache is wallet-only, NOT position; reading it from the drain is the same call site `_fetch_one_account` already uses).
+
+### Step 4 — coexistence with the 63 s REST cycle
+
+`_fetch_one_account` (`position_fetcher.py:331-403`) keeps running on its existing `position_check_interval` cadence. It still calls `runner.on_position_update` from the same code path. Two side effects:
+
+- `runner.on_position_update` will be called from two sites (drain + REST cycle). The function is already idempotent — it overwrites `_long_position.size` / `_short_position.size`, recomputes `position_ratio`, resets multipliers, recomputes them. No state is appended. Concurrent calls cannot happen (both are on main thread).
+- The REST cycle remains the fallback for WS gaps and the source of truth for fresh wallet data. Detection of "WS data incomplete" inside `_fetch_one_account` (`position_fetcher.py:359-364`) already covers that.
+
+### Step 5 — startup ordering
+
+`_fetch_positions_startup_batch` (`position_fetcher.py:266-297`) currently runs BEFORE the main loop enters `_tick()`. Keep that. By the time the main loop starts, both `_position_ws_data` and `_latest_position` may be populated (if WS was already up); the first drain tick will see `seq` matching whatever was last published and either dispatch or skip — both are correct because the startup REST already pushed the same data through `runner.on_position_update`. To avoid a duplicate dispatch on the very first tick, initialize `_last_processed_position_seq[(account, symbol)] = current_seq` after the startup batch completes.
+
+## Files to change
+
+### Apps / gridbot
+
+- `apps/gridbot/src/gridbot/orchestrator.py`
+  - `__init__`: add fields `_latest_position: dict[str, dict[str, dict]] = {}` and `_last_processed_position_seq: dict[tuple[str, str], int] = {}`.
+  - Add private method `_on_position(account_name: str, symbol: str)` — runs in WS thread; reads both sides from `position_fetcher.get_position_from_ws`, builds snapshot, bumps a per-`(account, symbol)` seq, writes `_latest_position[account][symbol]`. Mirrors `_on_ticker` style and atomicity rationale.
+  - Wire `_on_position` into `PositionFetcher` at construction (new constructor arg, see below).
+  - In `_tick()`, insert the new drain section between the existing order-drain (line 341) and ticker-dispatch (line 349). Use the seq comparison described in Algorithm Step 3.
+  - After `self._position_fetcher.fetch_and_update(startup=True)` at `orchestrator.py:245`, prime `_last_processed_position_seq` so the first `_tick()` skips re-dispatching the startup snapshot.
+
+- `apps/gridbot/src/gridbot/position_fetcher.py`
+  - `__init__`: accept new optional callable `on_position_changed: Callable[[str, str], None] | None = None`. Stored on `self`.
+  - `on_position_message` (`position_fetcher.py:97-162`): after the existing `setdefault` / dict-set block, call `self._on_position_changed(account_name, symbol)` if registered. Per-symbol — one call per `pos` entry processed.
+
+### Tests
+
+- `apps/gridbot/tests/test_orchestrator.py` (or the closest existing test file — verify which orchestrator-level test module exists; if none, create alongside `test_position_fetcher.py`):
+  - **Drain dispatches new snapshot**: simulate `_on_position(account, symbol)` write, run one `_tick()`, assert `runner.on_position_update` was called with the WS snapshot's long/short dicts.
+  - **Idempotent on unchanged seq**: two consecutive `_tick()` calls with no new push → `on_position_update` called exactly once.
+  - **Coalesce — only latest wins**: rapid sequence of WS pushes (long 0.1, then 0.2, then 0.3) with no `_tick()` between them → first `_tick()` dispatches 0.3 only, never 0.1 or 0.2.
+  - **Startup priming**: after `fetch_and_update(startup=True)`, the first `_tick()` does NOT re-dispatch the startup snapshot (asserts `on_position_update` was called exactly once during the test, by startup, not by the tick).
+  - **REST cycle still works**: with WS callback disabled, the existing 63 s REST path still calls `on_position_update` (covers fallback).
+- `apps/gridbot/tests/test_position_fetcher.py`:
+  - **Callback fires on `on_position_message`**: with a stub callback registered, calling `on_position_message` triggers the callback once per `(account, symbol)` regardless of how many sides arrive in the message.
+  - **Backward compat**: when no callback is registered (constructor arg absent / `None`), `on_position_message` behaves exactly as before — only writes to `_position_ws_data`.
+
+## Interaction with existing logic
+
+- **`_is_good_to_place` (`runner.py:664-713`)**: unchanged. It continues to read `self._long_position.size` / `self._short_position.size`. With this feature those fields are refreshed within ~100 ms of any WS position push, so reduce-only acceptance becomes correctly responsive (fixes the verified rejection at 16:36:09 / 16:36:28 in `/tmp/gridbot.log`).
+- **`amount_multiplier` (`runner.on_position_update:467-484`)**: now recomputed on every WS push instead of every 63 s. Multipliers stay coherent with current size, so the qty resolved by `_resolve_qty` in `_execute_place_intent` (`runner.py:715-...`) matches what `_is_good_to_place` validates against.
+- **Ticker / order / execution drain**: untouched. New drain inserted between order-drain and ticker-dispatch; the ordering matters only inasmuch as a position event ideally lands before the next ticker triggers `_check_and_place`, which is the natural ordering chosen here.
+- **Notifier alerts**: `on_position_update` already wraps its call in try/except inside `_fetch_one_account`. The new drain call site mirrors that try/except (per-runner alert via `_notifier.alert_exception(...)`, do NOT raise out of `_tick()` — same convention as the ticker/order/exec drains at `orchestrator.py:309-318`).
+- **`Position update` INFO log** (`runner.py:489`): will fire much more often (every WS push, deduped by `_latest_position` coalescing). Acceptable — it's already the canonical "position changed" trace. If frequency becomes noisy, follow-up can demote to DEBUG; out of scope here.
+
+## Coalesce vs queue — why coalesce
+
+Bybit pushes a position event on every PnL change, not only on size change. On a ticking market this is 5–20 events per second per symbol. A FIFO deque (the order/execution pattern) would force the runner to recompute multipliers for each one, with the only meaningful information being the latest. Coalescing (the ticker pattern) collapses the burst to one dispatch per main-loop tick, bounded at 10 Hz by `_CHECK_INTERVAL = 0.1` (`orchestrator.py:40`), regardless of WS push rate.
+
+The existing main-loop tick budget already absorbs ticker dispatch at the same rate; adding one more coalesced dispatch is comparable cost.
+
+## Out of scope
+
+- Reducing `position_check_interval` default (kept at 63 s; the new path makes 63 s acceptable as fallback).
+- Direct-from-cache read inside `_is_good_to_place` (variant 3 from the design discussion — rejected for state-divergence reasons).
+- Persisting position state across restarts (`_long_position.size` is rebuilt by startup REST every time; not changed).
+- Skip-if-unchanged optimization at WS-callback level (the `_latest_position` seq comparison already handles dedup at dispatch level; adding a second dedup at callback level is premature).
+- Changing the same-order-error detector behavior on untracked manual orders (separate concern; tracked elsewhere).
+- Demoting the per-tick `Position update` INFO log to DEBUG (re-evaluate after live observation).
+
+## Verification
+
+1. Unit tests: `uv run pytest apps/gridbot/tests/test_orchestrator.py apps/gridbot/tests/test_position_fetcher.py`.
+2. Live repro of the `/tmp/gridbot.log` 2026-05-02 16:36 scenario: with bot running and stable positions long=0.2 / short=0.2, do one market BUY 0.1 (long → 0.3). Assert in the log:
+   - A new `Position update - ratio=..., long_mult=...` INFO line appears within 1 s of the WS push (not after 63 s).
+   - A `Placing Limit Sell` line follows for the next reduce-only level above WAIT, with `qty=0.1`.
+3. Symmetric check: with long=0.3 / short=0.2, do one market SELL 0.1 (short → 0.3). Assert a `Placing Limit Buy` for the next reduce-only level below WAIT.
+4. WS-down fallback: simulate WS disconnect, do not push position events; verify `on_position_update` still fires from the periodic 63 s REST path (existing behavior preserved).
+5. Coalesce stress: synthesize 50 WS position events in <100 ms (e.g., via a unit test with mocked callback). Assert `on_position_update` is called exactly once on the next `_tick()`.
+6. No double-dispatch on startup: bot start → first 100 ms of the main loop → `on_position_update` is called exactly once total (by `_fetch_positions_startup_batch`), not twice.

--- a/docs/features/0023_REVIEW.md
+++ b/docs/features/0023_REVIEW.md
@@ -1,0 +1,85 @@
+# 0023 Review — Push WS position updates to runner via main-loop drain
+
+## Verdict
+
+No blocking findings found in the current implementation.
+
+The two issues from the prior review are resolved:
+
+- P1 incomplete WS cache could zero the opposite runner side: fixed by skipping publication from `_on_position()` until both `Buy` and `Sell` sides are present in the WS cache.
+- P2 startup priming could iterate a WS-mutated dict: fixed by extracting `_prime_position_seq()` and snapshotting both outer and inner dict items via `list(...)`.
+
+The implementation now matches the feature plan's core behavior: `PositionFetcher` publishes a post-cache-write callback, the orchestrator coalesces by `(account, symbol)`, `_tick()` drains before ticker processing, unchanged seqs are skipped, runner exceptions are isolated, incomplete WS snapshots are not dispatched, and the REST position cycle remains in place as fallback.
+
+Verification run:
+
+```bash
+uv run pytest apps/gridbot/tests/test_orchestrator.py apps/gridbot/tests/test_position_fetcher.py -q
+# 128 passed in 0.75s
+
+uv run ruff check apps/gridbot/src/gridbot/orchestrator.py apps/gridbot/src/gridbot/position_fetcher.py apps/gridbot/tests/test_orchestrator.py apps/gridbot/tests/test_position_fetcher.py
+# All checks passed
+```
+
+## Findings
+
+No actionable findings in the current implementation.
+
+## Resolved Since Prior Review
+
+### P1 — Incomplete WS cache no longer publishes half-snapshots
+
+`Orchestrator._on_position()` now reads both sides and returns early if either side is missing:
+
+- `apps/gridbot/src/gridbot/orchestrator.py:731-749`
+
+That prevents `_tick()` from calling `runner.on_position_update(long_position=<fresh>, short_position=None)` or the symmetric case, which previously could coerce the missing side to zero in `runner.py`.
+
+Regression coverage was added:
+
+- `apps/gridbot/tests/test_orchestrator.py:974` verifies a one-sided WS message is not dispatched and does not create a half-snapshot.
+- `apps/gridbot/tests/test_orchestrator.py:996` verifies dispatch resumes once the second side arrives and the snapshot is complete.
+
+### P2 — Startup priming no longer iterates live WS-written dict views
+
+Startup now calls `_prime_position_seq()`, which snapshots both dict levels before iterating:
+
+- `apps/gridbot/src/gridbot/orchestrator.py:261-265`
+- `apps/gridbot/src/gridbot/orchestrator.py:674-695`
+
+This removes the `RuntimeError: dictionary changed size during iteration` risk while pybit WS threads are already running.
+
+Regression coverage was added:
+
+- `apps/gridbot/tests/test_orchestrator.py:1017` exercises `_prime_position_seq()` against a mutating inner mapping and confirms the originally visible snapshot is primed without raising.
+
+## Plan Alignment
+
+Implemented correctly:
+
+- `PositionFetcher.__init__` accepts an optional `on_position_changed` callback.
+- `on_position_message()` keeps the existing cache write and notifies after successful writes.
+- Notifications are deduped to one callback per `(account, symbol)` per WS message.
+- Orchestrator wires the callback into `PositionFetcher`.
+- Orchestrator uses a coalesced latest-wins position slot and a seq map rather than FIFO queueing.
+- `_tick()` drains position snapshots before ticker processing, so a complete position push can affect same-tick order placement.
+- Startup seq priming avoids duplicate first-tick redispatch.
+- The periodic REST-backed `fetch_and_update()` path is still present and handles incomplete WS cache gaps.
+
+No snake_case/camelCase or `{data: ...}` nesting mismatch was found. `on_position_message()` still expects Bybit's existing `{"data": [...]}` shape and stores each `pos` dict as-is, matching the prior cache contract.
+
+## Test Review
+
+Coverage strengths:
+
+- Orchestrator tests cover dispatch, unchanged-seq idempotency, latest-wins coalescing, new push after drain, unmatched symbols, runner exception isolation, incomplete-cache skip, dispatch after the second side arrives, and startup seq priming.
+- Position fetcher tests cover callback firing, side-deduping by symbol, unregistered callback backward compatibility, filtered messages, callback exception isolation, and skipping callback after cache-write failure.
+- Tests are fast, isolated, and use mocks for REST and WebSocket clients.
+
+Residual non-blocking note:
+
+- The `_prime_position_seq()` regression test is a reasonable unit-level guard for the extracted helper, but it is not a true multithreaded stress test. Given the implementation snapshots with `list(...)`, this is acceptable for unit scope.
+
+## Structure / Style
+
+The feature remains small and placed in the right modules. `_prime_position_seq()` is a useful extraction because it makes the startup priming behavior testable. The incomplete-cache guard is documented where the decision is made, and the REST fallback remains the right place to handle missing WS sides.


### PR DESCRIPTION
## Summary
- Add a third coalescing WS→main event channel for position updates: `runner.on_position_update` now fires within ~100 ms of a Bybit position push instead of waiting up to 63 s for the periodic REST cycle.
- Live-verified end-to-end: a manual market fill → bot places the corresponding reduce-only order in 76–98 ms (`/tmp/gridbot.log` 2026-05-02 19:00:52 / 19:00:58).
- Architecture: `PositionFetcher.on_position_message` notifies via a new optional `on_position_changed(account, symbol)` callback, deduped per `(account, symbol)` per WS message. `Orchestrator._on_position` builds a paired long+short snapshot keyed by a monotonic seq; `_tick()` drains the latest snapshot before ticker dispatch. The 63 s REST cycle stays as fallback (and as the source of WS-cache seeding via its existing REST fallback for missing sides).
- Coalescing follows the ticker pattern (latest-wins), not the order/execution FIFO — Bybit pushes a position event on every PnL tick and most of those don't change size.

## Review fixes (incorporated)
- **P1** — `_on_position` skips publishing a snapshot when either side is missing from the WS cache. Otherwise `runner.on_position_update` would coerce the absent side to `Decimal('0')` and zero a position REST already knew was nonzero.
- **P2** — Startup priming (`_prime_position_seq`) iterates a `list(...)` snapshot of `_latest_position` to avoid `RuntimeError: dictionary changed size during iteration` when pybit WS threads insert concurrently.
- Tightened `_position_seq` docstring to reflect multi-account WS-thread model (one writer per `(account, symbol)`, benign duplicate-seq across accounts).

## Files
- `apps/gridbot/src/gridbot/orchestrator.py` (+138 / −0)
- `apps/gridbot/src/gridbot/position_fetcher.py` (+22 / −1)
- `apps/gridbot/tests/test_orchestrator.py` (+256 / −0)
- `apps/gridbot/tests/test_position_fetcher.py` (+81 / −0)
- `docs/features/0023_PLAN.md`, `docs/features/0023_REVIEW.md`

## Test plan
- [x] `uv run pytest apps/gridbot/tests/test_position_fetcher.py -q` — 25 passed (5 new)
- [x] `uv run pytest apps/gridbot/tests/test_orchestrator.py::TestOrchestratorWsPositionDrain -v` — 11 passed (8 happy-path + 2 P1 regressions + 1 P2 regression)
- [x] `uv run pytest apps/gridbot/tests/` — 359 passed
- [x] `uv run pytest packages/gridcore/tests/ packages/bybit_adapter/tests/ -q` — 514 passed, 1 skipped
- [x] `uv run ruff check ...` — clean
- [x] Live: manual market BUY 0.1 (long 0.3→0.4) → `Position update` INFO + `Placing Limit Sell qty=0.1 price=55.8` within ~100 ms (`/tmp/gridbot.log` 19:00:52)
- [x] Live: manual market SELL 0.1 (short 0.3→0.4) → `Placing Limit Buy qty=0.1 price=55.2` within ~76 ms (`/tmp/gridbot.log` 19:00:58)
- [x] No SAME ORDER ERROR; coalescing collapsed multiple WS pushes between ticks into single `Position update` INFOs

🤖 Generated with [Claude Code](https://claude.com/claude-code)