### PR TITLE
fix(runner): time-window guard for SAME ORDER detection (0025)

### DIFF
--- a/apps/gridbot/src/gridbot/runner.py
+++ b/apps/gridbot/src/gridbot/runner.py
@@ -948,14 +948,25 @@ class StrategyRunner:
 
         if (event.side == "Buy" and not is_closing) or (event.side == "Sell" and is_closing):
             buffer = self._recent_executions_long
+            buffer_label = "long"
         else:
             buffer = self._recent_executions_short
+            buffer_label = "short"
 
-        # Add to buffer (newest first)
+        # Add to buffer (newest first). Diagnostic fields (closed_size,
+        # order_link_id, buffer_label) are kept on the record so SAME ORDER
+        # ERROR can dump the actual classification path — needed to tell apart
+        # a real grid-duplicate (both fills truly the same intent) from a
+        # hedge-mode misclassification (classifier put two distinct hedge-pair
+        # fills into the same buffer because closedSize was reported as 0 by
+        # Bybit on a reduce-only fill).
         exec_record = {
             "order_id": event.order_id,
+            "order_link_id": event.order_link_id,
             "price": event.price,
             "side": event.side,
+            "closed_size": event.closed_size,
+            "buffer": buffer_label,
             "exchange_ts": event.exchange_ts,
         }
         buffer.appendleft(exec_record)
@@ -996,10 +1007,33 @@ class StrategyRunner:
                     # Same order ID (partial fills) - OK
                     return
                 # Different order IDs at same price = DUPLICATE ERROR
+                # Diagnostic dump: include closed_size, order_link_id, and
+                # tracked-order reduce_only (looked up via _tracked_orders)
+                # for both fills. This determines whether it's a real
+                # grid-duplicate (same reduce_only, both tracked) or a
+                # hedge-mode misclassification (different reduce_only or one
+                # untracked).
+                cur_tracked = self._tracked_orders.get(current.get("order_link_id", ""))
+                prev_tracked = self._tracked_orders.get(previous.get("order_link_id", ""))
+                cur_reduce_only = (
+                    cur_tracked.intent.reduce_only
+                    if cur_tracked and cur_tracked.intent else "unknown"
+                )
+                prev_reduce_only = (
+                    prev_tracked.intent.reduce_only
+                    if prev_tracked and prev_tracked.intent else "unknown"
+                )
                 logger.error(
                     f"{self.strat_id}: SAME ORDER ERROR - Two different orders filled "
                     f"at same price {current['price']} side={current['side']} "
-                    f"(order_ids: {current['order_id']}, {previous['order_id']})"
+                    f"(order_ids: {current['order_id']}, {previous['order_id']}) "
+                    f"[diagnostic: buffer={current.get('buffer','?')}, "
+                    f"current closed_size={current.get('closed_size','?')} "
+                    f"order_link_id={current.get('order_link_id','')!r} "
+                    f"reduce_only={cur_reduce_only}, "
+                    f"previous closed_size={previous.get('closed_size','?')} "
+                    f"order_link_id={previous.get('order_link_id','')!r} "
+                    f"reduce_only={prev_reduce_only}]"
                 )
                 self._same_order_error = True
                 if self._notifier:

--- a/apps/gridbot/src/gridbot/runner.py
+++ b/apps/gridbot/src/gridbot/runner.py
@@ -179,6 +179,11 @@ class StrategyRunner:
         self._recent_executions_long: deque[dict] = deque(maxlen=2)
         self._recent_executions_short: deque[dict] = deque(maxlen=2)
         self._same_order_error: bool = False
+        # Track which (order_id, order_id) pairs we already cross-checked
+        # against REST after a SAME ORDER trigger, to avoid hammering the API
+        # on the flapping error state. Entries here are frozenset of two
+        # order_ids; small set, never trimmed (resets on bot restart).
+        self._diagnosed_same_order_pairs: set[frozenset[str]] = set()
 
     @property
     def strat_id(self) -> str:
@@ -1043,4 +1048,62 @@ class StrategyRunner:
                         f"Order placement BLOCKED.",
                         error_key=f"same_order_{self.strat_id}",
                     )
+
+                # Diagnostic REST cross-check (rate-limited to once per
+                # order_id pair so the flap doesn't hammer the API). Verifies
+                # whether Bybit-side actually has two distinct fills, or the
+                # WS stream duplicated a single fill event. The latter would
+                # mean SAME ORDER is a WS-glitch false positive, not a real
+                # grid duplicate.
+                pair_key = frozenset((current["order_id"], previous["order_id"]))
+                if pair_key not in self._diagnosed_same_order_pairs:
+                    self._diagnosed_same_order_pairs.add(pair_key)
+                    self._diagnostic_rest_check_executions(current, previous)
                 return
+
+    def _diagnostic_rest_check_executions(self, current: dict, previous: dict) -> None:
+        """Cross-check SAME ORDER trigger against Bybit REST execution history.
+
+        Hypothesis being tested: WS execution stream may emit duplicate events
+        for a single Bybit-side fill, making `_check_same_orders` see "two
+        different orders" when there's actually one. REST `get_executions` is
+        the authoritative source — it returns Bybit's stored execution list.
+
+        For each of the two order_ids from the SAME ORDER pair, count how
+        many actual fills REST reports. If REST says 1 per orderId → buffer
+        was correct, real duplicate. If REST disagrees (e.g., 0 or some
+        order_id not in REST list) → WS lied.
+
+        Failures here are logged as ERROR but never raised — diagnostic is
+        best-effort, never breaks the main loop.
+        """
+        try:
+            # Access the rest_client through the executor. This is a
+            # diagnostic-only path; a proper API addition can come later.
+            rest_client = self._executor._client
+            executions, _ = rest_client.get_executions(
+                symbol=self.symbol, limit=50,
+            )
+            cur_id = current["order_id"]
+            prev_id = previous["order_id"]
+            cur_matches = [e for e in executions if e.get("orderId") == cur_id]
+            prev_matches = [e for e in executions if e.get("orderId") == prev_id]
+            verdict = (
+                "REAL_DUPLICATE" if len(cur_matches) >= 1 and len(prev_matches) >= 1
+                and cur_id != prev_id
+                else "WS_GLITCH_SUSPECTED"
+            )
+            logger.error(
+                f"{self.strat_id}: SAME ORDER REST cross-check — verdict={verdict} "
+                f"(REST returned {len(executions)} recent executions for {self.symbol}). "
+                f"current order_id={cur_id} → {len(cur_matches)} REST matches "
+                f"[{[(m.get('execId'), m.get('execPrice'), m.get('execQty'), m.get('orderLinkId'), m.get('execType')) for m in cur_matches[:3]]}]; "
+                f"previous order_id={prev_id} → {len(prev_matches)} REST matches "
+                f"[{[(m.get('execId'), m.get('execPrice'), m.get('execQty'), m.get('orderLinkId'), m.get('execType')) for m in prev_matches[:3]]}]"
+            )
+        except Exception as e:
+            logger.error(
+                f"{self.strat_id}: SAME ORDER REST cross-check failed "
+                f"(diagnostic only, ignoring): {e}", exc_info=True,
+            )
+

--- a/apps/gridbot/src/gridbot/runner.py
+++ b/apps/gridbot/src/gridbot/runner.py
@@ -51,6 +51,13 @@ _FLOAT_TO_DECIMAL = {
     2.0: Decimal("2"),
 }
 
+# Time window for SAME ORDER detection: only flag pairs whose exchange_ts
+# are within this many seconds. Concurrent grid duplicates (the bug bbu2
+# was designed to catch) fill within milliseconds; sequential grid-walk
+# replacements at the same price are minutes-to-hours apart and must not
+# trigger. See docs/features/0025_PLAN.md.
+_SAME_ORDER_TIME_WINDOW_SEC = 5.0
+
 
 @dataclass
 class TrackedOrder:
@@ -988,11 +995,23 @@ class StrategyRunner:
         self._check_same_orders_side(self._recent_executions_short)
 
     def _check_same_orders_side(self, executions: deque) -> None:
-        """Check execution buffer for same-price duplicates.
+        """Check execution buffer for same-price duplicates within a time window.
 
         Compares consecutive executions. If same price and side but different
-        order_id, this indicates a duplicate order was placed at the same
-        price level - a grid bug.
+        order_id AND the two fills happened within ``_SAME_ORDER_TIME_WINDOW_SEC``,
+        this indicates a duplicate order was placed at the same price level -
+        a grid bug.
+
+        Time-window rationale (feature 0025): bbu2's detector was designed
+        for *concurrent* grid duplication — two intents emitted for the same
+        slot in the same tick, so both fills land within milliseconds. Our
+        engine instead exhibits *sequential* grid-walk replacement: as price
+        walks up/down, an old level is rebuilt later at the same price,
+        minutes-to-hours after the original fill. Without a time-window
+        guard, every legitimate grid replacement looks like a duplicate. The
+        5-second window is comfortably above worst-case hedge-pair
+        concurrent-fill latency (<500 ms) and far below any plausible
+        grid-replacement gap.
 
         Set-on-error only: this method sets ``_same_order_error`` to
         True on detection and never clears it. The caller
@@ -1011,6 +1030,17 @@ class StrategyRunner:
                 if current["order_id"] == previous["order_id"]:
                     # Same order ID (partial fills) - OK
                     return
+                # Time-window guard: skip pairs that are far apart in time.
+                # Buffer is maxlen=2, so a single mismatched pair means no
+                # duplicate exists in the buffer at all — `return` is correct.
+                # If the buffer ever grows past 2, switch to `continue` so
+                # other pairs in the buffer can still be evaluated.
+                cur_ts = current.get("exchange_ts")
+                prev_ts = previous.get("exchange_ts")
+                if cur_ts is not None and prev_ts is not None:
+                    delta_sec = abs((cur_ts - prev_ts).total_seconds())
+                    if delta_sec > _SAME_ORDER_TIME_WINDOW_SEC:
+                        return
                 # Different order IDs at same price = DUPLICATE ERROR
                 # Diagnostic dump: include closed_size, order_link_id, and
                 # tracked-order reduce_only (looked up via _tracked_orders)

--- a/apps/gridbot/tests/test_runner.py
+++ b/apps/gridbot/tests/test_runner.py
@@ -1,6 +1,6 @@
 """Tests for gridbot strategy runner module."""
 
-from datetime import datetime, UTC
+from datetime import datetime, timedelta, UTC
 from decimal import Decimal
 from unittest.mock import Mock, MagicMock
 
@@ -1856,6 +1856,191 @@ class TestSameOrderDetection:
         # Buffer still has only 1 entry (the fully filled one)
         assert len(runner._recent_executions_long) == 1
         assert runner.same_order_error is False
+
+    def test_same_order_skips_when_fills_far_apart(self, runner, caplog):
+        """Sequential grid-walk replacement: two same-price fills 10 minutes apart.
+
+        This is the production failure mode that feature 0025 fixes.
+        Without the time-window guard, this fired SAME ORDER ERROR and
+        blocked placement on every legitimate grid replacement.
+        """
+        import logging
+
+        t0 = datetime.now(UTC)
+
+        event1 = ExecutionEvent(
+            event_type=EventType.EXECUTION,
+            symbol="BTCUSDT",
+            exchange_ts=t0,
+            local_ts=t0,
+            exec_id="exec_1",
+            order_id="order_1",
+            order_link_id="abc123",
+            side="Buy",
+            price=Decimal("50000.0"),
+            qty=Decimal("0.1"),
+            fee=Decimal("0.5"),
+            closed_pnl=Decimal("0"),
+        )
+        runner._check_same_orders(event1)
+
+        # Second fill at the same price, 10 minutes later — legitimate
+        # grid-walk replacement, not a duplicate.
+        t1 = t0 + timedelta(minutes=10)
+        event2 = ExecutionEvent(
+            event_type=EventType.EXECUTION,
+            symbol="BTCUSDT",
+            exchange_ts=t1,
+            local_ts=t1,
+            exec_id="exec_2",
+            order_id="order_2",
+            order_link_id="def456",
+            side="Buy",
+            price=Decimal("50000.0"),
+            qty=Decimal("0.1"),
+            fee=Decimal("0.5"),
+            closed_pnl=Decimal("0"),
+        )
+        with caplog.at_level(logging.ERROR):
+            runner._check_same_orders(event2)
+
+        assert runner.same_order_error is False
+        same_order_errors = [r for r in caplog.records if "SAME ORDER ERROR" in r.message]
+        assert same_order_errors == []
+
+    def test_same_order_fires_when_fills_within_window(self, runner):
+        """Concurrent grid duplication: two same-price fills 2 seconds apart.
+
+        Within the 5-second window, the detector still triggers — preserving
+        the original bbu2 protection against the bug it was designed to catch.
+        """
+        t0 = datetime.now(UTC)
+
+        event1 = ExecutionEvent(
+            event_type=EventType.EXECUTION,
+            symbol="BTCUSDT",
+            exchange_ts=t0,
+            local_ts=t0,
+            exec_id="exec_1",
+            order_id="order_1",
+            order_link_id="abc123",
+            side="Buy",
+            price=Decimal("50000.0"),
+            qty=Decimal("0.1"),
+            fee=Decimal("0.5"),
+            closed_pnl=Decimal("0"),
+        )
+        runner._check_same_orders(event1)
+
+        t1 = t0 + timedelta(seconds=2)
+        event2 = ExecutionEvent(
+            event_type=EventType.EXECUTION,
+            symbol="BTCUSDT",
+            exchange_ts=t1,
+            local_ts=t1,
+            exec_id="exec_2",
+            order_id="order_2",
+            order_link_id="def456",
+            side="Buy",
+            price=Decimal("50000.0"),
+            qty=Decimal("0.1"),
+            fee=Decimal("0.5"),
+            closed_pnl=Decimal("0"),
+        )
+        runner._check_same_orders(event2)
+
+        assert runner.same_order_error is True
+
+    def test_same_order_at_window_boundary(self, runner):
+        """Boundary: delta_sec == 5.0 still fires (we use strict `>`)."""
+        t0 = datetime.now(UTC)
+
+        event1 = ExecutionEvent(
+            event_type=EventType.EXECUTION,
+            symbol="BTCUSDT",
+            exchange_ts=t0,
+            local_ts=t0,
+            exec_id="exec_1",
+            order_id="order_1",
+            order_link_id="abc123",
+            side="Buy",
+            price=Decimal("50000.0"),
+            qty=Decimal("0.1"),
+            fee=Decimal("0.5"),
+            closed_pnl=Decimal("0"),
+        )
+        runner._check_same_orders(event1)
+
+        t1 = t0 + timedelta(seconds=5)
+        event2 = ExecutionEvent(
+            event_type=EventType.EXECUTION,
+            symbol="BTCUSDT",
+            exchange_ts=t1,
+            local_ts=t1,
+            exec_id="exec_2",
+            order_id="order_2",
+            order_link_id="def456",
+            side="Buy",
+            price=Decimal("50000.0"),
+            qty=Decimal("0.1"),
+            fee=Decimal("0.5"),
+            closed_pnl=Decimal("0"),
+        )
+        runner._check_same_orders(event2)
+
+        assert runner.same_order_error is True
+
+    def test_same_order_window_does_not_break_hedge_pair_isolation(self, runner):
+        """Regression-guard: concurrent hedge-pair fills at the same price.
+
+        Hedge mode emits an Open-Long Buy and a Close-Short Buy at the same
+        price simultaneously. ``closed_size`` routes them into different
+        buffers (long vs short), so even within the time window they must
+        never compare against each other and must not trigger SAME ORDER.
+        """
+        t0 = datetime.now(UTC)
+
+        # Open Long Buy: closed_size == 0 → long buffer
+        open_long = ExecutionEvent(
+            event_type=EventType.EXECUTION,
+            symbol="BTCUSDT",
+            exchange_ts=t0,
+            local_ts=t0,
+            exec_id="exec_open",
+            order_id="order_open",
+            order_link_id="open_link",
+            side="Buy",
+            price=Decimal("50000.0"),
+            qty=Decimal("0.1"),
+            fee=Decimal("0.5"),
+            closed_pnl=Decimal("0"),
+            closed_size=Decimal("0"),
+        )
+        runner._check_same_orders(open_long)
+
+        # Close Short Buy: closed_size > 0 → short buffer. Same price,
+        # ~1 ms later (within the time window).
+        t1 = t0 + timedelta(milliseconds=1)
+        close_short = ExecutionEvent(
+            event_type=EventType.EXECUTION,
+            symbol="BTCUSDT",
+            exchange_ts=t1,
+            local_ts=t1,
+            exec_id="exec_close",
+            order_id="order_close",
+            order_link_id="close_link",
+            side="Buy",
+            price=Decimal("50000.0"),
+            qty=Decimal("0.1"),
+            fee=Decimal("0.5"),
+            closed_pnl=Decimal("5.0"),
+            closed_size=Decimal("0.1"),
+        )
+        runner._check_same_orders(close_short)
+
+        assert runner.same_order_error is False
+        assert len(runner._recent_executions_long) == 1
+        assert len(runner._recent_executions_short) == 1
 
 
 class TestRunnerAuthCooldown:

--- a/docs/features/0025_PLAN.md
+++ b/docs/features/0025_PLAN.md
@@ -1,0 +1,118 @@
+# 0025_PLAN — SAME ORDER detector: time-window guard against grid-walk replacements
+
+## Description
+
+The `_check_same_orders` detector inherited from bbu2 flags two same-`(price, side)` fills with different `order_id`s as a grid duplicate and blocks all further placement. The detector was designed to catch **concurrent grid duplication** — a hypothetical bug where the engine emits two intents for the same grid slot in the same tick. In our codebase the actual production failure mode is different: **sequential grid replacement through walk**.
+
+Live evidence (2026-05-04, mainnet):
+
+- 9 SAME ORDER ERROR triggers in 12 hours (02:30, 03:03, 06:30, 07:09, 07:20, 07:35, 11:08, 11:27, 17:53).
+- Each trigger blocked placement for 5–30 minutes until a non-matching fill cleared the buffer.
+- Diagnostic REST cross-check on the 17:53 trigger returned `verdict=REAL_DUPLICATE` (both orders existed and filled on Bybit) — confirming both fills were real, not a WS glitch.
+- Bybit UI Order History (screenshot 2026-05-04) sealed the diagnosis: the two filled orders behind the 17:53 SAME ORDER were placed on grid replacements **2 hours apart** (15:56:53 and 17:53:29), both legitimately `Open Long @ 55.20 qty 0.1`. Between them no other `Open Long` fill displaced the older buffer entry, so when the new fill arrived the detector found a stale partner and triggered.
+- The same UI confirmed that "concurrent same-price double-placements" we initially suspected (e.g. 09:00:08 placing two Buy@56.0 within 1 ms) are legitimate **hedge-mode pairs** — one `Open Long`, one `Close Short` — that the buffer-splitter (via `closedSize`) correctly routes into different per-direction buffers and never compares against each other.
+
+The fix is a **time-window guard** on the detector: only flag if the two fills happened within a narrow window. Sequential replacements from grid walks have time gaps measured in minutes-to-hours; concurrent grid duplication (the bug bbu2 wanted to catch) would put both fills within milliseconds.
+
+User selections from prior conversation (verbatim):
+- "близкие во времени = подозрительные, далёкие = нормальные" — confirmed time-window semantic.
+- "5 секунд" — accepted as the default window.
+- "детектор это kill switch, а не auto-fix" — keep the existing block-and-self-clear behavior; do not add cancel-replace logic.
+
+## Context
+
+- Detector entry point: `apps/gridbot/src/gridbot/runner.py:899-973` (`_check_same_orders`).
+- Side-comparison loop: `apps/gridbot/src/gridbot/runner.py:974-1062` (`_check_same_orders_side`).
+- Buffer record schema (already enriched in diagnostic patch on `diag/same-order-investigation`): includes `exchange_ts`, `closed_size`, `order_link_id`, `buffer` label.
+- The fields needed for the fix (`exchange_ts`) are **already on `ExecutionEvent`** (`packages/gridcore/src/gridcore/events.py:81-103`) and **already populated into the buffer record** (`runner.py:954-960`). The fix only adds a `delta_t` comparison; no new fields, no normalizer changes.
+- Self-clearing behavior (no change planned): the wrapper resets `_same_order_error = False` at the top of every `_check_same_orders` invocation (`runner.py:968`); each new fill re-runs the side checks and clears the flag if the new buffer state no longer contains a matching pair. This natural clearance has been observed live (e.g. 03:03 → 03:13 self-cleared after a non-matching fill).
+- Buffer size unchanged at `maxlen=2` (`runner.py:179-180`) — keeps the bbu2-style pairwise-only check.
+
+## Reference
+
+- bbu2 detector original (no time-window): `bbu_reference/bbu2-master/bybit_api_usdt.py:157-169` (`_check_same_orders_side`). bbu2's grid does not walk in the way ours does, so the failure mode this fix addresses doesn't manifest there.
+- Hedge-pair split-by-direction (works correctly today, no change): `runner.py:947-952` — `Buy + closedSize=0 → long buffer`, `Buy + closedSize>0 → short buffer`. Verified live at 2026-05-04 18:04:25 (Close Short + Open Long both at 55.00, fills routed to different buffers, no SAME ORDER triggered).
+- Diagnostic patches that found the root cause: `diag/same-order-investigation` branch — `0df4eed` (closed_size + reduce_only dump) and `28358aa` (REST cross-check). Both can be cherry-picked or remain on their own branch; see "Out of scope".
+
+## Algorithm
+
+### Step 1 — add the time-window constant
+
+In `runner.py`, near the top of the file (alongside the `_FLOAT_TO_DECIMAL` constant or in a similar module-level location):
+
+```
+_SAME_ORDER_TIME_WINDOW_SEC = 5.0
+```
+
+5 seconds is comfortably above the maximum observed hedge-pair concurrent-fill latency (typically <500 ms even under load) and far below any plausible grid-replacement gap (minutes minimum). It can be tuned via constant later if needed.
+
+### Step 2 — add the guard in `_check_same_orders_side`
+
+In `runner.py` (line 974+), before the existing `(price, side)` comparison:
+
+1. Inside the per-pair loop, compute `delta_sec = abs((current["exchange_ts"] - previous["exchange_ts"]).total_seconds())`.
+2. If `delta_sec > _SAME_ORDER_TIME_WINDOW_SEC`: skip this pair (continue / return — see note below).
+3. Existing comparison logic runs only when both fills are within the window.
+
+**Loop continuation note**: with `maxlen=2` the buffer holds at most one pair, so on time-window miss we should `return` (mirroring the existing early-returns in this function). If the buffer is ever expanded, switch to `continue`. Comment this clearly.
+
+### Step 3 — propagate the new behavior to existing tests
+
+Existing tests in `apps/gridbot/tests/test_runner.py` that drive `_check_same_orders` likely use buffer records without `exchange_ts` or with stale timestamps that would now skip the duplicate check unintentionally. Audit and adjust:
+
+- For tests that **want** the duplicate to fire: ensure the two fills' `exchange_ts` differ by **<5 sec** (use `datetime.now(UTC)` for both, or set explicit close timestamps).
+- For tests that **want** no flag: optionally add a new test where timestamps differ by `>5 sec` and verify no flag fires.
+
+### Step 4 — new positive and negative tests
+
+Add to `apps/gridbot/tests/test_runner.py`:
+
+- `test_same_order_skips_when_fills_far_apart`: two fills with same `(price, side)` but `exchange_ts` 10 minutes apart — assert `_same_order_error` stays False, no logger.error call.
+- `test_same_order_fires_when_fills_within_window`: two fills with same `(price, side)`, `exchange_ts` 2 seconds apart, different `order_id` — assert flag set True.
+- `test_same_order_at_window_boundary`: `exchange_ts` exactly 5.0 seconds apart — verify documented behavior (we use strict `>`, so delta=5.0 still fires).
+- `test_same_order_window_does_not_break_hedge_pair_isolation`: simulate concurrent (delta <1 s) Open-Long Buy + Close-Short Buy fills (one with `closed_size=0`, one with `closed_size>0`), at the same price — assert each lands in its own buffer and no SAME ORDER fires (regression-guard for the existing buffer-split behavior, not changed by this fix but worth pinning).
+
+## Files to change
+
+### App / gridbot
+
+- `apps/gridbot/src/gridbot/runner.py`
+  - Add `_SAME_ORDER_TIME_WINDOW_SEC = 5.0` at module level.
+  - In `_check_same_orders_side`, insert the time-window guard at the top of the per-pair comparison (Step 2).
+  - Update the existing block comment about detector intent (`runner.py:974-988` area) to document the time-window semantic and rationale (sequential grid replacements via walk vs concurrent grid duplicates).
+
+### Tests
+
+- `apps/gridbot/tests/test_runner.py`
+  - Audit existing `_check_same_orders` tests for `exchange_ts` correctness (Step 3).
+  - Add 4 new tests (Step 4).
+
+## Diagnostic patches — kept as permanent safety net
+
+Two diagnostic commits originally lived on `diag/same-order-investigation` and have been cherry-picked onto this branch (per user intent: keep diagnostics active in production for ongoing visibility):
+
+- **`0a6091e`** (originally `0df4eed`) — extends the SAME ORDER ERROR log with `closed_size`, `order_link_id`, and the tracked-order `reduce_only` lookup. Permanent context dump on every detector trigger.
+- **`214293d`** (originally `28358aa`) — REST `get_executions` cross-check on first occurrence per `(order_id, order_id)` pair, prints `verdict=REAL_DUPLICATE | WS_GLITCH_SUSPECTED` plus per-fill execId/execPrice/execQty/orderLinkId/execType. Rate-limited via `_diagnosed_same_order_pairs` set so the SAME-order-error flap doesn't hammer the API.
+
+After this Feature 0025 ships, the detector will fire only on **genuine concurrent grid duplicates** (rare), and on every such event the diagnostic + REST cross-check confirms it's a real bug, not a false positive. Cost is ~100 lines of code that run only on rare degraded events — well worth keeping permanently.
+
+The original `diag/same-order-investigation` branch can be deleted after this PR merges.
+
+## Out of scope
+
+- Buffer size / `maxlen` increase. Keep at 2 (bbu2 pattern) — the time-window guard is the precise fix.
+- Auto-cancel of "duplicate" orders. Detector remains a kill-switch; operator handles cleanup.
+- `_is_good_to_place` exact-duplicate refactor. Not implicated — confirmed correctly allowing legitimate hedge-pairs through (different `reduce_only`).
+- The pybit `orderLinkId` not propagating through WS execution stream. Real but separate issue; doesn't block this fix because the detector now ignores it on long-gap cases anyway.
+- Notifier alert escalation behavior. Unchanged.
+
+## Verification
+
+1. Unit tests: `uv run pytest apps/gridbot/tests/test_runner.py -k same_order -v` — all pass, including the 4 new tests.
+2. Full sweep: `uv run pytest apps/gridbot/tests/ packages/gridcore/tests/ -q` — no regressions.
+3. Lint: `uv run ruff check apps/gridbot/src/gridbot/runner.py apps/gridbot/tests/test_runner.py` — clean.
+4. Live mainnet: merge fix → restart bot → run for ≥6 hours covering at least 2 grid walks across the same price level. Expected:
+   - Zero SAME ORDER ERROR triggers from sequential same-price replacements.
+   - The hedge-pair behavior at e.g. 18:04:25 (Close Short + Open Long at same price) continues to NOT trigger.
+   - If a real concurrent duplicate ever happens, it still triggers (verifies fix didn't disable the protection).
+5. Replay validation (optional): take the 2026-05-04 17:53:29 SAME ORDER pair (`951fcbfc` + `d8b9d487`, fills 2 hours apart) and run through the patched detector in a unit test. Assert no flag fires.

--- a/docs/features/0025_REVIEW.md
+++ b/docs/features/0025_REVIEW.md
@@ -1,0 +1,31 @@
+# 0025 Review — SAME ORDER time-window guard
+
+## Summary
+
+No blocking findings.
+
+The implementation matches `docs/features/0025_PLAN.md`:
+
+- Adds `_SAME_ORDER_TIME_WINDOW_SEC = 5.0` in `apps/gridbot/src/gridbot/runner.py`.
+- Stores `exchange_ts` in each SAME ORDER buffer record.
+- Applies a strict `delta_sec > 5.0` guard before flagging same-price/same-side/different-order fills.
+- Preserves the existing kill-switch behavior, buffer size, long/short buffer isolation, diagnostic logging, notifier alert, and REST cross-check behavior.
+- Adds tests for far-apart fills, within-window fills, exact boundary behavior, and hedge-pair isolation.
+
+## Findings
+
+None.
+
+## Review Notes
+
+- Timestamp alignment is correct: live execution events are normalized from Bybit `execTime` into UTC `datetime` values before reaching `StrategyRunner`, so subtracting `exchange_ts` values is safe for the live path.
+- The strict boundary behavior is documented and tested: `delta_sec == 5.0` still triggers, while `delta_sec > 5.0` skips.
+- The `return` on a time-window miss is consistent with the current `deque(maxlen=2)` design and is clearly documented for a future buffer-size change.
+- Existing positive SAME ORDER tests continue to pass because their `datetime.now(UTC)` timestamps are naturally within the window. The new explicit positive and boundary tests make that behavior less implicit.
+- The diagnostic REST cross-check remains best-effort and exception-contained, so keeping it after the new guard does not change detector semantics.
+
+## Verification
+
+- `uv run pytest apps/gridbot/tests/test_runner.py -k same_order -q` — 11 passed, 102 deselected.
+- `uv run pytest apps/gridbot/tests/ packages/gridcore/tests/ -q` — 764 passed, 1 skipped.
+- `uv run ruff check apps/gridbot/src/gridbot/runner.py apps/gridbot/tests/test_runner.py` — passed.


### PR DESCRIPTION
## Summary

- Add a 5s `exchange_ts` window guard to `_check_same_orders_side` so legitimate sequential grid-walk replacements at the same price (minutes-to-hours apart) no longer trigger SAME ORDER ERROR. The bbu2-derived detector was designed for *concurrent* grid duplication (sub-second); our engine instead exhibits *sequential* replacement, which produced 9 false-positive triggers in a 12-hour window on 2026-05-04 mainnet.
- Keeps detector behavior intact for genuine concurrent duplicates and for the hedge-pair Open-Long / Close-Short case (which is correctly split across long/short buffers).
- Includes the diagnostic commits from `diag/same-order-investigation` (closed_size + reduce_only dump and REST executions cross-check) as a permanent safety net so any future trigger emits full forensic context.
- See `docs/features/0025_PLAN.md` and `docs/features/0025_REVIEW.md` for full context, live evidence, and rationale.

## Test plan

- [x] `uv run pytest apps/gridbot/tests/test_runner.py -k same_order -v` — new and existing tests pass
- [ ] `uv run pytest apps/gridbot/tests/ packages/gridcore/tests/ -q` — full sweep, no regressions
- [ ] `uv run ruff check apps/gridbot/src/gridbot/runner.py apps/gridbot/tests/test_runner.py`
- [ ] Live mainnet: ≥6h covering ≥2 grid walks across the same price level — expect zero SAME ORDER ERROR from sequential replacements; hedge-pair fills at the same price continue to not trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)