### PR TITLE
fix(ws): disable private message-gap watchdog (0026)

### DIFF
--- a/apps/gridbot/src/gridbot/orchestrator.py
+++ b/apps/gridbot/src/gridbot/orchestrator.py
@@ -629,6 +629,7 @@ class Orchestrator:
             on_order=lambda msg, a=name: self._on_order(a, msg),
             on_execution=lambda msg, a=name: self._on_execution(a, msg),
             on_disconnect=lambda ts, a=name: self._on_ws_disconnect(a, "private", ts),
+            message_gap_watchdog_enabled=False,
         )
 
         logger.info(f"Initialized account: {name}")

--- a/apps/gridbot/tests/test_orchestrator.py
+++ b/apps/gridbot/tests/test_orchestrator.py
@@ -120,6 +120,26 @@ class TestOrchestratorInit:
     @patch("gridbot.orchestrator.BybitRestClient")
     @patch("gridbot.orchestrator.PublicWebSocketClient")
     @patch("gridbot.orchestrator.PrivateWebSocketClient")
+    def test_init_account_disables_private_message_gap_watchdog(
+        self,
+        mock_private_ws,
+        mock_public_ws,
+        mock_rest_client,
+        gridbot_config,
+        account_config,
+    ):
+        """Private WS is constructed with the message-gap watchdog disabled
+        (feature 0026 — TCP probe is the sole disconnect signal for private).
+        """
+        orchestrator = Orchestrator(gridbot_config)
+        orchestrator._init_account(account_config)
+
+        priv_kwargs = mock_private_ws.call_args.kwargs
+        assert priv_kwargs.get("message_gap_watchdog_enabled") is False
+
+    @patch("gridbot.orchestrator.BybitRestClient")
+    @patch("gridbot.orchestrator.PublicWebSocketClient")
+    @patch("gridbot.orchestrator.PrivateWebSocketClient")
     def test_init_strategy(
         self,
         mock_private_ws,

--- a/docs/features/0026_PLAN.md
+++ b/docs/features/0026_PLAN.md
@@ -1,0 +1,160 @@
+# 0026_PLAN — Disable private-WS message-gap watchdog (rely on TCP probe)
+
+## Description
+
+The private Bybit WebSocket heartbeat watchdog fires `Detected disconnection: no messages for 30.0s` ~every 30 seconds during quiet trading periods even though the connection is healthy. Overnight log evidence (`/tmp/gridbot.log` 2026-05-04 22:00 → 2026-05-05 09:00, lines 1438393-1527659): **1249 false disconnects vs 10 real reconnects** — a ~99% false-positive rate. Each false trigger forces a full WS reset cycle via `_on_ws_disconnect` → `client.reset()`, polluting logs and creating ~1249 ~1-second windows per night during which an arriving fill could be lost.
+
+Root cause confirmed: `_update_last_message_ts()` (`packages/bybit_adapter/src/bybit_adapter/ws_client.py:637` for private) is the only place that resets the watchdog clock, and it is only called from the four business-event handlers `_handle_execution`, `_handle_order`, `_handle_position`, `_handle_wallet` (lines 521, 530, 539, 548). pybit's protocol-level ping/pong frames (custom JSON `{"op": "ping"}`, 20 s interval — `.venv/.../pybit/_websocket_stream.py:36-37,70-73`) are filtered out by `_is_custom_pong` and never reach our handlers. So during quiet periods on the private channel (no fills, no order/position changes), the watchdog correctly observes "no business data" but incorrectly concludes "disconnected."
+
+The fix: **stop using the message-gap detector as a disconnect signal on the private channel.** Rely on Feature 0024's TCP-level probe (`_ws_health_check_once` in `apps/gridbot/src/gridbot/orchestrator.py:977-1024`), which polls pybit's native `ws.sock.connected` every 10 s and resets dead sockets actively. Public channel keeps its watchdog (ticker/trade traffic is dense; 30 s of silence on public *is* a real fault).
+
+User selections from prior research conversation:
+- "вариант D" — disable watchdog on private only, rely on Feature 0024 + pybit pong-timeout.
+- Public watchdog stays untouched ("на public канале watchdog оставить — там тишина = реальный признак проблемы").
+- Manual fault-injection test required before merge ("на dev-окружении выдернуть Wi-Fi на 30 с при пустом private канале").
+
+## Context
+
+### Watchdog source today
+
+- Constants: `packages/bybit_adapter/src/bybit_adapter/ws_client.py:29-30` — `DEFAULT_HEARTBEAT_INTERVAL = 5.0`, `DEFAULT_DISCONNECT_THRESHOLD = 30.0`.
+- `PrivateWebSocketClient` is a `@dataclass` (`:351`) with field defaults at `:380-389` (api keys, callbacks, `heartbeat_interval`, `disconnect_threshold`).
+- Private watchdog loop: `:595-665` (`_heartbeat_loop`). Disconnect is detected at `:617-624`; `on_disconnect` fires at `:631-633`.
+- Private `_update_last_message_ts`: `:637`. Called only from handlers at `:521, :530, :539, :548`.
+- Private `_heartbeat_thread` start: at the end of `connect()` at `:443`, via `_start_heartbeat_watchdog()` (`:555-570`).
+- `reset()` (`:506-517`): `_stop_heartbeat_watchdog()` → `_disconnect_internal()` → `self.connect()`. So gating heartbeat start inside `connect()` automatically covers the reset path.
+
+### TCP-probe path (Feature 0024) — kept as primary signal
+
+- `is_socket_alive()` private: `ws_client.py:489-503` → delegates to pybit's `WebSocket.is_connected()` → `ws.sock.connected` (TCP-level boolean from `websocket-client`).
+- Probe loop: `apps/gridbot/src/gridbot/orchestrator.py:977-1024` (`_ws_health_check_once`). Polls every `_WS_HEALTH_CHECK_INTERVAL = 10.0` s. Calls `client.reset()` if `is_socket_alive()` returns False.
+- pybit's infinite-reconnect (`retries=0` at `ws_client.py:416`) already wired by Feature 0024 — third defense layer that activates *after pybit's own error path notices a socket error*. Does not help against zombie-connected sockets where pybit never sees an error to trigger reconnect.
+- Detection latency on real disconnects (worst case, see derivation):
+  - pybit defaults: `ping_interval=20, ping_timeout=10` (`pybit/_websocket_stream.py:36-37`).
+  - Worst case: network drops immediately after a successful pong; next ping is up to 20 s away; pong-timeout adds 10 s; probe runs every 10 s → up to 10 s before reset is invoked.
+  - **Total worst case: ~40 s.** Typical case (drop mid-window): ~20-25 s.
+
+### Stale-flag health check (orthogonal, not changed here)
+
+- `is_connected()` (logical state-flag, not TCP): `ws_client.py:480-487`.
+- Used by older `_health_check_once` at `orchestrator.py:923, 949`. Out of scope; do not touch.
+
+### Existing tests for the watchdog
+
+- `packages/bybit_adapter/tests/test_ws_client.py` — `TestPrivateWebSocketClientDisconnectDetection`. Tests assert `on_disconnect` callback fires after threshold seconds of silence on the private client.
+
+## Algorithm
+
+The change is small and surgical: gate the private heartbeat watchdog behind a constructor flag, default-on (preserves current behavior for any caller that doesn't opt out), explicitly disabled for the orchestrator's private client.
+
+### Step 1 — add `message_gap_watchdog_enabled` field to `PrivateWebSocketClient`
+
+`PrivateWebSocketClient` is a `@dataclass`, so add a new field next to `disconnect_threshold` (`:389`):
+
+```
+message_gap_watchdog_enabled: bool = True
+```
+
+Default `True` preserves current behavior for callers that don't opt out (including all existing tests). The orchestrator opts out explicitly in Step 2.
+
+In `connect()` (private), at the heartbeat-start site `:443`, gate the call:
+- If `self.message_gap_watchdog_enabled` is False: log `INFO` "Heartbeat watchdog disabled for private (relying on TCP probe)" and skip `_start_heartbeat_watchdog()`.
+- Else: start as today.
+
+`reset()` (`:506-517`) calls `self.connect()` after disconnect, so the gate inside `connect()` automatically covers the reset path. No additional change in `reset()`. (A regression test in Step 5 locks this in.)
+
+The `_update_last_message_ts()` calls in handlers (`:521, :530, :539, :548`) still execute and still update `self._state.last_message_ts`. They are not no-ops — the field is just no longer read by any consumer when the watchdog is disabled. Leave them in: cheap, useful for debugging / future metrics.
+
+### Step 2 — wire the flag from orchestrator
+
+In `apps/gridbot/src/gridbot/orchestrator.py` at the `PrivateWebSocketClient(...)` construction site inside `_init_account` (around `:631`), pass `message_gap_watchdog_enabled=False`.
+
+Do NOT touch the `PublicWebSocketClient(...)` construction. Public watchdog stays as-is.
+
+### Step 3 — keep `on_disconnect` callback wired (deliberate, not oversight)
+
+Leave `on_disconnect=lambda ts, a=name: self._on_ws_disconnect(a, "private", ts)` (`orchestrator.py:631`) in place. With the watchdog disabled the callback never fires for the private channel.
+
+Rationale for keeping it (so future readers don't ask "why is this dormant callback wired?"):
+- Same `_on_ws_disconnect` method serves the public client, where the callback DOES fire. Removing only the private wiring creates inconsistency at the construction site.
+- Reversion path: if the TCP probe ever proves insufficient for private, flipping `message_gap_watchdog_enabled=True` immediately re-enables the full secondary signal — no re-wiring needed.
+- Tests that exercise `_on_ws_disconnect` for both kinds keep working with no scaffold changes.
+
+### Step 4 — confirm no other consumers of private watchdog state
+
+- `_state.last_message_ts` and `_state.reconnect_count` for private: grep usages. `reconnect_count` is updated only inside `_update_last_message_ts` when a previously-detected disconnect ends (`:631-635` reconnection path). With watchdog disabled, `reconnect_count` for private will stay at 0 — acceptable, since this counter is observability-only and the same information is captured by the probe-side `WS socket dead ... resetting` WARN.
+- No other production code depends on watchdog state for private. Tests do — see Step 5.
+
+### Step 5 — tests
+
+- `packages/bybit_adapter/tests/test_ws_client.py`:
+  - New: `test_private_watchdog_disabled_skips_heartbeat_thread` — construct `PrivateWebSocketClient(..., message_gap_watchdog_enabled=False)`, call `connect()`, assert `self._heartbeat_thread is None`. Also assert that `connect()` did not short-circuit: `is_connected() is True` and the patched pybit `WebSocket` mock saw the expected `execution_stream` / `order_stream` / `position_stream` / `wallet_stream` subscription calls.
+  - New: `test_private_watchdog_disabled_never_fires_on_disconnect` — same scaffold, set an `on_disconnect` spy, wait past threshold using the existing short-interval pattern (`heartbeat_interval=0.1, disconnect_threshold=0.3` + `time.sleep(0.5)` — see existing tests at `:42-49, :68-75`), assert spy was NOT called.
+  - New: `test_private_watchdog_disabled_survives_reset` — construct disabled, `connect()`, then `reset()`; assert `self._heartbeat_thread is None` after reset (regression guard for the gate-inside-connect approach).
+  - Existing `TestPrivateWebSocketClientDisconnectDetection` tests: leave unchanged — they construct without the new flag (default `True`), so the watchdog still runs and the existing assertions hold.
+
+- `apps/gridbot/tests/test_orchestrator.py`:
+  - New: `test_private_ws_constructed_with_watchdog_disabled` — patch `PrivateWebSocketClient`, call `_init_account`, assert the constructor was called with `message_gap_watchdog_enabled=False`.
+  - Existing tests for `_on_ws_disconnect` and `_ws_health_check_once`: leave unchanged. The probe path is the same; the callback path is just dormant for private.
+
+## Files to change
+
+### Adapter
+
+- `packages/bybit_adapter/src/bybit_adapter/ws_client.py`
+  - `PrivateWebSocketClient` dataclass (`:351, :380-389`): add field `message_gap_watchdog_enabled: bool = True` next to `disconnect_threshold`.
+  - `PrivateWebSocketClient.connect()` at `:443`: gate `_start_heartbeat_watchdog()` on the flag; log INFO when skipped.
+  - No changes to `PublicWebSocketClient`.
+
+### App / gridbot
+
+- `apps/gridbot/src/gridbot/orchestrator.py`
+  - `_init_account` at the `PrivateWebSocketClient(` constructor (around `:631`): pass `message_gap_watchdog_enabled=False`.
+
+### Tests
+
+- `packages/bybit_adapter/tests/test_ws_client.py` — three new tests under `TestPrivateWebSocketClientDisconnectDetection` (Step 5).
+- `apps/gridbot/tests/test_orchestrator.py` — one new constructor-args assertion (Step 5).
+
+## Interaction with existing logic
+
+- **Feature 0023 (WS position drain)**: orthogonal. Watchdog removal does not affect `_handle_position` data flow or per-symbol seq counters used for coalescing. The handler still fires; only the secondary timestamp update becomes unobserved.
+- **Feature 0024 (active reconnect on real disconnects)**: this plan *narrows* 0024 to its primary signal (TCP probe) on the private channel and removes the secondary signal (message-gap). The probe path is untouched; only the dormant callback path is bypassed.
+- **`_on_ws_disconnect` callback**: stays wired. With watchdog disabled it simply never fires for `kind="private"`. Public still uses it. No code removal — keeps the diff minimal and reversible.
+- **`reconnect_count` for private**: will stay at 0 in steady state (no detected gaps → no detected reconnections). Visible only in logs/state dumps, not used for control flow.
+- **Logs after fix**:
+  - The adapter-side WARN `Detected disconnection: no messages for 30.0s` (`ws_client.py:310, :622`) does NOT include public/private discriminator — both clients log identically. So a global grep cannot be used to assert "0 false private disconnects." Instead grep the orchestrator-side log which IS scoped:
+    - `rg -c "WS message gap detected for .*private" /tmp/gridbot.log` — expected `0` after fix (vs ~1249 baseline). The watchdog never starts → callback never fires → orchestrator log never emitted.
+    - `rg -c "WS message gap detected for .*public" /tmp/gridbot.log` — informational, not a pass/fail check. May be `0` on a healthy night; if real public-WS faults occur they should still surface here.
+  - `WS socket dead for {account}/private; resetting` (Feature 0024 probe-side WARN, `orchestrator.py:1011-1014`) should fire only on real network failures.
+
+## Risk and mitigations
+
+- **Risk: stalled read buffer (zombie socket)** — application thread blocked, pybit's read loop frozen, but `ws.sock.connected` stays True. The TCP probe would not catch this; the message-gap watchdog would have. Assessment: not observed in 11-hour overnight log; not a known Bybit failure mode; would equally affect public-WS handlers if it occurred. Defer mitigation unless observed in production.
+- **Risk: Bybit-side silent close that pybit does not notice** — covered by pybit's pong-timeout. After timeout, websocket-client teardown flips `ws.sock.connected = False` and probe catches it within 10 s. Latency: typically ~20-25 s, worst-case ~40 s (see Context for derivation). Comparable to the current 30 s message-gap threshold; the win of this plan is not faster detection but eliminating the false-positive flood that currently fires the same code path ~1249× per night.
+- **Risk: probe-loop bug** — if `_ws_health_check_once` is broken or skipped, the only safety net for private is pybit's own infinite reconnect (Feature 0024 sets `retries=0`). Mitigation: Step 5 tests assert constructor wiring, and Verification step 2 below requires manual fault-injection.
+
+## Out of scope
+
+- **Removing `_update_last_message_ts` calls from private handlers.** Cheap to leave; useful for future metrics or re-enabling the watchdog. Removal would obscure the diff.
+- **Removing `on_disconnect` wiring for private in orchestrator.** Same rationale — keep the wiring dormant rather than rip it out.
+- **Removing the older `_health_check_once` (stale-flag based) at `orchestrator.py:923, 949`.** Separate cleanup; orthogonal to this fix.
+- **Raising `DEFAULT_DISCONNECT_THRESHOLD` as an alternative** (variant A from research). Rejected: variant A masks the false-positive class behind a longer threshold but does not eliminate it; variant D (this plan) removes the class entirely on the channel where it manifests.
+- **Hooking pybit's internal `_on_pong()` to reset the watchdog clock** (variant B from research). Rejected: pybit's `_on_pong` is not a public API; would require monkey-patching internals.
+- **Sending application-level pings every 15 s** (variant C from research). Rejected: adds untested protocol chatter; redundant given pybit's existing 20 s keepalive and Feature 0024's 10 s probe.
+
+## Verification
+
+1. **Unit tests**: `uv run pytest packages/bybit_adapter/tests/test_ws_client.py apps/gridbot/tests/test_orchestrator.py -q`. Existing watchdog tests must still pass (default-on flag preserves current behavior); new tests cover the flag's effect.
+2. **Manual fault-injection on dev** (REQUIRED before merge — user-mandated):
+   - Start the bot against a quiet account so the private channel has no fills for several minutes.
+   - Confirm in `/tmp/gridbot.log`: zero `WS message gap detected for .*private` lines over a 5-minute quiet window (private-scoped grep).
+   - Disable Wi-Fi / pull network for ~60 s.
+   - Confirm: `WS socket dead for {account}/private; resetting` appears within ~40-45 s of the network drop. Worst-case derivation: up to 20 s for next pybit ping + 10 s pong-timeout + up to 10 s probe interval.
+   - Confirm: `Private WebSocket connected` appears immediately after.
+   - If `WS socket dead ... resetting` does NOT appear within 60 s, the probe path is broken — abort merge and investigate.
+3. **Overnight log validation post-deploy** (private-scoped):
+   - `rg -c "WS message gap detected for .*private" /tmp/gridbot.log` after 12 h on mainnet — expected `0` (vs ~1249 baseline).
+   - `rg -c "WS message gap detected for .*public" /tmp/gridbot.log` — informational only. Not a pass/fail check; a healthy night can be `0`.
+   - `rg -c "WS socket dead for .*private" /tmp/gridbot.log` — should match the count of real network drops observed externally (very low, single digits per day).
+4. **Cross-check fill survival**: grep for execution events in the post-deploy log; assert that ratios of fills to position-update events match pre-deploy ratios (no events lost during the now-absent reset windows).

--- a/docs/features/0026_REVIEW.md
+++ b/docs/features/0026_REVIEW.md
@@ -1,0 +1,54 @@
+# 0026 Review - Disable private-WS message-gap watchdog
+
+## Summary
+
+No blocking findings.
+
+The implementation matches `docs/features/0026_PLAN.md`:
+
+- Adds `message_gap_watchdog_enabled: bool = True` to `PrivateWebSocketClient`.
+- Gates only the private heartbeat watchdog start in `connect()`.
+- Leaves public watchdog behavior unchanged.
+- Passes `message_gap_watchdog_enabled=False` from `Orchestrator._init_account()` for gridbot private WS clients.
+- Keeps the private `on_disconnect` callback wired but dormant while the watchdog is disabled.
+- Leaves private business-event timestamp updates in place.
+- Adds focused adapter and orchestrator tests for the new flag.
+
+## Findings
+
+None.
+
+## Review Notes
+
+- Default behavior is preserved for callers outside gridbot, including `apps/event_saver/src/event_saver/collectors/private_collector.py`, because they do not pass the new flag.
+- The reset path is covered by the gate inside `connect()`: `reset()` still stops any existing watchdog, disconnects, and reconnects, and a disabled client does not recreate `_heartbeat_thread`.
+- No data-shape or alignment issue was introduced. The changed production code only adds a constructor flag and does not alter message payload parsing, callback payloads, or Bybit `{data: ...}` handling.
+- The public client remains untouched, so public message-gap detection still acts as the secondary disconnect signal.
+- The implementation is small and does not add new abstractions or large-file pressure.
+
+## Test Review
+
+Coverage added for the new behavior:
+
+- `test_private_watchdog_disabled_skips_heartbeat_thread` verifies disabled private connect still marks the wrapper connected and subscribes execution/order/position/wallet streams.
+- `test_private_watchdog_disabled_never_fires_on_disconnect` verifies silence past the threshold does not call `on_disconnect` when disabled.
+- `test_private_watchdog_disabled_survives_reset` verifies `reset()` does not re-enable the private watchdog.
+- `test_init_account_disables_private_message_gap_watchdog` verifies the orchestrator constructor wiring.
+
+Existing default-on watchdog tests remain unchanged and still cover backwards compatibility.
+
+Residual validation from the plan remains manual: the dev fault-injection Wi-Fi/network-drop test is still required before merge to prove the TCP probe catches real private socket failures within the expected window.
+
+## Verification
+
+```bash
+uv run pytest -q packages/bybit_adapter/tests/test_ws_client.py apps/gridbot/tests/test_orchestrator.py
+# 154 passed in 5.19s
+```
+
+```bash
+uv run ruff check packages/bybit_adapter/src/bybit_adapter/ws_client.py packages/bybit_adapter/tests/test_ws_client.py apps/gridbot/src/gridbot/orchestrator.py apps/gridbot/tests/test_orchestrator.py
+# All checks passed!
+```
+
+I also ran full-repo `uv run ruff check`; it still fails on pre-existing unrelated files under backtest/reference/test areas, not on the files touched by this feature.

--- a/packages/bybit_adapter/src/bybit_adapter/ws_client.py
+++ b/packages/bybit_adapter/src/bybit_adapter/ws_client.py
@@ -387,6 +387,7 @@ class PrivateWebSocketClient:
     on_reconnect: Optional[Callable[[datetime, datetime], None]] = None
     heartbeat_interval: float = DEFAULT_HEARTBEAT_INTERVAL
     disconnect_threshold: float = DEFAULT_DISCONNECT_THRESHOLD
+    message_gap_watchdog_enabled: bool = True
 
     _ws: Optional[WebSocket] = field(default=None, init=False, repr=False)
     _state: ConnectionState = field(default_factory=ConnectionState, init=False)
@@ -439,8 +440,14 @@ class PrivateWebSocketClient:
             self._state._detected_disconnect = False
             logger.info("Private WebSocket connected")
 
-            # Start heartbeat watchdog
-            self._start_heartbeat_watchdog()
+            # Start heartbeat watchdog (gated — see message_gap_watchdog_enabled)
+            if self.message_gap_watchdog_enabled:
+                self._start_heartbeat_watchdog()
+            else:
+                logger.info(
+                    "Heartbeat watchdog disabled for private "
+                    "(relying on TCP probe)"
+                )
 
     def disconnect(self) -> None:
         """Gracefully disconnect WebSocket."""

--- a/packages/bybit_adapter/tests/test_ws_client.py
+++ b/packages/bybit_adapter/tests/test_ws_client.py
@@ -232,6 +232,90 @@ class TestPrivateWebSocketClientDisconnectDetection:
         state = client.get_connection_state()
         assert state.reconnect_count == 2
 
+    @patch("bybit_adapter.ws_client.WebSocket")
+    def test_private_watchdog_disabled_skips_heartbeat_thread(self, mock_ws_class):
+        """When message_gap_watchdog_enabled=False, connect() does not start
+        the heartbeat thread, but still completes the connection and
+        subscribes to all configured streams.
+        """
+        mock_ws = MagicMock()
+        mock_ws_class.return_value = mock_ws
+
+        client = PrivateWebSocketClient(
+            api_key="test_key",
+            api_secret="test_secret",
+            testnet=True,
+            on_execution=lambda x: None,
+            on_order=lambda x: None,
+            on_position=lambda x: None,
+            on_wallet=lambda x: None,
+            heartbeat_interval=0.1,
+            disconnect_threshold=0.3,
+            message_gap_watchdog_enabled=False,
+        )
+
+        client.connect()
+
+        # Heartbeat thread must not be started.
+        assert client._heartbeat_thread is None
+        # connect() did not short-circuit: connection is logically up and
+        # all four stream subscriptions were registered with pybit.
+        assert client.is_connected() is True
+        mock_ws.execution_stream.assert_called_once()
+        mock_ws.order_stream.assert_called_once()
+        mock_ws.position_stream.assert_called_once()
+        mock_ws.wallet_stream.assert_called_once()
+
+        client.disconnect()
+
+    @patch("bybit_adapter.ws_client.WebSocket")
+    def test_private_watchdog_disabled_never_fires_on_disconnect(self, mock_ws_class):
+        """With watchdog disabled, on_disconnect callback never fires even
+        after the silence threshold is exceeded.
+        """
+        disconnect_callback = MagicMock()
+
+        client = PrivateWebSocketClient(
+            api_key="test_key",
+            api_secret="test_secret",
+            testnet=True,
+            on_execution=lambda x: None,
+            on_disconnect=disconnect_callback,
+            heartbeat_interval=0.1,
+            disconnect_threshold=0.3,
+            message_gap_watchdog_enabled=False,
+        )
+
+        client.connect()
+        # Wait well past the disconnect_threshold the watchdog WOULD use.
+        time.sleep(0.5)
+        client.disconnect()
+
+        assert not disconnect_callback.called
+
+    @patch("bybit_adapter.ws_client.WebSocket")
+    def test_private_watchdog_disabled_survives_reset(self, mock_ws_class):
+        """reset() must not re-enable the heartbeat thread when the watchdog
+        is disabled (regression guard for the gate-inside-connect approach).
+        """
+        client = PrivateWebSocketClient(
+            api_key="test_key",
+            api_secret="test_secret",
+            testnet=True,
+            on_execution=lambda x: None,
+            heartbeat_interval=0.1,
+            disconnect_threshold=0.3,
+            message_gap_watchdog_enabled=False,
+        )
+
+        client.connect()
+        assert client._heartbeat_thread is None
+
+        client.reset()
+        assert client._heartbeat_thread is None
+
+        client.disconnect()
+
 
 class TestPublicWebSocketClientEdgeCases:
     """Additional edge case tests for PublicWebSocketClient."""


### PR DESCRIPTION
## Summary

- Eliminates ~1249 false `Detected disconnection: no messages for 30.0s` events per night on the private Bybit WS by disabling the message-gap watchdog for the private channel.
- Root cause: pybit's protocol-level ping/pong frames bypass our business-event handlers (`_handle_execution/_handle_order/_handle_position/_handle_wallet`), so during quiet trading periods the watchdog sees zero updates for 30 s even though the socket is healthy — and triggers a wasteful full WS reset cycle.
- TCP-level probe from feature 0024 (`Orchestrator._ws_health_check_once`) is the sole disconnect signal for private now. Public channel keeps its watchdog (ticker/trade traffic is dense; 30 s of silence on public *is* a real fault).
- New constructor flag `message_gap_watchdog_enabled: bool = True` on `PrivateWebSocketClient` (default-on preserves current behavior for any other caller). Orchestrator opts out with `False`. `on_disconnect` callback wiring kept dormant for symmetry with public and reversibility.

See `docs/features/0026_PLAN.md` for the full plan, including risk analysis and the worst-case detection-latency derivation (~40 s upper bound: up to 20 s pybit ping interval + 10 s pong-timeout + 10 s probe interval).

## Test plan

- [x] Unit tests: `uv run pytest packages/bybit_adapter/tests/test_ws_client.py apps/gridbot/tests/test_orchestrator.py -q` — 154 passed.
- [x] Four new tests cover the flag's behavior:
  - `test_private_watchdog_disabled_skips_heartbeat_thread` (also asserts `connect()` did not short-circuit — `is_connected() == True`, all four stream subscriptions called).
  - `test_private_watchdog_disabled_never_fires_on_disconnect`.
  - `test_private_watchdog_disabled_survives_reset` (regression guard for the gate-inside-`connect()` approach — `reset()` calls `connect()` so the gate must hold).
  - `test_init_account_disables_private_message_gap_watchdog`.
- [ ] **Manual fault-injection on dev** (REQUIRED before merge):
  - Start the bot against a quiet account → confirm zero `WS message gap detected for .*private` lines in `/tmp/gridbot.log` over a 5-minute quiet window.
  - Pull network for ~60 s → confirm `WS socket dead for {acct}/private; resetting` appears within 40-45 s, followed by `Private WebSocket connected`.
  - Abort merge if the probe-side WARN does not appear within 60 s — the TCP probe path is broken.
- [ ] Post-deploy validation (private-scoped grep): `rg -c "WS message gap detected for .*private" /tmp/gridbot.log` after 12 h on mainnet — expected `0` (vs ~1249 baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)