### PR TITLE
feat(qty): bbu2 alignment of qty path (Feature 0028)

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -129,6 +129,34 @@ Successfully extracted pure strategy logic from `bbu2-master` into `packages/gri
    - Never modify reference code
    - **WARNING**: Reference code may contain bugs (e.g., short position liquidation risk logic)
 
+9. **Legacy bbu2 paths intentionally not ported**
+
+   These bbu2 code paths exist for products we do not target (Bybit
+   inverse contracts: BTCUSD, ETHUSD, etc.). gridcore is intentionally
+   scoped to Bybit linear USDT-perps. Future audits MUST recognize
+   these as legacy carve-outs and not re-flag them as divergences:
+
+   - **`"b..." amount mode`** — bbu2 `bybit_api_usdt.py:509-518`. The
+     "b" prefix means "btc-equivalent" with two branches: `BTCUSD` →
+     `btc_amount * price` (inverse), non-BTCUSD → `math.ceil(btc_amount
+     / price)` (legacy linear non-USDT). Removed from `gridcore/qty.py`
+     in Feature 0028. If a config tries to use `b...` it now raises
+     `ValueError: invalid amount string`.
+   - **`"x" mode currency derivation by symbol`** — bbu2
+     `bybit_api_usdt.py:496-501`. bbu2 picks `USDT` if `'USDT' in
+     symbol` else `symbol[:3]` (e.g., `BTC` for `BTCUSD`). This handles
+     inverse contracts margined in coin. Our `gridcore/qty.py` always
+     reads `wallet_balance` as USDT — correct for linear USDT-perps,
+     would need a redesign (not a bbu2 port) if USDC or inverse support
+     is ever added.
+   - **`BTCUSD`-specific branches anywhere in bbu2** — inverse
+     contract logic. Out of scope.
+
+   If you ever consider reintroducing inverse / non-USDT support,
+   start by re-reading the legacy paths in `bbu_reference/`, not by
+   re-porting them blindly: bbu2's `'USDT' in symbol` heuristic does
+   not handle USDC pairs (`BTCPERP`, `BTCUSDC`) correctly either.
+
 ## Package Management with uv
 
 This project uses [uv](https://github.com/astral-sh/uv) for package management.
@@ -1040,7 +1068,7 @@ Successfully implemented a backtest system using gridcore's GridEngine with trad
    - Backtest does NOT use gridcore.Position for PnL tracking
 
 3. **Quantity Calculation**
-   - Uses same amount format as gridbot: `"100"` (fixed USDT), `"x0.001"` (wallet fraction), `"b0.001"` (base currency)
+   - Uses same amount format as gridbot: `"100"` (fixed USDT), `"x0.001"` (wallet fraction). The legacy `"b..."` mode was removed in feature 0028 (see Section 9).
    - `qty_calculator` function passed to executor
 
 4. **Data Sources**
@@ -1835,7 +1863,7 @@ Two-layer: Runner logs + re-raises → Orchestrator catches + sends Telegram ale
 
 - **Order format for GridEngine**: camelCase keys (`orderId`, `orderLinkId`, `price` as string)
 - **`BacktestPositionTracker`** tracks PnL; **`gridcore.Position`** handles risk multipliers (different purposes)
-- **Quantity**: same amount format as gridbot (`"100"`, `"x0.001"`, `"b0.001"`); rounding uses `math.ceil`
+- **Quantity**: same amount format as gridbot (`"100"`, `"x0.001"`); rounding uses `math.ceil`. Legacy `"b..."` removed in 0028.
 - **Two-phase tick**: `process_fills()` → equity update → `execute_tick()` (fills reflected before sizing)
 - **Equity update**: Engine level, not runner level (aggregates all runners' unrealized PnL)
 - **`WindDownMode` StrEnum**: `LEAVE_OPEN`, `CLOSE_ALL`

--- a/apps/backtest/conf/backtest.yaml.example
+++ b/apps/backtest/conf/backtest.yaml.example
@@ -9,7 +9,7 @@ strategies:
     grid_step: 0.2
     amount: "x0.001"  # 0.1% of wallet per order
     max_margin: 8.0
-    long_koef: 1.0
+    early_imbalance_multiplier: 1.0
     min_liq_ratio: 0.8
     max_liq_ratio: 1.2
     min_total_margin: 0.15

--- a/apps/backtest/src/backtest/config.py
+++ b/apps/backtest/src/backtest/config.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Optional
 
 import yaml
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 class WindDownMode(StrEnum):
@@ -34,10 +34,15 @@ class BacktestStrategyConfig(BaseModel):
     # Position sizing
     amount: str = Field(
         default="x0.001",
-        description="Order amount: fixed USDT, 'x0.001' for wallet fraction, 'b0.001' for BTC equivalent",
+        description="Order amount: fixed USDT, or 'x0.001' for wallet fraction",
     )
     max_margin: float = Field(default=8.0, gt=0, description="Maximum margin per position")
-    long_koef: float = Field(default=1.0, gt=0, description="Long/short bias multiplier")
+    early_imbalance_multiplier: float = Field(
+        default=1.0,
+        gt=0,
+        le=100.0,
+        description="Multiplier applied to next order qty when long dominates short by 1.1-10x AND both positions are pre-liquidation (liq_price==0). Inherited asymmetric trigger from bbu2 (no short-dominant mirror). Upper bound 100 also rejects float('inf') from misconfigured YAML.",
+    )
 
     # Risk parameters (for Position)
     min_liq_ratio: float = Field(default=0.8, description="Minimum liquidation ratio")
@@ -67,6 +72,28 @@ class BacktestStrategyConfig(BaseModel):
         if isinstance(v, str):
             return Decimal(v)
         return v
+
+    @model_validator(mode="before")
+    @classmethod
+    def reject_renamed_long_koef(cls, data):
+        """Catch legacy `long_koef` config name and force migration.
+
+        Pydantic ignores unknown fields by default, so a config with
+        `long_koef: 1.5` would silently load and the renamed
+        `early_imbalance_multiplier` would stay at default 1.0 — the user
+        would believe the multiplier is active when it is not. Reject
+        explicitly with a migration message instead of silent acceptance.
+        Renamed in feature 0028 (D-3) for clearer semantics.
+        """
+        if isinstance(data, dict) and "long_koef" in data:
+            raise ValueError(
+                "Config field 'long_koef' was renamed to "
+                "'early_imbalance_multiplier' in feature 0028. The semantic "
+                "is unchanged (multiplier on next-order qty when long "
+                "dominates short by 1.1-10x AND both positions pre-"
+                "liquidation). Rename the field in your YAML."
+            )
+        return data
 
     @field_validator("commission_rate", mode="before")
     @classmethod

--- a/apps/backtest/src/backtest/runner.py
+++ b/apps/backtest/src/backtest/runner.py
@@ -23,6 +23,7 @@ from gridcore import (
     Position,
     PositionState,
     RiskConfig,
+    apply_early_imbalance,
 )
 from gridcore.instrument_info import InstrumentInfo
 from gridcore.pnl import calc_position_value, calc_margin_ratio, calc_maintenance_margin, MMTiers, MM_TIERS, MM_TIERS_DEFAULT
@@ -655,34 +656,16 @@ class BacktestRunner:
         multiplier = self.get_amount_multiplier(intent.direction, intent.side)
         result = base_qty * Decimal(str(multiplier))
 
-        # bbu2 ref: bbu_reference/bbu2-master/bybit_api_usdt.py:257-261.
-        # Asymmetric: fires only when long dominates short (1.1 < ratio < 10),
-        # AND both sides are still pre-liquidation. Inherited from bbu2 design.
-        # Applied before round_qty to mirror bbu2 __round_amount(amount * mult).
-        # Skipped when risk module is disabled (backtest convention).
-        #
-        # IMPORTANT: bbu2 uses SIZE-based ratio (`long.size / short.size` at
-        # bbu2 bybit_api_usdt.py:548). We must NOT read Position.position_ratio
-        # here — that field is overwritten with a MARGIN-based ratio by
-        # Position.calculate_amount_multiplier (gridcore/position.py:231).
-        # Compute size ratio inline from Position.size.
+        # bbu2 early-imbalance multiplier — see gridcore.qty.apply_early_imbalance
+        # for full semantic. Outer guard skips when risk module is disabled
+        # (Position instances are None in that mode — backtest convention).
         if self._enable_risk:
-            early_imb = self._config.early_imbalance_multiplier
-            if early_imb != 1.0:
-                long_size = float(self._long_position.size)
-                short_size = float(self._short_position.size)
-                if short_size > 0:
-                    size_ratio = long_size / short_size
-                elif long_size > 0:
-                    size_ratio = float("inf")
-                else:
-                    size_ratio = 1.0
-                long_liq = self._long_position.liquidation_price
-                short_liq = self._short_position.liquidation_price
-                if (1.1 < size_ratio < 10
-                        and long_liq == 0
-                        and short_liq == 0):
-                    result = result * Decimal(str(early_imb))
+            result = apply_early_imbalance(
+                result,
+                self._long_position,
+                self._short_position,
+                self._config.early_imbalance_multiplier,
+            )
 
         # Re-round after multiplier to ensure qty aligns with exchange qty_step
         # (matches live runner _resolve_qty lines 526-527)

--- a/apps/backtest/src/backtest/runner.py
+++ b/apps/backtest/src/backtest/runner.py
@@ -579,6 +579,25 @@ class BacktestRunner:
             self._short_tracker, wallet_balance, DirectionType.SHORT
         )
 
+        # Cache size-based position_ratio + liq_price on both Position
+        # instances so consumers (e.g. early_imbalance_multiplier in
+        # _apply_risk_to_qty) read consistent values even when one side
+        # is empty and calculate_amount_multiplier is skipped below.
+        long_size = float(long_state.size) if long_state.size else 0.0
+        short_size = float(short_state.size) if short_state.size else 0.0
+        if short_size > 0:
+            position_ratio = long_size / short_size
+        elif long_size > 0:
+            position_ratio = float("inf")
+        else:
+            position_ratio = 1.0
+        self._long_position.position_ratio = position_ratio
+        self._short_position.position_ratio = position_ratio
+        self._long_position.size = long_state.size
+        self._short_position.size = short_state.size
+        self._long_position.liquidation_price = long_state.liquidation_price
+        self._short_position.liquidation_price = short_state.liquidation_price
+
         # Reset then calculate (bbu2 pattern — cross-position effects preserved)
         self._long_position.reset_amount_multiplier()
         self._short_position.reset_amount_multiplier()
@@ -635,6 +654,35 @@ class BacktestRunner:
 
         multiplier = self.get_amount_multiplier(intent.direction, intent.side)
         result = base_qty * Decimal(str(multiplier))
+
+        # bbu2 ref: bbu_reference/bbu2-master/bybit_api_usdt.py:257-261.
+        # Asymmetric: fires only when long dominates short (1.1 < ratio < 10),
+        # AND both sides are still pre-liquidation. Inherited from bbu2 design.
+        # Applied before round_qty to mirror bbu2 __round_amount(amount * mult).
+        # Skipped when risk module is disabled (backtest convention).
+        #
+        # IMPORTANT: bbu2 uses SIZE-based ratio (`long.size / short.size` at
+        # bbu2 bybit_api_usdt.py:548). We must NOT read Position.position_ratio
+        # here — that field is overwritten with a MARGIN-based ratio by
+        # Position.calculate_amount_multiplier (gridcore/position.py:231).
+        # Compute size ratio inline from Position.size.
+        if self._enable_risk:
+            early_imb = self._config.early_imbalance_multiplier
+            if early_imb != 1.0:
+                long_size = float(self._long_position.size)
+                short_size = float(self._short_position.size)
+                if short_size > 0:
+                    size_ratio = long_size / short_size
+                elif long_size > 0:
+                    size_ratio = float("inf")
+                else:
+                    size_ratio = 1.0
+                long_liq = self._long_position.liquidation_price
+                short_liq = self._short_position.liquidation_price
+                if (1.1 < size_ratio < 10
+                        and long_liq == 0
+                        and short_liq == 0):
+                    result = result * Decimal(str(early_imb))
 
         # Re-round after multiplier to ensure qty aligns with exchange qty_step
         # (matches live runner _resolve_qty lines 526-527)

--- a/apps/backtest/tests/test_config.py
+++ b/apps/backtest/tests/test_config.py
@@ -52,6 +52,18 @@ class TestBacktestStrategyConfig:
 
         assert config.commission_rate == Decimal("0.0001")
 
+    def test_legacy_long_koef_rejected_with_migration_message(self):
+        """Reject legacy `long_koef` so migrating users do not silently lose
+        the multiplier (Pydantic ignores unknown fields by default)."""
+        import pytest
+        with pytest.raises(ValueError, match="renamed to 'early_imbalance_multiplier'"):
+            BacktestStrategyConfig(
+                strat_id="test",
+                symbol="BTCUSDT",
+                tick_size="0.1",
+                long_koef=1.5,
+            )
+
 
 class TestBacktestConfig:
     """Tests for BacktestConfig."""

--- a/apps/backtest/tests/test_runner.py
+++ b/apps/backtest/tests/test_runner.py
@@ -700,6 +700,171 @@ class TestBacktestRunnerRiskMultipliers:
         assert called_with[0] == 95000.0
 
 
+class TestEarlyImbalanceMultiplierBacktest:
+    """Tests for early_imbalance_multiplier in backtest qty path.
+
+    Mirrors apps/gridbot tests for live/backtest parity.
+    bbu2 ref: bbu_reference/bbu2-master/bybit_api_usdt.py:257-261.
+    """
+
+    def _build_runner(self, early_imb: float, enable_risk: bool = True):
+        config = BacktestStrategyConfig(
+            strat_id="test_early_imb",
+            symbol="BTCUSDT",
+            tick_size=Decimal("0.1"),
+            grid_count=50,
+            grid_step=0.2,
+            amount="x0.001",
+            max_margin=8.0,
+            commission_rate=Decimal("0.0002"),
+            min_liq_ratio=0.8,
+            max_liq_ratio=1.2,
+            min_total_margin=0.15,
+            leverage=10,
+            maintenance_margin_rate=0.005,
+            enable_risk_multipliers=enable_risk,
+            early_imbalance_multiplier=early_imb,
+        )
+        session = BacktestSession(session_id="test_early_imb", initial_balance=Decimal("10000"))
+        fill_sim = TradeThroughFillSimulator()
+        order_mgr = BacktestOrderManager(
+            fill_simulator=fill_sim,
+            commission_rate=config.commission_rate,
+        )
+
+        def qty_from_usdt(intent, wallet_balance):
+            if intent.price <= 0:
+                return Decimal("0")
+            return Decimal("100") / intent.price  # base = 100/50000 = 0.002
+
+        executor = BacktestExecutor(order_manager=order_mgr, qty_calculator=qty_from_usdt)
+        return BacktestRunner(
+            strategy_config=config,
+            executor=executor,
+            session=session,
+        )
+
+    def _make_intent(self):
+        return PlaceLimitIntent.create(
+            symbol="BTCUSDT", side="Buy", price=Decimal("50000"),
+            qty=Decimal("0"), grid_level=1, direction="long",
+        )
+
+    def _set_size_ratio(self, runner, long_size: str, short_size: str):
+        """Set sizes (NOT position_ratio) — bbu2 keys early_imbalance on size."""
+        runner._long_position.size = Decimal(long_size)
+        runner._short_position.size = Decimal(short_size)
+
+    def test_default_multiplier_is_no_op(self):
+        runner = self._build_runner(early_imb=1.0)
+        self._set_size_ratio(runner, "2", "1")
+        runner._long_position.liquidation_price = Decimal("0")
+        runner._short_position.liquidation_price = Decimal("0")
+
+        result = runner._apply_risk_to_qty(self._make_intent(), Decimal("10000"))
+        # base 0.002, mult 1.0, no early-imb boost
+        assert result == Decimal("0.002")
+
+    def test_fires_when_long_dominates_and_both_pre_liquidation(self):
+        runner = self._build_runner(early_imb=1.5)
+        self._set_size_ratio(runner, "2", "1")
+        runner._long_position.liquidation_price = Decimal("0")
+        runner._short_position.liquidation_price = Decimal("0")
+
+        result = runner._apply_risk_to_qty(self._make_intent(), Decimal("10000"))
+        # base 0.002 * 1.5 = 0.003
+        assert result == Decimal("0.003")
+
+    def test_no_op_when_ratio_out_of_band(self):
+        runner = self._build_runner(early_imb=1.5)
+        self._set_size_ratio(runner, "11", "1")
+        runner._long_position.liquidation_price = Decimal("0")
+        runner._short_position.liquidation_price = Decimal("0")
+
+        result = runner._apply_risk_to_qty(self._make_intent(), Decimal("10000"))
+        assert result == Decimal("0.002")
+
+    def test_no_op_when_long_liq_price_set(self):
+        runner = self._build_runner(early_imb=1.5)
+        self._set_size_ratio(runner, "2", "1")
+        runner._long_position.liquidation_price = Decimal("45000")
+        runner._short_position.liquidation_price = Decimal("0")
+
+        result = runner._apply_risk_to_qty(self._make_intent(), Decimal("10000"))
+        assert result == Decimal("0.002")
+
+    def test_no_op_when_short_empty_size_ratio_inf(self):
+        """short.size=0, long.size>0 → size_ratio=inf, out of band → no-op."""
+        runner = self._build_runner(early_imb=1.5)
+        self._set_size_ratio(runner, "2", "0")  # short empty → ratio = inf
+        runner._long_position.liquidation_price = Decimal("0")
+        runner._short_position.liquidation_price = Decimal("0")
+
+        result = runner._apply_risk_to_qty(self._make_intent(), Decimal("10000"))
+        assert result == Decimal("0.002")
+
+    def test_uses_size_not_margin_ratio(self):
+        """Regression: must read sizes, not Position.position_ratio (margin-based after calculate_amount_multiplier)."""
+        runner = self._build_runner(early_imb=1.5)
+        # Equal sizes (size_ratio=1.0 — out of band) but poison position_ratio.
+        self._set_size_ratio(runner, "1", "1")
+        runner._long_position.position_ratio = 2.0
+        runner._short_position.position_ratio = 2.0
+        runner._long_position.liquidation_price = Decimal("0")
+        runner._short_position.liquidation_price = Decimal("0")
+
+        result = runner._apply_risk_to_qty(self._make_intent(), Decimal("10000"))
+        assert result == Decimal("0.002")
+
+    def test_end_to_end_through_update_risk_multipliers(self):
+        """End-to-end: drive trackers via process_fill, then _update_risk_multipliers
+        and _apply_risk_to_qty. Confirms backtest plumbing wires Position.size +
+        liquidation_price correctly through the real pipeline (not direct field
+        access). Mirrors live e2e test in apps/gridbot/tests/test_runner.py.
+
+        Setup: long entry $25k size 2.0, short entry $50k size 1.0,
+        wallet large enough that estimated liq is far above market → liq=0.
+        size_ratio=2.0 (in band) but margin_ratio≈1.0 (out of band).
+        """
+        runner = self._build_runner(early_imb=1.5)
+        # Inflate session balance so liquidation estimates land at 0
+        # (long: liq <= 0 floored to 0; short: liq > 2*entry returned as 0).
+        runner._session.current_balance = Decimal("1000000")
+
+        # Drive long: process_fill with Buy (opens long).
+        runner._long_tracker.process_fill(
+            side="Buy", qty=Decimal("2.0"), price=Decimal("25000"),
+        )
+        # Drive short: process_fill with Sell (opens short).
+        runner._short_tracker.process_fill(
+            side="Sell", qty=Decimal("1.0"), price=Decimal("50000"),
+        )
+
+        # Drive the real risk-multiplier update path.
+        runner._update_risk_multipliers(last_price=50000.0)
+
+        # Plumbing assertion.
+        assert runner._long_position.size == Decimal("2.0")
+        assert runner._short_position.size == Decimal("1.0")
+        assert runner._long_position.liquidation_price == Decimal("0")
+        assert runner._short_position.liquidation_price == Decimal("0")
+
+        # Capture position-rules multiplier and compute expected.
+        strategy_mult = Decimal(str(runner.get_amount_multiplier("long", "Buy")))
+        # base from fixture: 100 / 50000 = 0.002
+        expected_pre_round = Decimal("0.002") * strategy_mult * Decimal("1.5")
+        # Backtest fixture has no instrument_info → no rounding.
+        result = runner._apply_risk_to_qty(self._make_intent(), Decimal("1000000"))
+        assert result == expected_pre_round
+        # Sanity: with mult=1.5 active, qty must exceed the no-boost baseline.
+        assert result > Decimal("0.002") * strategy_mult
+
+    # Note: when enable_risk=False, BacktestRunner does NOT install
+    # _apply_risk_to_qty as the executor's qty_calculator (runner.py:121-137),
+    # so the early_imb path is unreachable by construction. No separate test
+    # needed for that case.
+
+
 class TestBacktestRunnerRiskIntegration:
     """Integration test: risk-enabled runner with qty_calculator places non-zero orders."""
 

--- a/apps/gridbot/conf/gridbot.yaml.example
+++ b/apps/gridbot/conf/gridbot.yaml.example
@@ -16,7 +16,7 @@ strategies:
     grid_step: 0.2
     amount: "x0.001"  # 0.1% of wallet per order
     max_margin: 8
-    long_koef: 1.0
+    early_imbalance_multiplier: 1.0
     min_liq_ratio: 0.8
     max_liq_ratio: 1.2
     min_total_margin: 0.15
@@ -30,7 +30,7 @@ strategies:
     grid_step: 0.2
     amount: "x0.001"
     max_margin: 8
-    long_koef: 1.0
+    early_imbalance_multiplier: 1.0
     shadow_mode: true  # Shadow mode for testing
 
 # Database connection

--- a/apps/gridbot/src/gridbot/config.py
+++ b/apps/gridbot/src/gridbot/config.py
@@ -38,10 +38,15 @@ class StrategyConfig(BaseModel):
     # Position sizing
     amount: str = Field(
         default="x0.001",
-        description="Order amount: fixed USDT, 'x0.001' for wallet fraction, 'b0.001' for BTC equivalent",
+        description="Order amount: fixed USDT, or 'x0.001' for wallet fraction",
     )
     max_margin: float = Field(default=8.0, gt=0, description="Maximum margin per position")
-    long_koef: float = Field(default=1.0, gt=0, description="Long/short bias multiplier")
+    early_imbalance_multiplier: float = Field(
+        default=1.0,
+        gt=0,
+        le=100.0,
+        description="Multiplier applied to next order qty when long dominates short by 1.1-10x AND both positions are pre-liquidation (liq_price==0). Inherited asymmetric trigger from bbu2 (no short-dominant mirror). Upper bound 100 also rejects float('inf') from misconfigured YAML.",
+    )
 
     # Risk parameters (for Position)
     min_liq_ratio: float = Field(default=0.8, description="Minimum liquidation ratio")
@@ -58,6 +63,28 @@ class StrategyConfig(BaseModel):
         if isinstance(v, str):
             return Decimal(v)
         return v
+
+    @model_validator(mode="before")
+    @classmethod
+    def reject_renamed_long_koef(cls, data):
+        """Catch legacy `long_koef` config name and force migration.
+
+        Pydantic ignores unknown fields by default, so a config with
+        `long_koef: 1.5` would silently load and the renamed
+        `early_imbalance_multiplier` would stay at default 1.0 — the user
+        would believe the multiplier is active when it is not. Reject
+        explicitly with a migration message instead of silent acceptance.
+        Renamed in feature 0028 (D-3) for clearer semantics.
+        """
+        if isinstance(data, dict) and "long_koef" in data:
+            raise ValueError(
+                "Config field 'long_koef' was renamed to "
+                "'early_imbalance_multiplier' in feature 0028. The semantic "
+                "is unchanged (multiplier on next-order qty when long "
+                "dominates short by 1.1-10x AND both positions pre-"
+                "liquidation). Rename the field in your YAML."
+            )
+        return data
 
 
 class TelegramConfig(BaseModel):

--- a/apps/gridbot/src/gridbot/runner.py
+++ b/apps/gridbot/src/gridbot/runner.py
@@ -474,6 +474,12 @@ class StrategyRunner:
             # Update position managers
             self._long_position.position_ratio = position_ratio
             self._short_position.position_ratio = position_ratio
+            self._long_position.liquidation_price = (
+                long_state.liquidation_price if long_state else Decimal('0')
+            )
+            self._short_position.liquidation_price = (
+                short_state.liquidation_price if short_state else Decimal('0')
+            )
 
             has_position = long_state is not None or short_state is not None
             has_valid_price = (
@@ -561,6 +567,34 @@ class StrategyRunner:
             return replace(intent, qty=Decimal("0"))
         multiplier = _FLOAT_TO_DECIMAL.get(mult_float, Decimal(str(mult_float)))
         resolved_qty = base_qty * multiplier
+
+        # bbu2 ref: bbu_reference/bbu2-master/bybit_api_usdt.py:257-261.
+        # Asymmetric: fires only when long dominates short (1.1 < ratio < 10),
+        # AND both sides are still pre-liquidation. Inherited from bbu2 design.
+        # Applied before round_qty to mirror bbu2 __round_amount(amount * mult).
+        #
+        # IMPORTANT: bbu2 uses SIZE-based ratio (`long.size / short.size` at
+        # bbu2 bybit_api_usdt.py:548). We must NOT read Position.position_ratio
+        # here — that field is overwritten with a MARGIN-based ratio by
+        # Position.calculate_amount_multiplier (gridcore/position.py:231).
+        # Margin ratio diverges from size ratio because long/short entry
+        # prices differ. Compute size ratio inline from Position.size.
+        early_imb = self._config.early_imbalance_multiplier
+        if early_imb != 1.0:
+            long_size = float(self._long_position.size)
+            short_size = float(self._short_position.size)
+            if short_size > 0:
+                size_ratio = long_size / short_size
+            elif long_size > 0:
+                size_ratio = float("inf")
+            else:
+                size_ratio = 1.0
+            long_liq = self._long_position.liquidation_price
+            short_liq = self._short_position.liquidation_price
+            if (1.1 < size_ratio < 10
+                    and long_liq == 0
+                    and short_liq == 0):
+                resolved_qty = resolved_qty * Decimal(str(early_imb))
 
         # Re-round after multiplier to ensure qty aligns with exchange qty_step
         if self._instrument_info and resolved_qty > 0:

--- a/apps/gridbot/src/gridbot/runner.py
+++ b/apps/gridbot/src/gridbot/runner.py
@@ -33,6 +33,7 @@ from gridcore import (
     calc_position_value,
     calc_margin_ratio,
     create_qty_calculator,
+    apply_early_imbalance,
 )
 
 from gridbot.config import StrategyConfig
@@ -568,33 +569,15 @@ class StrategyRunner:
         multiplier = _FLOAT_TO_DECIMAL.get(mult_float, Decimal(str(mult_float)))
         resolved_qty = base_qty * multiplier
 
-        # bbu2 ref: bbu_reference/bbu2-master/bybit_api_usdt.py:257-261.
-        # Asymmetric: fires only when long dominates short (1.1 < ratio < 10),
-        # AND both sides are still pre-liquidation. Inherited from bbu2 design.
-        # Applied before round_qty to mirror bbu2 __round_amount(amount * mult).
-        #
-        # IMPORTANT: bbu2 uses SIZE-based ratio (`long.size / short.size` at
-        # bbu2 bybit_api_usdt.py:548). We must NOT read Position.position_ratio
-        # here — that field is overwritten with a MARGIN-based ratio by
-        # Position.calculate_amount_multiplier (gridcore/position.py:231).
-        # Margin ratio diverges from size ratio because long/short entry
-        # prices differ. Compute size ratio inline from Position.size.
-        early_imb = self._config.early_imbalance_multiplier
-        if early_imb != 1.0:
-            long_size = float(self._long_position.size)
-            short_size = float(self._short_position.size)
-            if short_size > 0:
-                size_ratio = long_size / short_size
-            elif long_size > 0:
-                size_ratio = float("inf")
-            else:
-                size_ratio = 1.0
-            long_liq = self._long_position.liquidation_price
-            short_liq = self._short_position.liquidation_price
-            if (1.1 < size_ratio < 10
-                    and long_liq == 0
-                    and short_liq == 0):
-                resolved_qty = resolved_qty * Decimal(str(early_imb))
+        # bbu2 early-imbalance multiplier — applied before round_qty to mirror
+        # bbu2 __round_amount(amount * mult). See gridcore.qty.apply_early_imbalance
+        # for the full semantic (including the size-vs-margin ratio invariant).
+        resolved_qty = apply_early_imbalance(
+            resolved_qty,
+            self._long_position,
+            self._short_position,
+            self._config.early_imbalance_multiplier,
+        )
 
         # Re-round after multiplier to ensure qty aligns with exchange qty_step
         if self._instrument_info and resolved_qty > 0:

--- a/apps/gridbot/tests/test_config.py
+++ b/apps/gridbot/tests/test_config.py
@@ -116,6 +116,20 @@ class TestStrategyConfig:
                 grid_step=0,
             )
 
+    def test_legacy_long_koef_rejected_with_migration_message(self):
+        """Pydantic ignores unknown fields by default — without an explicit
+        guard, a config with `long_koef: 1.5` would silently load and the
+        renamed `early_imbalance_multiplier` would stay at default 1.0.
+        Reject explicitly with a migration message."""
+        with pytest.raises(ValueError, match="renamed to 'early_imbalance_multiplier'"):
+            StrategyConfig(
+                strat_id="test",
+                account="test",
+                symbol="BTCUSDT",
+                tick_size=Decimal("0.1"),
+                long_koef=1.5,
+            )
+
 
 class TestGridbotConfig:
     """Tests for GridbotConfig model."""

--- a/apps/gridbot/tests/test_runner.py
+++ b/apps/gridbot/tests/test_runner.py
@@ -824,9 +824,9 @@ class TestQtyResolution:
         resolved = runner._resolve_qty(intent)
         assert resolved.qty == Decimal("0.002")
 
-    def test_resolve_qty_fixed_base(self, strategy_config, mock_executor, instrument_info):
-        """Fixed base amount: 'b0.005' → always 0.005."""
-        strategy_config.amount = "b0.005"
+    def test_resolve_qty_fixed_usdt_yields_expected_base(self, strategy_config, mock_executor, instrument_info):
+        """Fixed USDT amount '250' at price 50000 → 0.005 base qty."""
+        strategy_config.amount = "250"
         runner = StrategyRunner(
             strategy_config=strategy_config,
             executor=mock_executor,
@@ -974,7 +974,7 @@ class TestResolveQtyExtended:
 
     def test_multiplier_0_5_rerounds(self, strategy_config, mock_executor, instrument_info):
         """Multiplier 0.5 halves qty, then re-rounds up to qty_step."""
-        strategy_config.amount = "b0.003"
+        strategy_config.amount = "150"  # 150/50000 = 0.003 base qty
         runner = StrategyRunner(
             strategy_config=strategy_config,
             executor=mock_executor,
@@ -988,7 +988,7 @@ class TestResolveQtyExtended:
             qty=Decimal("0"), grid_level=1, direction="long",
         )
         resolved = runner._resolve_qty(intent)
-        # base = 0.003 (rounded to 0.003), * 0.5 = 0.0015, re-rounds up to 0.002
+        # base = 0.003, * 0.5 = 0.0015, re-rounds up to 0.002
         assert resolved.qty == Decimal("0.002")
 
     def test_min_qty_clamping(self, strategy_config, mock_executor):
@@ -1000,7 +1000,7 @@ class TestResolveQtyExtended:
             min_qty=Decimal("0.01"),  # high min_qty
             max_qty=Decimal("1000"),
         )
-        strategy_config.amount = "b0.001"
+        strategy_config.amount = "50"  # 50/50000 = 0.001 base qty
         runner = StrategyRunner(
             strategy_config=strategy_config,
             executor=mock_executor,
@@ -1025,7 +1025,7 @@ class TestResolveQtyExtended:
             min_qty=Decimal("0.001"),
             max_qty=Decimal("0.005"),  # low max_qty
         )
-        strategy_config.amount = "b0.01"
+        strategy_config.amount = "500"  # 500/50000 = 0.01 base qty
         runner = StrategyRunner(
             strategy_config=strategy_config,
             executor=mock_executor,
@@ -1095,6 +1095,183 @@ class TestResolveQtyExtended:
         qty_zero_records = [r for r in caplog.records if "Resolved qty=0" in r.message]
         assert len(qty_zero_records) == 1
         assert qty_zero_records[0].levelno == logging.DEBUG
+
+
+class TestEarlyImbalanceMultiplier:
+    """Tests for the early-imbalance qty multiplier (bbu2 ref: bybit_api_usdt.py:257-261).
+
+    Asymmetric trigger: fires only when long dominates short
+    (1.1 < ratio < 10) AND both positions are pre-liquidation
+    (liq_price == 0). No symmetric short-dominant mirror.
+    """
+
+    def _make_intent(self):
+        return PlaceLimitIntent.create(
+            symbol="BTCUSDT", side="Buy", price=Decimal("50000"),
+            qty=Decimal("0"), grid_level=1, direction="long",
+        )
+
+    def _set_size_ratio(self, runner, long_size: str, short_size: str):
+        """Set sizes (NOT position_ratio) — bbu2 keys early_imbalance on size."""
+        runner._long_position.size = Decimal(long_size)
+        runner._short_position.size = Decimal(short_size)
+
+    def test_default_multiplier_is_no_op(self, runner):
+        """Default early_imbalance_multiplier=1.0 → qty unchanged regardless of state."""
+        self._set_size_ratio(runner, "2", "1")  # size_ratio = 2.0
+        runner._long_position.liquidation_price = Decimal("0")
+        runner._short_position.liquidation_price = Decimal("0")
+
+        resolved = runner._resolve_qty(self._make_intent())
+        # base = 10000 * 0.001 / 50000 = 0.0002 → round_up to 0.001
+        assert resolved.qty == Decimal("0.001")
+
+    def test_fires_when_long_dominates_and_both_pre_liquidation(self, strategy_config, mock_executor, instrument_info):
+        """size_ratio=2.0, both liq=0, mult=1.5 → qty scaled by 1.5 before round_qty."""
+        strategy_config.early_imbalance_multiplier = 1.5
+        strategy_config.amount = "100"  # base = 100/50000 = 0.002
+        r = StrategyRunner(
+            strategy_config=strategy_config,
+            executor=mock_executor,
+            instrument_info=instrument_info,
+        )
+        r._wallet_balance = Decimal("10000")
+        self._set_size_ratio(r, "2", "1")
+        r._long_position.liquidation_price = Decimal("0")
+        r._short_position.liquidation_price = Decimal("0")
+
+        resolved = r._resolve_qty(self._make_intent())
+        # base 0.002 * mult 1.0 (no risk) * early 1.5 = 0.003
+        assert resolved.qty == Decimal("0.003")
+
+    def test_no_op_when_ratio_out_of_band(self, strategy_config, mock_executor, instrument_info):
+        """size_ratio=11 (above 10) → multiplier suppressed even with mult=1.5."""
+        strategy_config.early_imbalance_multiplier = 1.5
+        strategy_config.amount = "100"
+        r = StrategyRunner(
+            strategy_config=strategy_config,
+            executor=mock_executor,
+            instrument_info=instrument_info,
+        )
+        r._wallet_balance = Decimal("10000")
+        self._set_size_ratio(r, "11", "1")
+        r._long_position.liquidation_price = Decimal("0")
+        r._short_position.liquidation_price = Decimal("0")
+
+        resolved = r._resolve_qty(self._make_intent())
+        # base 0.002, no early-imb boost
+        assert resolved.qty == Decimal("0.002")
+
+    def test_no_op_when_long_liq_price_set(self, strategy_config, mock_executor, instrument_info):
+        """long.liq_price > 0 → not pre-liquidation, multiplier suppressed."""
+        strategy_config.early_imbalance_multiplier = 1.5
+        strategy_config.amount = "100"
+        r = StrategyRunner(
+            strategy_config=strategy_config,
+            executor=mock_executor,
+            instrument_info=instrument_info,
+        )
+        r._wallet_balance = Decimal("10000")
+        self._set_size_ratio(r, "2", "1")
+        r._long_position.liquidation_price = Decimal("45000")
+        r._short_position.liquidation_price = Decimal("0")
+
+        resolved = r._resolve_qty(self._make_intent())
+        assert resolved.qty == Decimal("0.002")
+
+    def test_no_op_when_short_empty_size_ratio_inf(self, strategy_config, mock_executor, instrument_info):
+        """short.size=0, long.size>0 → size_ratio=inf, out of band (10), no-op.
+
+        Regression guard: catches a bug that flipped the inf branch to 1.0
+        (which would put us in the `1.0 < 1.1` band — also no-op by accident,
+        but for the wrong reason). Strict `< 10` keeps inf out.
+        """
+        strategy_config.early_imbalance_multiplier = 1.5
+        strategy_config.amount = "100"
+        r = StrategyRunner(
+            strategy_config=strategy_config,
+            executor=mock_executor,
+            instrument_info=instrument_info,
+        )
+        r._wallet_balance = Decimal("10000")
+        self._set_size_ratio(r, "2", "0")  # short empty → ratio = inf
+        r._long_position.liquidation_price = Decimal("0")
+        r._short_position.liquidation_price = Decimal("0")
+
+        resolved = r._resolve_qty(self._make_intent())
+        assert resolved.qty == Decimal("0.002")
+
+    def test_uses_size_not_margin_ratio(self, strategy_config, mock_executor, instrument_info):
+        """Regression: must read sizes, not Position.position_ratio (which is margin-based after calculate_amount_multiplier)."""
+        strategy_config.early_imbalance_multiplier = 1.5
+        strategy_config.amount = "100"
+        r = StrategyRunner(
+            strategy_config=strategy_config,
+            executor=mock_executor,
+            instrument_info=instrument_info,
+        )
+        r._wallet_balance = Decimal("10000")
+        # Sizes are EQUAL (size_ratio=1.0, out of band) but margin-ratio
+        # field set to 2.0. With the bug, code reads margin_ratio=2.0 and
+        # incorrectly fires. Fixed code reads sizes → 1.0 → no-op.
+        self._set_size_ratio(r, "1", "1")
+        r._long_position.position_ratio = 2.0  # poisoned
+        r._short_position.position_ratio = 2.0
+        r._long_position.liquidation_price = Decimal("0")
+        r._short_position.liquidation_price = Decimal("0")
+
+        resolved = r._resolve_qty(self._make_intent())
+        assert resolved.qty == Decimal("0.002")
+
+    def test_end_to_end_through_on_position_update(self, strategy_config, mock_executor, instrument_info):
+        """End-to-end: drive on_position_update with realistic exchange dicts,
+        then call _resolve_qty. Proves the plumbing wires Position.size and
+        Position.liquidation_price correctly even after calculate_amount_multiplier
+        runs and overwrites position_ratio.
+
+        Critical setup: long entry $25k, short entry $50k. With size_ratio=2.0
+        (in band), margin_ratio = 2 * (25000/50000) = 1.0 (OUT of band).
+        If the implementation regressed to read position_ratio, the multiplier
+        would NOT fire. Reading sizes (correct), it fires.
+        """
+        strategy_config.early_imbalance_multiplier = 1.5
+        strategy_config.amount = "100"
+        r = StrategyRunner(
+            strategy_config=strategy_config,
+            executor=mock_executor,
+            instrument_info=instrument_info,
+        )
+
+        # Both positions pre-liquidation (liqPrice=0). Different entry prices
+        # so size_ratio diverges from margin_ratio.
+        long_pos = {"size": "2.0", "avgPrice": "25000", "liqPrice": "0"}
+        short_pos = {"size": "1.0", "avgPrice": "50000", "liqPrice": "0"}
+        r.on_position_update(
+            long_position=long_pos,
+            short_position=short_pos,
+            wallet_balance=10000.0,
+            last_close=50000.0,
+        )
+
+        # Plumbing assertion: Position.size and liquidation_price set via real path.
+        assert r._long_position.size == Decimal("2.0")
+        assert r._short_position.size == Decimal("1.0")
+        assert r._long_position.liquidation_price == Decimal("0")
+        assert r._short_position.liquidation_price == Decimal("0")
+
+        # Capture the position-rules multiplier so the test isolates early_imb.
+        strategy_mult = Decimal(str(r.get_amount_multiplier("long", "Buy")))
+        # Expected: base * strategy_mult * early_imb, then round_qty (ceil to 0.001)
+        # base = 100 / 50000 = 0.002
+        from decimal import ROUND_UP
+        expected_pre_round = Decimal("0.002") * strategy_mult * Decimal("1.5")
+        steps = (expected_pre_round / Decimal("0.001")).to_integral_value(rounding=ROUND_UP)
+        expected_qty = steps * Decimal("0.001")
+
+        resolved = r._resolve_qty(self._make_intent())
+        assert resolved.qty == expected_qty
+        # Sanity: with mult=1.5 active, qty must exceed the no-boost result.
+        assert resolved.qty > Decimal("0.002") * strategy_mult
 
 
 class TestSameOrderDetection:

--- a/apps/replay/src/replay/config.py
+++ b/apps/replay/src/replay/config.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Optional
 
 import yaml
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from backtest.config import WindDownMode
 
@@ -36,10 +36,15 @@ class ReplayStrategyConfig(BaseModel):
     # Position sizing
     amount: str = Field(
         default="x0.001",
-        description="Order amount: fixed USDT, 'x0.001' wallet fraction, 'b0.001' BTC equivalent",
+        description="Order amount: fixed USDT, or 'x0.001' wallet fraction",
     )
     max_margin: float = Field(default=8.0, gt=0, description="Maximum margin per position")
-    long_koef: float = Field(default=1.0, gt=0, description="Long/short bias multiplier")
+    early_imbalance_multiplier: float = Field(
+        default=1.0,
+        gt=0,
+        le=100.0,
+        description="Multiplier applied to next order qty when long dominates short by 1.1-10x AND both positions are pre-liquidation (liq_price==0). Inherited asymmetric trigger from bbu2 (no short-dominant mirror). Upper bound 100 also rejects float('inf') from misconfigured YAML.",
+    )
 
     # Risk
     enable_risk_multipliers: bool = Field(
@@ -58,6 +63,28 @@ class ReplayStrategyConfig(BaseModel):
     def parse_decimal_fields(cls, v):
         """Convert string/numeric to Decimal."""
         return _parse_decimal(v)
+
+    @model_validator(mode="before")
+    @classmethod
+    def reject_renamed_long_koef(cls, data):
+        """Catch legacy `long_koef` config name and force migration.
+
+        Pydantic ignores unknown fields by default, so a config with
+        `long_koef: 1.5` would silently load and the renamed
+        `early_imbalance_multiplier` would stay at default 1.0 — the user
+        would believe the multiplier is active when it is not. Reject
+        explicitly with a migration message instead of silent acceptance.
+        Renamed in feature 0028 (D-3) for clearer semantics.
+        """
+        if isinstance(data, dict) and "long_koef" in data:
+            raise ValueError(
+                "Config field 'long_koef' was renamed to "
+                "'early_imbalance_multiplier' in feature 0028. The semantic "
+                "is unchanged (multiplier on next-order qty when long "
+                "dominates short by 1.1-10x AND both positions pre-"
+                "liquidation). Rename the field in your YAML."
+            )
+        return data
 
 
 class ReplayConfig(BaseModel):

--- a/apps/replay/src/replay/engine.py
+++ b/apps/replay/src/replay/engine.py
@@ -107,7 +107,7 @@ class ReplayEngine:
             grid_step=config.strategy.grid_step,
             amount=config.strategy.amount,
             max_margin=config.strategy.max_margin,
-            long_koef=config.strategy.long_koef,
+            early_imbalance_multiplier=config.strategy.early_imbalance_multiplier,
             commission_rate=config.strategy.commission_rate,
             enable_risk_multipliers=config.strategy.enable_risk_multipliers,
         )

--- a/apps/replay/tests/test_config.py
+++ b/apps/replay/tests/test_config.py
@@ -24,6 +24,12 @@ class TestReplayStrategyConfig:
         with pytest.raises(ValidationError):
             ReplayStrategyConfig(tick_size=Decimal("0.1"), grid_count=2)
 
+    def test_legacy_long_koef_rejected_with_migration_message(self):
+        """Reject legacy `long_koef` so migrating users do not silently lose
+        the multiplier (Pydantic ignores unknown fields by default)."""
+        with pytest.raises(ValidationError, match="renamed to 'early_imbalance_multiplier'"):
+            ReplayStrategyConfig(tick_size=Decimal("0.1"), long_koef=1.5)
+
 
 class TestReplayConfig:
     """Tests for ReplayConfig."""

--- a/docs/features/0028_PLAN.md
+++ b/docs/features/0028_PLAN.md
@@ -1,0 +1,523 @@
+# 0028_PLAN — Systematic bbu2 alignment audit of gridcore
+
+## Description
+
+Feature 0027 found and fixed two independent bbu2-divergences in
+`packages/gridcore/src/gridcore/position.py` (formula inversion + rule
+ordering). Production impact was real (1-hour incorrect `Sell=2.0`
+firing on a losing short, 2026-05-06 00:42:14). Two unrelated bugs in
+one file is sufficient prior to suspect more divergences elsewhere in
+gridcore — which was extracted from `bbu_reference/bbu2-master/` but
+not line-by-line audited end-to-end since.
+
+This audit systematically sweeps `packages/gridcore/` against its bbu2
+reference equivalents, classifies every divergence, and produces:
+
+- An audit matrix (one row per decision point) annotated with severity,
+  category, and decision impact.
+- A list of fixes batched by function/invariant (one PR per cluster,
+  not per row).
+- A list of explicitly-confirmed intentional deltas, recorded so future
+  audits do not re-flag them.
+
+Goal restated: **zero unexplained decision-impacting divergences from
+bbu2**. Each divergence either gets fixed or carries a written
+rationale.
+
+## Reference pinning
+
+Audit base — repo commit and bbu2 reference blob SHAs at audit start.
+Any change to `bbu_reference/**` during the audit is out of scope and
+must land as a separate PR before this audit is signed off.
+
+- Repo HEAD at audit start: `2dfcd24d1c766cac75ab4c0ba8a63ffb215c8d12`
+- `bbu_reference/bbu2-master/position.py`         blob: `9a8cb3fbcb9d0a905d0a98a3a243e1345b55d670`
+- `bbu_reference/bbu2-master/greed.py`            blob: `6685ce9fc51835fe71bf1edae61719a8a2c8d327`
+- `bbu_reference/bbu2-master/strat.py`            blob: `36237d0d8da78667de3409eb6581aa9085bc238e`
+- `bbu_reference/bbu2-master/bybit_api_usdt.py`   blob: `58af0e7db8455a28b0dc1c318575cbcf4c888f04`
+- `bbu_reference/bbu2-master/settings.py`         blob: `7955d46697be3134fc8983f685fb812e00262393`
+- `bbu_reference/bbu2-master/conf/config.yaml`    blob: `2a207d4cf32744a469a9c61785b54335243153a5`
+
+### Operational verification
+
+`git rev-parse HEAD:<path>` proves the committed blob, but not the
+working copy. The audit can drift silently if reference files are
+edited unstaged. Required checks:
+
+- **Before AND after every working session:**
+  - `git status --short bbu_reference` → must be empty (no unstaged or
+    untracked changes under `bbu_reference/`).
+  - `git diff --exit-code -- bbu_reference` → must exit 0.
+- **For every pinned-reference citation** (e.g., `bbu2/position.py:58`):
+  - Confirm `git hash-object bbu_reference/bbu2-master/<file>` equals
+    the pinned blob SHA above. If mismatched, treat the file as drifted
+    and read content via `git show <pinned_blob_sha>` or
+    `git show 2dfcd24d:bbu_reference/bbu2-master/<file>` instead of
+    the working copy until the drift is resolved.
+- **Audit head re-pin if it must change:** any change to
+  `bbu_reference/**` lands as a separate PR; audit then explicitly
+  re-pins to the new HEAD + new blob SHAs and re-validates already-
+  reviewed rows.
+
+## Scope
+
+### In scope (audit targets)
+
+| gridcore module | bbu2 reference equivalent | Notes |
+|---|---|---|
+| `packages/gridcore/src/gridcore/position.py` | `bbu2/position.py` + `bybit_api_usdt.py:406-412, 540-548` | Risk multiplier rules + shared `position_ratio` propagation. |
+| `packages/gridcore/src/gridcore/grid.py` | `bbu2/greed.py` | **Mapping verified by `grid.py` docstring: "Extracted from bbu2-master/greed.py".** Build/update grid, anchor/center, `_is_too_close`. |
+| `packages/gridcore/src/gridcore/engine.py` | `bbu2/strat.py:79-182` + `bbu2/bybit_api_usdt.py` (event/order handling) | `on_event`, fill handling, intent generation, reduce-only / duplicate-placement gates. |
+| `packages/gridcore/src/gridcore/qty.py` | `bbu2/bybit_api_usdt.py:246-273, 490-538` | Amount parsing (`x` / `b` / numeric), rounding via instrument info. |
+| `packages/gridcore/src/gridcore/config.py` | `bbu2/settings.py:__add_default()` + `bbu2/conf/config.yaml` | Defaults and field semantics. |
+| `packages/gridcore/src/gridcore/instrument_info.py` | `bbu2/bybit_api_usdt.py.round_price()` and `__round_amount()` | Tick/qty rounding rules. |
+| `packages/gridcore/src/gridcore/events.py`, `intents.py` | `bbu2/strat.py` + `bybit_api_usdt.py` semantic equivalents (`handle_ticker`, `handle_execution`, `handle_order`, `_get_reduce_only`, `_is_good_to_place`, `new_limit_order`) | **Boundary semantic audit only** — shape is intentionally different. Use the explicit checklist in Phase 4 (events/intents). Not a test-suite. |
+| `apps/gridbot/src/gridbot/runner.py:_resolve_qty` (narrow exception) | `bbu2/bybit_api_usdt.py.__get_amount` + `__round_amount` | **Narrow exception to "executor out of scope"**: only the qty-floor / min-notional / risk-multiplier composition path. NOT a wider executor audit. Anything past `_resolve_qty` (placement, cancel, lifecycle) stays out. |
+
+### Out of scope
+
+- `packages/gridcore/src/gridcore/pnl.py` — bbu2 reads `liqPrice` from
+  Bybit and computes `liq_price / last_close`; it does not compute
+  liquidation or MM tiers itself. Audit pnl.py only against the narrow
+  bbu2 surface that exists (`liq_ratio`, simple margin ratio); do
+  **not** audit MM tiers / liquidation formulas against bbu2 — they
+  must be audited against Bybit docs/API in a separate effort.
+- `packages/gridcore/src/gridcore/persistence.py` — feature 0021,
+  intentionally larger scope than bbu2's `Greed.read_from_db()` /
+  `write_to_db()`. Note the semantic delta in the "Known intentional
+  deltas" section but do not audit further.
+- I/O layer (orchestrator, executor, runner) — covered by 0017
+  invariants; bbu2's `controller.py` + `bybit_api_usdt.py` I/O model
+  is fundamentally different.
+- `apps/backtest/**`, `apps/gridbot/**` non-strategy code, `apps/
+  comparator/**`, `apps/recorder/**`, `apps/replay/**`, `apps/
+  event_saver/**`.
+- Parameter tuning. This audit is about *correctness of porting*, not
+  about whether bbu2's tuning is good.
+
+## Methodology
+
+### Phase 1 — Pre-audit prep (~1h)
+
+1.1 Re-read `docs/features/0027_PLAN.md` end-to-end. Reuse its citation
+    style (`bbu_reference/...path...:line`) and its bbu2-rule-table
+    presentation.
+1.2 Snapshot the audit matrix template (Section "Audit matrix").
+1.3 Run the full **Operational verification** sequence from the
+    "Reference pinning" section (status / diff / hash-object). Do
+    NOT use `git rev-parse HEAD:<path>` alone — it does not detect
+    unstaged drift. Repeat at the start and end of every working
+    session.
+
+### Phase 2 — Audit matrix construction (~1 day)
+
+For each (gridcore module, bbu2 equivalent) pair in the In Scope table,
+walk function-by-function and decision-point-by-decision-point. For
+position.py and engine.py, build a **rule table** (predicate, priority,
+action, target side/direction, multiplier, zero-or-boundary behavior)
+in addition to the matrix.
+
+Special attention to:
+
+- Formulas — numerator/denominator orientation (0027 Bug A).
+- `if`/`elif` chain ordering (0027 Bug B).
+- Strictness — `<` vs `<=`.
+- Default values and zero-guards.
+- Which condition state is **shared** between long/short (0027 Bug A
+  was about a missing shared assignment).
+- Rounding direction (`round`, `floor`, `ceil`) in qty/price.
+
+Each row of the audit matrix:
+
+| ID | Module/function | bbu2 ref (file:line) | gridcore (file:line) | Status | Category | Severity | Decision impact | Evidence | Notes |
+
+`Evidence` values: `code` (citation in source), `test` (passing/
+failing test asserts the claim), `doc` (feature plan or README),
+`user-memory` (saved in auto-memory dir), `oracle` (executable oracle
+result).
+
+**Minimum evidence per category (sign-off gate):**
+
+| Category | Required evidence |
+|---|---|
+| Behavioral Bug | `code` AND (`test` OR `oracle`). |
+| Config Delta | `code` for both defaults and live values; `doc` if Intentional. `user-memory` alone is insufficient. |
+| Intentional Improvement | `doc` OR `code` plus a written rationale on the row. `user-memory` may support but not replace. |
+| Architecture Delta | `doc` OR `code` plus rationale. |
+| Reference Bug | `code` AND (`oracle` OR `test`); external source acceptable as supplement. |
+| Exchange-API Delta | `doc` (Bybit changelog / API ref) OR `code` plus written rationale. |
+| Performance/Operational | `code` AND `doc` or rationale. |
+
+"Rationale" alone without at least one evidence value is insufficient
+for sign-off.
+
+Status: `match` / `divergent` / `unclear` / `gridcore-only` /
+`bbu2-only`.
+
+### Phase 3 — Config drift audit (~2h)
+
+3.1 Sweep `bbu2/settings.py.__add_default()` and
+    `bbu2/conf/config.yaml` for every parameter. For each, locate its
+    counterpart in `gridcore/config.py`, `apps/gridbot/src/gridbot/
+    config.py`, or `apps/backtest/src/backtest/config.py`.
+3.2 Note: parameter present-with-different-default, present-with-
+    different-semantics, missing, or gridcore-only.
+3.3 Distinguish **two layers** of config:
+    - **Defaults layer** — bbu2 `settings.py.__add_default()` vs
+      gridcore `config.py` field defaults.
+    - **Live values layer** — bbu2 `conf/config.yaml` vs `conf/
+      gridbot_test.yaml`. Defaults can match while live values diverge
+      (e.g., `grid_step` default 0.2 in both, but our live conf is
+      0.3). Both layers must be swept.
+
+3.4 Confirmed initial findings (verified at audit base `2dfcd24d`):
+
+| Parameter | bbu2 default | Our default | Status |
+|---|---|---|---|
+| `max_margin` | 5 | 8 | Config Delta — verify intent |
+| `min_total_margin` | 0 | 0.15 | Config Delta — verify intent |
+| `long_koef` | 1.0 | 1.0 | Match (defaults) — but verify *application* (Phase 4) |
+| `increase_same_position_on_low_margin` | False | False | Match (verified `position.py:61`, used `:385`) |
+| `grid_count` (bbu `greed_count`) | 40 | 50 | Config Delta — verify intent |
+| `grid_step` (bbu `greed_step`) | 0.2 | 0.2 | Match (defaults); live conf 0.3 — Live-Value Delta |
+| `amount` semantics (`x`/`b`/numeric) | TBD | TBD | Audit `qty.py` |
+| `min_amount_usdt` (bbu hardcoded 5) | 5 | TBD | Audit `runner._resolve_qty` (narrow scope exception) |
+
+3.5 Additional Settings.__add_default() parameters to sweep
+    explicitly (not yet in the table; check before treating as
+    out-of-scope):
+    - **Risk thresholds (must be Match rows):** `min_liq_ratio = 0.8`,
+      `max_liq_ratio = 1.2`. Our `StrategyConfig` defaults are 0.8/1.2
+      (`apps/gridbot/src/gridbot/config.py:47-48`); runner passes them
+      into `RiskConfig` (which declares the fields without defaults at
+      `packages/gridcore/src/gridcore/position.py:57-58`). Verify and
+      record.
+    - account-level `exchange = bybit_usdt`
+    - account-level `key`/`secret` fallback from `default_key`
+    - strategy `direction` default (`long`?)
+    - amount-level `is_testnet = False` vs our `testnet`
+    - global `intervals.check` vs our `position_check_interval`,
+      `order_sync_interval`, `auth_cooldown_minutes`
+    - `server_config.debug`
+    - `ERROR_PRICE = 0.13` (likely removed; confirm and document
+      removal)
+    - Config shape: bbu2 `pair_timeframes` + `amounts` linked by
+      `strat` vs our `strategies[].account` linkage. Note as
+      Architecture Delta.
+
+    **Explicit ignore (record once, do not audit further):**
+    - `telegram`, `bm_keys`, `default_key`, `keysfiles`,
+      `serverfiles`, `yamlfiles` — bbu2 I/O / config-shape
+      plumbing. Out of scope.
+    - `check.start` / `check.period` — read in bbu2 config.yaml,
+      but assignments are commented out in the active code path.
+      Mark as bbu2-unused/dead config and ignore.
+
+3.6 Each Config Delta gets a row in the main audit matrix with
+    Evidence column populated (default-source citation).
+
+### Phase 4 — Executable oracles (~1 day)
+
+For divergences that require behavioral confirmation (not just visual
+read), build pure-function oracles in tests. Do **not** attempt
+wholesale `import bbu2` — bbu2 is not a clean package (relative
+imports, pybit/telegram/db dependencies).
+
+Approach per module:
+
+- **position.py** — write a small oracle in `packages/gridcore/tests/`
+  that copies/translates the long and short rule branches from bbu2's
+  `Position.__calc_amount_multiplier` (`bbu_reference/bbu2-master/
+  position.py:52-92`). The branches are inline inside that single
+  private method, not in separate helpers — there is no
+  `_adjust_long/short_amount_multiplier` in bbu2. Translate the inline
+  branches verbatim to call our `PositionState` shape, then run
+  table-driven cases through both the oracle and our
+  `calculate_amount_multiplier`; assert equivalence. A partial
+  template exists in 0027's tests.
+- **greed.py** — import `bbu_reference/bbu2-master/greed.Greed` with
+  monkey-patched stubs. **Stub mechanism (concrete):**
+  1. Add `bbu_reference/bbu2-master` to `sys.path`.
+  2. **BEFORE** `import greed`, populate `sys.modules` with fakes
+     for the three modules `greed.py` actually imports at top level:
+     `db_files`, `loggers`, `bybit_api_usdt`. Minimal surface:
+     - `db_files.DbFiles` — `read_greed`, `write_greed` (no-op).
+     - `loggers.Loggers` — `log_exception` (no-op).
+     - `bybit_api_usdt.BybitApiUsdt.round_price(symbol, price,
+       ticksize=None)` — pure arithmetic. Maintain a small
+       `symbol → tick` map covering every symbol used in oracle
+       cases. Resolution rule, mirroring bbu2's
+       `BybitApiUsdt.ticksizes[symbol]`:
+       1. If `ticksize is not None`, use it.
+       2. Else, look up `symbol` in the map and use that tick.
+       3. Identity (no rounding) **only as a last resort** for
+          symbols explicitly out of test scope. Never silently
+          return unrounded prices for in-test symbols — that
+          desynchronizes the oracle from real bbu2 behavior and
+          can mask divergences.
+       **Verify the signature against bbu2 at audit time** —
+       historically it has been `(symbol, price, ticksize=None)`,
+       not `(price, tick)`.
+  3. `strat` is **NOT** a module to stub — `greed.py` does not
+     `import strat`. It receives a `strat` object as a constructor
+     argument. Pass a small fake with the attributes Greed reads
+     (at minimum `.id`; add more as `AttributeError` surfaces
+     during oracle execution).
+  4. Importing greed without these stubs pulls pybit / network /
+     telegram / DB transitively and will fail.
+
+  **Oracle invocation policy:** call only **public methods**
+  (`build_greed`, `update_greed`). Do NOT call private methods
+  directly (`__center_greed`, `__is_too_close`) — they are name-
+  mangled and have DB write side effects. Cover center/out-of-bounds/
+  too-close scenarios via observed outputs of public calls instead.
+- **qty.py** — table-driven oracle: enumerate `amount` strings (`x...`,
+  `b...`, numeric), prices, instrument info; assert our output matches
+  hand-derived bbu2 output from `__get_amount` and `__round_amount`.
+  Include `min_amount_usdt = 5` floor as a test case.
+- **engine.py** — scenario traces, **bounded scope**. Define
+  inputs (current grid + active limits + last_close + a sequence of
+  fills/tickers) and expected output intent stream. Two tiers:
+
+  **Tier 1 — Minimum required (manually-derived expected outputs):**
+  1. Price eligibility: buy below market, sell above market,
+     `grid_step/2` gate.
+  2. Side mismatch — cancel + replace.
+  3. Outside-grid limit — cancel.
+  4. Reduce-only flag mapping.
+  5. Too many active limits → rebuild/cancel path.
+  6. Order sorting — nearest-to-WAIT priority.
+
+  **Tier 2 — Hard scenarios (do NOT manually derive):** fill/ticker
+  ordering after 0017/0022 changes, same-order error lifecycle,
+  long-vs-short full-direction dispatch with live limit refresh,
+  reduce-only qty gate (qty lives in runner/executor — out of pure
+  engine scope). For these, either:
+  - cite exact bbu2 lines verbatim and prove behavioral identity
+    line-by-line, OR
+  - run a fake-controller execution of bbu2 `Strat50` with the stubs
+    above, capturing its intent stream as the oracle, OR
+  - mark as "deferred — requires comparator-replay validation
+    (Variant A)".
+
+  Don't manually invent expected outputs for Tier 2.
+- **events.py / intents.py** — **checklist, not test-suite.** For each
+  bbu2 entrypoint, fill in:
+
+  | bbu2 site | Our path | Expected effect | Verified by |
+  |---|---|---|---|
+  | `handle_ticker` | `engine.on_event(TickerEvent)` | … | code/test |
+  | `handle_execution` | `engine.on_event(ExecutionEvent)` | … | code/test |
+  | `handle_order` | … | … | … |
+  | `_get_reduce_only` | … | … | … |
+  | `_is_good_to_place` | … | … | … |
+  | `new_limit_order` | `PlaceLimitIntent.create(...)` | … | … |
+
+  Each row asserts equivalence by citation, not by running tests. Do
+  not refactor.
+
+### Phase 5 — Triage and fix batching
+
+5.1 Group divergences in the audit matrix by *invariant* or
+    *function*, not by row.
+5.2 Each cluster → one PR following the 0027 template
+    (production-evidence section, regression-test cases enumerated,
+    diff size budget).
+5.3 PR ordering — most decision-impacting first, lowest blast radius
+    last.
+
+### Phase 6 — Sign-off
+
+6.1 Audit matrix has zero `divergent + unresolved` rows in
+    `Behavioral Bug` category.
+6.2 Every `Intentional Improvement` / `Architecture Delta` /
+    `Config Delta` / `Reference Bug` / `Exchange-API Delta` /
+    `Performance/Operational` row has a written rationale AND
+    satisfies the per-category minimum evidence rule from the
+    "Audit matrix" section.
+6.3 **No `Needs confirmation` carve-outs may remain unresolved.**
+    Each item in the "Needs confirmation" list of "Known intentional
+    deltas" must be either upgraded to Confirmed (with Evidence) or
+    reclassified as a divergence row (Behavioral Bug / Config Delta /
+    etc.) before sign-off. TBD is not a final state.
+6.4 Final audit report committed as `docs/features/
+    0028_AUDIT_REPORT.md`. Subsequent fix PRs reference it.
+6.5 The audit report **must explicitly name the residual risk**
+    that this audit does NOT cover: `gridcore` is shared between live
+    and backtest, but post-`qty.py` enforcement diverges
+    (`apps/gridbot/src/gridbot/runner.py:_resolve_qty` clamps
+    min_qty/max_qty; `apps/backtest` has its own path). Confirming
+    bbu2 alignment in `gridcore` plus the narrow `_resolve_qty`
+    boundary does not validate live/backtest semantic parity past
+    that point. That parity question belongs to Variant A
+    (comparator-replay), which is deferred.
+
+## Classification taxonomy
+
+| Category | Definition |
+|---|---|
+| Behavioral Bug | Divergence changes the trading decision in normal market conditions. Default fix path. |
+| Intentional Improvement | Our code is deliberately better than bbu2 (e.g., extra zero-guard, drift recenter). Requires written rationale. |
+| Reference Bug | bbu2 itself appears wrong; our code already correct. Document and move on. |
+| Architecture Delta | Different API/event shape, but boundary behavior equivalent (e.g., events vs imperative calls). No fix needed. |
+| Config Delta | Parameter default or semantics differ. Either align or carry rationale. |
+| Exchange-API Delta | Difference forced by Bybit v5 vs v3 API changes since bbu2 was written. Document. |
+| Performance/Operational | Polling cadence, REST rate, cache strategy, persistence, reconnect behavior. Out of risk-correctness scope but still flagged. |
+
+Severity (orthogonal to category):
+
+- **Critical** — affects routine decisions (e.g., 0027 Bug A).
+- **Major** — affects boundary/rare conditions (zero margin, zero
+  size, market gap).
+- **Minor** — implementation difference, observable only in logs.
+
+`Decision impact` column values: `place` / `cancel` / `qty` /
+`multiplier` / `persistence` / `logging-only`.
+
+## Known intentional deltas (carve-outs)
+
+Split into **Confirmed** (documented in feature plan or directly
+visible in code) and **Needs confirmation** (rationale exists but is
+weak — must be upgraded to Confirmed during audit or reclassified).
+
+### Confirmed (do not re-flag)
+
+- `grid.py` duplicate-price guard — required by deterministic
+  `client_order_id` (intent identity). Evidence: `intents.py` coid
+  hash construction.
+- `engine.py` per-tick drift detector + auto-recenter — feature 0022.
+  Evidence: `docs/features/0022_PLAN.md`, code in `engine.py`.
+- `apps/gridbot` sync polling main loop — feature 0017. Evidence:
+  `docs/features/0017_PLAN.md` Invariants section.
+- `persistence.py` — feature 0021, larger scope than bbu2's
+  `read_from_db` / `write_to_db`. Evidence:
+  `docs/features/0021_PLAN.md`.
+- Hedge-mode reduce-only rejection on `position_size <= qty` —
+  confirmed in code (`runner._is_good_to_place`) and in user memory.
+- `pnl.py` MM tiers / liquidation price formulas — bbu2 has no
+  equivalent; ported from Bybit docs. Out of scope, but explicit
+  carve-out so audit doesn't drift back into pnl.
+
+### Needs confirmation (treat as TBD until evidenced)
+
+- Per-direction sequential dispatch (long fully → short fully). Code
+  exists; user-memory says intentional, but no feature plan documents
+  the rationale. **Action:** during Phase 2 of engine audit, locate
+  the dispatch site and either find a feature-plan reference or
+  upgrade rationale to a written note in this plan + code comment.
+- `amount_multiplier` forward-only (no cancel-replace of existing
+  orders on multiplier change). User memory says intentional, but
+  could be operational limitation rather than design. **Action:**
+  during position.py audit, confirm or reclassify; cite issue/plan
+  if found.
+- `(account, symbol)` collision ban — claim is "bbu2 enforces
+  implicitly via single-strategy config shape". **Action:** verify
+  by reading bbu2 `settings.py` + `controller.py` config-loading
+  code; either confirm or remove the claim.
+- `orderLinkId`/`client_order_id` boundary (likely from feature
+  0016). **Action:** check `docs/features/0016_*` for whether
+  `orderLinkId` was intentionally removed from outbound REST and
+  document as Confirmed if so.
+
+## Priority targets (start here)
+
+Reordered by **decision-impact-per-hour** (real order-size and
+strategy-decision changes first; config rationale second; engine gates
+last because of high cost-per-finding via Tier-2 hard scenarios):
+
+1. **`amount` semantics + `min_amount_usdt = 5` floor** — single qty
+   path. bbu2 `b` mode does `math.ceil(btc_amount / price)` for non-
+   BTC symbols. Confirm our `qty.py` and `runner._resolve_qty`
+   together produce identical orders to bbu2 `__get_amount`. Direct
+   real-order-size impact, isolated, table-driven test.
+2. **`long_koef` application** — bbu2 multiplies amount when
+   `1.1 < position_ratio < 10 AND both liq_price == 0`. Defaults match
+   (1.0), but the *application* point is unaudited. `qty.py` does
+   not appear to use `long_koef`; locate where (if anywhere) it
+   applies in our code, or confirm it is silently dropped (which
+   would be a Behavioral Bug in disguise as a config Match).
+3. **Config drift sweep** (Phase 3). Three confirmed deltas
+   (`max_margin` 5→8, `min_total_margin` 0→0.15, `grid_count` 40→50)
+   plus the additional sweep list in 3.5. Per item: ~15 min to
+   classify (align / document / Live-Value Delta). Not all are
+   "5-minute decisions" — some require evidence of intent before
+   marking Intentional Improvement.
+4. **`grid.py` ↔ `greed.py` build/update/recenter** — 0027 found two
+   bugs in a single file; greed/grid is the next-densest logic
+   surface. Stub-import of bbu2 greed makes this tractable.
+5. **Rule table for `position.py`** — re-derive after 0027 to confirm
+   no third silent divergence remains in the same file. Cheap
+   straightforward audit using the 0027 oracle template.
+6. **`engine.py` reduce-only and duplicate-placement gates** —
+   Tier-1 scenarios from Phase 4. Tier-2 scenarios deferred unless
+   Variant A (comparator-replay) becomes available.
+
+## Deliverables
+
+- `docs/features/0028_AUDIT_REPORT.md` — full audit matrix + carve-outs
+  + sign-off status.
+- One or more fix PRs, each in the 0027 template, batched by
+  invariant/function.
+- Updates to `RULES.md` capturing each `Intentional Improvement` /
+  `Architecture Delta` so future audits do not re-flag them.
+- Oracle test files — **retained case-by-case, not by default.**
+  Retain when the oracle directly asserts a behavioral invariant that
+  ongoing development could break (e.g., position-rules oracle).
+  Discard or move to a non-CI scratch dir when the oracle was a one-
+  shot audit instrument with no future regression value (e.g.,
+  table-driven qty cases that duplicate existing tests).
+
+## Out of scope
+
+- pnl.py MM-tier and liquidation formula audit against bbu2 (covered
+  by Bybit docs in a separate effort).
+- Refactoring gridcore module structure.
+- Changing `bbu_reference/bbu2-master/**` files.
+- Re-running the 0017 sync refactor logic check (covered by Variant A
+  comparator path, deferred).
+- Performance work, polling cadence tuning.
+- Live-bot operational changes.
+- Behavior changes outside the strategy layer (orchestrator / executor
+  / runner).
+
+## Constraints
+
+- No `--no-verify` on commits.
+- Do not modify any memory file.
+- Do not restart or otherwise touch the running production bot during
+  the audit.
+- Do not change `bbu_reference/**` during the audit window.
+- Each fix PR is opened but NOT auto-merged. Risk-management changes
+  require human approval.
+- If a third bug or refactor temptation surfaces during audit, stop
+  and surface it in the audit report before opening fixes.
+
+## Verification
+
+1. Audit matrix complete — every function in the In Scope table has a
+   row (or explicit "no decision points" note).
+2. Every `divergent` row classified into the taxonomy.
+3. No `Behavioral Bug + Critical + unresolved` rows at sign-off.
+4. Each fix PR passes `uv run pytest packages/gridcore/tests/ apps/
+   gridbot/tests/ -q`.
+5. `uv run ruff check packages/gridcore/src/gridcore/` clean.
+6. Reference pinning re-verified at sign-off (no drift in
+   `bbu_reference/**` blob SHAs from audit base).
+
+## References
+
+- `docs/features/0027_PLAN.md` — citation/test-template precedent.
+- `bbu_reference/bbu2-master/position.py:55-92` — bbu2 rule chains.
+- `bbu_reference/bbu2-master/greed.py` — bbu2 grid logic source for
+  `gridcore/grid.py`.
+- `bbu_reference/bbu2-master/bybit_api_usdt.py:246-273, 490-538` — qty
+  / amount / round logic.
+- `bbu_reference/bbu2-master/bybit_api_usdt.py:540-560` — shared
+  `position_ratio` reference.
+- `bbu_reference/bbu2-master/settings.py:__add_default()` — config
+  defaults.
+- `packages/gridcore/src/gridcore/position.py` — primary 0027 fix
+  surface.
+- `packages/gridcore/src/gridcore/grid.py` — docstring confirms
+  greed.py provenance.
+- User memory (auto-memory dir) — pre-confirmed intentional deltas.

--- a/packages/gridcore/src/gridcore/__init__.py
+++ b/packages/gridcore/src/gridcore/__init__.py
@@ -14,7 +14,7 @@ from gridcore.engine import GridEngine
 from gridcore.position import PositionState, Position, PositionRiskManager, RiskConfig, DirectionType, SideType
 from gridcore.persistence import GridStateStore
 from gridcore.instrument_info import InstrumentInfo
-from gridcore.qty import create_qty_calculator
+from gridcore.qty import create_qty_calculator, apply_early_imbalance
 from gridcore.pnl import (
     calc_unrealised_pnl,
     calc_unrealised_pnl_pct,
@@ -53,6 +53,7 @@ __all__ = [
     "GridStateStore",
     "InstrumentInfo",
     "create_qty_calculator",
+    "apply_early_imbalance",
     "calc_unrealised_pnl",
     "calc_unrealised_pnl_pct",
     "calc_position_value",

--- a/packages/gridcore/src/gridcore/position.py
+++ b/packages/gridcore/src/gridcore/position.py
@@ -90,6 +90,20 @@ class Position:
             direction: 'long' or 'short'
             risk_config: Risk management parameters
 
+        Instance attributes (mutated by runners between ticks):
+            size: Latest position size in contracts; mirror of
+                PositionState.size, kept as a plain field so consumers
+                like _resolve_qty / _apply_risk_to_qty can read it
+                without rebuilding a snapshot.
+            liquidation_price: Latest exchange liq_price; same caching
+                pattern as size. Read by the early_imbalance_multiplier
+                gate to detect the pre-liquidation phase.
+            position_ratio: Set externally as a size-based ratio, then
+                OVERWRITTEN by calculate_amount_multiplier with a
+                margin-based ratio (long_margin / short_margin). Do
+                NOT read this for size-based bbu2 conditions; compute
+                size_ratio inline from `size` instead.
+
         Reference: bbu2-master/position.py:8-22
         """
         self.direction = direction
@@ -97,6 +111,7 @@ class Position:
         self.amount_multiplier = {self.SIDE_BUY: 1.0, self.SIDE_SELL: 1.0}
         self.position_ratio = 1.0
         self.size: Decimal = Decimal('0')
+        self.liquidation_price: Decimal = Decimal('0')
         self._opposite: Optional['Position'] = None
 
     def set_opposite(self, opposite: 'Position') -> None:

--- a/packages/gridcore/src/gridcore/qty.py
+++ b/packages/gridcore/src/gridcore/qty.py
@@ -14,6 +14,26 @@ from gridcore.intents import PlaceLimitIntent
 # Type alias for qty calculator callable
 QtyCalculator = Callable[[PlaceLimitIntent, Decimal], Decimal]
 
+# bbu2 hardcodes a $5 USDT minimum notional in __get_amount; matches
+# `min_amount_usdt = 5` at bbu_reference/bbu2-master/bybit_api_usdt.py:491.
+_MIN_NOTIONAL_USDT = Decimal("5")
+
+
+def _apply_min_notional(raw_qty: Decimal, price: Decimal) -> Decimal:
+    """Bump qty up to the $5 USDT notional floor when below it.
+
+    Mirrors bbu2 bybit_api_usdt.py:520-522:
+        min_amount = min_amount_usdt / price
+        if amount < min_amount:
+            amount = self.__round_amount(min_amount)
+    Strict `<` (boundary at exactly $5 passes through unchanged).
+    """
+    if price <= 0:
+        return raw_qty
+    if raw_qty * price < _MIN_NOTIONAL_USDT:
+        return _MIN_NOTIONAL_USDT / price
+    return raw_qty
+
 
 def create_qty_calculator(
     amount_str: str,
@@ -23,12 +43,12 @@ def create_qty_calculator(
 
     Amount formats:
     - "x0.001": Fraction of wallet balance (0.1%)
-    - "b0.001": Fixed base currency amount (BTC)
     - "100": Fixed USDT amount
 
     Quantities are rounded up to instrument's qty_step when instrument_info
     is provided (matching bbu2 behavior). Without instrument_info, raw
-    (unrounded) quantities are returned.
+    (unrounded) quantities are returned. A $5 USDT min-notional floor is
+    applied before rounding (bbu2 parity).
 
     Args:
         amount_str: Amount pattern from config.
@@ -55,27 +75,33 @@ def create_qty_calculator(
     if amount_str.startswith("x"):
         fraction = _parse_decimal(amount_str[1:])
 
+        # Fraction mode short-circuits on wallet_balance <= 0: a wallet-
+        # fraction config logically has zero base when there is no wallet,
+        # and emitting the $5 floor in that state would put orders on the
+        # exchange that cannot be margined. Asymmetric vs USDT mode below,
+        # which is explicit and not derived from wallet — there a non-zero
+        # absolute amount is still meaningful even at wallet=0 (e.g., for
+        # restored-state edge cases where positions exist before the wallet
+        # snapshot lands). Documented divergence, not a bug.
         def qty_from_fraction(intent: PlaceLimitIntent, wallet_balance: Decimal) -> Decimal:
-            if intent.price <= 0:
+            if intent.price <= 0 or wallet_balance <= 0:
                 return Decimal("0")
-            return _round(wallet_balance * fraction / intent.price)
+            raw = wallet_balance * fraction / intent.price
+            raw = _apply_min_notional(raw, intent.price)
+            return _round(raw)
 
         return qty_from_fraction
-
-    elif amount_str.startswith("b"):
-        base_qty = _parse_decimal(amount_str[1:])
-
-        def qty_fixed_base(intent: PlaceLimitIntent, wallet_balance: Decimal) -> Decimal:
-            return _round(base_qty)
-
-        return qty_fixed_base
 
     else:
         usdt_amount = _parse_decimal(amount_str)
 
         def qty_from_usdt(intent: PlaceLimitIntent, wallet_balance: Decimal) -> Decimal:
+            # No wallet_balance check: USDT mode is wallet-independent
+            # (see asymmetry note in qty_from_fraction above).
             if intent.price <= 0:
                 return Decimal("0")
-            return _round(usdt_amount / intent.price)
+            raw = usdt_amount / intent.price
+            raw = _apply_min_notional(raw, intent.price)
+            return _round(raw)
 
         return qty_from_usdt

--- a/packages/gridcore/src/gridcore/qty.py
+++ b/packages/gridcore/src/gridcore/qty.py
@@ -10,6 +10,7 @@ from typing import Callable, Optional
 
 from gridcore.instrument_info import InstrumentInfo
 from gridcore.intents import PlaceLimitIntent
+from gridcore.position import Position
 
 # Type alias for qty calculator callable
 QtyCalculator = Callable[[PlaceLimitIntent, Decimal], Decimal]
@@ -17,6 +18,63 @@ QtyCalculator = Callable[[PlaceLimitIntent, Decimal], Decimal]
 # bbu2 hardcodes a $5 USDT minimum notional in __get_amount; matches
 # `min_amount_usdt = 5` at bbu_reference/bbu2-master/bybit_api_usdt.py:491.
 _MIN_NOTIONAL_USDT = Decimal("5")
+
+# Early-imbalance trigger band — bbu2 reference
+# `bbu_reference/bbu2-master/bybit_api_usdt.py:257-261`. Asymmetric:
+# fires only when long.size / short.size lands in this open band.
+_EARLY_IMBALANCE_MIN_RATIO = 1.1
+_EARLY_IMBALANCE_MAX_RATIO = 10.0
+
+
+def apply_early_imbalance(
+    qty: Decimal,
+    long_position: Position,
+    short_position: Position,
+    multiplier: float,
+) -> Decimal:
+    """Apply bbu2 early-imbalance multiplier to a resolved qty.
+
+    Mirrors bbu2 bybit_api_usdt.py:257-261 — multiplies the next order's
+    qty by `multiplier` when:
+      - `_EARLY_IMBALANCE_MIN_RATIO < size_ratio < _EARLY_IMBALANCE_MAX_RATIO`
+        (asymmetric: long must dominate short; no short-dominant mirror)
+      - both positions are pre-liquidation (`liquidation_price == 0`)
+
+    bbu2 uses a SIZE-based ratio (`long.size / short.size`). Reads
+    `Position.size` directly. Do NOT use `Position.position_ratio`,
+    which is overwritten with margin-based ratio inside
+    `Position.calculate_amount_multiplier` (`gridcore/position.py:231`).
+
+    Args:
+        qty: The qty already composed with `amount_multiplier`, before
+            instrument-step rounding (matches bbu2 ordering: multiplier
+            is applied before `__round_amount`).
+        long_position: Long-direction Position with current `size` and
+            `liquidation_price` cached.
+        short_position: Short-direction Position with same.
+        multiplier: User-configured `early_imbalance_multiplier`. The
+            common no-op case (== 1.0) short-circuits without any of
+            the size/liq reads.
+
+    Returns:
+        `qty * multiplier` if the bbu2 trigger fires, else `qty`
+        unchanged.
+    """
+    if multiplier == 1.0:
+        return qty
+    long_size = float(long_position.size)
+    short_size = float(short_position.size)
+    if short_size > 0:
+        size_ratio = long_size / short_size
+    elif long_size > 0:
+        size_ratio = float("inf")  # short empty — out of band by `< MAX`
+    else:
+        size_ratio = 1.0
+    if (_EARLY_IMBALANCE_MIN_RATIO < size_ratio < _EARLY_IMBALANCE_MAX_RATIO
+            and long_position.liquidation_price == 0
+            and short_position.liquidation_price == 0):
+        return qty * Decimal(str(multiplier))
+    return qty
 
 
 def _apply_min_notional(raw_qty: Decimal, price: Decimal) -> Decimal:

--- a/packages/gridcore/tests/test_qty.py
+++ b/packages/gridcore/tests/test_qty.py
@@ -86,29 +86,57 @@ class TestFixedUSDT:
         assert qty == Decimal("0")
 
 
-class TestFixedBase:
-    """Tests for 'b...' fixed base currency amount strings."""
+class TestMinNotionalFloor:
+    """Tests for the $5 USDT min-notional floor (bbu2 parity)."""
 
-    def test_basic_base(self, instrument_info):
-        calc = create_qty_calculator("b0.005", instrument_info)
+    def test_fraction_below_floor_bumps_up(self, instrument_info):
+        calc = create_qty_calculator("x0.001", instrument_info)
+        intent = _make_intent("50000")
+        # 100 * 0.001 / 50000 = 0.000002 → notional 0.10 USDT (well below $5)
+        # Floor: 5 / 50000 = 0.0001 → rounded up to qty_step 0.001
+        qty = calc(intent, Decimal("100"))
+        assert qty == Decimal("0.001")
+
+    def test_usdt_below_floor_bumps_up(self, instrument_info):
+        # Fixed 1 USDT request → 1/50000 = 0.00002, notional $1 < $5 floor.
+        # Floor: 5 / 50000 = 0.0001 → rounded up to qty_step 0.001
+        calc = create_qty_calculator("1", instrument_info)
         intent = _make_intent("50000")
         qty = calc(intent, Decimal("10000"))
-        # Fixed base = 0.005, rounds up to 0.005
-        assert qty == Decimal("0.005")
+        assert qty == Decimal("0.001")
 
-    def test_base_rounds_up(self, instrument_info):
-        calc = create_qty_calculator("b0.0015", instrument_info)
+    # Note: a true strict-`<` vs `<=` boundary discriminator at exactly $5
+    # cannot be written numerically — at the boundary `_MIN_NOTIONAL / price`
+    # equals the raw qty, so both implementations yield identical output.
+    # We rely on `test_floor_just_below_5_fires` (firing path) and
+    # `test_floor_just_above_5_passes_through` (non-firing path) to cover
+    # both sides of the boundary instead.
+
+    def test_floor_just_above_5_passes_through(self):
+        # Notional slightly above $5 must NOT be bumped (passthrough).
+        # amount "5.01" at price 40000 → 0.00012525 raw.
+        calc = create_qty_calculator("5.01", None)
+        intent = _make_intent("40000")
+        qty = calc(intent, Decimal("10000"))
+        assert qty == Decimal("5.01") / Decimal("40000")  # passthrough
+
+    def test_floor_just_below_5_fires(self):
+        # Notional $4.99 (strictly below $5) MUST be bumped to floor.
+        # Discriminator: without instrument_info, raw output reveals whether
+        # floor fired. amount "4.99" at price 40000 → 0.00012475 raw.
+        # Floor fires: replaces with 5/40000 = 0.000125.
+        calc = create_qty_calculator("4.99", None)
+        intent = _make_intent("40000")
+        qty = calc(intent, Decimal("10000"))
+        assert qty == Decimal("5") / Decimal("40000")  # bumped to floor
+        assert qty != Decimal("4.99") / Decimal("40000")  # not passthrough
+
+    def test_above_floor_passthrough(self, instrument_info):
+        # 100 / 50000 = 0.002, notional 100 USDT >> 5; passthrough.
+        calc = create_qty_calculator("100", instrument_info)
         intent = _make_intent("50000")
         qty = calc(intent, Decimal("10000"))
-        # 0.0015 rounds up to 0.002
         assert qty == Decimal("0.002")
-
-    def test_base_ignores_price_and_balance(self, instrument_info):
-        calc = create_qty_calculator("b0.01", instrument_info)
-        intent = _make_intent("0")
-        qty = calc(intent, Decimal("0"))
-        # Fixed base always returns the amount, regardless of price/balance
-        assert qty == Decimal("0.01")
 
 
 class TestNoInstrumentInfo:
@@ -141,10 +169,6 @@ class TestEdgeCases:
         with pytest.raises(ValueError, match="invalid amount string"):
             create_qty_calculator("xnotanumber")
 
-    def test_invalid_base_raises(self):
-        with pytest.raises(ValueError, match="invalid amount string"):
-            create_qty_calculator("bnotanumber")
-
     def test_invalid_usdt_raises(self):
         with pytest.raises(ValueError, match="invalid amount string"):
             create_qty_calculator("notanumber")
@@ -153,9 +177,11 @@ class TestEdgeCases:
         with pytest.raises(ValueError, match="invalid amount string"):
             create_qty_calculator("x")
 
-    def test_bare_b_raises(self):
+    def test_legacy_b_mode_now_rejected(self):
+        # "b..." mode (BTC-equivalent for inverse contracts) is removed.
+        # Strings starting with "b" route through the numeric branch and fail.
         with pytest.raises(ValueError, match="invalid amount string"):
-            create_qty_calculator("b")
+            create_qty_calculator("b0.005")
 
     def test_negative_price(self, instrument_info):
         calc = create_qty_calculator("100", instrument_info)

--- a/tests/integration/test_shadow_validation.py
+++ b/tests/integration/test_shadow_validation.py
@@ -10,13 +10,13 @@ that the backtest faithfully reproduces the same trading decisions as
 the live execution path, using deterministic client_order_id matching.
 """
 
-import math
 import pytest
 from dataclasses import replace
 from decimal import Decimal
 
 from gridcore import DirectionType
 from gridcore.instrument_info import InstrumentInfo
+from gridcore.qty import create_qty_calculator
 
 from backtest.config import BacktestConfig, BacktestStrategyConfig, WindDownMode
 from backtest.engine import BacktestEngine
@@ -89,17 +89,21 @@ def _make_price_events():
 
 
 def _qty_calculator(intent, wallet_balance):
-    """Match BacktestEngine's qty calculator for fixed USDT amount.
+    """Use the canonical gridcore qty calculator instead of reimplementing.
 
-    Replicates the logic in BacktestEngine._create_qty_calculator()
-    with InstrumentInfo.round_qty() rounding up to qty_step.
+    Earlier this re-derived the qty math inline, which silently diverged from
+    production after feature 0028 added the $5 USDT min-notional floor.
+    Delegate to the same factory both gridbot and backtest use to guarantee
+    parity going forward.
     """
-    if intent.price <= 0:
-        return Decimal("0")
-    raw_qty = Decimal(AMOUNT) / intent.price
-    # Round up to nearest qty_step (matching InstrumentInfo.round_qty behavior)
-    steps = math.ceil(float(raw_qty) / float(QTY_STEP))
-    return Decimal(str(steps)) * QTY_STEP
+    info = InstrumentInfo(
+        symbol=SYMBOL,
+        qty_step=QTY_STEP,
+        tick_size=Decimal(TICK_SIZE),
+        min_qty=QTY_STEP,
+        max_qty=Decimal("1000"),
+    )
+    return create_qty_calculator(AMOUNT, info)(intent, wallet_balance)
 
 
 def _run_path_a(events):


### PR DESCRIPTION
## Summary

Systematic bbu2-alignment audit of the qty path in `packages/gridcore/qty.py` and adjacent runner code. Closes 4 priority targets from `docs/features/0028_PLAN.md`:

- **D-1** — Removed legacy `"b..."` amount mode (BTC-equivalent for inverse contracts). gridcore is scoped to Bybit linear USDT-perps; "b..." now raises `ValueError: invalid amount string`.
- **D-2** — Added `$5 USDT` min-notional floor in `qty.py` matching bbu2 `bybit_api_usdt.py:520-522`. Strict `<` boundary; both fraction and numeric modes covered.
- **D-3** — Renamed config field `long_koef` → `early_imbalance_multiplier` and **implemented** its application in both live (`StrategyRunner._resolve_qty`) and backtest (`BacktestRunner._apply_risk_to_qty`). Was declared but never read — silent footgun at any non-default value. Trigger: `1.1 < size_ratio < 10` AND `long.liq_price == 0` AND `short.liq_price == 0` (bbu2 ref `bybit_api_usdt.py:257-261`). Migration validator on all three Strategy configs rejects legacy `long_koef` with a clear error message.
- **D-5** — Added Section 9 "Legacy bbu2 paths intentionally not ported" in `RULES.md` so future audits don't re-flag inverse-contract paths.

## Why

Feature 0027 found two independent bbu2-divergences in a single file (`position.py`). 0028_PLAN started a systematic sweep; this PR closes the qty-path priorities. Default `early_imbalance_multiplier=1.0` is a no-op short-circuit, so live behavior is unchanged for the running session.

## Implementation notes

- **Size-based ratio, not margin-based.** `Position.position_ratio` is overwritten with `long_margin / short_margin` inside `calculate_amount_multiplier` (`gridcore/position.py:231`). For bbu2 parity the early_imbalance gate must use SIZE ratio, so both runners compute it inline from `Position.size`. Regression test `test_uses_size_not_margin_ratio` poisons `position_ratio` to catch any code that reverts.
- **Backtest/live parity.** `Position.size` and `Position.liquidation_price` are now cached on Position instances (live had `size` already; this adds `liquidation_price` and extends backtest to mirror).
- **Pydantic guards.** `early_imbalance_multiplier: Field(gt=0, le=100.0)` rejects non-finite YAML values; migration validator rejects legacy field name with a clear message instead of silently ignoring it.

## Test plan

- [x] `uv run pytest packages/gridcore/ apps/gridbot/ apps/backtest/ apps/replay/ tests/ -q` → 1233 passed, 1 skipped, 3 pre-existing fails in `test_risk_limit_info.py` (unrelated).
- [x] `uv run ruff check` clean on modified files.
- [x] bbu2 reference pinning verified (`git status --short bbu_reference` empty; `git diff --exit-code -- bbu_reference` clean).
- [x] New regression tests:
  - `TestEarlyImbalanceMultiplier` (gridbot, 6 cases) including end-to-end through `on_position_update` with discriminating geometry (size_ratio=2.0 in band, margin_ratio≈1.0 out of band).
  - `TestEarlyImbalanceMultiplierBacktest` (backtest, 6 cases) including end-to-end through `process_fill` → `_update_risk_multipliers`.
  - `TestMinNotionalFloor` (3 cases: just-below floor / just-above passthrough / both modes).
  - Migration validator tests in 3 `test_config.py` files.
- [ ] Manual: load `conf/gridbot_test.yaml` (no `early_imbalance_multiplier` set) → starts on default 1.0 → multiplier path is no-op for live session. **Behavioral change for live is zero on default config.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)