### PR TITLE
feat(0029): seed-aware replay for live/backtest shadow validation

### DIFF
--- a/apps/backtest/src/backtest/order_manager.py
+++ b/apps/backtest/src/backtest/order_manager.py
@@ -3,6 +3,7 @@
 Manages limit orders in simulation, checks for fills, and generates execution events.
 """
 
+import logging
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -12,6 +13,9 @@ from typing import Optional
 from gridcore import ExecutionEvent, EventType
 
 from backtest.fill_simulator import TradeThroughFillSimulator
+
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -151,6 +155,16 @@ class BacktestOrderManager:
                 ``exchange_ts``.
         """
         for seed in orders:
+            # 0029 PR #68 P1: defense-in-depth against a malformed seed
+            # batch with duplicate exchange_order_id (would otherwise
+            # silently overwrite the first entry).
+            if seed.exchange_order_id in self.active_orders:
+                logger.warning(
+                    "Duplicate exchange_order_id %r in seed batch; skipping "
+                    "second occurrence",
+                    seed.exchange_order_id,
+                )
+                continue
             order = SimulatedOrder(
                 order_id=seed.exchange_order_id,
                 client_order_id=seed.client_id,

--- a/apps/backtest/src/backtest/order_manager.py
+++ b/apps/backtest/src/backtest/order_manager.py
@@ -117,6 +117,56 @@ class BacktestOrderManager:
         self._client_order_ids.add(client_order_id)
         return order
 
+    def seed_active_orders(self, orders) -> None:
+        """Register pre-existing live orders as active simulated orders.
+
+        Used by the replay engine (feature 0029) to seed the order book
+        with orders that were live on the exchange at ``seed.at_ts``.
+        Each seed becomes a ``SimulatedOrder`` with status ``"pending"``
+        (the active-state marker the simulator uses) and is inserted
+        into ``self.active_orders`` keyed by ``exchange_order_id``;
+        ``client_id`` is recorded in ``self._client_order_ids`` for
+        deduplication.
+
+        Subsequent ``check_fills`` calls iterate ``self.active_orders``
+        and run the fill simulator on every order;
+        ``TradeThroughFillSimulator._should_fill`` reads only ``side``
+        / ``price`` / ``current_price`` (with strict ``<`` for Buy and
+        strict ``>`` for Sell — see ``fill_simulator.py``), so seeded
+        orders are eligible for fills as soon as price crosses the
+        limit strictly.
+
+        ``grid_level`` is set to ``0`` for every seeded order: live
+        active orders carry no level metadata, and the simulator does
+        not consult ``grid_level`` for fill eligibility — the field
+        exists only for grid-internal accounting that does not apply
+        to externally-seeded orders.
+
+        Args:
+            orders: Iterable of ``ActiveOrderSeed`` from
+                ``apps/replay/src/replay/snapshot_loader.py``. Accepted
+                as duck-typed objects with attributes ``client_id``,
+                ``exchange_order_id``, ``symbol``, ``side``, ``direction``,
+                ``price``, ``remaining_qty``, ``reduce_only``,
+                ``exchange_ts``.
+        """
+        for seed in orders:
+            order = SimulatedOrder(
+                order_id=seed.exchange_order_id,
+                client_order_id=seed.client_id,
+                symbol=seed.symbol,
+                side=seed.side,
+                price=seed.price,
+                qty=seed.remaining_qty,
+                direction=seed.direction,
+                grid_level=0,
+                status="pending",
+                created_ts=seed.exchange_ts,
+                reduce_only=seed.reduce_only,
+            )
+            self.active_orders[seed.exchange_order_id] = order
+            self._client_order_ids.add(seed.client_id)
+
     def cancel_order(self, order_id: str, timestamp: datetime) -> bool:
         """Cancel order from simulated order book.
 

--- a/apps/backtest/src/backtest/position_tracker.py
+++ b/apps/backtest/src/backtest/position_tracker.py
@@ -95,6 +95,35 @@ class BacktestPositionTracker:
         self.symbol = symbol
         self.state = PositionState()
 
+    def seed_state(self, seed) -> None:
+        """Direct state write from a PositionStateSeed. Bypasses process_fill.
+
+        Used by replay engine (feature 0029) to restore live position state
+        at ``seed.at_ts`` without replaying history. Sets ``size``,
+        ``avg_entry_price``, and ``liquidation_price`` from the seed and
+        zeroes ``realized_pnl``, ``commission_paid``, ``funding_paid`` so
+        the replay accounting window starts fresh from ``at_ts`` (any
+        pre-seed PnL belongs to the live session).
+
+        Args:
+            seed: A ``PositionStateSeed`` from
+                ``apps/replay/src/replay/snapshot_loader.py``. Accepted as a
+                duck-typed object with ``size``, ``entry_price``, and
+                ``liquidation_price`` attributes (all ``Decimal``).
+
+        Note: The seeded ``liquidation_price`` is the snapshot value from
+        Bybit (``PositionSnapshot.liq_price``). It survives until the next
+        ``BacktestRunner._update_risk_multipliers`` call, at which point
+        the backtest's ``_estimate_liquidation_price`` overwrites it. See
+        feature 0029 plan, "Edge cases — liquidation_price divergence".
+        """
+        self.state.size = seed.size
+        self.state.avg_entry_price = seed.entry_price
+        self.state.liquidation_price = seed.liquidation_price
+        self.state.realized_pnl = Decimal("0")
+        self.state.commission_paid = Decimal("0")
+        self.state.funding_paid = Decimal("0")
+
     def process_fill(
         self,
         side: str,

--- a/apps/backtest/src/backtest/position_tracker.py
+++ b/apps/backtest/src/backtest/position_tracker.py
@@ -42,6 +42,12 @@ class PositionState:
     maintenance_margin: Decimal = field(default_factory=lambda: Decimal("0"))
     mmr_rate: Decimal = field(default_factory=lambda: Decimal("0"))
 
+    # 0029: seeded directly from PositionSnapshot.liq_price (Bybit's value)
+    # at replay start. Lives until the first _update_risk_multipliers call,
+    # at which point _estimate_liquidation_price overwrites it. Default 0
+    # (the same sentinel `Position.liquidation_price` uses).
+    liquidation_price: Decimal = field(default_factory=lambda: Decimal("0"))
+
 
 class BacktestPositionTracker:
     """Track position and calculate PnL for backtest.

--- a/apps/backtest/src/backtest/runner.py
+++ b/apps/backtest/src/backtest/runner.py
@@ -70,6 +70,8 @@ class BacktestRunner:
         short_tracker: Optional[BacktestPositionTracker] = None,
         anchor_price: Optional[float] = None,
         instrument_info: Optional[InstrumentInfo] = None,
+        restored_grid: Optional[list[dict]] = None,
+        seeded_active_orders: Optional[list] = None,
     ):
         """Initialize backtest runner.
 
@@ -80,15 +82,29 @@ class BacktestRunner:
             long_tracker: Position tracker for long direction.
             short_tracker: Position tracker for short direction.
             anchor_price: Optional anchor price for grid initialization.
+                Ignored when ``restored_grid`` is provided (matches live).
             instrument_info: Optional instrument info for qty re-rounding
                 after risk multiplier application.
+            restored_grid: Optional serialized grid (list of {side, price})
+                passed through to ``GridEngine.__init__(restored_grid=...)``.
+                Used by replay (feature 0029) to seed the grid from the
+                shared ``GridStateStore`` JSON file. When provided,
+                ``anchor_price`` is ignored — mirrors live runner's
+                ``_load_grid_state()`` → ``GridEngine`` flow.
+            seeded_active_orders: Optional list of ``ActiveOrderSeed``
+                objects (replay feature 0029). When non-empty, the order
+                manager is pre-loaded with these as active orders via
+                ``BacktestOrderManager.seed_active_orders``. The orders
+                participate in fill checks on the very first tick.
         """
         self._config = strategy_config
         self._executor = executor
         self._session = session
         self._instrument_info = instrument_info
 
-        # Create GridEngine
+        # Create GridEngine. When restored_grid is provided, anchor_price is
+        # ignored (matches live: a restored grid has its own structure and
+        # WAIT center; anchor is only used as the fresh-build origin).
         grid_config = GridConfig(
             grid_count=strategy_config.grid_count,
             grid_step=strategy_config.grid_step,
@@ -98,7 +114,8 @@ class BacktestRunner:
             tick_size=strategy_config.tick_size,
             config=grid_config,
             strat_id=strategy_config.strat_id,
-            anchor_price=anchor_price,
+            anchor_price=anchor_price if restored_grid is None else None,
+            restored_grid=restored_grid,
         )
 
         # Position trackers (create if not provided)
@@ -128,6 +145,15 @@ class BacktestRunner:
             )
             self._long_position, self._short_position = Position.create_linked_pair(risk_config)
 
+            # 0029 seeding: when trackers were pre-seeded (via seed_state)
+            # before the runner was constructed, copy size + liquidation_price
+            # into the gridcore.Position instances as well. Without this, the
+            # first tick's early_imbalance gate (D-3 from feature 0028) and
+            # _apply_*_position_rules margin/liq branches see Position.size=0
+            # and liquidation_price=0 — i.e., the seeded snapshot is invisible
+            # until the first fill triggers _update_risk_multipliers.
+            self._copy_seeded_state_to_positions()
+
             # Compose risk multiplier with existing qty_calculator so that
             # base qty (from amount pattern + rounding) is computed first,
             # then scaled by the risk multiplier.
@@ -137,11 +163,45 @@ class BacktestRunner:
             self._long_position = None
             self._short_position = None
 
+        # 0029 seeding: register active orders pre-existing on the live exchange
+        # at seed.at_ts. Done after Grid setup so the order manager is fully
+        # initialised; subsequent process_tick calls run fill_simulator over
+        # these orders alongside any newly-placed ones.
+        if seeded_active_orders:
+            self._executor.order_manager.seed_active_orders(seeded_active_orders)
+
         # Last price seen (needed for multiplier recalculation)
         self._last_price: Optional[Decimal] = None
 
         # Track whether grid has been built
         self._grid_built = False
+
+    def _copy_seeded_state_to_positions(self) -> None:
+        """Mirror seeded tracker state into gridcore.Position instances.
+
+        Called only when ``enable_risk_multipliers=True``. Detects a seeded
+        tracker by a non-zero ``state.size`` OR non-zero
+        ``state.liquidation_price`` (a fresh tracker has both at zero).
+        Without this copy, the very first tick's early_imbalance gate
+        (feature 0028 D-3) and ``_apply_*_position_rules`` margin/liq
+        branches read ``Position.size=0`` / ``liquidation_price=0`` and
+        the seeded snapshot has no effect until the first fill triggers
+        ``_update_risk_multipliers``.
+
+        Uses the same liq_price the tracker holds, so the gridcore side
+        sees Bybit's snapshot value until the next risk update overwrites
+        with ``_estimate_liquidation_price`` (see feature 0029 plan,
+        "Edge cases — liquidation_price divergence after first risk update").
+        """
+        long_state = self._long_tracker.state
+        if long_state.size != 0 or long_state.liquidation_price != 0:
+            self._long_position.size = long_state.size
+            self._long_position.liquidation_price = long_state.liquidation_price
+
+        short_state = self._short_tracker.state
+        if short_state.size != 0 or short_state.liquidation_price != 0:
+            self._short_position.size = short_state.size
+            self._short_position.liquidation_price = short_state.liquidation_price
 
     @property
     def strat_id(self) -> str:

--- a/apps/backtest/tests/test_runner.py
+++ b/apps/backtest/tests/test_runner.py
@@ -1,6 +1,7 @@
 """Tests for backtest runner."""
 
 import logging
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
 
@@ -1240,3 +1241,261 @@ class TestGetPendingCloseQty:
             )
         assert runner._get_pending_close_qty(DirectionType.LONG) == Decimal("0.08")
         assert runner._get_pending_close_qty(DirectionType.SHORT) == Decimal("0.07")
+
+
+class TestSeedAwareConstruction:
+    """Tests for replay-driven seeding of trackers, order manager, and runner.
+
+    Covers feature 0029 Phase 2B: replay constructs the runner with
+    pre-populated position state, active orders on the exchange, and a
+    restored grid layout. Seed dataclasses live in
+    ``apps/replay/src/replay/snapshot_loader.py`` (Phase 2A); these tests
+    use lightweight stand-ins matching the documented attribute set so the
+    backtest side stays decoupled from the loader module's import path.
+    """
+
+    # --- minimal seed stand-ins (duck typed; mirror Phase 2A dataclasses) ---
+
+    @dataclass
+    class _PositionStateSeed:
+        direction: str
+        size: Decimal
+        entry_price: Decimal
+        liquidation_price: Decimal
+
+    @dataclass
+    class _ActiveOrderSeed:
+        client_id: str
+        exchange_order_id: str
+        symbol: str
+        side: str
+        direction: str
+        price: Decimal
+        remaining_qty: Decimal
+        reduce_only: bool
+        exchange_ts: datetime
+
+    # --- fixtures ---
+
+    @pytest.fixture
+    def seed_strategy_config(self):
+        """Strategy config with risk multipliers enabled (matches replay use)."""
+        return BacktestStrategyConfig(
+            strat_id="test_seed",
+            symbol="BTCUSDT",
+            tick_size=Decimal("0.1"),
+            grid_count=50,
+            grid_step=0.2,
+            amount="x0.001",
+            max_margin=8.0,
+            commission_rate=Decimal("0.0002"),
+            min_liq_ratio=0.8,
+            max_liq_ratio=1.2,
+            min_total_margin=0.15,
+            leverage=10,
+            maintenance_margin_rate=0.005,
+            enable_risk_multipliers=True,
+        )
+
+    @pytest.fixture
+    def seed_runner_components(self, seed_strategy_config):
+        """Build trackers/executor/session/order_manager wired together."""
+        session = BacktestSession(
+            session_id="test_seed", initial_balance=Decimal("10000"),
+        )
+        fill_sim = TradeThroughFillSimulator()
+        order_mgr = BacktestOrderManager(
+            fill_simulator=fill_sim,
+            commission_rate=seed_strategy_config.commission_rate,
+        )
+
+        def qty_from_usdt(intent, wallet_balance):
+            if intent.price <= 0:
+                return Decimal("0")
+            return Decimal("100") / intent.price
+
+        executor = BacktestExecutor(
+            order_manager=order_mgr, qty_calculator=qty_from_usdt,
+        )
+        return seed_strategy_config, executor, session, order_mgr
+
+    # --- A. tracker.seed_state ---
+
+    def test_seed_state_writes_position_fields(self):
+        """seed_state writes size/entry/liq and zeroes the accounting fields."""
+        from backtest.position_tracker import BacktestPositionTracker
+
+        tracker = BacktestPositionTracker(
+            direction="long", commission_rate=Decimal("0.0002"),
+        )
+        # Pre-populate the accounting fields so we can prove they get reset.
+        tracker.state.realized_pnl = Decimal("123")
+        tracker.state.commission_paid = Decimal("4.5")
+        tracker.state.funding_paid = Decimal("0.7")
+
+        seed = self._PositionStateSeed(
+            direction="long",
+            size=Decimal("2.0"),
+            entry_price=Decimal("25000"),
+            liquidation_price=Decimal("20000"),
+        )
+        tracker.seed_state(seed)
+
+        assert tracker.state.size == Decimal("2.0")
+        assert tracker.state.avg_entry_price == Decimal("25000")
+        assert tracker.state.liquidation_price == Decimal("20000")
+        assert tracker.state.realized_pnl == Decimal("0")
+        assert tracker.state.commission_paid == Decimal("0")
+        assert tracker.state.funding_paid == Decimal("0")
+
+    # --- B. order_manager.seed_active_orders ---
+
+    def test_seed_active_orders_register_in_store(self):
+        """Both seeded orders land in active_orders + their client_ids."""
+        from backtest.order_manager import BacktestOrderManager
+
+        order_mgr = BacktestOrderManager(
+            fill_simulator=TradeThroughFillSimulator(),
+            commission_rate=Decimal("0.0002"),
+        )
+        ts = datetime(2025, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        seed1 = self._ActiveOrderSeed(
+            client_id="LX-001",
+            exchange_order_id="exch-A",
+            symbol="BTCUSDT",
+            side="Buy",
+            direction="long",
+            price=Decimal("49000"),
+            remaining_qty=Decimal("0.05"),
+            reduce_only=False,
+            exchange_ts=ts,
+        )
+        # client_id deliberately equals exchange_order_id to mirror the
+        # `client_id = order_link_id or order_id` fallback case (live order
+        # placed before the orderLinkId fix where order_link_id is NULL).
+        seed2 = self._ActiveOrderSeed(
+            client_id="exch-B",
+            exchange_order_id="exch-B",
+            symbol="BTCUSDT",
+            side="Sell",
+            direction="short",
+            price=Decimal("51000"),
+            remaining_qty=Decimal("0.04"),
+            reduce_only=False,
+            exchange_ts=ts,
+        )
+
+        order_mgr.seed_active_orders([seed1, seed2])
+
+        assert "exch-A" in order_mgr.active_orders
+        assert "exch-B" in order_mgr.active_orders
+        assert order_mgr.active_orders["exch-A"].client_order_id == "LX-001"
+        assert order_mgr.active_orders["exch-B"].client_order_id == "exch-B"
+        assert order_mgr.active_orders["exch-A"].grid_level == 0
+        assert "LX-001" in order_mgr._client_order_ids
+        assert "exch-B" in order_mgr._client_order_ids
+
+    # --- C. seeded order participates in fill check ---
+
+    def test_seed_active_order_fills_on_strict_cross(self):
+        """Seeded Buy@50000 does NOT fill at 50001, DOES fill at 49999."""
+        from backtest.order_manager import BacktestOrderManager
+
+        order_mgr = BacktestOrderManager(
+            fill_simulator=TradeThroughFillSimulator(),
+            commission_rate=Decimal("0.0002"),
+        )
+        ts = datetime(2025, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        seed = self._ActiveOrderSeed(
+            client_id="LX-buy",
+            exchange_order_id="exch-buy",
+            symbol="BTCUSDT",
+            side="Buy",
+            direction="long",
+            price=Decimal("50000"),
+            remaining_qty=Decimal("0.1"),
+            reduce_only=False,
+            exchange_ts=ts,
+        )
+        order_mgr.seed_active_orders([seed])
+
+        # Above limit + at limit: no fill (strict <).
+        fills_above = order_mgr.check_fills(
+            current_price=Decimal("50001"), timestamp=ts, symbol=None,
+        )
+        assert fills_above == []
+        assert "exch-buy" in order_mgr.active_orders
+
+        # Below limit: fill.
+        fills_below = order_mgr.check_fills(
+            current_price=Decimal("49999"), timestamp=ts, symbol=None,
+        )
+        assert len(fills_below) == 1
+        assert fills_below[0].order_id == "exch-buy"
+        assert fills_below[0].order_link_id == "LX-buy"
+        assert fills_below[0].price == Decimal("50000")
+        assert "exch-buy" not in order_mgr.active_orders
+
+    # --- D. runner propagates restored_grid ---
+
+    def test_runner_propagates_restored_grid(self, seed_runner_components):
+        """restored_grid is plumbed through GridEngine and rebuilt on Grid."""
+        config, executor, session, _ = seed_runner_components
+        restored = [
+            {"side": "Buy", "price": "49000"},
+            {"side": "Sell", "price": "51000"},
+        ]
+
+        runner = BacktestRunner(
+            strategy_config=config,
+            executor=executor,
+            session=session,
+            restored_grid=restored,
+        )
+
+        grid = runner._engine.grid.grid
+        assert len(grid) == 2
+        # Grid.restore_grid coerces side to GridSideType and price to float.
+        assert str(grid[0]["side"]) in ("GridSideType.BUY", "Buy")
+        assert grid[0]["price"] == 49000.0
+        assert grid[1]["price"] == 51000.0
+
+    # --- E. runner copies seeded state into gridcore.Position ---
+
+    def test_runner_copies_seeded_state_to_gridcore_position(
+        self, seed_runner_components,
+    ):
+        """Pre-seeded tracker state lands on gridcore.Position via runner ctor."""
+        from backtest.position_tracker import BacktestPositionTracker
+
+        config, executor, session, _ = seed_runner_components
+
+        long_tracker = BacktestPositionTracker(
+            direction="long", commission_rate=config.commission_rate,
+        )
+        short_tracker = BacktestPositionTracker(
+            direction="short", commission_rate=config.commission_rate,
+        )
+        # Pre-seed (mirrors what ReplayEngine does in Phase 3 before
+        # constructing the runner).
+        long_tracker.seed_state(self._PositionStateSeed(
+            direction="long",
+            size=Decimal("2"),
+            entry_price=Decimal("25000"),
+            liquidation_price=Decimal("0"),
+        ))
+
+        runner = BacktestRunner(
+            strategy_config=config,
+            executor=executor,
+            session=session,
+            long_tracker=long_tracker,
+            short_tracker=short_tracker,
+        )
+
+        assert runner._long_position is not None
+        assert runner._long_position.size == Decimal("2")
+        assert runner._long_position.liquidation_price == Decimal("0")
+        # Short was not seeded → remains zero on the gridcore side.
+        assert runner._short_position.size == Decimal("0")
+        assert runner._short_position.liquidation_price == Decimal("0")

--- a/apps/comparator/src/comparator/loader.py
+++ b/apps/comparator/src/comparator/loader.py
@@ -104,20 +104,28 @@ class LiveTradeLoader:
         if symbol:
             executions = [e for e in executions if e.symbol == symbol]
 
-        # Group by (order_link_id, order_id) to separate partial fills from
-        # lifecycle reuse. Same order_link_id + same order_id = partial fills
-        # (aggregate). Same order_link_id + different order_id = ID reuse
+        # Group by (client_id, order_id) to separate partial fills from
+        # lifecycle reuse. Same client_id + same order_id = partial fills
+        # (aggregate). Same client_id + different order_id = ID reuse
         # (separate trades).
+        #
+        # 0029: client_id = order_link_id or order_id. Live didn't always send
+        # orderLinkId before cross-cutting #1; rows with NULL order_link_id are
+        # joined via the Bybit-assigned order_id instead. The previous
+        # skip-on-NULL behaviour silently dropped those executions.
         grouped: dict[tuple[str, str], list[PrivateExecution]] = defaultdict(list)
-        skipped = 0
+        fallback_hits = 0
         for ex in executions:
+            client_id = ex.order_link_id or ex.order_id
             if not ex.order_link_id:
-                skipped += 1
-                continue
-            grouped[(ex.order_link_id, ex.order_id)].append(ex)
+                fallback_hits += 1
+            grouped[(client_id, ex.order_id)].append(ex)
 
-        if skipped:
-            logger.info("Skipped %d executions without order_link_id", skipped)
+        if fallback_hits:
+            logger.info(
+                "Used order_id fallback for %d executions without order_link_id",
+                fallback_hits,
+            )
 
         trades = []
         for (client_id, _order_id), fills in grouped.items():
@@ -129,7 +137,7 @@ class LiveTradeLoader:
         # Assign occurrence index per client_order_id (handles ID reuse)
         _assign_occurrences(trades)
 
-        logger.info("Loaded %d live trades (%d raw executions)", len(trades), len(executions) - skipped)
+        logger.info("Loaded %d live trades (%d raw executions)", len(trades), len(executions))
         return trades
 
     def _aggregate_fills(

--- a/apps/comparator/tests/test_loader.py
+++ b/apps/comparator/tests/test_loader.py
@@ -134,16 +134,18 @@ class TestLiveTradeLoader:
         expected_ts = ts + timedelta(seconds=1)
         assert t.timestamp.replace(tzinfo=None) == expected_ts.replace(tzinfo=None)
 
-    def test_skips_null_order_link_id(self, db):
-        """Executions without order_link_id are skipped."""
+    def test_null_order_link_id_falls_back_to_order_id(self, db):
+        """Executions without order_link_id use order_id as the client_id (0029)."""
         run_id = self._seed_data(db)
         ts = datetime(2025, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
 
+        # Execution with no order_link_id: should fall back to order_id="oid_e1"
         self._add_execution(
             db, run_id, "e1", None, "Buy",
             Decimal("100000"), Decimal("0.001"), Decimal("0.02"), Decimal("0"),
             ts,
         )
+        # Execution with order_link_id present
         self._add_execution(
             db, run_id, "e2", "client_1", "Buy",
             Decimal("100000"), Decimal("0.001"), Decimal("0.02"), Decimal("0"),
@@ -154,8 +156,78 @@ class TestLiveTradeLoader:
             loader = LiveTradeLoader(session)
             trades = loader.load(run_id, ts - timedelta(hours=1), ts + timedelta(hours=1))
 
+        # Both executions are now loaded; one via order_link_id, the other
+        # via order_id fallback.
+        assert len(trades) == 2
+        client_ids = {t.client_order_id for t in trades}
+        assert client_ids == {"client_1", "oid_e1"}
+
+    def test_loader_groups_by_order_link_id_when_present(self, db):
+        """When order_link_id is present, it is used as the client_order_id (0029)."""
+        run_id = self._seed_data(db)
+        ts = datetime(2025, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+        self._add_execution(
+            db, run_id, "e1", "LX-1", "Buy",
+            Decimal("100000"), Decimal("0.001"), Decimal("0.02"), Decimal("0"),
+            ts, order_id="ORD-A",
+        )
+
+        with db.get_session() as session:
+            loader = LiveTradeLoader(session)
+            trades = loader.load(run_id, ts - timedelta(hours=1), ts + timedelta(hours=1))
+
         assert len(trades) == 1
-        assert trades[0].client_order_id == "client_1"
+        assert trades[0].client_order_id == "LX-1"
+
+    def test_loader_falls_back_to_order_id_when_link_id_null(self, db):
+        """When order_link_id is NULL, order_id is used as the client_order_id (0029)."""
+        run_id = self._seed_data(db)
+        ts = datetime(2025, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+        self._add_execution(
+            db, run_id, "e1", None, "Buy",
+            Decimal("100000"), Decimal("0.001"), Decimal("0.02"), Decimal("0"),
+            ts, order_id="ORD-B",
+        )
+
+        with db.get_session() as session:
+            loader = LiveTradeLoader(session)
+            trades = loader.load(run_id, ts - timedelta(hours=1), ts + timedelta(hours=1))
+
+        assert len(trades) == 1
+        assert trades[0].client_order_id == "ORD-B"
+
+    def test_loader_separates_distinct_link_id_and_distinct_order_id(self, db):
+        """Two rows where fallback yields the same client_id but order_ids
+        differ remain distinct, because the group key is (client_id, order_id) (0029)."""
+        run_id = self._seed_data(db)
+        ts = datetime(2025, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+        # Row 1: order_link_id='LX', order_id='A' → client_id='LX'
+        self._add_execution(
+            db, run_id, "e1", "LX", "Buy",
+            Decimal("100000"), Decimal("0.001"), Decimal("0.02"), Decimal("0"),
+            ts, order_id="A",
+        )
+        # Row 2: order_link_id=None, order_id='LX' → client_id='LX' via fallback
+        self._add_execution(
+            db, run_id, "e2", None, "Buy",
+            Decimal("100000"), Decimal("0.001"), Decimal("0.02"), Decimal("0"),
+            ts + timedelta(seconds=1), order_id="LX",
+        )
+
+        with db.get_session() as session:
+            loader = LiveTradeLoader(session)
+            trades = loader.load(run_id, ts - timedelta(hours=1), ts + timedelta(hours=1))
+
+        # Both produce client_id='LX' but distinct order_ids → 2 separate trades.
+        assert len(trades) == 2
+        # Both share the same client_order_id, but occurrence assignment
+        # separates them.
+        assert all(t.client_order_id == "LX" for t in trades)
+        occurrences = sorted(t.occurrence for t in trades)
+        assert occurrences == [0, 1]
 
     def test_symbol_filter(self, db):
         """Symbol filter only returns matching trades."""

--- a/apps/event_saver/src/event_saver/writers/order_writer.py
+++ b/apps/event_saver/src/event_saver/writers/order_writer.py
@@ -123,6 +123,9 @@ class OrderWriter:
                     price=event.price,
                     qty=event.qty,
                     leaves_qty=event.leaves_qty,
+                    # 0029: persist reduce_only so seed-aware replay can derive
+                    # direction in hedge-mode (Buy+reduce_only=long-close, etc).
+                    reduce_only=event.reduce_only,
                     raw_json=None,
                 )
                 )

--- a/apps/event_saver/src/event_saver/writers/position_writer.py
+++ b/apps/event_saver/src/event_saver/writers/position_writer.py
@@ -42,6 +42,7 @@ class PositionWriter:
         db: DatabaseFactory,
         batch_size: int = 50,
         flush_interval: float = 10.0,
+        run_id: Optional[str] = None,
     ):
         """Initialize position writer.
 
@@ -49,10 +50,14 @@ class PositionWriter:
             db: DatabaseFactory instance for session management.
             batch_size: Number of snapshots to buffer before bulk insert.
             flush_interval: Maximum seconds between flushes.
+            run_id: Recorder run identifier (feature 0029). Stamped on every
+                emitted ORM row so seed-aware replay can scope queries to
+                one run. None for back-compat / pre-0029 callers.
         """
         self._db = db
         self._batch_size = batch_size
         self._flush_interval = flush_interval
+        self._run_id = run_id
 
         self._buffer: deque[PositionSnapshot] = deque()
         self._last_flush: datetime = datetime.now(UTC)
@@ -200,6 +205,7 @@ class PositionWriter:
 
                     snapshots.append(
                         PositionSnapshot(
+                            run_id=self._run_id,
                             account_id=str(account_id),
                             symbol=pos.get("symbol", ""),
                             exchange_ts=exchange_ts,

--- a/apps/event_saver/src/event_saver/writers/wallet_writer.py
+++ b/apps/event_saver/src/event_saver/writers/wallet_writer.py
@@ -42,6 +42,7 @@ class WalletWriter:
         db: DatabaseFactory,
         batch_size: int = 50,
         flush_interval: float = 10.0,
+        run_id: Optional[str] = None,
     ):
         """Initialize wallet writer.
 
@@ -49,10 +50,15 @@ class WalletWriter:
             db: DatabaseFactory instance for session management.
             batch_size: Number of snapshots to buffer before bulk insert.
             flush_interval: Maximum seconds between flushes.
+            run_id: Recorder run identifier (feature 0029). Stamped on every
+                emitted ORM row so seed-aware replay can scope queries to
+                one run. None for back-compat / pre-0029 callers; rows get
+                ``run_id=NULL`` and are excluded by run-scoped seed lookups.
         """
         self._db = db
         self._batch_size = batch_size
         self._flush_interval = flush_interval
+        self._run_id = run_id
 
         self._buffer: deque[WalletSnapshot] = deque()
         self._last_flush: datetime = datetime.now(UTC)
@@ -200,6 +206,7 @@ class WalletWriter:
                     for coin_data in coins:
                         snapshots.append(
                             WalletSnapshot(
+                                run_id=self._run_id,
                                 account_id=str(account_id),
                                 exchange_ts=exchange_ts,
                                 local_ts=local_ts,

--- a/apps/gridbot/src/gridbot/executor.py
+++ b/apps/gridbot/src/gridbot/executor.py
@@ -175,6 +175,7 @@ class IntentExecutor:
                 price=str(intent.price),
                 reduce_only=intent.reduce_only,
                 position_idx=position_idx,
+                order_link_id=intent.client_order_id,
             )
 
             order_id = result.get("orderId")

--- a/apps/gridbot/tests/test_executor.py
+++ b/apps/gridbot/tests/test_executor.py
@@ -108,6 +108,7 @@ class TestExecutorPlaceOrder:
             price="50000.0",
             reduce_only=False,
             position_idx=1,  # long direction
+            order_link_id=place_intent.client_order_id,
         )
 
     def test_place_order_short_direction(self, executor, mock_rest_client):
@@ -135,7 +136,39 @@ class TestExecutorPlaceOrder:
             price="50000.0",
             reduce_only=False,
             position_idx=2,  # short direction
+            order_link_id=intent.client_order_id,
         )
+
+    def test_execute_place_passes_orderLinkId_from_client_order_id(
+        self, executor, mock_rest_client
+    ):
+        """Test execute_place passes intent.client_order_id as order_link_id kwarg.
+
+        This is critical for Feature 0029 (seed-aware replay): the live executor
+        must propagate the deterministic SHA256-based client_order_id to Bybit
+        so private_executions rows have a non-NULL order_link_id that matches
+        the replay's deterministic client_order_id, enabling comparator parity.
+        """
+        # Build an intent and override its (frozen) client_order_id to "abc123"
+        # so we can assert exact propagation regardless of identity hash logic.
+        base_intent = PlaceLimitIntent.create(
+            symbol="BTCUSDT",
+            side="Buy",
+            price=Decimal("50000.0"),
+            qty=Decimal("0.001"),
+            grid_level=10,
+            direction="long",
+            reduce_only=False,
+        )
+        from dataclasses import replace
+        intent = replace(base_intent, client_order_id="abc123")
+
+        result = executor.execute_place(intent)
+
+        assert result.success is True
+        # Verify the kwarg was forwarded verbatim.
+        _, kwargs = mock_rest_client.place_order.call_args
+        assert kwargs.get("order_link_id") == "abc123"
 
     def test_place_order_failure(self, executor, mock_rest_client, place_intent):
         """Test order placement failure."""

--- a/apps/recorder/src/recorder/recorder.py
+++ b/apps/recorder/src/recorder/recorder.py
@@ -167,10 +167,16 @@ class Recorder:
             await self._trade_writer.start_auto_flush()
 
         if self._config.account:
+            # 0029: stamp run_id on every wallet/position row so seed-aware
+            # replay can scope its lookups to one recorder run. Order rows
+            # already carry run_id via OrderUpdateEvent.run_id; passing the
+            # kwarg is a no-op for Order/Execution/Trade/Ticker writers and
+            # is only consumed by Wallet/Position writers.
+            run_id_str = str(self._run_id) if self._run_id else None
             self._execution_writer = ExecutionWriter(**writer_kwargs)
             self._order_writer = OrderWriter(**writer_kwargs)
-            self._position_writer = PositionWriter(**writer_kwargs)
-            self._wallet_writer = WalletWriter(**writer_kwargs)
+            self._position_writer = PositionWriter(**writer_kwargs, run_id=run_id_str)
+            self._wallet_writer = WalletWriter(**writer_kwargs, run_id=run_id_str)
             await self._execution_writer.start_auto_flush()
             await self._order_writer.start_auto_flush()
             await self._position_writer.start_auto_flush()

--- a/apps/recorder/src/recorder/recorder.py
+++ b/apps/recorder/src/recorder/recorder.py
@@ -306,6 +306,21 @@ class Recorder:
             f"positions={position_count} rows, open_orders={order_count}"
         )
 
+        # 0029 cross-cutting #4: empty wallet OR position dimension means
+        # the seed loader will not find a t=0 row and Phase 4's pre-check
+        # will refuse to seed from this run. Surface this loudly at recorder
+        # start so an operator catches credential/permissions problems early
+        # instead of finding out hours later when replay refuses. open_orders
+        # legitimately can be zero (clean account) — not warned on.
+        if wallet_count == 0 or position_count == 0:
+            logger.warning(
+                "Initial REST snapshot incomplete: "
+                f"wallet_rows={wallet_count}, position_rows={position_count} "
+                "(zero on either dimension means seed-aware replay from this "
+                "run_id will fail Phase 4 pre-check; check API credentials / "
+                "permissions / category=linear settleCoin=USDT scope)"
+            )
+
     async def _snapshot_wallet(
         self,
         client: BybitRestClient,

--- a/apps/recorder/src/recorder/recorder.py
+++ b/apps/recorder/src/recorder/recorder.py
@@ -10,6 +10,7 @@ import signal
 import threading
 from concurrent.futures import Future
 from datetime import datetime, UTC
+from decimal import Decimal
 from typing import Optional
 from uuid import UUID, uuid4
 
@@ -20,6 +21,12 @@ from grid_db import (
     BybitAccount,
     Strategy,
     Run,
+    Order,
+    OrderRepository,
+    PositionSnapshot,
+    PositionSnapshotRepository,
+    WalletSnapshot,
+    WalletSnapshotRepository,
 )
 from gridcore.events import PublicTradeEvent, ExecutionEvent, OrderUpdateEvent, TickerEvent
 
@@ -130,6 +137,18 @@ class Recorder:
             )
 
             await self._init_writers()
+
+            # 0029 Cross-cutting #4: write the t=0 row of the recording session
+            # via REST BEFORE the private collector subscribes. Bybit's private
+            # streams are event-driven, so a quiet account would otherwise leave
+            # the seed-aware replay loader returning NULL for wallet/positions/
+            # orders even though state existed live. Failures here are logged
+            # but DO NOT abort recorder start (the WS stream still gets captured;
+            # Phase 4's pre-check will refuse to seed from a run missing the
+            # initial snapshot).
+            if self._config.account:
+                await self._write_initial_rest_snapshot()
+
             await self._init_collectors()
 
             # Start health logging
@@ -219,6 +238,321 @@ class Recorder:
                 on_gap_detected=self._handle_private_gap,
             )
             await self._private_collector.start()
+
+    async def _write_initial_rest_snapshot(self) -> None:
+        """Write a one-shot REST snapshot as the t=0 row of the recording.
+
+        0029 Cross-cutting #4. Bybit private streams are event-driven; a quiet
+        account between recorder start and the first wallet/position/order
+        change leaves the seed-aware replay loader returning NULL. This method
+        fetches wallet, positions, and open orders via REST and persists them
+        directly through the snapshot repositories so the loader's
+        ``latest <= at_ts`` query always finds at least one row per dimension.
+
+        Contract (per docs/features/0029_PLAN.md "Initial-snapshot row contract"):
+        - WalletSnapshot: one row per coin returned by ``get_wallet_balance``
+          (downstream filters to USDT; writing all coins is fine).
+        - PositionSnapshot: ALWAYS two rows per configured symbol — one
+          ``side='Buy'`` and one ``side='Sell'`` — even when the corresponding
+          side is absent in the REST response (size=0, entry_price=0,
+          liq_price=NULL). The "always two rows" invariant lets the loader
+          treat exactly one side missing as ``SeedDataQualityError`` rather
+          than a benign "no activity" case.
+        - Order: one row per open order with ``status``, ``leaves_qty``,
+          ``reduce_only``, ``order_link_id`` from the response. ``exchange_ts``
+          and ``local_ts`` are the REST-call wall-clock (NOT the order's
+          original ``createdTime``) so this snapshot row sorts BEFORE any
+          subsequent WS-stream rows for the same ``order_id`` in this run.
+
+        All rows are stamped with ``self._run_id`` so they share scope with
+        subsequent stream rows.
+
+        Errors per call are logged and swallowed: the recorder must still
+        capture the WS stream even when REST is degraded.
+        """
+        if not self._config.account or not self._run_id:
+            return
+
+        # Authenticated REST client for private endpoints. The recorder's
+        # existing self._reconciler client uses empty credentials (public
+        # endpoints only), so a fresh client is required here. It is
+        # one-shot — no need to retain.
+        try:
+            auth_client = BybitRestClient(
+                api_key=self._config.account.api_key.get_secret_value(),
+                api_secret=self._config.account.api_secret.get_secret_value(),
+                testnet=self._config.testnet,
+            )
+        except Exception as e:
+            logger.error(f"Failed to construct authenticated REST client for initial snapshot: {e}")
+            return
+
+        run_id_str = str(self._run_id)
+        account_id_str = str(_RECORDER_ACCOUNT_ID)
+        snapshot_ts = datetime.now(UTC)
+
+        wallet_count = await self._snapshot_wallet(
+            auth_client, run_id_str, account_id_str, snapshot_ts
+        )
+        position_count = await self._snapshot_positions(
+            auth_client, run_id_str, account_id_str, snapshot_ts
+        )
+        order_count = await self._snapshot_open_orders(
+            auth_client, run_id_str, account_id_str, snapshot_ts
+        )
+
+        logger.info(
+            f"Initial REST snapshot: wallet={wallet_count} coins, "
+            f"positions={position_count} rows, open_orders={order_count}"
+        )
+
+    async def _snapshot_wallet(
+        self,
+        client: BybitRestClient,
+        run_id: str,
+        account_id: str,
+        snapshot_ts: datetime,
+    ) -> int:
+        """REST-fetch wallet balance and write one row per coin. Returns row count."""
+        try:
+            result = await asyncio.to_thread(client.get_wallet_balance, "UNIFIED")
+        except Exception as e:
+            logger.error(f"Initial snapshot: get_wallet_balance failed: {e}")
+            return 0
+
+        # Bybit V5 shape: result["list"][0]["coin"] = list of per-coin dicts.
+        accounts = result.get("list") or []
+        snapshots: list[WalletSnapshot] = []
+        for acct in accounts:
+            for coin_data in acct.get("coin") or []:
+                try:
+                    snapshots.append(
+                        WalletSnapshot(
+                            run_id=run_id,
+                            account_id=account_id,
+                            exchange_ts=snapshot_ts,
+                            local_ts=snapshot_ts,
+                            coin=coin_data.get("coin", ""),
+                            wallet_balance=Decimal(
+                                str(coin_data.get("walletBalance") or "0")
+                            ),
+                            available_balance=Decimal(
+                                str(
+                                    coin_data.get("availableToWithdraw")
+                                    or coin_data.get("availableBalance")
+                                    or "0"
+                                )
+                            ),
+                            raw_json=coin_data,
+                        )
+                    )
+                except Exception as e:
+                    logger.warning(
+                        f"Initial snapshot: skipped malformed wallet coin row: {e}"
+                    )
+                    continue
+
+        if not snapshots:
+            return 0
+
+        try:
+            await asyncio.to_thread(self._bulk_insert_wallet_snapshots, snapshots)
+        except Exception as e:
+            logger.error(f"Initial snapshot: wallet bulk_insert failed: {e}")
+            return 0
+        return len(snapshots)
+
+    def _bulk_insert_wallet_snapshots(self, snapshots: list[WalletSnapshot]) -> None:
+        with self._db.get_session() as session:
+            WalletSnapshotRepository(session).bulk_insert(snapshots)
+
+    async def _snapshot_positions(
+        self,
+        client: BybitRestClient,
+        run_id: str,
+        account_id: str,
+        snapshot_ts: datetime,
+    ) -> int:
+        """REST-fetch positions and write BOTH sides per configured symbol.
+
+        Contract: ALWAYS exactly two rows per symbol (Buy + Sell). When the
+        REST response omits a side, write a zero-size row for it.
+        """
+        snapshots: list[PositionSnapshot] = []
+        for symbol in self._config.symbols:
+            try:
+                positions = await asyncio.to_thread(client.get_positions, symbol)
+            except Exception as e:
+                logger.error(
+                    f"Initial snapshot: get_positions({symbol}) failed: {e}"
+                )
+                # Still write zero-rows for both sides so the loader's
+                # "exactly one side missing" check doesn't fire on a
+                # transient REST failure.
+                positions = []
+
+            # Index by side for O(1) lookup.
+            by_side: dict[str, dict] = {}
+            for pos in positions:
+                if pos.get("symbol") != symbol:
+                    continue
+                side = pos.get("side")
+                if side in ("Buy", "Sell"):
+                    by_side[side] = pos
+
+            for side in ("Buy", "Sell"):
+                pos = by_side.get(side)
+                if pos is not None:
+                    try:
+                        snapshots.append(
+                            PositionSnapshot(
+                                run_id=run_id,
+                                account_id=account_id,
+                                symbol=symbol,
+                                exchange_ts=snapshot_ts,
+                                local_ts=snapshot_ts,
+                                side=side,
+                                size=Decimal(str(pos.get("size") or "0")),
+                                entry_price=Decimal(
+                                    str(pos.get("entryPrice") or pos.get("avgPrice") or "0")
+                                ),
+                                liq_price=(
+                                    Decimal(str(pos.get("liqPrice")))
+                                    if pos.get("liqPrice") not in (None, "", "0")
+                                    else None
+                                ),
+                                unrealised_pnl=(
+                                    Decimal(str(pos.get("unrealisedPnl")))
+                                    if pos.get("unrealisedPnl") not in (None, "")
+                                    else None
+                                ),
+                                raw_json=pos,
+                            )
+                        )
+                        continue
+                    except Exception as e:
+                        logger.warning(
+                            f"Initial snapshot: malformed position row "
+                            f"({symbol} {side}); writing zero-row: {e}"
+                        )
+                # Absent (or malformed): write the contract zero-row.
+                snapshots.append(
+                    PositionSnapshot(
+                        run_id=run_id,
+                        account_id=account_id,
+                        symbol=symbol,
+                        exchange_ts=snapshot_ts,
+                        local_ts=snapshot_ts,
+                        side=side,
+                        size=Decimal("0"),
+                        entry_price=Decimal("0"),
+                        liq_price=None,
+                        unrealised_pnl=None,
+                        raw_json=None,
+                    )
+                )
+
+        if not snapshots:
+            return 0
+
+        try:
+            await asyncio.to_thread(self._bulk_insert_position_snapshots, snapshots)
+        except Exception as e:
+            logger.error(f"Initial snapshot: position bulk_insert failed: {e}")
+            return 0
+        return len(snapshots)
+
+    def _bulk_insert_position_snapshots(self, snapshots: list[PositionSnapshot]) -> None:
+        with self._db.get_session() as session:
+            PositionSnapshotRepository(session).bulk_insert(snapshots)
+
+    async def _snapshot_open_orders(
+        self,
+        client: BybitRestClient,
+        run_id: str,
+        account_id: str,
+        snapshot_ts: datetime,
+    ) -> int:
+        """REST-fetch open orders for configured symbols and write one row each.
+
+        ``exchange_ts``/``local_ts`` are the snapshot timestamp (REST-call
+        wall-clock), NOT the order's ``createdTime``. This guarantees the
+        snapshot row sorts BEFORE any subsequent WS-stream rows for the same
+        ``order_id`` in this run, so the loader's MAX(exchange_ts) GROUP BY
+        order_id picks up a later WS state when one exists.
+        """
+        models: list[Order] = []
+        for symbol in self._config.symbols:
+            try:
+                orders = await asyncio.to_thread(
+                    client.get_open_orders, symbol, "Limit"
+                )
+            except Exception as e:
+                logger.error(
+                    f"Initial snapshot: get_open_orders({symbol}) failed: {e}"
+                )
+                continue
+
+            for order in orders:
+                try:
+                    qty = Decimal(str(order.get("qty") or "0"))
+                    cum_exec_qty = Decimal(str(order.get("cumExecQty") or "0"))
+                    leaves_from_resp = order.get("leavesQty")
+                    leaves_qty = (
+                        Decimal(str(leaves_from_resp))
+                        if leaves_from_resp not in (None, "")
+                        else qty - cum_exec_qty
+                    )
+                    status = "PartiallyFilled" if cum_exec_qty > 0 else "New"
+                    # If the response carries an explicit orderStatus, prefer it.
+                    if order.get("orderStatus"):
+                        status = order["orderStatus"]
+
+                    order_link_id = order.get("orderLinkId") or None
+                    reduce_only_raw = order.get("reduceOnly")
+                    reduce_only = (
+                        bool(reduce_only_raw)
+                        if reduce_only_raw is not None
+                        else False
+                    )
+
+                    models.append(
+                        Order(
+                            run_id=run_id,
+                            account_id=account_id,
+                            order_id=order.get("orderId", ""),
+                            order_link_id=order_link_id,
+                            symbol=order.get("symbol", symbol),
+                            exchange_ts=snapshot_ts,
+                            local_ts=snapshot_ts,
+                            status=status,
+                            side=order.get("side", ""),
+                            price=Decimal(str(order.get("price") or "0")),
+                            qty=qty,
+                            leaves_qty=leaves_qty,
+                            reduce_only=reduce_only,
+                            raw_json=order,
+                        )
+                    )
+                except Exception as e:
+                    logger.warning(
+                        f"Initial snapshot: skipped malformed open order: {e}"
+                    )
+                    continue
+
+        if not models:
+            return 0
+
+        try:
+            await asyncio.to_thread(self._bulk_insert_orders, models)
+        except Exception as e:
+            logger.error(f"Initial snapshot: order bulk_insert failed: {e}")
+            return 0
+        return len(models)
+
+    def _bulk_insert_orders(self, models: list[Order]) -> None:
+        with self._db.get_session() as session:
+            OrderRepository(session).bulk_insert(models)
 
     async def stop(self, *, error: bool = False) -> None:
         """Stop all components gracefully.

--- a/apps/recorder/tests/test_initial_rest_snapshot.py
+++ b/apps/recorder/tests/test_initial_rest_snapshot.py
@@ -267,3 +267,63 @@ class TestInitialRestSnapshot:
             assert all(r.size == r.size.__class__("0") for r in pos_rows)
 
         await recorder.stop()
+
+    @patch("recorder.recorder.PrivateCollector")
+    @patch("recorder.recorder.PublicCollector")
+    @patch("recorder.recorder.BybitRestClient")
+    async def test_warning_emitted_when_wallet_snapshot_empty(
+        self, mock_rest_cls, mock_pub_cls, mock_priv_cls,
+        config_with_account, db, caplog,
+    ):
+        """When wallet REST returns empty (e.g. credential issue), an explicit
+        WARNING is logged so operator catches the seeding-blocker at recorder
+        start instead of finding out hours later when replay's pre-check fails.
+        Open orders being zero is NOT warned on (clean account is valid).
+        """
+        import logging
+
+        mock_pub_cls.return_value = _make_pub_mock()
+        mock_priv = _make_priv_mock()
+        mock_priv_cls.return_value = mock_priv
+
+        # Wallet response empty → wallet_count == 0 → WARNING expected.
+        # Position response has one Buy row for the configured symbol; the
+        # contract still writes a zero Sell row, so position_count == 2 > 0.
+        # Open orders empty — must NOT trip the warning by itself.
+        snapshot_client = _stub_rest_client(
+            wallet_response={"list": []},
+            positions_by_symbol={
+                "BTCUSDT": [
+                    {
+                        "symbol": "BTCUSDT",
+                        "side": "Buy",
+                        "size": "0.5",
+                        "entryPrice": "50000",
+                        "liqPrice": "45000",
+                        "unrealisedPnl": "0",
+                    }
+                ]
+            },
+            open_orders_by_symbol={"BTCUSDT": []},
+        )
+        mock_rest_cls.side_effect = [MagicMock(), snapshot_client]
+
+        recorder = Recorder(config=config_with_account, db=db)
+        with caplog.at_level(logging.WARNING, logger="recorder.recorder"):
+            await recorder.start()
+
+        warnings = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING
+            and "Initial REST snapshot incomplete" in r.message
+        ]
+        assert len(warnings) == 1, (
+            f"expected exactly one incomplete-snapshot warning, "
+            f"got {len(warnings)}: {[r.message for r in warnings]}"
+        )
+        assert "wallet_rows=0" in warnings[0].message
+        # position_rows>0 in this scenario; spot-check that the message
+        # surfaces the actual count so the warning is actionable.
+        assert "position_rows=" in warnings[0].message
+
+        await recorder.stop()

--- a/apps/recorder/tests/test_initial_rest_snapshot.py
+++ b/apps/recorder/tests/test_initial_rest_snapshot.py
@@ -1,0 +1,269 @@
+"""Tests for the recorder's initial REST snapshot (0029 Cross-cutting #4).
+
+The recorder writes a t=0 row of wallet/positions/open-orders to the DB so the
+seed-aware replay loader always finds at least one row per dimension, even on
+quiet accounts where Bybit's event-driven private streams emit no updates for
+many minutes after connect.
+
+Contract (from docs/features/0029_PLAN.md "Initial-snapshot row contract"):
+- Wallet: one row per coin returned by ``get_wallet_balance``.
+- Positions: ALWAYS two rows per configured symbol (Buy + Sell), even when the
+  REST response omits a side (write a zero-size row in that case).
+- Orders: one row per open order with reduce_only / order_link_id from the
+  response and ``exchange_ts``/``local_ts`` set to the snapshot wall-clock.
+- REST failures must NOT abort recorder start.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from grid_db import Order, PositionSnapshot, WalletSnapshot
+from recorder.recorder import Recorder
+
+
+def _make_pub_mock():
+    mock_pub = MagicMock()
+    mock_pub.start = AsyncMock()
+    mock_pub.stop = AsyncMock()
+    mock_pub.get_connection_state.return_value = None
+    return mock_pub
+
+
+def _make_priv_mock():
+    mock_priv = MagicMock()
+    mock_priv.start = AsyncMock()
+    mock_priv.stop = AsyncMock()
+    return mock_priv
+
+
+def _stub_rest_client(
+    *,
+    wallet_response: dict,
+    positions_by_symbol: dict[str, list[dict]],
+    open_orders_by_symbol: dict[str, list[dict]],
+):
+    """Return a mock BybitRestClient configured with canned responses.
+
+    ``positions_by_symbol`` and ``open_orders_by_symbol`` are keyed by the
+    symbol passed to ``get_positions(symbol)`` / ``get_open_orders(symbol, ...)``.
+    """
+    mock = MagicMock()
+    mock.get_wallet_balance.return_value = wallet_response
+    mock.get_positions.side_effect = lambda symbol: positions_by_symbol.get(
+        symbol, []
+    )
+    mock.get_open_orders.side_effect = lambda symbol, order_type="Limit": (
+        open_orders_by_symbol.get(symbol, [])
+    )
+    return mock
+
+
+class TestInitialRestSnapshot:
+    """End-to-end tests for ``_write_initial_rest_snapshot``."""
+
+    @patch("recorder.recorder.PrivateCollector")
+    @patch("recorder.recorder.PublicCollector")
+    @patch("recorder.recorder.BybitRestClient")
+    async def test_writes_two_rows_per_symbol_even_when_no_position(
+        self, mock_rest_cls, mock_pub_cls, mock_priv_cls, config_with_account, db
+    ):
+        """REST returns only a Buy row → recorder writes 2 rows (Buy + Sell @ size=0)."""
+        mock_pub_cls.return_value = _make_pub_mock()
+        mock_priv_cls.return_value = _make_priv_mock()
+
+        # Snapshot client returns one Buy position; the contract requires the
+        # recorder to ALSO write a zero-size Sell row to keep the loader's
+        # "exactly one side missing" invariant unambiguous.
+        snapshot_client = _stub_rest_client(
+            wallet_response={"list": []},
+            positions_by_symbol={
+                "BTCUSDT": [
+                    {
+                        "symbol": "BTCUSDT",
+                        "side": "Buy",
+                        "size": "0.5",
+                        "entryPrice": "50000.0",
+                        "liqPrice": "45000.0",
+                        "unrealisedPnl": "100.0",
+                    }
+                ],
+            },
+            open_orders_by_symbol={"BTCUSDT": []},
+        )
+        # First BybitRestClient(...) call is the public reconciler client
+        # (empty creds); the second is the authenticated snapshot client.
+        # MagicMock() instance for the reconciler is fine — it's never called.
+        mock_rest_cls.side_effect = [MagicMock(), snapshot_client]
+
+        recorder = Recorder(config=config_with_account, db=db)
+        await recorder.start()
+
+        with db.get_session() as session:
+            rows = (
+                session.query(PositionSnapshot)
+                .filter(PositionSnapshot.run_id == str(recorder._run_id))
+                .filter(PositionSnapshot.symbol == "BTCUSDT")
+                .all()
+            )
+            assert len(rows) == 2, (
+                f"Expected exactly 2 position rows (one Buy, one Sell); got {len(rows)}"
+            )
+            sides = {r.side for r in rows}
+            assert sides == {"Buy", "Sell"}
+
+            buy_row = next(r for r in rows if r.side == "Buy")
+            sell_row = next(r for r in rows if r.side == "Sell")
+
+            assert buy_row.size == pytest.approx(buy_row.size.__class__("0.5"))
+            assert sell_row.size == sell_row.size.__class__("0")
+            assert sell_row.entry_price == sell_row.entry_price.__class__("0")
+            assert sell_row.liq_price is None
+
+        await recorder.stop()
+
+    @patch("recorder.recorder.PrivateCollector")
+    @patch("recorder.recorder.PublicCollector")
+    @patch("recorder.recorder.BybitRestClient")
+    async def test_wallet_writes_per_coin(
+        self, mock_rest_cls, mock_pub_cls, mock_priv_cls, config_with_account, db
+    ):
+        """Wallet response with USDT + BTC → 2 wallet rows."""
+        mock_pub_cls.return_value = _make_pub_mock()
+        mock_priv_cls.return_value = _make_priv_mock()
+
+        snapshot_client = _stub_rest_client(
+            wallet_response={
+                "list": [
+                    {
+                        "coin": [
+                            {
+                                "coin": "USDT",
+                                "walletBalance": "10000.5",
+                                "availableToWithdraw": "9500.25",
+                            },
+                            {
+                                "coin": "BTC",
+                                "walletBalance": "0.25",
+                                "availableToWithdraw": "0.20",
+                            },
+                        ]
+                    }
+                ]
+            },
+            positions_by_symbol={"BTCUSDT": []},
+            open_orders_by_symbol={"BTCUSDT": []},
+        )
+        mock_rest_cls.side_effect = [MagicMock(), snapshot_client]
+
+        recorder = Recorder(config=config_with_account, db=db)
+        await recorder.start()
+
+        with db.get_session() as session:
+            rows = (
+                session.query(WalletSnapshot)
+                .filter(WalletSnapshot.run_id == str(recorder._run_id))
+                .all()
+            )
+            assert len(rows) == 2, f"Expected 2 wallet rows (one per coin); got {len(rows)}"
+            coins = {r.coin for r in rows}
+            assert coins == {"USDT", "BTC"}
+
+            usdt_row = next(r for r in rows if r.coin == "USDT")
+            assert usdt_row.wallet_balance == usdt_row.wallet_balance.__class__("10000.5")
+            assert usdt_row.available_balance == usdt_row.available_balance.__class__("9500.25")
+
+        await recorder.stop()
+
+    @patch("recorder.recorder.PrivateCollector")
+    @patch("recorder.recorder.PublicCollector")
+    @patch("recorder.recorder.BybitRestClient")
+    async def test_open_orders_capture_reduce_only(
+        self, mock_rest_cls, mock_pub_cls, mock_priv_cls, config_with_account, db
+    ):
+        """Open order with reduceOnly=True → row.reduce_only is True."""
+        mock_pub_cls.return_value = _make_pub_mock()
+        mock_priv_cls.return_value = _make_priv_mock()
+
+        snapshot_client = _stub_rest_client(
+            wallet_response={"list": []},
+            positions_by_symbol={"BTCUSDT": []},
+            open_orders_by_symbol={
+                "BTCUSDT": [
+                    {
+                        "orderId": "exchange-id-123",
+                        "orderLinkId": "client-id-abc",
+                        "symbol": "BTCUSDT",
+                        "side": "Sell",
+                        "price": "55000.0",
+                        "qty": "0.1",
+                        "cumExecQty": "0",
+                        "leavesQty": "0.1",
+                        "reduceOnly": True,
+                        "orderType": "Limit",
+                    }
+                ]
+            },
+        )
+        mock_rest_cls.side_effect = [MagicMock(), snapshot_client]
+
+        recorder = Recorder(config=config_with_account, db=db)
+        await recorder.start()
+
+        with db.get_session() as session:
+            rows = (
+                session.query(Order)
+                .filter(Order.run_id == str(recorder._run_id))
+                .all()
+            )
+            assert len(rows) == 1
+            row = rows[0]
+            assert row.reduce_only is True
+            assert row.order_link_id == "client-id-abc"
+            assert row.order_id == "exchange-id-123"
+            assert row.status == "New"
+            assert row.leaves_qty == row.leaves_qty.__class__("0.1")
+
+        await recorder.stop()
+
+    @patch("recorder.recorder.PrivateCollector")
+    @patch("recorder.recorder.PublicCollector")
+    @patch("recorder.recorder.BybitRestClient")
+    async def test_rest_failure_does_not_abort_recorder(
+        self, mock_rest_cls, mock_pub_cls, mock_priv_cls, config_with_account, db
+    ):
+        """All REST calls raise → recorder.start() still completes; private collector started."""
+        mock_pub_cls.return_value = _make_pub_mock()
+        mock_priv = _make_priv_mock()
+        mock_priv_cls.return_value = mock_priv
+
+        snapshot_client = MagicMock()
+        snapshot_client.get_wallet_balance.side_effect = RuntimeError("REST down")
+        snapshot_client.get_positions.side_effect = RuntimeError("REST down")
+        snapshot_client.get_open_orders.side_effect = RuntimeError("REST down")
+        mock_rest_cls.side_effect = [MagicMock(), snapshot_client]
+
+        recorder = Recorder(config=config_with_account, db=db)
+        await recorder.start()  # must not raise
+
+        # Private collector must still have been created and started.
+        mock_priv_cls.assert_called_once()
+        mock_priv.start.assert_awaited_once()
+        assert recorder._private_collector is not None
+        assert recorder._running is True
+
+        # Even on full REST failure, the contract still writes the
+        # zero-row position pair so loader semantics stay binary
+        # (both-empty handled by Phase 4 pre-check, exactly-one-side-missing
+        # treated as corrupt).
+        with db.get_session() as session:
+            pos_rows = (
+                session.query(PositionSnapshot)
+                .filter(PositionSnapshot.run_id == str(recorder._run_id))
+                .all()
+            )
+            assert len(pos_rows) == 2
+            assert {r.side for r in pos_rows} == {"Buy", "Sell"}
+            assert all(r.size == r.size.__class__("0") for r in pos_rows)
+
+        await recorder.stop()

--- a/apps/replay/src/replay/config.py
+++ b/apps/replay/src/replay/config.py
@@ -87,6 +87,73 @@ class ReplayStrategyConfig(BaseModel):
         return data
 
 
+class SeedConfig(BaseModel):
+    """Seed-aware replay configuration (feature 0029).
+
+    When ``enabled=True`` the replay engine reconstructs live's state at
+    ``at_ts`` from the recorder DB (positions, wallet, active orders) and
+    the shared ``GridStateStore`` JSON file (grid level list). This closes
+    the state-gap that otherwise makes replay diverge from live on the
+    very first tick even when the strategy is identical.
+
+    All four DB-backed loaders are scoped by ``run_id`` (resolved by the
+    engine from ``ReplayConfig.run_id`` / auto-discovery) and
+    ``account_id``; the grid loader is keyed by ``strat_id``.
+
+    Validation: when ``enabled=True``, ``at_ts``, ``account_id``, and
+    ``strat_id`` are all required. ``grid_state_path`` and ``wallet_coin``
+    have safe defaults so a minimal seed YAML stays terse.
+
+    Default ``enabled=False`` preserves the existing blank-start replay
+    flow for callers that don't have recorded private-stream data.
+    """
+
+    enabled: bool = Field(
+        default=False,
+        description="Enable seed-from-recorder mode (feature 0029)",
+    )
+    at_ts: Optional[datetime] = Field(
+        default=None,
+        description="Moment to seed from (typically replay window start). Required when enabled.",
+    )
+    account_id: Optional[str] = Field(
+        default=None,
+        description="Account ID for run-scoped DB queries. Required when enabled.",
+    )
+    strat_id: Optional[str] = Field(
+        default=None,
+        description="Strategy identifier used as GridStateStore key. Required when enabled.",
+    )
+    grid_state_path: str = Field(
+        default="db/grid_anchor.json",
+        description="Path to grid-state JSON file shared with live (legacy filename retained from feature 0021).",
+    )
+    wallet_coin: str = Field(
+        default="USDT",
+        description="Wallet coin to seed initial balance from.",
+    )
+
+    @model_validator(mode="after")
+    def require_seed_fields_when_enabled(self):
+        """Reject incomplete seed configs at load time.
+
+        Pydantic ``Optional`` fields default to ``None`` to keep the
+        ``enabled=False`` happy path terse, but with ``enabled=True`` the
+        loader queries depend on all three. Failing here surfaces the
+        misconfig before the engine starts a partial seed.
+        """
+        if self.enabled:
+            missing = [
+                name for name in ("at_ts", "account_id", "strat_id")
+                if getattr(self, name) is None
+            ]
+            if missing:
+                raise ValueError(
+                    f"seed.enabled=True requires fields: {', '.join(missing)}"
+                )
+        return self
+
+
 class ReplayConfig(BaseModel):
     """Root configuration for replay engine."""
 
@@ -113,6 +180,11 @@ class ReplayConfig(BaseModel):
 
     strategy: ReplayStrategyConfig = Field(
         ..., description="Grid strategy configuration"
+    )
+
+    seed: SeedConfig = Field(
+        default_factory=SeedConfig,
+        description="Seed-from-recorder configuration (feature 0029); off by default.",
     )
 
     # Backtest parameters

--- a/apps/replay/src/replay/engine.py
+++ b/apps/replay/src/replay/engine.py
@@ -14,11 +14,21 @@ from dataclasses import dataclass
 from decimal import Decimal
 from typing import Optional
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
-from grid_db import DatabaseFactory, Run, RunRepository, redact_db_url
+from sqlalchemy import func
+
+from grid_db import (
+    DatabaseFactory,
+    PositionSnapshot,
+    Run,
+    RunRepository,
+    WalletSnapshot,
+    redact_db_url,
+)
 
 from gridcore import DirectionType, create_qty_calculator
+from gridcore.persistence import GridStateStore
 
 from backtest.config import BacktestStrategyConfig, WindDownMode
 from backtest.data_provider import HistoricalDataProvider, InMemoryDataProvider
@@ -40,10 +50,27 @@ from comparator import (
     ValidationMetrics,
 )
 
-from replay.config import ReplayConfig
+from replay.config import ReplayConfig, SeedConfig
+from replay.snapshot_loader import (
+    ActiveOrderSeed,
+    GridStateSeed,
+    PositionStateSeed,
+    load_active_orders,
+    load_grid_state,
+    load_position_snapshots,
+    load_wallet_snapshot,
+)
 
 
 logger = logging.getLogger(__name__)
+
+
+# Minimum gap between the latest required initial-snapshot row and seed.at_ts.
+# Used by the Phase 4 pre-check (which lives in the engine — see Phase 3 plan).
+# 5 seconds matches the example in docs/features/0029_PLAN.md and gives enough
+# slack for clock skew between recorder and live without masking the
+# "initial REST snapshot has not landed yet" misconfig.
+_SEED_PRE_CHECK_MARGIN = timedelta(seconds=5)
 
 
 @dataclass
@@ -112,8 +139,39 @@ class ReplayEngine:
             enable_risk_multipliers=config.strategy.enable_risk_multipliers,
         )
 
-        session = BacktestSession(initial_balance=config.initial_balance)
-        runner = self._init_runner(strategy_config, session)
+        # 2a. Load seed material (positions/wallet/orders/grid) when enabled.
+        # When disabled this returns the all-None tuple and the runner
+        # constructs from scratch — preserving pre-0029 behaviour exactly.
+        (
+            wallet_seed,
+            long_seed,
+            short_seed,
+            grid_seed,
+            order_seeds,
+        ) = self._load_seed(config, run_id)
+
+        initial_balance = wallet_seed if wallet_seed is not None else config.initial_balance
+        session = BacktestSession(initial_balance=initial_balance)
+        runner = self._init_runner(
+            strategy_config,
+            session,
+            long_seed=long_seed,
+            short_seed=short_seed,
+            grid_seed=grid_seed,
+            order_seeds=order_seeds,
+        )
+
+        if config.seed.enabled:
+            logger.info(
+                "Seeded run_id=%s: long.size=%s, short.size=%s, "
+                "anchor_or_grid_levels=%s, balance=%s, active_orders=%s",
+                run_id,
+                long_seed.size if long_seed is not None else Decimal("0"),
+                short_seed.size if short_seed is not None else Decimal("0"),
+                len(grid_seed.grid) if grid_seed is not None else 0,
+                initial_balance,
+                len(order_seeds) if order_seeds is not None else 0,
+            )
 
         # 3. Create data provider
         if data_provider is not None:
@@ -279,8 +337,35 @@ class ReplayEngine:
         self,
         strategy_config: BacktestStrategyConfig,
         session: BacktestSession,
+        long_seed: Optional[PositionStateSeed] = None,
+        short_seed: Optional[PositionStateSeed] = None,
+        grid_seed: Optional[GridStateSeed] = None,
+        order_seeds: Optional[list[ActiveOrderSeed]] = None,
     ) -> BacktestRunner:
-        """Initialize a BacktestRunner for the replay."""
+        """Initialize a BacktestRunner for the replay.
+
+        Args:
+            strategy_config: Backtest strategy config (already projected
+                from ``ReplayConfig``).
+            session: Pre-constructed ``BacktestSession`` — when seeding,
+                its ``initial_balance`` is the wallet snapshot.
+            long_seed: Optional long-direction position seed; when present
+                AND non-zero, ``BacktestPositionTracker.seed_state`` is
+                called before the runner gets the tracker. Skipping the
+                ``seed_state`` call on a zero seed avoids polluting the
+                tracker with a no-op write — both branches yield the same
+                tracker state, but the unconditional path is cheaper to
+                reason about, so we still call it whenever a seed exists.
+            short_seed: Same for short direction.
+            grid_seed: Optional grid-state seed; ``grid_seed.grid`` (the
+                full level list) is forwarded to ``BacktestRunner`` as
+                ``restored_grid``, which routes through
+                ``GridEngine.__init__(restored_grid=...)``.
+            order_seeds: Optional list of pre-existing live orders; passed
+                to ``BacktestRunner`` as ``seeded_active_orders``, which
+                pre-loads the ``BacktestOrderManager`` so they participate
+                in fill checks on the first tick.
+        """
         instrument_info = self._instrument_provider.get(strategy_config.symbol)
         logger.info(
             f"Instrument {strategy_config.symbol}: "
@@ -308,6 +393,14 @@ class ReplayEngine:
             commission_rate=strategy_config.commission_rate,
         )
 
+        # Seed trackers BEFORE handing them to BacktestRunner so the
+        # runner's _copy_seeded_state_to_positions sees the seeded values
+        # when constructing the gridcore.Position pair (risk path).
+        if long_seed is not None:
+            long_tracker.seed_state(long_seed)
+        if short_seed is not None:
+            short_tracker.seed_state(short_seed)
+
         return BacktestRunner(
             strategy_config=strategy_config,
             executor=executor,
@@ -315,7 +408,151 @@ class ReplayEngine:
             long_tracker=long_tracker,
             short_tracker=short_tracker,
             instrument_info=instrument_info,
+            restored_grid=grid_seed.grid if grid_seed is not None else None,
+            seeded_active_orders=order_seeds,
         )
+
+    def _load_seed(
+        self,
+        config: ReplayConfig,
+        run_id: str,
+    ) -> tuple[
+        Optional[Decimal],
+        Optional[PositionStateSeed],
+        Optional[PositionStateSeed],
+        Optional[GridStateSeed],
+        Optional[list[ActiveOrderSeed]],
+    ]:
+        """Load all four seed dimensions for a replay run.
+
+        Returns ``(None, None, None, None, None)`` when ``seed.enabled``
+        is False — caller falls back to blank-start construction.
+
+        When enabled:
+
+        1. Runs the Phase 4 pre-check inline: both ``wallet_snapshots``
+           and ``position_snapshots`` must have at least one row for the
+           ``run_id`` AND the latest of those two ``MIN(exchange_ts)``
+           values must be ``<= seed.at_ts - 5s``. ``orders`` is excluded
+           from the pre-check because a clean grid legitimately has no
+           open orders at recorder start.
+        2. Loads grid state from the shared ``GridStateStore`` JSON file
+           (returns ``None`` on no-entry / legacy / step-or-count
+           mismatch — replay then falls back to fresh-build).
+        3. Loads position pair, wallet balance, and active orders inside
+           a single DB session.
+
+        Args:
+            config: Full replay config (read for ``seed`` and ``symbol``).
+            run_id: Resolved recorder run identifier.
+        """
+        seed: SeedConfig = config.seed
+        if not seed.enabled:
+            return (None, None, None, None, None)
+
+        # Defensive: validators run at config load, but a programmatic
+        # constructor that bypasses model validation could leave these
+        # None. Guard so the loaders below don't get None where they
+        # expect strings/datetimes.
+        if seed.at_ts is None or seed.account_id is None or seed.strat_id is None:
+            raise ValueError(
+                "seed.enabled=True but at_ts/account_id/strat_id are unset"
+            )
+
+        # Grid state lives outside the DB; load before opening a session.
+        grid_seed = load_grid_state(
+            GridStateStore(file_path=seed.grid_state_path),
+            seed.strat_id,
+            expected_step=config.strategy.grid_step,
+            expected_count=config.strategy.grid_count,
+        )
+
+        with self._db.get_session() as db_session:
+            self._seed_pre_check(db_session, run_id, seed.at_ts)
+
+            long_seed, short_seed = load_position_snapshots(
+                db_session,
+                run_id,
+                seed.account_id,
+                config.symbol,
+                seed.at_ts,
+            )
+            wallet_seed = load_wallet_snapshot(
+                db_session,
+                run_id,
+                seed.account_id,
+                seed.at_ts,
+                coin=seed.wallet_coin,
+            )
+            order_seeds = load_active_orders(
+                db_session,
+                run_id,
+                seed.account_id,
+                config.symbol,
+                seed.at_ts,
+            )
+
+        return wallet_seed, long_seed, short_seed, grid_seed, order_seeds
+
+    @staticmethod
+    def _seed_pre_check(
+        db_session,
+        run_id: str,
+        at_ts: datetime,
+    ) -> None:
+        """Phase 4 pre-check (lives in engine per Phase 3 plan).
+
+        Confirms the recorder's initial REST snapshot landed for both
+        wallet and position dimensions before ``at_ts``. ``orders`` is
+        intentionally excluded — a clean account legitimately has zero
+        open orders at recorder start, so a strict ``MIN`` requirement
+        would falsely reject a valid happy path.
+
+        Raises ``ValueError`` (not ``SeedError``) so the failure surfaces
+        as a config / setup error to the operator, distinct from data-
+        quality errors raised by the loaders.
+        """
+        wallet_min = (
+            db_session.query(func.min(WalletSnapshot.exchange_ts))
+            .filter(WalletSnapshot.run_id == run_id)
+            .scalar()
+        )
+        position_min = (
+            db_session.query(func.min(PositionSnapshot.exchange_ts))
+            .filter(PositionSnapshot.run_id == run_id)
+            .scalar()
+        )
+
+        missing = []
+        if wallet_min is None:
+            missing.append("wallet_snapshots")
+        if position_min is None:
+            missing.append("position_snapshots")
+        if missing:
+            raise ValueError(
+                f"Seed pre-check failed for run_id={run_id}: no rows in "
+                f"{', '.join(missing)}. Recorder must write an initial REST "
+                "snapshot on private-stream connect; this run cannot be seeded."
+            )
+
+        # Compare ts values without tzinfo — SQLite may strip timezone on read,
+        # so wallet_min / position_min may be naive while at_ts may be aware
+        # (or vice versa). Strip uniformly before comparing.
+        def _strip_tz(dt: datetime) -> datetime:
+            return dt.replace(tzinfo=None) if dt.tzinfo is not None else dt
+
+        latest_min = max(wallet_min, position_min)
+        required_at_ts = _strip_tz(latest_min) + _SEED_PRE_CHECK_MARGIN
+
+        if _strip_tz(at_ts) < required_at_ts:
+            raise ValueError(
+                f"Seed pre-check failed for run_id={run_id}: seed.at_ts "
+                f"({at_ts}) must be at least {_SEED_PRE_CHECK_MARGIN.total_seconds():.0f}s "
+                f"after the latest initial-snapshot row "
+                f"(wallet_min={wallet_min}, position_min={position_min}, "
+                f"latest_min={latest_min}). Initial REST snapshot has not "
+                "landed yet — seeding would silently fall back to defaults."
+            )
 
     def _create_qty_calculator(self, config, instrument_info):
         """Create qty calculator from amount pattern.

--- a/apps/replay/src/replay/snapshot_loader.py
+++ b/apps/replay/src/replay/snapshot_loader.py
@@ -1,0 +1,419 @@
+"""Seed-aware replay snapshot loader (feature 0029, Phase 2A).
+
+Pure functions that translate recorder-DB rows + ``GridStateStore`` JSON
+into plain seed dataclasses ready for the replay engine to inject into a
+``BacktestRunner``. The loader owns no DB session and no exchange I/O — it
+just adapts the persistence layer to the seed contract documented in
+``docs/features/0029_PLAN.md``.
+
+Four loaders, one per seed dimension:
+
+* :func:`load_grid_state` — wraps :class:`GridStateStore` with a tolerant
+  ``None``-on-mismatch fallback that mirrors live's behaviour at
+  ``apps/gridbot/src/gridbot/runner.py:248-263``.
+* :func:`load_position_snapshots` — always returns a ``(long, short)``
+  pair. Both-absent maps to ``(zero, zero)`` (caught upstream by Phase 4
+  pre-check); one-side-only is a corrupt run and raises
+  :class:`SeedDataQualityError`.
+* :func:`load_wallet_snapshot` — returns ``Optional[Decimal]`` so the
+  caller decides the blank-fallback amount.
+* :func:`load_active_orders` — ``[]`` is a valid clean-account result;
+  per-row ``reduce_only IS NULL`` raises :class:`SeedSchemaError`.
+
+Direction derivation for active orders follows Bybit hedge-mode:
+
+============================  =========
+side, reduce_only             direction
+============================  =========
+``Buy``,  ``False``           ``long``
+``Sell``, ``False``           ``short``
+``Buy``,  ``True``            ``short`` (closing short by buying)
+``Sell``, ``True``            ``long``  (closing long by selling)
+============================  =========
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from grid_db import (
+    OrderRepository,
+    PositionSnapshotRepository,
+    WalletSnapshotRepository,
+)
+
+from gridcore.persistence import GridStateStore
+
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Seed dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class GridStateSeed:
+    """Saved grid state for replay restoration.
+
+    ``grid`` is the full ordered list of ``{'side': ..., 'price': ...}``
+    dicts as persisted by :meth:`GridStateStore.save`. ``anchor_price`` is
+    intentionally NOT stored — live drops it post-feature-0021 and replay
+    reconstructs it via ``Grid.wait_center()`` after ``restore_grid``.
+    """
+
+    strat_id: str
+    grid: list[dict]
+    grid_step: float
+    grid_count: int
+
+
+@dataclass(frozen=True)
+class PositionStateSeed:
+    """Per-direction seed for ``BacktestPositionTracker.seed_state``.
+
+    ``direction`` is ``'long'`` or ``'short'`` (lowercase, matching
+    ``DirectionType`` string values). ``leverage`` is NOT seeded —
+    ``PositionSnapshot`` does not store it; replay reads leverage from
+    its strategy config at tracker init time.
+    """
+
+    direction: str
+    size: Decimal
+    entry_price: Decimal
+    liquidation_price: Decimal
+
+
+@dataclass(frozen=True)
+class ActiveOrderSeed:
+    """Pre-existing exchange order to inject into ``BacktestOrderManager``.
+
+    ``client_id = order_link_id or order_id`` — the fallback covers
+    pre-cross-cutting-#1 orders that were placed without an
+    ``orderLinkId``. ``direction`` is derived from ``(side, reduce_only)``
+    per Bybit hedge-mode rules; see module docstring.
+    """
+
+    client_id: str
+    exchange_order_id: str
+    symbol: str
+    side: str
+    direction: str
+    price: Decimal
+    remaining_qty: Decimal
+    reduce_only: bool
+    exchange_ts: datetime
+
+
+# ---------------------------------------------------------------------------
+# Exception hierarchy
+# ---------------------------------------------------------------------------
+
+
+class SeedError(Exception):
+    """Base class for all seed-time loader errors."""
+
+
+class SeedSchemaError(SeedError):
+    """A row required by the seed contract is missing a column added by
+    the Phase 1 migration (e.g. ``Order.reduce_only IS NULL``).
+
+    Recorder data captured before the migration ran is unsafe to seed
+    from because direction would have to be guessed from ``side`` alone.
+    """
+
+
+class SeedConfigMismatchError(SeedError):
+    """Saved grid ``grid_step`` / ``grid_count`` differ from the replay
+    config. Reserved for future use — currently the grid loader treats a
+    mismatch as a tolerant ``None`` fallback to match live.
+    """
+
+
+class SeedDataQualityError(SeedError):
+    """Exactly one position side is present for a run when both are
+    required by the recorder's initial-REST-snapshot contract.
+
+    The recorder writes BOTH sides (``Buy`` and ``Sell``, including
+    zero-size rows) on private-stream connect; missing one side means
+    the run is corrupt and seeding from it is unsafe.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+# Bybit hedge-mode direction lookup, keyed by (side, reduce_only).
+# A Buy that opens a position is long; a Buy with reduceOnly closes a
+# short, so the order belongs to the short direction. Symmetrically for
+# Sell. Documented in the module docstring.
+_DIRECTION_BY_SIDE_REDUCE: dict[tuple[str, bool], str] = {
+    ("Buy", False): "long",
+    ("Sell", False): "short",
+    ("Buy", True): "short",
+    ("Sell", True): "long",
+}
+
+
+def _zero_position_seed(direction: str) -> PositionStateSeed:
+    """Construct an empty seed for a direction with no recorded activity."""
+    return PositionStateSeed(
+        direction=direction,
+        size=Decimal("0"),
+        entry_price=Decimal("0"),
+        liquidation_price=Decimal("0"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Loaders
+# ---------------------------------------------------------------------------
+
+
+def load_grid_state(
+    state_store: GridStateStore,
+    strat_id: str,
+    expected_step: float,
+    expected_count: int,
+) -> Optional[GridStateSeed]:
+    """Load saved grid state for a strategy, with tolerant fallback.
+
+    Returns ``None`` (with an INFO log) on any of:
+
+    * No saved entry for ``strat_id``.
+    * Legacy anchor-only format (``GridStateStore.load`` already returns
+      ``None`` and emits its own INFO log; we just propagate).
+    * ``grid_step`` / ``grid_count`` differ from the replay config.
+
+    The replay engine treats ``None`` as "blank-build a fresh grid",
+    matching live's tolerant behaviour at
+    ``apps/gridbot/src/gridbot/runner.py:248-263``. JSON / IO errors from
+    the store itself propagate.
+
+    Args:
+        state_store: Read-only handle to the grid-state JSON file.
+        strat_id: Strategy identifier used as the key in the store.
+        expected_step: Replay config ``grid_step`` for fingerprint check.
+        expected_count: Replay config ``grid_count`` for fingerprint check.
+
+    Returns:
+        :class:`GridStateSeed` on a clean match, else ``None``.
+    """
+    entry = state_store.load(strat_id)
+    if entry is None:
+        # GridStateStore.load already logs INFO for the legacy-format
+        # path; the no-entry path is silent in the store, so log here.
+        logger.info(
+            "%s: no saved grid state, will build fresh grid", strat_id,
+        )
+        return None
+
+    saved_step = entry.get("grid_step")
+    saved_count = entry.get("grid_count")
+    if saved_step != expected_step or saved_count != expected_count:
+        logger.info(
+            "%s: saved grid (step=%s, count=%s) differs from replay config "
+            "(step=%s, count=%s); building fresh grid",
+            strat_id, saved_step, saved_count, expected_step, expected_count,
+        )
+        return None
+
+    return GridStateSeed(
+        strat_id=strat_id,
+        grid=entry["grid"],
+        grid_step=saved_step,
+        grid_count=saved_count,
+    )
+
+
+def load_position_snapshots(
+    db_session: Session,
+    run_id: str,
+    account_id: str,
+    symbol: str,
+    at_ts: datetime,
+) -> tuple[PositionStateSeed, PositionStateSeed]:
+    """Load the (long, short) position seed pair for a recorder run.
+
+    The recorder's initial REST snapshot writes BOTH sides on
+    private-stream connect (including zero-size rows for the absent
+    side). The loader leans on that invariant:
+
+    * Both sides present  → seed both from the snapshot rows.
+    * Both sides absent   → ``(zero, zero)``. Phase 4 pre-check rejects
+      this case before replay starts when the snapshot has not yet
+      landed, so reaching it here means the run legitimately had no
+      activity AND no initial snapshot — the (zero, zero) is harmless.
+    * Exactly one side    → :class:`SeedDataQualityError`. The recorder
+      run is corrupt; seeding would assume the wrong default for the
+      missing side.
+
+    Snapshot ``liq_price`` may be ``NULL``; we coerce to ``Decimal('0')``.
+
+    Args:
+        db_session: Read-only DB session.
+        run_id: Recorder run identifier.
+        account_id: Account ID.
+        symbol: Trading symbol (e.g. ``'BTCUSDT'``).
+        at_ts: Inclusive upper bound on ``exchange_ts``.
+
+    Returns:
+        Tuple ``(long_seed, short_seed)``.
+
+    Raises:
+        SeedDataQualityError: Exactly one side has no rows for this run.
+    """
+    repo = PositionSnapshotRepository(db_session)
+    buy_snap = repo.get_latest_before(run_id, account_id, symbol, "Buy", at_ts)
+    sell_snap = repo.get_latest_before(run_id, account_id, symbol, "Sell", at_ts)
+
+    if buy_snap is None and sell_snap is None:
+        return _zero_position_seed("long"), _zero_position_seed("short")
+
+    if buy_snap is None or sell_snap is None:
+        present = "Buy" if buy_snap is not None else "Sell"
+        missing = "Sell" if buy_snap is not None else "Buy"
+        raise SeedDataQualityError(
+            f"Position snapshot for run_id={run_id}, account_id={account_id}, "
+            f"symbol={symbol} has only side={present} (missing {missing}); "
+            "recorder's initial REST snapshot must write both sides — run is corrupt"
+        )
+
+    long_seed = PositionStateSeed(
+        direction="long",
+        size=buy_snap.size,
+        entry_price=buy_snap.entry_price,
+        liquidation_price=buy_snap.liq_price if buy_snap.liq_price is not None else Decimal("0"),
+    )
+    short_seed = PositionStateSeed(
+        direction="short",
+        size=sell_snap.size,
+        entry_price=sell_snap.entry_price,
+        liquidation_price=sell_snap.liq_price if sell_snap.liq_price is not None else Decimal("0"),
+    )
+    return long_seed, short_seed
+
+
+def load_wallet_snapshot(
+    db_session: Session,
+    run_id: str,
+    account_id: str,
+    at_ts: datetime,
+    coin: str = "USDT",
+) -> Optional[Decimal]:
+    """Load the latest wallet balance for a run/account/coin.
+
+    Returns ``None`` when no snapshot exists for this combination — the
+    caller (``ReplayEngine``) decides whether to fall back to
+    ``config.initial_balance``. There is no global staleness threshold:
+    Bybit private streams are event-driven and a quiet wallet may sit
+    unchanged for arbitrary periods.
+
+    Args:
+        db_session: Read-only DB session.
+        run_id: Recorder run identifier.
+        account_id: Account ID.
+        at_ts: Inclusive upper bound on ``exchange_ts``.
+        coin: Coin symbol; defaults to ``'USDT'``.
+
+    Returns:
+        Latest ``wallet_balance`` as a :class:`Decimal`, or ``None``.
+    """
+    repo = WalletSnapshotRepository(db_session)
+    snap = repo.get_latest_before(run_id, account_id, coin, at_ts)
+    if snap is None:
+        return None
+    return snap.wallet_balance
+
+
+def load_active_orders(
+    db_session: Session,
+    run_id: str,
+    account_id: str,
+    symbol: str,
+    at_ts: datetime,
+) -> list[ActiveOrderSeed]:
+    """Load the set of open orders that existed live at ``at_ts``.
+
+    Returns ``[]`` for a clean account with no live orders — that is a
+    valid happy path (an empty grid that has not placed yet). Each
+    returned seed has ``client_id = order_link_id or order_id`` so the
+    comparator can match across the ``orderLinkId``-introduction window.
+
+    ``direction`` is derived from ``(side, reduce_only)`` per Bybit
+    hedge-mode rules (see module docstring).
+
+    Args:
+        db_session: Read-only DB session.
+        run_id: Recorder run identifier.
+        account_id: Account ID.
+        symbol: Trading symbol.
+        at_ts: Inclusive upper bound on ``exchange_ts``.
+
+    Returns:
+        List of :class:`ActiveOrderSeed`, ordered as the repository
+        returned them (insertion order; the simulator does not depend
+        on a particular ordering).
+
+    Raises:
+        SeedSchemaError: A returned row has ``reduce_only IS NULL``,
+            indicating it predates the Phase 1 schema migration.
+    """
+    repo = OrderRepository(db_session)
+    rows = repo.get_active_at(run_id, account_id, symbol, at_ts)
+    seeds: list[ActiveOrderSeed] = []
+    for row in rows:
+        if row.reduce_only is None:
+            raise SeedSchemaError(
+                f"Order order_id={row.order_id} (run_id={run_id}, account_id="
+                f"{account_id}, symbol={symbol}) has reduce_only=NULL; "
+                "row predates the Phase 1 migration and cannot be safely seeded"
+            )
+        direction = _DIRECTION_BY_SIDE_REDUCE.get((row.side, bool(row.reduce_only)))
+        if direction is None:
+            # Defensive: side is constrained to 'Buy'/'Sell' at the schema
+            # level, so the lookup should always succeed. If a future writer
+            # introduces a new side value, fail loudly rather than guess.
+            raise SeedSchemaError(
+                f"Order order_id={row.order_id} has unexpected side={row.side!r}; "
+                "expected 'Buy' or 'Sell'"
+            )
+        client_id = row.order_link_id or row.order_id
+        seeds.append(
+            ActiveOrderSeed(
+                client_id=client_id,
+                exchange_order_id=row.order_id,
+                symbol=row.symbol,
+                side=row.side,
+                direction=direction,
+                price=row.price,
+                remaining_qty=row.leaves_qty,
+                reduce_only=bool(row.reduce_only),
+                exchange_ts=row.exchange_ts,
+            )
+        )
+    return seeds
+
+
+__all__ = [
+    "GridStateSeed",
+    "PositionStateSeed",
+    "ActiveOrderSeed",
+    "SeedError",
+    "SeedSchemaError",
+    "SeedConfigMismatchError",
+    "SeedDataQualityError",
+    "load_grid_state",
+    "load_position_snapshots",
+    "load_wallet_snapshot",
+    "load_active_orders",
+]

--- a/apps/replay/tests/test_engine_seed.py
+++ b/apps/replay/tests/test_engine_seed.py
@@ -1,0 +1,502 @@
+"""End-to-end tests for ReplayEngine seeding (feature 0029, Phase 3).
+
+These tests construct a ``ReplayEngine`` with ``seed.enabled=True`` against
+an in-memory recorder DB pre-populated with one of each snapshot dimension
+(positions long+short, wallet, active order) plus a ``GridStateStore`` JSON
+file. They stop short of running ticks — the seed payload is verified
+directly on the constructed ``BacktestRunner``, ``BacktestSession`` and
+``BacktestOrderManager`` to keep the test focused on the wiring.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from grid_db import (
+    BybitAccount,
+    Order,
+    OrderRepository,
+    PositionSnapshot,
+    PositionSnapshotRepository,
+    Run,
+    Strategy,
+    User,
+    WalletSnapshot,
+    WalletSnapshotRepository,
+)
+
+from gridcore.persistence import GridStateStore
+
+from replay.config import ReplayConfig, ReplayStrategyConfig, SeedConfig
+from replay.engine import ReplayEngine
+
+
+# ---------------------------------------------------------------------------
+# Local fixtures
+# ---------------------------------------------------------------------------
+
+
+SYMBOL = "BTCUSDT"
+STRAT_ID = "ltcusdt_test"  # arbitrary key; matches GridStateStore convention
+
+
+@pytest.fixture
+def seed_ts():
+    """Wall-clock moment at which we seed (replay window start)."""
+    return datetime(2026, 5, 7, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def snapshot_ts(seed_ts):
+    """Initial REST snapshot lands well before seed.at_ts (pre-check happy)."""
+    return seed_ts - timedelta(seconds=60)
+
+
+@pytest.fixture
+def seeded_db(db, seed_ts, snapshot_ts):
+    """Populate the in-memory DB with one row per snapshot dimension.
+
+    Layout matches the recorder's "initial REST snapshot" contract:
+      * Wallet: one USDT row at ``snapshot_ts``.
+      * Positions: BOTH sides (long/short) at ``snapshot_ts``; long has
+        ``size>0`` (real position), short has ``size=0`` (zero-row half).
+      * Orders: one open buy at ``snapshot_ts`` + the prerequisite Run row.
+    """
+    with db.get_session() as session:
+        user = User(user_id="user-1", username="seedtest")
+        account = BybitAccount(
+            account_id="acc-1",
+            user_id="user-1",
+            account_name="seed_account",
+            environment="testnet",
+        )
+        strategy = Strategy(
+            strategy_id="strat-1",
+            account_id="acc-1",
+            strategy_type="recorder",
+            symbol=SYMBOL,
+            config_json={},
+        )
+        run = Run(
+            run_id="seed-run",
+            user_id="user-1",
+            account_id="acc-1",
+            strategy_id="strat-1",
+            run_type="recording",
+            status="running",
+            start_ts=snapshot_ts - timedelta(minutes=5),
+            end_ts=seed_ts + timedelta(hours=1),
+        )
+        session.add_all([user, account, strategy, run])
+        session.commit()
+
+        PositionSnapshotRepository(session).bulk_insert([
+            PositionSnapshot(
+                run_id="seed-run",
+                account_id="acc-1",
+                symbol=SYMBOL,
+                exchange_ts=snapshot_ts,
+                local_ts=snapshot_ts,
+                side="Buy",  # long
+                size=Decimal("1.5"),
+                entry_price=Decimal("100000"),
+                liq_price=Decimal("90000"),
+            ),
+            PositionSnapshot(
+                run_id="seed-run",
+                account_id="acc-1",
+                symbol=SYMBOL,
+                exchange_ts=snapshot_ts,
+                local_ts=snapshot_ts,
+                side="Sell",  # short — present but zero size, per contract
+                size=Decimal("0"),
+                entry_price=Decimal("0"),
+                liq_price=None,
+            ),
+        ])
+        WalletSnapshotRepository(session).bulk_insert([
+            WalletSnapshot(
+                run_id="seed-run",
+                account_id="acc-1",
+                exchange_ts=snapshot_ts,
+                local_ts=snapshot_ts,
+                coin="USDT",
+                wallet_balance=Decimal("12345.67"),
+                available_balance=Decimal("12000.00"),
+            ),
+        ])
+        OrderRepository(session).bulk_insert([
+            Order(
+                run_id="seed-run",
+                account_id="acc-1",
+                order_id="ORD-SEED-1",
+                order_link_id="LX-SEED-1",
+                symbol=SYMBOL,
+                exchange_ts=snapshot_ts,
+                local_ts=snapshot_ts,
+                status="New",
+                side="Buy",
+                price=Decimal("99000"),
+                qty=Decimal("0.1"),
+                leaves_qty=Decimal("0.1"),
+                reduce_only=False,
+            ),
+        ])
+        session.commit()
+
+    return db
+
+
+@pytest.fixture
+def grid_state_path(tmp_path):
+    """Write a small grid-state JSON file matching the strategy fingerprint."""
+    path = tmp_path / "grid_anchor.json"
+    store = GridStateStore(file_path=str(path))
+    # Strict ascending price + Buy...Buy → Sell...Sell pattern
+    # so Grid.is_grid_correct() accepts the restored layout.
+    grid = [
+        {"side": "Buy", "price": 99600.0},
+        {"side": "Buy", "price": 99800.0},
+        {"side": "Sell", "price": 100200.0},
+        {"side": "Sell", "price": 100400.0},
+    ]
+    store.save(STRAT_ID, grid, grid_step=0.2, grid_count=4)
+    store.flush()
+    return str(path)
+
+
+@pytest.fixture
+def seed_config(seed_ts, grid_state_path):
+    return SeedConfig(
+        enabled=True,
+        at_ts=seed_ts,
+        account_id="acc-1",
+        strat_id=STRAT_ID,
+        grid_state_path=grid_state_path,
+        wallet_coin="USDT",
+    )
+
+
+@pytest.fixture
+def replay_config(seed_ts, seed_config):
+    """Replay config using the seed fingerprint matching grid_state_path."""
+    return ReplayConfig(
+        database_url="sqlite:///:memory:",
+        run_id="seed-run",
+        symbol=SYMBOL,
+        start_ts=seed_ts,
+        end_ts=seed_ts + timedelta(hours=1),
+        strategy=ReplayStrategyConfig(
+            tick_size=Decimal("0.1"),
+            grid_count=4,
+            grid_step=0.2,
+            enable_risk_multipliers=True,
+        ),
+        initial_balance=Decimal("10000"),
+        enable_funding=False,
+        seed=seed_config,
+    )
+
+
+@pytest.fixture
+def mock_instrument():
+    """Patch the InstrumentInfoProvider — the test does not run ticks."""
+    with patch("replay.engine.InstrumentInfoProvider") as mock_cls:
+        info = MagicMock()
+        info.qty_step = Decimal("0.001")
+        info.tick_size = Decimal("0.1")
+        info.round_qty = lambda q: max(Decimal("0.001"), q.quantize(Decimal("0.001")))
+        mock_cls.return_value.get.return_value = info
+        yield info
+
+
+# ---------------------------------------------------------------------------
+# A. Happy path — full pipeline seeds correctly
+# ---------------------------------------------------------------------------
+
+
+class TestReplayEngineSeedingPipeline:
+    """End-to-end: every seed dimension lands on the constructed runner."""
+
+    def test_replay_engine_seeds_through_full_pipeline(
+        self, seeded_db, replay_config, mock_instrument,
+    ):
+        """Construct the engine and inspect the BacktestRunner directly.
+
+        We exercise ``_load_seed`` + ``_init_runner`` by calling them
+        rather than ``run()`` so the test does not depend on a data
+        provider with the right shape — Phase 3 is about wiring, not
+        execution.
+        """
+        engine = ReplayEngine(config=replay_config, db=seeded_db)
+
+        # Mirror the run() call sequence: resolve run → load seed → build runner.
+        run_id, _start, _end = engine._resolve_run(replay_config)
+        assert run_id == "seed-run"
+
+        wallet_seed, long_seed, short_seed, grid_seed, order_seeds = engine._load_seed(
+            replay_config, run_id,
+        )
+
+        # Seed payload survived loading.
+        assert wallet_seed == Decimal("12345.67")
+        assert long_seed.size == Decimal("1.5")
+        assert long_seed.entry_price == Decimal("100000")
+        assert long_seed.liquidation_price == Decimal("90000")
+        assert short_seed.size == Decimal("0")
+        assert grid_seed is not None
+        assert len(grid_seed.grid) == 4
+        assert len(order_seeds) == 1
+        assert order_seeds[0].client_id == "LX-SEED-1"
+
+        # Build session + runner the same way run() does.
+        from backtest.config import BacktestStrategyConfig
+        from backtest.session import BacktestSession
+
+        strategy_config = BacktestStrategyConfig(
+            strat_id="replay_btcusdt",
+            symbol=SYMBOL,
+            tick_size=replay_config.strategy.tick_size,
+            grid_count=replay_config.strategy.grid_count,
+            grid_step=replay_config.strategy.grid_step,
+            amount=replay_config.strategy.amount,
+            max_margin=replay_config.strategy.max_margin,
+            early_imbalance_multiplier=replay_config.strategy.early_imbalance_multiplier,
+            commission_rate=replay_config.strategy.commission_rate,
+            enable_risk_multipliers=replay_config.strategy.enable_risk_multipliers,
+        )
+        session = BacktestSession(initial_balance=wallet_seed)
+        runner = engine._init_runner(
+            strategy_config,
+            session,
+            long_seed=long_seed,
+            short_seed=short_seed,
+            grid_seed=grid_seed,
+            order_seeds=order_seeds,
+        )
+
+        # Wallet → BacktestSession.initial_balance.
+        assert session.initial_balance == Decimal("12345.67")
+
+        # Position seeds → trackers.
+        assert runner.long_tracker.state.size == Decimal("1.5")
+        assert runner.long_tracker.state.avg_entry_price == Decimal("100000")
+        assert runner.long_tracker.state.liquidation_price == Decimal("90000")
+        # Short seed is zero — tracker stays at default.
+        assert runner.short_tracker.state.size == Decimal("0")
+
+        # Position seeds also propagated into gridcore.Position when risk is on.
+        assert runner._long_position is not None
+        assert runner._long_position.size == Decimal("1.5")
+        assert runner._long_position.liquidation_price == Decimal("90000")
+        # Short Position stays at default (zero seed → no copy).
+        assert runner._short_position is not None
+        assert runner._short_position.size == Decimal("0")
+
+        # Active order seed → BacktestOrderManager.active_orders +
+        # _client_order_ids. Keyed by exchange_order_id (not client_id).
+        order_manager = runner.order_manager
+        assert "ORD-SEED-1" in order_manager.active_orders
+        seeded_order = order_manager.active_orders["ORD-SEED-1"]
+        assert seeded_order.client_order_id == "LX-SEED-1"
+        assert seeded_order.side == "Buy"
+        assert seeded_order.direction == "long"
+        assert seeded_order.price == Decimal("99000")
+        assert seeded_order.qty == Decimal("0.1")
+        assert seeded_order.reduce_only is False
+        assert "LX-SEED-1" in order_manager._client_order_ids
+
+        # Grid seed → GridEngine.grid was restored from the seeded levels.
+        # Grid.restore_grid keeps the level list intact.
+        assert len(runner.engine.grid.grid) == 4
+
+
+# ---------------------------------------------------------------------------
+# B. Pre-check: seed.at_ts too early relative to initial REST snapshot
+# ---------------------------------------------------------------------------
+
+
+class TestReplayEnginePreCheck:
+    """Engine refuses to seed when the recorder snapshot has not landed."""
+
+    def test_replay_engine_pre_check_rejects_when_at_ts_too_early(
+        self, db, seed_ts, snapshot_ts, grid_state_path, mock_instrument,
+    ):
+        """Snapshot rows at T0; seed.at_ts at T0-1s → ValueError surface.
+
+        The error message must include both the seed.at_ts and the
+        snapshot timestamp so the operator can diagnose without
+        re-querying the DB.
+        """
+        # Insert position+wallet at T0 (snapshot_ts), no orders.
+        snapshot_t0 = snapshot_ts
+        with db.get_session() as session:
+            user = User(user_id="user-1", username="precheck")
+            account = BybitAccount(
+                account_id="acc-1", user_id="user-1",
+                account_name="seed", environment="testnet",
+            )
+            strategy = Strategy(
+                strategy_id="strat-1", account_id="acc-1",
+                strategy_type="recorder", symbol=SYMBOL, config_json={},
+            )
+            run = Run(
+                run_id="precheck-run",
+                user_id="user-1", account_id="acc-1", strategy_id="strat-1",
+                run_type="recording", status="running",
+                start_ts=snapshot_t0 - timedelta(minutes=1),
+                end_ts=snapshot_t0 + timedelta(hours=1),
+            )
+            session.add_all([user, account, strategy, run])
+            session.commit()
+
+            PositionSnapshotRepository(session).bulk_insert([
+                PositionSnapshot(
+                    run_id="precheck-run", account_id="acc-1", symbol=SYMBOL,
+                    exchange_ts=snapshot_t0, local_ts=snapshot_t0,
+                    side="Buy", size=Decimal("0"), entry_price=Decimal("0"),
+                    liq_price=None,
+                ),
+                PositionSnapshot(
+                    run_id="precheck-run", account_id="acc-1", symbol=SYMBOL,
+                    exchange_ts=snapshot_t0, local_ts=snapshot_t0,
+                    side="Sell", size=Decimal("0"), entry_price=Decimal("0"),
+                    liq_price=None,
+                ),
+            ])
+            WalletSnapshotRepository(session).bulk_insert([
+                WalletSnapshot(
+                    run_id="precheck-run", account_id="acc-1",
+                    exchange_ts=snapshot_t0, local_ts=snapshot_t0,
+                    coin="USDT",
+                    wallet_balance=Decimal("100"), available_balance=Decimal("100"),
+                ),
+            ])
+            session.commit()
+
+        early_at_ts = snapshot_t0 - timedelta(seconds=1)
+        config = ReplayConfig(
+            database_url="sqlite:///:memory:",
+            run_id="precheck-run",
+            symbol=SYMBOL,
+            start_ts=seed_ts,
+            end_ts=seed_ts + timedelta(hours=1),
+            strategy=ReplayStrategyConfig(
+                tick_size=Decimal("0.1"),
+                grid_count=4,
+                grid_step=0.2,
+                enable_risk_multipliers=True,
+            ),
+            initial_balance=Decimal("10000"),
+            enable_funding=False,
+            seed=SeedConfig(
+                enabled=True,
+                at_ts=early_at_ts,
+                account_id="acc-1",
+                strat_id=STRAT_ID,
+                grid_state_path=grid_state_path,
+            ),
+        )
+
+        engine = ReplayEngine(config=config, db=db)
+
+        with pytest.raises(ValueError) as excinfo:
+            engine._load_seed(config, "precheck-run")
+
+        msg = str(excinfo.value)
+        # Both timestamps must be in the message for diagnosability.
+        assert "precheck-run" in msg
+        # at_ts (the rejected one) appears.
+        assert str(early_at_ts.year) in msg  # at least the year identifies the ts
+        # latest_min / wallet_min / position_min appears (snapshot_t0).
+        assert "wallet_min" in msg or "position_min" in msg or "latest_min" in msg
+
+    def test_pre_check_rejects_when_wallet_snapshot_missing(
+        self, db, seed_ts, snapshot_ts, grid_state_path, mock_instrument,
+    ):
+        """Position snapshot exists but wallet does not → pre-check fails."""
+        with db.get_session() as session:
+            user = User(user_id="user-1", username="precheck")
+            account = BybitAccount(
+                account_id="acc-1", user_id="user-1",
+                account_name="seed", environment="testnet",
+            )
+            strategy = Strategy(
+                strategy_id="strat-1", account_id="acc-1",
+                strategy_type="recorder", symbol=SYMBOL, config_json={},
+            )
+            run = Run(
+                run_id="no-wallet-run",
+                user_id="user-1", account_id="acc-1", strategy_id="strat-1",
+                run_type="recording", status="running",
+                start_ts=snapshot_ts - timedelta(minutes=1),
+                end_ts=seed_ts + timedelta(hours=1),
+            )
+            session.add_all([user, account, strategy, run])
+            session.commit()
+
+            PositionSnapshotRepository(session).bulk_insert([
+                PositionSnapshot(
+                    run_id="no-wallet-run", account_id="acc-1", symbol=SYMBOL,
+                    exchange_ts=snapshot_ts, local_ts=snapshot_ts,
+                    side="Buy", size=Decimal("0"), entry_price=Decimal("0"),
+                    liq_price=None,
+                ),
+                PositionSnapshot(
+                    run_id="no-wallet-run", account_id="acc-1", symbol=SYMBOL,
+                    exchange_ts=snapshot_ts, local_ts=snapshot_ts,
+                    side="Sell", size=Decimal("0"), entry_price=Decimal("0"),
+                    liq_price=None,
+                ),
+            ])
+            session.commit()
+
+        config = ReplayConfig(
+            database_url="sqlite:///:memory:",
+            run_id="no-wallet-run",
+            symbol=SYMBOL,
+            start_ts=seed_ts, end_ts=seed_ts + timedelta(hours=1),
+            strategy=ReplayStrategyConfig(
+                tick_size=Decimal("0.1"), grid_count=4, grid_step=0.2,
+                enable_risk_multipliers=True,
+            ),
+            initial_balance=Decimal("10000"),
+            enable_funding=False,
+            seed=SeedConfig(
+                enabled=True, at_ts=seed_ts,
+                account_id="acc-1", strat_id=STRAT_ID,
+                grid_state_path=grid_state_path,
+            ),
+        )
+
+        engine = ReplayEngine(config=config, db=db)
+        with pytest.raises(ValueError, match="wallet_snapshots"):
+            engine._load_seed(config, "no-wallet-run")
+
+
+# ---------------------------------------------------------------------------
+# C. Disabled seed preserves blank-start behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestReplayEngineSeedDisabled:
+    def test_disabled_seed_returns_all_none(self, db, seed_ts, mock_instrument):
+        config = ReplayConfig(
+            database_url="sqlite:///:memory:",
+            run_id="any-run",
+            symbol=SYMBOL,
+            start_ts=seed_ts,
+            end_ts=seed_ts + timedelta(hours=1),
+            strategy=ReplayStrategyConfig(tick_size=Decimal("0.1")),
+            initial_balance=Decimal("10000"),
+            enable_funding=False,
+        )
+        assert config.seed.enabled is False
+
+        engine = ReplayEngine(config=config, db=db)
+        result = engine._load_seed(config, "any-run")
+        assert result == (None, None, None, None, None)

--- a/apps/replay/tests/test_snapshot_loader.py
+++ b/apps/replay/tests/test_snapshot_loader.py
@@ -1,0 +1,592 @@
+"""Tests for replay.snapshot_loader (feature 0029, Phase 2A)."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+
+from grid_db import (
+    BybitAccount,
+    Order,
+    OrderRepository,
+    PositionSnapshot,
+    PositionSnapshotRepository,
+    Run,
+    Strategy,
+    User,
+    WalletSnapshot,
+    WalletSnapshotRepository,
+)
+
+from gridcore.persistence import GridStateStore
+
+from replay.snapshot_loader import (
+    ActiveOrderSeed,
+    GridStateSeed,
+    PositionStateSeed,
+    SeedDataQualityError,
+    SeedSchemaError,
+    load_active_orders,
+    load_grid_state,
+    load_position_snapshots,
+    load_wallet_snapshot,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (the replay conftest only provides ``db``; we replicate the
+# session + sample-entities pattern from shared/db/tests/conftest.py here).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def session(db):
+    """Provide a session per-test, rolling back at teardown."""
+    sess = db.session_factory()
+    try:
+        yield sess
+    finally:
+        sess.rollback()
+        sess.close()
+
+
+@pytest.fixture
+def sample_user(session):
+    user = User(username="testuser", email="test@example.com")
+    session.add(user)
+    session.flush()
+    return user
+
+
+@pytest.fixture
+def sample_account(session, sample_user):
+    account = BybitAccount(
+        user_id=sample_user.user_id,
+        account_name="test_account",
+        environment="testnet",
+    )
+    session.add(account)
+    session.flush()
+    return account
+
+
+@pytest.fixture
+def sample_strategy(session, sample_account):
+    strategy = Strategy(
+        account_id=sample_account.account_id,
+        strategy_type="GridStrategy",
+        symbol="BTCUSDT",
+        config_json={"grid_count": 50, "grid_step": 0.2},
+    )
+    session.add(strategy)
+    session.flush()
+    return strategy
+
+
+@pytest.fixture
+def sample_run(session, sample_user, sample_account, sample_strategy):
+    run = Run(
+        user_id=sample_user.user_id,
+        account_id=sample_account.account_id,
+        strategy_id=sample_strategy.strategy_id,
+        run_type="recording",
+        status="running",
+        start_ts=datetime(2026, 5, 7, 9, 0, 0, tzinfo=timezone.utc),
+    )
+    session.add(run)
+    session.flush()
+    return run
+
+
+@pytest.fixture
+def base_ts():
+    return datetime(2026, 5, 7, 10, 0, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# load_grid_state
+# ---------------------------------------------------------------------------
+
+
+class TestLoadGridState:
+    """Tolerant grid-state loader: returns None on every miss path."""
+
+    def test_happy_path_returns_seed(self, tmp_path):
+        store = GridStateStore(file_path=str(tmp_path / "grid.json"))
+        grid = [
+            {"side": "Buy", "price": 99.8},
+            {"side": "Buy", "price": 99.6},
+            {"side": "Sell", "price": 100.2},
+        ]
+        store.save("strat-A", grid, grid_step=0.2, grid_count=3)
+        store.flush()
+
+        seed = load_grid_state(store, "strat-A", expected_step=0.2, expected_count=3)
+        assert isinstance(seed, GridStateSeed)
+        assert seed.strat_id == "strat-A"
+        assert seed.grid_step == 0.2
+        assert seed.grid_count == 3
+        assert seed.grid == grid
+
+    def test_no_entry_logs_info_and_returns_none(self, tmp_path, caplog):
+        store = GridStateStore(file_path=str(tmp_path / "grid.json"))
+
+        with caplog.at_level(logging.INFO, logger="replay.snapshot_loader"):
+            seed = load_grid_state(store, "missing-strat", 0.2, 50)
+
+        assert seed is None
+        assert any(
+            "no saved grid state" in rec.message
+            for rec in caplog.records
+            if rec.name == "replay.snapshot_loader"
+        )
+
+    def test_legacy_anchor_only_format_logs_info_and_returns_none(
+        self, tmp_path, caplog
+    ):
+        # Hand-write a legacy entry with no `grid` field. GridStateStore.load
+        # already detects this shape, logs INFO, and returns None — the
+        # loader propagates and emits its own "no saved grid state" log.
+        path = tmp_path / "grid.json"
+        import json
+
+        path.write_text(json.dumps({
+            "strat-legacy": {
+                "anchor_price": 50000.0,
+                "grid_step": 0.2,
+                "grid_count": 50,
+            }
+        }))
+
+        store = GridStateStore(file_path=str(path))
+
+        with caplog.at_level(logging.INFO):
+            seed = load_grid_state(store, "strat-legacy", 0.2, 50)
+
+        assert seed is None
+        # Either the GridStateStore log OR the loader's no-entry log
+        # qualifies as "an INFO log explaining why".
+        assert any(
+            "Legacy anchor format" in rec.message
+            or "no saved grid state" in rec.message
+            for rec in caplog.records
+        )
+
+    def test_step_mismatch_logs_info_and_returns_none(self, tmp_path, caplog):
+        store = GridStateStore(file_path=str(tmp_path / "grid.json"))
+        grid = [{"side": "Buy", "price": 100.0}]
+        store.save("strat-S", grid, grid_step=0.2, grid_count=1)
+        store.flush()
+
+        with caplog.at_level(logging.INFO, logger="replay.snapshot_loader"):
+            seed = load_grid_state(store, "strat-S", expected_step=0.5, expected_count=1)
+
+        assert seed is None
+        assert any(
+            "differs from replay config" in rec.message
+            for rec in caplog.records
+            if rec.name == "replay.snapshot_loader"
+        )
+
+    def test_count_mismatch_returns_none(self, tmp_path):
+        store = GridStateStore(file_path=str(tmp_path / "grid.json"))
+        store.save(
+            "strat-C",
+            [{"side": "Buy", "price": 100.0}],
+            grid_step=0.2,
+            grid_count=1,
+        )
+        store.flush()
+
+        seed = load_grid_state(store, "strat-C", expected_step=0.2, expected_count=99)
+        assert seed is None
+
+
+# ---------------------------------------------------------------------------
+# load_position_snapshots
+# ---------------------------------------------------------------------------
+
+
+class TestLoadPositionSnapshots:
+    """Per the recorder initial-snapshot contract, both sides must be
+    present together."""
+
+    def test_both_sides_present_seeds_both(
+        self, session, sample_account, sample_run, base_ts
+    ):
+        repo = PositionSnapshotRepository(session)
+        repo.bulk_insert([
+            PositionSnapshot(
+                run_id=sample_run.run_id,
+                account_id=str(sample_account.account_id),
+                symbol="BTCUSDT",
+                exchange_ts=base_ts, local_ts=base_ts,
+                side="Buy",
+                size=Decimal("1.5"),
+                entry_price=Decimal("50000"),
+                liq_price=Decimal("45000"),
+            ),
+            PositionSnapshot(
+                run_id=sample_run.run_id,
+                account_id=str(sample_account.account_id),
+                symbol="BTCUSDT",
+                exchange_ts=base_ts, local_ts=base_ts,
+                side="Sell",
+                size=Decimal("0.5"),
+                entry_price=Decimal("51000"),
+                liq_price=Decimal("55000"),
+            ),
+        ])
+
+        long_seed, short_seed = load_position_snapshots(
+            session,
+            sample_run.run_id,
+            str(sample_account.account_id),
+            "BTCUSDT",
+            base_ts + timedelta(seconds=1),
+        )
+
+        assert isinstance(long_seed, PositionStateSeed)
+        assert long_seed.direction == "long"
+        assert long_seed.size == Decimal("1.5")
+        assert long_seed.entry_price == Decimal("50000")
+        assert long_seed.liquidation_price == Decimal("45000")
+
+        assert short_seed.direction == "short"
+        assert short_seed.size == Decimal("0.5")
+        assert short_seed.entry_price == Decimal("51000")
+        assert short_seed.liquidation_price == Decimal("55000")
+
+    def test_both_sides_absent_returns_zero_pair(
+        self, session, sample_account, sample_run, base_ts
+    ):
+        long_seed, short_seed = load_position_snapshots(
+            session,
+            sample_run.run_id,
+            str(sample_account.account_id),
+            "BTCUSDT",
+            base_ts,
+        )
+        assert long_seed.direction == "long"
+        assert long_seed.size == Decimal("0")
+        assert long_seed.entry_price == Decimal("0")
+        assert long_seed.liquidation_price == Decimal("0")
+        assert short_seed.direction == "short"
+        assert short_seed.size == Decimal("0")
+
+    def test_one_side_only_raises_data_quality_error(
+        self, session, sample_account, sample_run, base_ts
+    ):
+        repo = PositionSnapshotRepository(session)
+        repo.bulk_insert([
+            PositionSnapshot(
+                run_id=sample_run.run_id,
+                account_id=str(sample_account.account_id),
+                symbol="BTCUSDT",
+                exchange_ts=base_ts, local_ts=base_ts,
+                side="Buy",
+                size=Decimal("1.0"),
+                entry_price=Decimal("50000"),
+                liq_price=Decimal("45000"),
+            ),
+        ])
+
+        with pytest.raises(SeedDataQualityError, match="missing Sell"):
+            load_position_snapshots(
+                session,
+                sample_run.run_id,
+                str(sample_account.account_id),
+                "BTCUSDT",
+                base_ts + timedelta(seconds=1),
+            )
+
+    def test_one_side_only_sell_raises_data_quality_error(
+        self, session, sample_account, sample_run, base_ts
+    ):
+        repo = PositionSnapshotRepository(session)
+        repo.bulk_insert([
+            PositionSnapshot(
+                run_id=sample_run.run_id,
+                account_id=str(sample_account.account_id),
+                symbol="BTCUSDT",
+                exchange_ts=base_ts, local_ts=base_ts,
+                side="Sell",
+                size=Decimal("1.0"),
+                entry_price=Decimal("51000"),
+                liq_price=Decimal("55000"),
+            ),
+        ])
+
+        with pytest.raises(SeedDataQualityError, match="missing Buy"):
+            load_position_snapshots(
+                session,
+                sample_run.run_id,
+                str(sample_account.account_id),
+                "BTCUSDT",
+                base_ts + timedelta(seconds=1),
+            )
+
+    def test_null_liq_price_coerces_to_zero(
+        self, session, sample_account, sample_run, base_ts
+    ):
+        repo = PositionSnapshotRepository(session)
+        repo.bulk_insert([
+            PositionSnapshot(
+                run_id=sample_run.run_id,
+                account_id=str(sample_account.account_id),
+                symbol="BTCUSDT",
+                exchange_ts=base_ts, local_ts=base_ts,
+                side="Buy",
+                size=Decimal("0"),
+                entry_price=Decimal("0"),
+                liq_price=None,  # zero-size side from initial REST snapshot
+            ),
+            PositionSnapshot(
+                run_id=sample_run.run_id,
+                account_id=str(sample_account.account_id),
+                symbol="BTCUSDT",
+                exchange_ts=base_ts, local_ts=base_ts,
+                side="Sell",
+                size=Decimal("0"),
+                entry_price=Decimal("0"),
+                liq_price=None,
+            ),
+        ])
+
+        long_seed, short_seed = load_position_snapshots(
+            session,
+            sample_run.run_id,
+            str(sample_account.account_id),
+            "BTCUSDT",
+            base_ts + timedelta(seconds=1),
+        )
+        assert long_seed.liquidation_price == Decimal("0")
+        assert short_seed.liquidation_price == Decimal("0")
+
+
+# ---------------------------------------------------------------------------
+# load_wallet_snapshot
+# ---------------------------------------------------------------------------
+
+
+class TestLoadWalletSnapshot:
+    def test_happy_path_returns_decimal(
+        self, session, sample_account, sample_run, base_ts
+    ):
+        repo = WalletSnapshotRepository(session)
+        repo.bulk_insert([
+            WalletSnapshot(
+                run_id=sample_run.run_id,
+                account_id=str(sample_account.account_id),
+                exchange_ts=base_ts, local_ts=base_ts,
+                coin="USDT",
+                wallet_balance=Decimal("12345.67"),
+                available_balance=Decimal("12000.00"),
+            ),
+        ])
+
+        balance = load_wallet_snapshot(
+            session,
+            sample_run.run_id,
+            str(sample_account.account_id),
+            base_ts + timedelta(seconds=1),
+        )
+        assert balance == Decimal("12345.67")
+
+    def test_coin_filter_isolates_usdt_from_btc(
+        self, session, sample_account, sample_run, base_ts
+    ):
+        repo = WalletSnapshotRepository(session)
+        repo.bulk_insert([
+            WalletSnapshot(
+                run_id=sample_run.run_id,
+                account_id=str(sample_account.account_id),
+                exchange_ts=base_ts, local_ts=base_ts,
+                coin="USDT",
+                wallet_balance=Decimal("100"),
+                available_balance=Decimal("100"),
+            ),
+            WalletSnapshot(
+                run_id=sample_run.run_id,
+                account_id=str(sample_account.account_id),
+                exchange_ts=base_ts, local_ts=base_ts,
+                coin="BTC",
+                wallet_balance=Decimal("0.5"),
+                available_balance=Decimal("0.5"),
+            ),
+        ])
+
+        usdt = load_wallet_snapshot(
+            session,
+            sample_run.run_id,
+            str(sample_account.account_id),
+            base_ts + timedelta(seconds=1),
+            coin="USDT",
+        )
+        assert usdt == Decimal("100")
+
+    def test_no_rows_returns_none(
+        self, session, sample_account, sample_run, base_ts
+    ):
+        balance = load_wallet_snapshot(
+            session,
+            sample_run.run_id,
+            str(sample_account.account_id),
+            base_ts,
+        )
+        assert balance is None
+
+
+# ---------------------------------------------------------------------------
+# load_active_orders
+# ---------------------------------------------------------------------------
+
+
+class TestLoadActiveOrders:
+    def test_empty_list_for_clean_account(
+        self, session, sample_account, sample_run, base_ts
+    ):
+        seeds = load_active_orders(
+            session,
+            sample_run.run_id,
+            str(sample_account.account_id),
+            "BTCUSDT",
+            base_ts,
+        )
+        assert seeds == []
+
+    def test_happy_path_with_order_link_id_and_fallback(
+        self, session, sample_account, sample_run, base_ts
+    ):
+        repo = OrderRepository(session)
+        repo.bulk_insert([
+            # Has order_link_id → client_id == order_link_id.
+            Order(
+                run_id=sample_run.run_id,
+                account_id=str(sample_account.account_id),
+                order_id="ORD-LX-1",
+                order_link_id="LX-1",
+                symbol="BTCUSDT",
+                exchange_ts=base_ts, local_ts=base_ts,
+                status="New", side="Buy",
+                price=Decimal("99.8"), qty=Decimal("0.001"),
+                leaves_qty=Decimal("0.001"),
+                reduce_only=False,
+            ),
+            # No order_link_id → client_id falls back to order_id.
+            Order(
+                run_id=sample_run.run_id,
+                account_id=str(sample_account.account_id),
+                order_id="ORD-NOLINK-2",
+                order_link_id=None,
+                symbol="BTCUSDT",
+                exchange_ts=base_ts, local_ts=base_ts,
+                status="PartiallyFilled", side="Sell",
+                price=Decimal("100.2"), qty=Decimal("0.002"),
+                leaves_qty=Decimal("0.001"),
+                reduce_only=False,
+            ),
+        ])
+
+        seeds = load_active_orders(
+            session,
+            sample_run.run_id,
+            str(sample_account.account_id),
+            "BTCUSDT",
+            base_ts + timedelta(seconds=10),
+        )
+
+        assert len(seeds) == 2
+        by_oid = {s.exchange_order_id: s for s in seeds}
+
+        s1 = by_oid["ORD-LX-1"]
+        assert isinstance(s1, ActiveOrderSeed)
+        assert s1.client_id == "LX-1"  # order_link_id wins
+        assert s1.side == "Buy"
+        assert s1.direction == "long"
+        assert s1.remaining_qty == Decimal("0.001")
+        assert s1.reduce_only is False
+
+        s2 = by_oid["ORD-NOLINK-2"]
+        assert s2.client_id == "ORD-NOLINK-2"  # fallback to order_id
+        assert s2.side == "Sell"
+        assert s2.direction == "short"
+        assert s2.remaining_qty == Decimal("0.001")
+
+    def test_reduce_only_null_raises_schema_error(
+        self, session, sample_account, sample_run, base_ts
+    ):
+        repo = OrderRepository(session)
+        repo.bulk_insert([
+            Order(
+                run_id=sample_run.run_id,
+                account_id=str(sample_account.account_id),
+                order_id="ORD-NULL-RO",
+                order_link_id="LX-NULL",
+                symbol="BTCUSDT",
+                exchange_ts=base_ts, local_ts=base_ts,
+                status="New", side="Buy",
+                price=Decimal("99.8"), qty=Decimal("0.001"),
+                leaves_qty=Decimal("0.001"),
+                reduce_only=None,  # pre-Phase-1 row
+            ),
+        ])
+
+        with pytest.raises(SeedSchemaError, match="reduce_only=NULL"):
+            load_active_orders(
+                session,
+                sample_run.run_id,
+                str(sample_account.account_id),
+                "BTCUSDT",
+                base_ts + timedelta(seconds=10),
+            )
+
+    @pytest.mark.parametrize(
+        "side, reduce_only, expected_direction",
+        [
+            ("Buy", False, "long"),
+            ("Sell", False, "short"),
+            ("Buy", True, "short"),
+            ("Sell", True, "long"),
+        ],
+    )
+    def test_direction_derivation_all_combos(
+        self,
+        session,
+        sample_account,
+        sample_run,
+        base_ts,
+        side,
+        reduce_only,
+        expected_direction,
+    ):
+        repo = OrderRepository(session)
+        repo.bulk_insert([
+            Order(
+                run_id=sample_run.run_id,
+                account_id=str(sample_account.account_id),
+                order_id=f"ORD-{side}-{reduce_only}",
+                order_link_id=f"LX-{side}-{reduce_only}",
+                symbol="BTCUSDT",
+                exchange_ts=base_ts, local_ts=base_ts,
+                status="New", side=side,
+                price=Decimal("100"), qty=Decimal("0.001"),
+                leaves_qty=Decimal("0.001"),
+                reduce_only=reduce_only,
+            ),
+        ])
+
+        seeds = load_active_orders(
+            session,
+            sample_run.run_id,
+            str(sample_account.account_id),
+            "BTCUSDT",
+            base_ts + timedelta(seconds=10),
+        )
+        assert len(seeds) == 1
+        assert seeds[0].direction == expected_direction
+        assert seeds[0].side == side
+        assert seeds[0].reduce_only is reduce_only

--- a/docs/features/0029_PLAN.md
+++ b/docs/features/0029_PLAN.md
@@ -1,0 +1,711 @@
+# 0029_PLAN — Seed-aware replay for live/backtest shadow validation
+
+## Description
+
+Replay engine currently starts from blank state (empty positions, fresh
+grid built from anchor in config, zero balance). Live gridbot, by
+contrast, runs with restored grid state (`db/grid_anchor.json` from
+feature 0021), open positions, accumulated wallet balance, and active
+orders on the exchange. The state-gap means even a strategy-identical
+replay diverges from live on the very first tick — not because the
+strategy moved, but because the starting state differs.
+
+This feature adds a **seeding** layer to replay so a recorded live
+session can be replayed from the exact state live had at
+`start_ts`, restoring four dimensions: grid (full level list), position
+state per direction, wallet balance, and active orders on the exchange.
+Source of truth is the recorder database (private streams populated by
+`apps/recorder` running with API credentials) plus the
+`GridStateStore` JSON file shared with live.
+
+After seeding, a comparator pass on the same window can isolate
+strategy divergences from state divergences.
+
+**Four changes outside `apps/replay` are folded into this PR scope**
+(0029 is invalid without them; full detail in "Cross-cutting work in
+scope" below):
+
+1. `apps/gridbot/src/gridbot/executor.py` + `BybitRestClient.place_order`
+   — live sends `orderLinkId = intent.client_order_id` on every
+   placement. Without this, replay's deterministic SHA256-based
+   `client_order_id` cannot join with live's random Bybit `order_id`
+   on any order placed after `start_ts`.
+2. `apps/comparator/src/comparator/loader.py` — apply
+   `client_id = order_link_id or order_id` fallback so seeded /
+   pre-fix-(1) executions still match.
+3. `shared/db/src/grid_db/models.py` + recorder order writer — add
+   `Order.reduce_only` column, populate via the private-orders WS
+   frame.
+4. `apps/recorder/src/recorder/recorder.py` — on private-stream
+   connect, fetch a one-shot REST snapshot of wallet (USDT),
+   positions (both sides, including zero-size), and open orders,
+   write them as the t=0 row of the recording session.
+
+Out of scope: the existing recorder private-stream capture
+(`apps/recorder/src/recorder/recorder.py:165-260` already writes to
+`position_snapshots`, `wallet_snapshots`, `orders` for ongoing WS
+events). Out of scope: adding grid state to recorder schema —
+current path is to share the `GridStateStore` JSON file directly
+between live and replay.
+
+In-scope additions to the recorder side: see Cross-cutting items 3
+(`Order.reduce_only` schema + writer plumbing) and 4 (initial REST
+snapshot at private-stream connect).
+
+Out of scope but flagged: live `db/grid_anchor.json` is currently in
+**legacy anchor-only format** (`{anchor_price, grid_step, grid_count}`,
+no `grid` field). After feature 0021 the expected schema is
+`{grid: [{side, price}, ...], grid_step, grid_count}` per strat_id.
+The current file suggests live persistence has not produced a full-
+grid save since 0021 deploy, OR there is a code path still writing
+the legacy shape. Replay handles a legacy file with a tolerant info-
+log + fresh-build fallback (matches live's behaviour at
+`runner.py:248-263`); track the live-side root cause separately.
+
+## Decisions baked in
+
+- **Single seed source: recorder DB** for positions / wallet /
+  orders; **grid state always from `GridStateStore`**
+  (`packages/gridcore/src/gridcore/persistence.py`). No
+  `seed.mode`, no JSON-files alternative — adds surface, no clear
+  use case while the recorder is the only realistic capture path.
+  Both live and replay use the same `GridStateStore` and the same
+  JSON file.
+- **Grid is seeded as a full level list, NOT as `anchor_price`**.
+  After feature 0021, `GridStateStore.save(grid, grid_step, grid_count)`
+  persists the ordered list of `{side, price}` per strat_id. Live
+  restores via `Grid.restore_grid(...)` (`grid.py:166-197`) called
+  from `GridEngine.__init__(restored_grid=...)` (`engine.py:74-79`);
+  replay takes the same path. `anchor_price` remains only as the
+  fallback "where to build a fresh grid" when no saved entry exists.
+  Legacy anchor-only files (no `grid` field) trigger a runtime info
+  log + fresh-build fallback rather than a hard refusal — matches
+  live's tolerant behaviour at `runner.py:248-263`.
+- **Risk state is seeded into BOTH backtest trackers AND
+  `gridcore.Position`** when `enable_risk_multipliers=True`. Setting
+  only `BacktestPositionTracker.state` (which feeds backtest PnL) is
+  insufficient: `gridcore.Position.size` and
+  `Position.liquidation_price` drive the early_imbalance gate (D-3
+  from feature 0028) and `_apply_*_position_rules` margin/liq
+  branches. Both must reflect the seeded snapshot at t=start_ts.
+- **`liquidation_price` divergence after first risk-update is
+  ACCEPTED, not eliminated.** Live uses Bybit's `liqPrice`; the
+  backtest path's `BacktestRunner._build_position_state` always
+  recomputes via `_estimate_liquidation_price`. We seed the exchange
+  liq into both `BacktestPositionTracker.state.liquidation_price` and
+  `gridcore.Position.liquidation_price` for the FIRST tick window;
+  on the next position update inside replay, the estimator value
+  takes over. Document this transition; comparator must classify
+  liq-driven divergences as known-noise after the transition tick.
+- **Stale-snapshot policy is dimension-specific, not a single
+  threshold.** Private streams are event-driven on Bybit — quiet
+  wallets/positions can sit unchanged for many minutes. Defaults:
+  - `position`: latest snapshot per direction is treated as
+    "current" indefinitely. The recorder's initial REST snapshot
+    writes BOTH sides (including zero-size rows) at the start of
+    every run, so the loader expects both sides to be present for
+    the run; one-side-only is `SeedDataQualityError` (corrupt run),
+    both-empty falls under the Phase 4 pre-check (snapshot has not
+    landed yet).
+  - `wallet`: same — latest is current.
+  - `orders`: built by walking order-update snapshots per `order_id`
+    (latest update ≤ `at_ts`); no global staleness.
+  - `grid_state`: presence-or-fallback; no staleness.
+  Loud-fail is reserved for SCHEMA / config-mismatch errors, not
+  for time gaps. (If recorder ever adds REST-heartbeat snapshots,
+  revisit this and reintroduce a global staleness threshold.)
+- **Active orders are seeded with `client_id = order_link_id or
+  order_id` fallback for pre-existing orders, AND live starts
+  sending `orderLinkId` for new orders.** The fallback alone covers
+  only the seeded snapshot. Any order placed by live after start_ts
+  would still have a random Bybit `order_id` that does not match
+  replay's deterministic `client_order_id` — comparator parity smoke
+  would report 0% match on new fills. Wiring `orderLinkId =
+  intent.client_order_id` into `BybitRestClient.place_order` (~3 LOC
+  change) closes this. Same `client_id = order_link_id or order_id`
+  logic also lands in `apps/comparator/src/comparator/loader.py` so
+  pre-fix executions still join.
+- **Position direction policy is governed by the initial REST
+  snapshot contract.** Bybit hedge-mode only emits per-side updates
+  on activity, but the recorder's initial REST snapshot at run
+  start writes BOTH sides for every symbol (with size=0 when the
+  exchange returns no entry for that side). This makes the loader
+  behaviour binary:
+  - Both sides present for the run → seed both.
+  - Both sides empty (zero rows for this `run_id` + symbol) →
+    `(zero, zero)` fallback. Phase 4 pre-check enforces that the
+    initial snapshot has landed before `seed.at_ts`, so this case
+    only occurs when the snapshot has not yet been written —
+    pre-check rejects it.
+  - Exactly one side missing → `SeedDataQualityError` (corrupt run;
+    initial snapshot did not write a complete pair).
+- **Snapshot at exactly `start_ts`** is not guaranteed. Replay accepts
+  the latest snapshot ≤ `start_ts` per dimension and replays forward
+  from it.
+- **Recorder must produce an initial private snapshot at start.**
+  Bybit's private streams are event-driven — between recorder start
+  and the first wallet/position/order change there can be an
+  arbitrary window during which the loader's "latest ≤ at_ts" query
+  returns NOTHING, even though state existed live. Replay would then
+  silently fall back to `config.initial_balance` / blank positions
+  — looks healthy, is wrong. Required: recorder must, on connect,
+  fetch a one-shot REST snapshot of wallet / positions / open
+  orders and write it as the t=0 row for that recording session.
+  Verify this in `apps/recorder/src/recorder/recorder.py` before
+  trusting any pre-Phase-4 seed run; included as Cross-cutting #4
+  in this PR. Phase 4 pre-checks that the recorded window starts
+  with at least one private snapshot of each dimension that has
+  any subsequent activity.
+
+## Files / functions
+
+### Data layer
+
+- `shared/db/src/grid_db/models.py:307-405` — three columns added
+  by Phase 1 step 1: `Order.reduce_only` (nullable bool),
+  `PositionSnapshot.run_id` (FK → `runs.run_id`),
+  `WalletSnapshot.run_id` (FK → `runs.run_id`). `shared/db/` has no
+  migration framework; new DBs get the columns via
+  `Base.metadata.create_all`, existing SQLite/Postgres deploys
+  apply three `ALTER TABLE ... ADD COLUMN` statements per the
+  runbook in Phase 1.
+
+  New indexes (also Phase 1):
+  - `(run_id, account_id, symbol, side, exchange_ts)` on
+    `position_snapshots` — supports `get_latest_before`.
+  - `(run_id, account_id, coin, exchange_ts)` on `wallet_snapshots`
+    — supports `get_latest_before`.
+  - `(run_id, account_id, symbol, exchange_ts)` on `orders` — the
+    existing `ix_orders_account_exchange_ts` is account-only and
+    stops short of the new run-scoped query.
+- `shared/db/src/grid_db/repositories.py` — add three lookup methods.
+  Schema realities (verified in `models.py`):
+  - `PositionSnapshot` has no `leverage` column; `side` is `'Buy'/'Sell'`,
+    not `'long'/'short'`. Direction must be derived: `'long'` when
+    `side=='Buy'`, `'short'` when `side=='Sell'` (Bybit hedge-mode
+    convention).
+  - `WalletSnapshot` has a `coin` column — must filter to USDT.
+  - `Order` is a stream of state-change snapshots, NOT a lifecycle
+    table. There is no `created_at`/`closed_at`. **`reduce_only` is
+    not currently persisted** — add a `reduce_only: bool` column
+    (nullable for back-compat) and populate it from the private
+    orders WS frame's `reduceOnly` field via recorder's order
+    writer. `OrderUpdateEvent` (`packages/gridcore/src/gridcore/events.py`)
+    also gains the field. This is in 0029 scope.
+  Methods (all three accept `run_id` after the schema additions in
+  Phase 1 step 1, so wallet/position/order seed queries are uniformly
+  scoped to one recorder run):
+  - `PositionSnapshotRepository.get_latest_before(run_id, account_id, symbol, side, at_ts)`
+    → `Optional[PositionSnapshot]`. SELECT … ORDER BY exchange_ts DESC
+    LIMIT 1 with `run_id, account_id, symbol, side, exchange_ts <=
+    at_ts`.
+  - `WalletSnapshotRepository.get_latest_before(run_id, account_id, coin, at_ts)`
+    → `Optional[WalletSnapshot]`. Same shape, plus `coin` filter
+    (default `'USDT'`).
+  - `OrderRepository.get_active_at(run_id, account_id, symbol, at_ts)`
+    → `list[Order]`. Algorithm: filter by `run_id` first (protects
+    against an order whose last snapshot was `'New'` in a PREVIOUS
+    run leaking in if recorder was killed before the terminal
+    update), then per `order_id` take the LATEST snapshot with
+    `exchange_ts <= at_ts`; keep only those where the latest snapshot
+    has `status in ('New', 'PartiallyFilled')` AND `leaves_qty > 0`.
+    Implementable as a self-join (correlated subquery
+    `MAX(exchange_ts) GROUP BY order_id`) or as in-Python aggregation
+    over a single ordered fetch when the result set is small.
+- `packages/gridcore/src/gridcore/persistence.py` — `GridStateStore.load(strat_id)`
+  already returns the full saved entry (`grid: list[{side, price}]`,
+  `grid_step`, `grid_count`) or `None`. No new code; replay reuses it
+  read-only. The schema fingerprint check (saved step/count vs current
+  config) is enforced inside the loader function below.
+
+### New module
+
+- `apps/replay/src/replay/snapshot_loader.py` — pure functions, no
+  DB session ownership. Returns plain dataclasses ready to inject:
+  - `load_grid_state(state_store: GridStateStore, strat_id: str, expected_step: float, expected_count: int) -> Optional[GridStateSeed]`
+    — wraps `state_store.load(strat_id)`. Returns `None` (let the engine
+    fall back to fresh build) when: no entry; entry is in legacy
+    anchor-only format (no `grid` field); `grid_step`/`grid_count`
+    differ from replay config. Each "no" path emits an info log
+    explaining why, mirroring live's tolerance.
+  - `load_position_snapshots(db_session, run_id, account_id, symbol, at_ts) -> tuple[PositionStateSeed, PositionStateSeed]`
+    — one per direction. The contract requires the recorder's initial
+    REST snapshot to write BOTH sides (long and short) including
+    zero-size rows. Loader behaviour:
+    - Both sides present → return both as `PositionStateSeed`.
+    - Neither side present in the run → return `(zero, zero)` (the
+      run had not received any position activity yet AND the initial
+      snapshot has not landed; pre-check in Phase 4 step 2 catches
+      this).
+    - Exactly one side missing → raise `SeedDataQualityError`. After
+      the initial-snapshot contract this should never happen; if it
+      does, the recorder run is corrupt and seeding from it is unsafe.
+  - `load_wallet_snapshot(db_session, run_id, account_id, at_ts, coin: str = 'USDT') -> Optional[Decimal]`
+    — returns `None` if no wallet snapshot exists for the coin
+    within this run (caller decides fallback to
+    `config.initial_balance`).
+  - `load_active_orders(db_session, run_id, account_id, symbol, at_ts) -> list[ActiveOrderSeed]`
+    — empty list is a valid happy path (clean grid, no live orders
+    yet). Each row has `client_id = order_link_id or order_id` so
+    matching never fails on a missing `orderLinkId`. `reduce_only` is
+    read from the new `Order.reduce_only` column (added by the
+    recorder-schema extension — see Edge cases). `direction` derived
+    from `side` + `reduce_only` per Bybit hedge-mode rules
+    (`Buy + reduceOnly=False -> long`; `Sell + reduceOnly=False -> short`;
+    `Buy + reduceOnly=True -> short`; `Sell + reduceOnly=True -> long`).
+    If a row has `reduce_only=NULL` (pre-extension data), the loader
+    raises `SeedSchemaError` rather than guess.
+  No `SeedStaleError` is raised by this iteration (see Decisions on
+  dimension-specific staleness).
+
+### Replay engine wiring
+
+- `apps/replay/src/replay/config.py` — extend `ReplayConfig` with a
+  nested `seed:` section:
+  - `enabled: bool` (default `false` — keep existing blank-start
+    behaviour for users who don't have recorded data)
+  - `at_ts: datetime` (typically equals replay window start)
+  - `account_id: str` (required when `enabled`)
+  - `strat_id: str` (required when `enabled`; grid-state lookup key)
+  - `grid_state_path: str` (default `db/grid_anchor.json` — legacy
+    filename retained from 0021; consumed via `GridStateStore`)
+  - `wallet_coin: str` (default `"USDT"`)
+- `apps/replay/src/replay/engine.py:69-end` (`ReplayEngine.__init__`,
+  `ReplayEngine.run`) — between data-provider construction and
+  `BacktestRunner` instantiation, call the seed loaders and pass the
+  results into the runner. Add a "seed summary" log line:
+  `Seeded: long.size=…, short.size=…, anchor=…, balance=…, active_orders=N`.
+
+### Backtest runner / engine / order manager
+
+- `apps/backtest/src/backtest/runner.py:64-110` — `BacktestRunner.__init__`
+  already accepts `long_tracker`, `short_tracker`, `anchor_price`. Extend
+  with new optional kwargs:
+  - `restored_grid: Optional[list[dict]] = None` — passed through to
+    `GridEngine.__init__(restored_grid=...)`. Mirrors live runner's
+    `_load_grid_state()` → `GridEngine` flow.
+  - `seeded_active_orders: Optional[list[ActiveOrderSeed]] = None` —
+    after tracker/Grid setup, call
+    `BacktestOrderManager.seed_active_orders(...)`.
+  - When risk multipliers are enabled AND position seeds are provided,
+    BacktestRunner ALSO copies seeded fields into the
+    `gridcore.Position` instances (`self._long_position.size`,
+    `.liquidation_price`) directly after tracker.seed_state(). Without
+    this, the first tick's risk update / early_imbalance gate runs on
+    stale `Position.size = 0` and `liquidation_price = 0`.
+  When `restored_grid` is provided, `anchor_price` is ignored
+  (matches live).
+- `apps/backtest/src/backtest/position_tracker.py:46-90` — add
+  `BacktestPositionTracker.seed_state(seed: PositionStateSeed)` that
+  sets `self.state.size`, `self.state.avg_entry_price`,
+  `self.state.liquidation_price` (new field — see below),
+  `self.state.realized_pnl=0`, `self.state.commission_paid=0`
+  directly. Bypasses `process_fill`. The seeded
+  `liquidation_price` is the snapshot value from
+  `PositionSnapshot.liq_price`; it survives until the next replay
+  position update reaches `_estimate_liquidation_price`. Document
+  this transition in code comments.
+- `apps/backtest/src/backtest/position_tracker.py:27` — add field
+  `liquidation_price: Decimal = Decimal('0')` to `PositionState`.
+- `apps/backtest/src/backtest/order_manager.py:35-120` —
+  `BacktestOrderManager` currently builds orders from intents via
+  `_handle_place_intent`. Add `seed_active_orders(orders: list[ActiveOrderSeed])`
+  that registers each seed as a `SimulatedOrder` into both
+  `self.active_orders: dict[str, SimulatedOrder]` (public, no
+  underscore — `order_manager.py:57`) and `self._client_order_ids:
+  set[str]` (`order_manager.py:62`). Required fields per row:
+  `client_id`, `exchange_order_id` (set as the simulator's
+  `order_id`), `side`, `price`, `remaining_qty`, `reduce_only`,
+  `direction`. The `TradeThroughFillSimulator._should_fill` reads
+  only `side` / `limit_price` / `current_price` and uses STRICT
+  comparisons (`current_price < limit` for Buy, `current_price >
+  limit` for Sell — `fill_simulator.py:71-74`), so well-formed
+  seeded orders are fillable as soon as price crosses the limit
+  strictly. Tests must cover the case where `client_id` was derived
+  from `order_id` (i.e. `order_link_id` was NULL on the live
+  order) — comparator parity must still work.
+
+### Seed dataclass shapes (for type safety)
+
+Add to `apps/replay/src/replay/snapshot_loader.py`:
+
+- `GridStateSeed(strat_id: str, grid: list[dict], grid_step: float, grid_count: int)`
+  — full level list. `anchor_price` is NOT part of the seed; live
+  doesn't store it post-0021, and replay reconstructs it from
+  `wait_center()` after `restore_grid` if needed.
+- `PositionStateSeed(direction: str, size: Decimal, entry_price: Decimal, liquidation_price: Decimal)`
+  — no `leverage`: `PositionSnapshot` doesn't store it. Replay reads
+  `leverage` from its strategy config (`BacktestStrategyConfig.leverage`,
+  default 10) for tracker initialization, same as today.
+- `ActiveOrderSeed(client_id: str, exchange_order_id: str, side: str, direction: str, price: Decimal, remaining_qty: Decimal, reduce_only: bool, exchange_ts: datetime)`
+  — `client_id = order_link_id or order_id`. `direction` derived from
+  `side + reduce_only` per Bybit hedge-mode rules. No `grid_level` in
+  the seed itself; `BacktestOrderManager.seed_active_orders` builds
+  each `SimulatedOrder` with `grid_level=0` (the simulator ignores
+  this field for fill eligibility — only `side`/`price`/`current_price`
+  are read; the field exists for grid-internal accounting that
+  doesn't apply to externally-seeded orders).
+
+## Algorithm
+
+### Phase 1 — data-layer additions
+
+1. **Schema additions on three tables.**
+
+   a) `Order.reduce_only: bool` (nullable) — adapter populates from
+      `reduceOnly` in the private-stream frame; `OrderUpdateEvent`
+      gains the field.
+
+   b) `PositionSnapshot.run_id: str` (FK → `runs.run_id`, nullable
+      until backfill, then non-nullable for new rows). Required so
+      `load_position_snapshots` can scope to the current recorder
+      run and avoid pulling stale rows from a previous run that
+      shared the same `account_id` / `symbol`.
+
+   c) `WalletSnapshot.run_id: str` (FK → `runs.run_id`, same nullable-
+      then-required pattern). Same rationale.
+
+   `shared/db/` has no migration framework; new DBs get the columns
+   via `Base.metadata.create_all()`. Existing deploys: ship a runbook
+   with three `ALTER TABLE ... ADD COLUMN` statements (no DEFAULT,
+   so old rows stay NULL). The loaders and repository methods treat
+   NULL `run_id` as "pre-migration row, ignore for run-scoped
+   queries"; the loader for `Order.reduce_only` treats NULL as
+   `SeedSchemaError`.
+
+   Recorder writer plumbing: `WalletWriter.__init__` and
+   `PositionWriter.__init__`
+   (`apps/event_saver/src/event_saver/writers/wallet_writer.py:40`,
+   `position_writer.py:40`) currently do not take `run_id`. Add the
+   parameter; recorder passes its existing `self._run_id`
+   (`apps/recorder/src/recorder/recorder.py:92, 160-177`) on
+   construction; writer stamps every emitted ORM row with it.
+
+   **Runbook note:** existing recordings (orders rows with NULL
+   `reduce_only`, OR wallet/position rows with NULL `run_id`) cannot
+   be used for seeding. They remain queryable for trade-comparison
+   purposes via `private_executions`, but Phase 4's seed step must be
+   driven from a recorder run started AFTER this migration ships.
+2. In `repositories.py`, add the three `get_latest_before` /
+   `get_active_at` methods using the run-scoped indexes added in
+   Phase 1 step 1 (the existing `ix_orders_account_exchange_ts` and
+   `ix_position_snapshots_account_ts` are not enough; the new
+   indexes listed in Data layer are required for these queries to
+   stay cheap as recordings grow).
+3. In `position_tracker.py`, extend `PositionState` with
+   `liquidation_price`. All existing call-sites that construct
+   `PositionState` get a default `Decimal('0')` and continue to work.
+4. Unit-test repositories on a fixture DB:
+   - `get_latest_before` with two snapshots — query "before ts"
+     returns the right one; query with `ts` between gives the older.
+   - `get_active_at` with two `Order` rows for the same `order_id`
+     across different `run_id`s — pre-existing "New" row from prior
+     run does NOT leak (covered by Cross-cutting tests #3, restated
+     here so the repository test exists alongside the loader tests).
+   - `get_latest_before` for `PositionSnapshot` returning exactly
+     one side (e.g. only `'Buy'` rows for a `run_id` / symbol while
+     `'Sell'` is absent) — `load_position_snapshots` lifts this to
+     `SeedDataQualityError`; the repository itself returns
+     `(snapshot, None)` and the loader does the classification.
+   - Pre-migration row (`reduce_only IS NULL`) on active-order
+     query must surface as a clear error, not a silent `False`.
+
+### Phase 2A — snapshot loader (parallel with 2B)
+
+1. Implement `snapshot_loader.py` with the four loader functions and
+   the seed dataclasses.
+2. `load_grid_state` instantiates a `GridStateStore`, calls
+   `.load(strat_id)`. Tolerant return-`None` fallback (matches live's
+   `runner.py:248-263`) on: no entry; legacy anchor-only format (no
+   `grid` field); `grid_step`/`grid_count` mismatch with replay
+   config. Each fallback path emits an INFO log explaining why. The
+   only loud failure is a malformed JSON / IO error from the store
+   itself — let that propagate.
+3. Each DB-backed loader returns the latest snapshot ≤ `at_ts` per
+   dimension and does NOT compute or reject on staleness — private
+   streams are event-driven on Bybit and quiet wallets/positions
+   sit unchanged for arbitrary periods (see "Decisions baked in"
+   for the dimension-specific policy). The only failures:
+   - `load_position_snapshots`: `SeedDataQualityError` if exactly
+     one side has rows for this `run_id` while the other is empty
+     (initial REST snapshot must write both); both empty maps to
+     `(zero, zero)` and is caught by Phase 4 pre-check.
+   - `load_active_orders`: `SeedSchemaError` per-row if
+     `reduce_only IS NULL` (pre-Phase-1-migration recorder data).
+4. Unit-tests against a fixture DB / temp JSON covering: no snapshot
+   → caller fallback path returns `None`; legacy grid file → INFO
+   log + `None`; config mismatch on grid → INFO log + `None`;
+   pre-extension order row (NULL `reduce_only`) → `SeedSchemaError`;
+   happy path returns expected seed dataclass; old-but-not-rejected
+   snapshot (e.g. 6 hours stale wallet) returns the dataclass with
+   no error.
+
+### Phase 2B — backtest runner / order manager seeding (parallel with 2A)
+
+1. `BacktestPositionTracker.seed_state(seed)` — direct state write,
+   no commission / no realized PnL.
+2. `BacktestOrderManager.seed_active_orders(orders)` — inject
+   pre-existing orders using the seed `client_id` (which is
+   `order_link_id` when present, else the Bybit-assigned `order_id`
+   per the fallback rule). Each seed becomes a `SimulatedOrder`
+   written into `self.active_orders[exchange_order_id]` and its
+   `client_id` added to `self._client_order_ids`. Verify they
+   participate in the next `process_tick` fill check
+   (TradeThroughFillSimulator).
+3. Unit tests:
+   - seed → confirm seeded orders appear in
+     `order_manager.active_orders` (public dict; no
+     `get_active_orders()` accessor exists) and
+     `_client_order_ids`.
+   - seed Buy@55.0 → tick at 55.0 → fill_simulator returns
+     `should_fill=False` (strict `<`); tick at 54.9 → fill triggers
+     → tracker updates. Mirror for Sell with strict `>`.
+   - **wallet-seed-survives-update_equity**: construct
+     `BacktestSession(initial_balance=Decimal("123.45"))`, call
+     `session.update_equity(timestamp, unrealized_pnl=Decimal("0"))`
+     once; assert `session.current_balance == Decimal("123.45")`.
+     This test guards against a future regression where someone
+     "fixes" the seed by writing only `current_balance` post-init.
+   - seed → tick → seeded `Position.liquidation_price` is unchanged
+     UNTIL a fill triggers `_update_risk_multipliers` (see Edge
+     cases below for the documented overwrite race).
+
+### Phase 3 — replay engine orchestration
+
+1. `ReplayConfig` schema extension (`seed:` block) — `enabled:
+   bool`, `at_ts`, `account_id`, `strat_id`, `grid_state_path`,
+   `wallet_coin`. No `mode` field; the only source is the recorder
+   DB plus `GridStateStore` for the grid file (legacy `from_files`
+   mode dropped).
+2. `ReplayEngine.run`:
+   - If `seed.enabled is False`: existing blank-start behaviour.
+   - If `seed.enabled is True`:
+     - Resolve `account_id`, open DB session.
+     - Call all four loaders. Tolerant fallback paths return `None`
+       and the engine treats them as blank for that dimension.
+     - `wallet_seed: Optional[Decimal] = load_wallet_snapshot(...)`.
+       Construct `BacktestSession(initial_balance=wallet_seed)` when
+       not None; otherwise
+       `BacktestSession(initial_balance=config.initial_balance)`.
+     - Construct `BacktestPositionTracker` per direction, call
+       `seed_state(...)` for each direction with a non-empty seed.
+     - Copy seeded `size` / `liquidation_price` into the
+       corresponding `gridcore.Position` instances when
+       `enable_risk_multipliers=True`.
+     - Pass `restored_grid` (from `GridStateSeed.grid`) +
+       `seeded_active_orders` into `BacktestRunner.__init__`.
+     - Log seed summary line.
+3. End-to-end smoke test: write fixture snapshots into a temp DB +
+   a temp `GridStateStore` JSON file, create a one-tick replay window,
+   assert: `BacktestRunner._long_position.size` and
+   `_short_position.size` match seeded values;
+   `BacktestSession.initial_balance` matches the wallet seed;
+   `BacktestOrderManager.active_orders` count matches; constructed
+   `Grid.grid` equals the seeded list (level-by-level via
+   `Grid.restore_grid` path); legacy anchor-only file logs INFO and
+   falls back to fresh build (no exception); pre-extension order row
+   (NULL `reduce_only`) raises `SeedSchemaError`.
+
+### Phase 4 — comparator parity smoke
+
+1. Run a tiny live + recorder window (e.g. 10 minutes of LTCUSDT)
+   with private streams enabled. Recorder must be on a build that
+   includes the `Order.reduce_only` column AND the initial REST
+   snapshot at private-stream connect (Cross-cutting #3 + #4) —
+   recordings produced before either change are not eligible.
+2. **Pre-check:** for the chosen `run_id`, query
+   `MIN(exchange_ts)` on `wallet_snapshots` AND
+   `position_snapshots` (filtered by `run_id`). Both must return a
+   non-NULL value (the recorder's initial REST snapshot writes one
+   wallet row and a long+short pair of position rows on connect —
+   these are mandatory). Take the latest of the two and assert
+   `seed.at_ts >= that_value + small_margin` (e.g. 5s).
+   `orders` is INTENTIONALLY NOT in the pre-check: a clean account
+   may legitimately have zero open orders at recorder start, in
+   which case the table contains no rows for this `run_id` and a
+   strict `MIN` requirement would falsely reject a valid happy path.
+   `load_active_orders` returning `[]` for an empty-orders run is
+   correct.
+3. Run replay with `seed.enabled=true, seed.at_ts=window_start` over
+   the same window.
+4. Run `comparator` over the result. Assert `match_rate ≥ 0.95` on
+   matched executions (looser threshold for first run; tighten as
+   sources of divergence are diagnosed).
+
+## Cross-cutting work in scope
+
+These pieces are required for 0029 to deliver any measurable parity
+and live in this PR (not a separate "0029a"):
+
+1. **Live executor sends `orderLinkId`** —
+   `BybitRestClient.place_order`
+   (`packages/bybit_adapter/src/bybit_adapter/rest_client.py:452-499`)
+   already accepts `order_link_id: Optional[str]` and plumbs it to
+   pybit. The executor at `apps/gridbot/src/gridbot/executor.py:170-187`
+   currently does not pass it; the change is one kwarg
+   `order_link_id=intent.client_order_id`.
+2. **Comparator `client_id` fallback** —
+   `apps/comparator/src/comparator/loader.py:_aggregate_fills` (~lines
+   113-117) currently skips executions where `order_link_id is None`.
+   Replace the skip with `client_id = ex.order_link_id or ex.order_id`
+   so old/seeded executions still match. After (1) lands, the new
+   pathway is rare — the fallback exists to keep this PR's recorded
+   data testable even though some early executions predate (1).
+3. **`Order.reduce_only` schema + writer** — column add (nullable for
+   back-compat), recorder's order writer reads `reduceOnly` from the
+   private-orders WS frame.
+4. **Recorder initial REST snapshot** —
+   `apps/recorder/src/recorder/recorder.py` on private-stream connect
+   calls one-shot REST: `get_wallet_balance`, `get_positions`,
+   `get_open_orders`. Writes them as the t=0 row of the recording
+   session. Without this, "latest ≤ at_ts" silently returns NULL on
+   quiet streams and seeding falls back to defaults.
+
+   **Initial-snapshot row contract:**
+   - `WalletSnapshot`: one row per `coin` returned by
+     `get_wallet_balance` (we filter to USDT downstream, but writing
+     all coins is fine), `account_id` set, `exchange_ts = local_ts =
+     now()` taken at REST-call time, `wallet_balance` and
+     `available_balance` from the response.
+   - `PositionSnapshot`: ALWAYS two rows per symbol — one with
+     `side='Buy'` (long) and one with `side='Sell'` (short) — even
+     when the corresponding side is absent in the REST response
+     (in that case `size=0`, `entry_price=0`, `liq_price=NULL`).
+     The "always two rows" invariant lets the loader treat the
+     presence of exactly one side as a `SeedDataQualityError`
+     rather than a benign "no activity" case.
+   - `Order`: one row per open order from `get_open_orders`,
+     `status='New'` (or `'PartiallyFilled'` if `cumExecQty>0`),
+     `leaves_qty=qty-cumExecQty`, `reduce_only` from the response,
+     `order_link_id` from the response (may be NULL for orders
+     placed before Cross-cutting #1 lands). `exchange_ts` and
+     `local_ts` set to the snapshot timestamp (REST-call wall-clock),
+     NOT the order's original `createdTime`. This guarantees the
+     snapshot row sorts BEFORE any subsequent WS-stream rows for the
+     same `order_id` in the same `run_id`, so the loader's
+     `MAX(exchange_ts) GROUP BY order_id` always picks up the
+     latest WS state when one exists, and falls back to the snapshot
+     row only when no further updates have arrived.
+   - All three DB-snapshot dimensions (wallet, positions, orders)
+     use the same `run_id` as the subsequent stream rows so the
+     loader's per-account / per-symbol queries see the snapshot row
+     first chronologically. Grid state is a JSON file (no run_id);
+     replay reads it via `GridStateStore.load(strat_id)` independent
+     of the recording session.
+
+## Cross-cutting tests
+
+In addition to the per-phase tests in the Algorithm section, two
+tests verify the cross-cutting changes work end-to-end:
+
+- **Live executor → REST client passes `order_link_id`.** Mock
+  `BybitRestClient.place_order`, drive `IntentExecutor.execute_place`
+  with a `PlaceLimitIntent(client_order_id="abc123", ...)`, assert
+  the REST mock was called with `order_link_id="abc123"`. Lives in
+  `apps/gridbot/tests/test_executor.py`.
+- **Comparator `client_id` fallback groups by both branches.** Build
+  a fixture `private_executions` set containing two rows: one with
+  `order_link_id='LX1', order_id='ORD-A'`, one with
+  `order_link_id=None, order_id='ORD-B'`. Run `LiveTradeLoader.load`,
+  assert the result contains exactly two `NormalizedTrade` records,
+  with `client_order_id == 'LX1'` and `client_order_id == 'ORD-B'`
+  respectively (the second proving the fallback path). Lives in
+  `apps/comparator/tests/test_loader.py`.
+- **`OrderRepository.get_active_at` filters by run_id.** Insert two
+  Order rows for the same `order_id` and `account_id` but different
+  `run_id`s — the older run with `status='New', leaves_qty>0` (no
+  terminal update because recorder was killed) and the new run with
+  no rows yet. Call `get_active_at(run_id=NEW, ...)`; assert empty
+  result. Without this filter the stale "New" row would leak into
+  the new run's seed and produce a phantom active order.
+
+## Edge cases and known limitations
+
+- **Recenter between snapshot and start_ts.** If the live grid
+  recentered after the saved JSON was last written, the file is
+  stale relative to live state at start_ts. `GridStateStore` has
+  no per-save timestamp metadata to detect this. Mitigation:
+  copy `db/grid_anchor.json` at the same wall-clock moment as
+  start_ts; or require `seed.at_ts` ≈ file mtime; or extend
+  GridStateStore to embed a `saved_at` timestamp per strat_id
+  (separate small change, not part of this feature).
+- **Legacy `db/grid_anchor.json` format.** Live currently has the
+  anchor-only legacy format on disk (no `grid` field). Replay will
+  log INFO and fall back to a fresh anchor-based build (matches
+  live's tolerant `runner.py:248-263` behaviour). Comparator parity
+  on the grid dimension will be poor until live produces a fresh
+  full-grid save — but seeding for positions / wallet / orders
+  proceeds normally.
+- **Funding accruals.** Live's wallet_balance reflects funding
+  received between snapshot and start_ts; replay's
+  `FundingSimulator` will replay funding from start_ts. Discrepancies
+  are reported by comparator separately and are not blockers for
+  intent parity.
+- **`Position.amount_multiplier` not seeded.** Multipliers are
+  derived state — `calculate_amount_multiplier` recomputes them on
+  the first risk-update tick from seeded position fields. No need to
+  seed.
+- **`liquidation_price` divergence after the first risk update.**
+  Live uses Bybit's `liqPrice`; backtest's
+  `_estimate_liquidation_price` differs. Order of overwrite on
+  tick 1 (`apps/backtest/src/backtest/engine.py:334-348`):
+  1. `runner.process_fills(tick)` runs FIRST. If a seeded active
+     order fills on tick 1, `_process_fill` calls
+     `_update_risk_multipliers` (`runner.py:470`) which writes
+     `_estimate_liquidation_price` into
+     `self._long_position.liquidation_price` /
+     `self._short_position.liquidation_price` (`runner.py:599-600`)
+     — the seeded liq is overwritten BEFORE `execute_tick` reads
+     it on the same tick.
+  2. `session.update_equity(...)` — does not touch liq_price.
+  3. `runner.execute_tick(tick)` reads whatever liq_price is in
+     place at this point.
+  Therefore: the seeded liq_price is effective for tick 1's risk
+  decisions ONLY when no seeded active order crosses on that tick.
+  If a seeded order does cross, the very tick that uses it is the
+  same tick that overwrites it. This is acceptable: comparator
+  classifies any liq-driven divergence after a fill on the seeded
+  orders as known-noise.
+- **`reduce_only` extraction.** `direction` for a Bybit hedge-mode
+  order needs both `side` and `reduce_only` (a `Sell` is open-short
+  if `reduce_only=False`, close-long if `reduce_only=True`). The
+  schema + writer changes that surface `reduce_only` are in scope —
+  Phase 1 step 1 + Cross-cutting #3 above. Pre-extension rows
+  (NULL `reduce_only`) raise `SeedSchemaError` rather than silently
+  defaulting to `False` and emitting wrong directions.
+- **Position direction is derived from `side`, not stored.**
+  PositionSnapshot side is `'Buy'` (long) / `'Sell'` (short) per
+  Bybit hedge-mode convention. Loader maps once.
+- **Wallet seed must set `BacktestSession.initial_balance`, not just
+  `current_balance`.** `session.update_equity()` recomputes
+  `equity = self.initial_balance + total_realized_pnl + unrealized_pnl
+  - total_commission + total_funding` and writes that into
+  `current_balance` (`apps/backtest/src/backtest/session.py:176-185`).
+  On the very first tick, `realized_pnl=commission=funding=0` and
+  `unrealized_pnl≈0`, so `current_balance` is reset to
+  `self.initial_balance` — wiping a seed that only touched
+  `current_balance`. Two acceptable fixes:
+  (a) construct `BacktestSession(initial_balance=wallet_seed)` so the
+  baseline IS the seeded number; the equity-curve baseline becomes the
+  live wallet at `at_ts`, which is the right meaning for "replay starts
+  here";
+  (b) introduce a separate `balance_baseline: Decimal` field used by
+  `update_equity` and seeded independently.
+  This plan picks (a): `ReplayEngine` passes
+  `initial_balance=wallet_seed` (a `Decimal`, not a dataclass — the
+  loader returns `Optional[Decimal]` directly) into
+  `BacktestSession(...)` and skips `current_balance` post-init writes.
+  When `wallet_seed is None` (no snapshot found, blank-start), fall
+  back to `config.initial_balance` as before.
+
+## References
+
+- `db/grid_anchor.json` — live grid state file (format set by
+  `gridcore.persistence.GridStateStore`).
+- `apps/recorder/src/recorder/recorder.py:165-260` — private-stream
+  capture (writes the four snapshot tables).
+- `apps/comparator/src/comparator/loader.py:LiveTradeLoader` — already
+  reads `private_executions`; will get richer ground truth once
+  replay produces matching IDs.
+- `docs/features/0028_PLAN.md` — neighbour audit; sets the bbu2-
+  alignment context this validation closes the loop on.

--- a/packages/bybit_adapter/src/bybit_adapter/normalizer.py
+++ b/packages/bybit_adapter/src/bybit_adapter/normalizer.py
@@ -326,6 +326,8 @@ class BybitNormalizer:
                 price=Decimal(order_data.get("price", "0")),
                 qty=Decimal(order_data.get("qty", "0")),
                 leaves_qty=Decimal(order_data.get("leavesQty", "0")),
+                # 0029: required for active-order seed direction derivation.
+                reduce_only=bool(order_data.get("reduceOnly", False)),
             )
             events.append(event)
 

--- a/packages/gridcore/src/gridcore/events.py
+++ b/packages/gridcore/src/gridcore/events.py
@@ -117,6 +117,9 @@ class OrderUpdateEvent(Event):
     price: Decimal = Decimal('0')
     qty: Decimal = Decimal('0')
     leaves_qty: Decimal = Decimal('0')  # Remaining unfilled quantity
+    # 0029: required for direction derivation in active-order seed path.
+    # Adapter populates from `reduceOnly` in the private-stream payload.
+    reduce_only: bool = False
 
     def __post_init__(self):
         if self.event_type != EventType.ORDER_UPDATE:

--- a/shared/db/src/grid_db/models.py
+++ b/shared/db/src/grid_db/models.py
@@ -334,6 +334,9 @@ class Order(Base):
     price: Mapped[Decimal] = mapped_column(Numeric(20, 8), nullable=False)
     qty: Mapped[Decimal] = mapped_column(Numeric(20, 8), nullable=False)
     leaves_qty: Mapped[Decimal] = mapped_column(Numeric(20, 8), nullable=False)
+    # 0029: needed for active-order seed direction derivation. Nullable for
+    # back-compat with pre-0029 rows; loader treats NULL as SeedSchemaError.
+    reduce_only: Mapped[Optional[bool]] = mapped_column(nullable=True)
     raw_json: Mapped[Optional[dict[str, Any]]] = mapped_column(JSON)
 
     # Relationships
@@ -342,6 +345,9 @@ class Order(Base):
     __table_args__ = (
         Index("ix_orders_account_exchange_ts", "account_id", "exchange_ts"),
         Index("ix_orders_run_id", "run_id"),
+        # 0029: supports OrderRepository.get_active_at(run_id, account_id, symbol, at_ts).
+        Index("ix_orders_run_account_symbol_ts",
+              "run_id", "account_id", "symbol", "exchange_ts"),
         UniqueConstraint("account_id", "order_id", "exchange_ts",
                         name="uq_orders_account_order_ts"),
     )
@@ -361,6 +367,14 @@ class PositionSnapshot(Base):
         primary_key=True,
         autoincrement=True,
     )
+    # 0029: scopes seed queries to one recorder run, prevents cross-run
+    # leak of stale snapshots when accounts are reused. Nullable for
+    # back-compat with pre-0029 rows.
+    run_id: Mapped[Optional[str]] = mapped_column(
+        String(36),
+        ForeignKey("runs.run_id", ondelete="CASCADE"),
+        nullable=True,
+    )
     account_id: Mapped[str] = mapped_column(String(36), nullable=False)
     symbol: Mapped[str] = mapped_column(String(20), nullable=False)
     exchange_ts: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
@@ -374,6 +388,12 @@ class PositionSnapshot(Base):
 
     __table_args__ = (
         Index("ix_position_snapshots_account_ts", "account_id", "exchange_ts"),
+        # 0029: supports PositionSnapshotRepository.get_latest_before
+        # (run_id, account_id, symbol, side, at_ts).
+        Index(
+            "ix_position_snapshots_run_account_symbol_side_ts",
+            "run_id", "account_id", "symbol", "side", "exchange_ts",
+        ),
     )
 
 
@@ -391,6 +411,12 @@ class WalletSnapshot(Base):
         primary_key=True,
         autoincrement=True,
     )
+    # 0029: same as PositionSnapshot.run_id — run-scoping for seed.
+    run_id: Mapped[Optional[str]] = mapped_column(
+        String(36),
+        ForeignKey("runs.run_id", ondelete="CASCADE"),
+        nullable=True,
+    )
     account_id: Mapped[str] = mapped_column(String(36), nullable=False)
     exchange_ts: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     local_ts: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
@@ -401,4 +427,10 @@ class WalletSnapshot(Base):
 
     __table_args__ = (
         Index("ix_wallet_snapshots_account_ts", "account_id", "exchange_ts"),
+        # 0029: supports WalletSnapshotRepository.get_latest_before
+        # (run_id, account_id, coin, at_ts).
+        Index(
+            "ix_wallet_snapshots_run_account_coin_ts",
+            "run_id", "account_id", "coin", "exchange_ts",
+        ),
     )

--- a/shared/db/src/grid_db/repositories.py
+++ b/shared/db/src/grid_db/repositories.py
@@ -2,6 +2,7 @@
 
 from typing import Generic, TypeVar, Optional, List
 
+from sqlalchemy import func, tuple_
 from sqlalchemy.orm import Session
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.dialects.postgresql import insert as postgresql_insert
@@ -794,6 +795,71 @@ class OrderRepository(BaseRepository[Order]):
         )
         return result[0] if result else None
 
+    def get_active_at(
+        self,
+        run_id: str,
+        account_id: str,
+        symbol: str,
+        at_ts: datetime,
+    ) -> List[Order]:
+        """Get the latest active-state snapshot per order for a moment in time.
+
+        Used by the seed-aware replay loader (feature 0029) to reconstruct
+        the set of open orders that existed live at ``at_ts``. The ``orders``
+        table stores a stream of state-change snapshots, so "active orders
+        at at_ts" = "for each order_id in this run/account/symbol, take the
+        latest snapshot at-or-before at_ts; keep it iff status is active and
+        leaves_qty > 0".
+
+        Run-scoping is mandatory: an order whose terminal update was missed
+        because recorder restarted would have a "New" snapshot in a previous
+        run that must NOT leak into a later run's seed.
+
+        Args:
+            run_id: Recorder run identifier.
+            account_id: Account ID.
+            symbol: Trading symbol.
+            at_ts: Inclusive upper bound on ``exchange_ts``.
+
+        Returns:
+            List of latest-per-order Order rows whose latest state at at_ts
+            is ``'New'`` or ``'PartiallyFilled'`` AND ``leaves_qty > 0``.
+        """
+        # Subquery: for each order_id in this scope, the latest exchange_ts
+        # at-or-before at_ts. Composite (order_id, max_ts) is then joined
+        # back to the Order table to fetch the full row.
+        latest_per_order = (
+            self.session.query(
+                Order.order_id.label("oid"),
+                func.max(Order.exchange_ts).label("max_ts"),
+            )
+            .filter(
+                Order.run_id == run_id,
+                Order.account_id == account_id,
+                Order.symbol == symbol,
+                Order.exchange_ts <= at_ts,
+            )
+            .group_by(Order.order_id)
+            .subquery()
+        )
+
+        return (
+            self.session.query(Order)
+            .join(
+                latest_per_order,
+                tuple_(Order.order_id, Order.exchange_ts)
+                == tuple_(latest_per_order.c.oid, latest_per_order.c.max_ts),
+            )
+            .filter(
+                Order.run_id == run_id,
+                Order.account_id == account_id,
+                Order.symbol == symbol,
+                Order.status.in_(("New", "PartiallyFilled")),
+                Order.leaves_qty > 0,
+            )
+            .all()
+        )
+
     def bulk_insert(self, orders: List[Order]) -> int:
         """Bulk insert orders for efficient high-volume data insertion.
 
@@ -823,6 +889,10 @@ class OrderRepository(BaseRepository[Order]):
                 "price": order.price,
                 "qty": order.qty,
                 "leaves_qty": order.leaves_qty,
+                # 0029: persist reduce_only for active-order seed direction
+                # derivation. None for pre-0029 callers, treated as
+                # SeedSchemaError by the loader.
+                "reduce_only": order.reduce_only,
                 "raw_json": order.raw_json,
             }
             for order in orders
@@ -889,6 +959,7 @@ class PositionSnapshotRepository(BaseRepository[PositionSnapshot]):
         # Convert ORM instances to dict for insert
         snapshots_data = [
             {
+                "run_id": s.run_id,  # 0029: run-scoped seed lookups
                 "account_id": s.account_id,
                 "symbol": s.symbol,
                 "exchange_ts": s.exchange_ts,
@@ -933,6 +1004,43 @@ class PositionSnapshotRepository(BaseRepository[PositionSnapshot]):
             .first()
         )
 
+    def get_latest_before(
+        self,
+        run_id: str,
+        account_id: str,
+        symbol: str,
+        side: str,
+        at_ts: datetime,
+    ) -> Optional[PositionSnapshot]:
+        """Get the latest snapshot for a run/account/symbol/side at-or-before at_ts.
+
+        Used by the seed-aware replay loader (feature 0029) to scope position
+        seeding to one recorder run. Pre-0029 rows have NULL ``run_id`` and
+        are excluded.
+
+        Args:
+            run_id: Recorder run identifier.
+            account_id: Account ID.
+            symbol: Trading symbol.
+            side: 'Buy' (long) or 'Sell' (short) — Bybit hedge-mode convention.
+            at_ts: Inclusive upper bound on ``exchange_ts``.
+
+        Returns:
+            Latest matching PositionSnapshot, or None if no row exists.
+        """
+        return (
+            self.session.query(PositionSnapshot)
+            .filter(
+                PositionSnapshot.run_id == run_id,
+                PositionSnapshot.account_id == account_id,
+                PositionSnapshot.symbol == symbol,
+                PositionSnapshot.side == side,
+                PositionSnapshot.exchange_ts <= at_ts,
+            )
+            .order_by(PositionSnapshot.exchange_ts.desc())
+            .first()
+        )
+
 
 class WalletSnapshotRepository(BaseRepository[WalletSnapshot]):
     """Repository for WalletSnapshot operations."""
@@ -955,6 +1063,7 @@ class WalletSnapshotRepository(BaseRepository[WalletSnapshot]):
         # Convert ORM instances to dict for insert
         snapshots_data = [
             {
+                "run_id": s.run_id,  # 0029: run-scoped seed lookups
                 "account_id": s.account_id,
                 "exchange_ts": s.exchange_ts,
                 "local_ts": s.local_ts,
@@ -1021,6 +1130,39 @@ class WalletSnapshotRepository(BaseRepository[WalletSnapshot]):
             .filter(
                 WalletSnapshot.account_id == account_id,
                 WalletSnapshot.coin == coin,
+            )
+            .order_by(WalletSnapshot.exchange_ts.desc())
+            .first()
+        )
+
+    def get_latest_before(
+        self,
+        run_id: str,
+        account_id: str,
+        coin: str,
+        at_ts: datetime,
+    ) -> Optional[WalletSnapshot]:
+        """Get the latest wallet snapshot for a run/account/coin at-or-before at_ts.
+
+        Used by the seed-aware replay loader (feature 0029). Pre-0029 rows
+        have NULL ``run_id`` and are excluded.
+
+        Args:
+            run_id: Recorder run identifier.
+            account_id: Account ID.
+            coin: Coin symbol (e.g., 'USDT').
+            at_ts: Inclusive upper bound on ``exchange_ts``.
+
+        Returns:
+            Latest matching WalletSnapshot, or None if no row exists.
+        """
+        return (
+            self.session.query(WalletSnapshot)
+            .filter(
+                WalletSnapshot.run_id == run_id,
+                WalletSnapshot.account_id == account_id,
+                WalletSnapshot.coin == coin,
+                WalletSnapshot.exchange_ts <= at_ts,
             )
             .order_by(WalletSnapshot.exchange_ts.desc())
             .first()

--- a/shared/db/tests/test_repositories.py
+++ b/shared/db/tests/test_repositories.py
@@ -1,6 +1,6 @@
 """Tests for repository pattern with multi-tenant filtering."""
 
-from datetime import datetime, UTC
+from datetime import datetime, timedelta, UTC
 
 from grid_db.repositories import (
     BaseRepository,
@@ -1155,6 +1155,250 @@ class TestWalletSnapshotRepository:
             base_ts - timedelta(hours=1),
         )
         assert len(results) == 0
+
+
+class TestSeedAwareReplayRepositoryMethods:
+    """Feature 0029: get_latest_before / get_active_at on the three
+    private-stream repositories. Run-scoped queries that the seed loader
+    in apps/replay relies on."""
+
+    def test_position_get_latest_before_picks_older_when_ts_between(
+        self, session, sample_account, sample_run
+    ):
+        from grid_db import PositionSnapshotRepository, PositionSnapshot
+        from decimal import Decimal
+        from datetime import timedelta
+
+        repo = PositionSnapshotRepository(session)
+        base = datetime(2026, 5, 7, 10, 0, 0, tzinfo=UTC)
+        repo.bulk_insert([
+            PositionSnapshot(
+                run_id=sample_run.run_id,
+                account_id=str(sample_account.account_id),
+                symbol="BTCUSDT", exchange_ts=base, local_ts=base,
+                side="Buy", size=Decimal("1.0"), entry_price=Decimal("50000"),
+            ),
+            PositionSnapshot(
+                run_id=sample_run.run_id,
+                account_id=str(sample_account.account_id),
+                symbol="BTCUSDT",
+                exchange_ts=base + timedelta(seconds=10),
+                local_ts=base + timedelta(seconds=10),
+                side="Buy", size=Decimal("2.0"), entry_price=Decimal("50100"),
+            ),
+        ])
+
+        # at_ts strictly between → older row.
+        between = base + timedelta(seconds=5)
+        got = repo.get_latest_before(
+            sample_run.run_id, str(sample_account.account_id),
+            "BTCUSDT", "Buy", between,
+        )
+        assert got is not None
+        assert got.size == Decimal("1.0")
+
+        # at_ts at or after the newer row → newer row.
+        got = repo.get_latest_before(
+            sample_run.run_id, str(sample_account.account_id),
+            "BTCUSDT", "Buy", base + timedelta(seconds=20),
+        )
+        assert got is not None
+        assert got.size == Decimal("2.0")
+
+    def test_position_get_latest_before_excludes_other_runs(
+        self, session, sample_user, sample_account, sample_strategy, sample_run
+    ):
+        """Same account/symbol/side in a DIFFERENT run must not leak in."""
+        from grid_db import PositionSnapshotRepository, PositionSnapshot
+        from grid_db.models import Run
+        from decimal import Decimal
+
+        # Make a second run for the same account.
+        other_run = Run(
+            user_id=sample_user.user_id,
+            account_id=sample_account.account_id,
+            strategy_id=sample_strategy.strategy_id,
+            run_type="live", status="completed",
+            start_ts=datetime(2026, 5, 6, tzinfo=UTC),
+        )
+        session.add(other_run)
+        session.flush()
+
+        repo = PositionSnapshotRepository(session)
+        ts = datetime(2026, 5, 7, 10, 0, 0, tzinfo=UTC)
+        repo.bulk_insert([
+            PositionSnapshot(
+                run_id=other_run.run_id,  # OTHER RUN
+                account_id=str(sample_account.account_id),
+                symbol="BTCUSDT", exchange_ts=ts, local_ts=ts,
+                side="Buy", size=Decimal("99"),
+                entry_price=Decimal("50000"),
+            ),
+        ])
+
+        # Queried with sample_run.run_id → no row.
+        got = repo.get_latest_before(
+            sample_run.run_id, str(sample_account.account_id),
+            "BTCUSDT", "Buy", ts + timedelta(seconds=10),
+        )
+        assert got is None
+
+    def test_wallet_get_latest_before_filters_by_coin_and_run(
+        self, session, sample_account, sample_run
+    ):
+        from grid_db import WalletSnapshotRepository, WalletSnapshot
+        from decimal import Decimal
+        from datetime import timedelta
+
+        repo = WalletSnapshotRepository(session)
+        base = datetime(2026, 5, 7, 10, 0, 0, tzinfo=UTC)
+        repo.bulk_insert([
+            WalletSnapshot(
+                run_id=sample_run.run_id,
+                account_id=str(sample_account.account_id),
+                exchange_ts=base, local_ts=base,
+                coin="USDT",
+                wallet_balance=Decimal("100"),
+                available_balance=Decimal("100"),
+            ),
+            WalletSnapshot(
+                run_id=sample_run.run_id,
+                account_id=str(sample_account.account_id),
+                exchange_ts=base, local_ts=base,
+                coin="BTC",  # different coin — must not be returned for USDT query
+                wallet_balance=Decimal("0.5"),
+                available_balance=Decimal("0.5"),
+            ),
+        ])
+
+        got = repo.get_latest_before(
+            sample_run.run_id, str(sample_account.account_id),
+            "USDT", base + timedelta(seconds=1),
+        )
+        assert got is not None
+        assert got.coin == "USDT"
+        assert got.wallet_balance == Decimal("100")
+
+    def test_order_get_active_at_returns_only_latest_active(
+        self, session, sample_account, sample_run
+    ):
+        """Per order_id, only the latest snapshot at_or_before at_ts; only
+        active states (New/PartiallyFilled) with leaves_qty > 0 are kept.
+        """
+        from grid_db import OrderRepository, Order
+        from decimal import Decimal
+        from datetime import timedelta
+
+        repo = OrderRepository(session)
+        base = datetime(2026, 5, 7, 10, 0, 0, tzinfo=UTC)
+        repo.bulk_insert([
+            # Order 1: New then Filled — should NOT be in active set.
+            Order(
+                run_id=sample_run.run_id,
+                account_id=str(sample_account.account_id),
+                order_id="O1", symbol="BTCUSDT",
+                exchange_ts=base, local_ts=base,
+                status="New", side="Buy",
+                price=Decimal("50000"), qty=Decimal("0.001"),
+                leaves_qty=Decimal("0.001"), reduce_only=False,
+            ),
+            Order(
+                run_id=sample_run.run_id,
+                account_id=str(sample_account.account_id),
+                order_id="O1", symbol="BTCUSDT",
+                exchange_ts=base + timedelta(seconds=5),
+                local_ts=base + timedelta(seconds=5),
+                status="Filled", side="Buy",
+                price=Decimal("50000"), qty=Decimal("0.001"),
+                leaves_qty=Decimal("0"), reduce_only=False,
+            ),
+            # Order 2: only New — IS in active set.
+            Order(
+                run_id=sample_run.run_id,
+                account_id=str(sample_account.account_id),
+                order_id="O2", symbol="BTCUSDT",
+                exchange_ts=base + timedelta(seconds=2),
+                local_ts=base + timedelta(seconds=2),
+                status="New", side="Sell",
+                price=Decimal("51000"), qty=Decimal("0.002"),
+                leaves_qty=Decimal("0.002"), reduce_only=False,
+            ),
+        ])
+
+        active = repo.get_active_at(
+            sample_run.run_id, str(sample_account.account_id),
+            "BTCUSDT", base + timedelta(seconds=10),
+        )
+        assert len(active) == 1
+        assert active[0].order_id == "O2"
+
+    def test_order_get_active_at_excludes_prior_run(
+        self, session, sample_user, sample_account, sample_strategy, sample_run
+    ):
+        """Stale 'New' row from a previous run must not leak when recorder
+        was killed before the terminal update."""
+        from grid_db import OrderRepository, Order
+        from grid_db.models import Run
+        from decimal import Decimal
+        from datetime import timedelta
+
+        prior_run = Run(
+            user_id=sample_user.user_id,
+            account_id=sample_account.account_id,
+            strategy_id=sample_strategy.strategy_id,
+            run_type="live", status="completed",
+            start_ts=datetime(2026, 5, 6, tzinfo=UTC),
+        )
+        session.add(prior_run)
+        session.flush()
+
+        repo = OrderRepository(session)
+        ts = datetime(2026, 5, 6, 12, 0, 0, tzinfo=UTC)
+        repo.bulk_insert([
+            Order(
+                run_id=prior_run.run_id,  # PRIOR RUN
+                account_id=str(sample_account.account_id),
+                order_id="O-leaked", symbol="BTCUSDT",
+                exchange_ts=ts, local_ts=ts,
+                status="New", side="Buy",
+                price=Decimal("50000"), qty=Decimal("0.001"),
+                leaves_qty=Decimal("0.001"), reduce_only=False,
+            ),
+        ])
+
+        # New run starts the next day; query at later timestamp.
+        active = repo.get_active_at(
+            sample_run.run_id, str(sample_account.account_id),
+            "BTCUSDT", datetime(2026, 5, 7, 13, 0, 0, tzinfo=UTC),
+        )
+        assert active == []
+
+    def test_order_get_active_at_persists_reduce_only(
+        self, session, sample_account, sample_run
+    ):
+        """The new column must round-trip through bulk_insert + query."""
+        from grid_db import OrderRepository, Order
+        from decimal import Decimal
+
+        repo = OrderRepository(session)
+        ts = datetime(2026, 5, 7, 10, 0, 0, tzinfo=UTC)
+        repo.bulk_insert([
+            Order(
+                run_id=sample_run.run_id,
+                account_id=str(sample_account.account_id),
+                order_id="O-ro", symbol="BTCUSDT",
+                exchange_ts=ts, local_ts=ts,
+                status="New", side="Sell",
+                price=Decimal("51000"), qty=Decimal("0.001"),
+                leaves_qty=Decimal("0.001"), reduce_only=True,
+            ),
+        ])
+        active = repo.get_active_at(
+            sample_run.run_id, str(sample_account.account_id),
+            "BTCUSDT", ts + timedelta(seconds=10),
+        )
+        assert len(active) == 1
+        assert active[0].reduce_only is True
 
 
 class TestTickerSnapshotRepository:


### PR DESCRIPTION
## Summary

Implements feature 0029 — seed-aware replay so a recorded live session can be replayed from the exact state live had at `start_ts`, restoring grid + positions + wallet + active orders. Closes the state-gap that previously made strategy-identical replay diverge from live on tick 1 because of starting state, not strategy. After this PR, comparator parity smoke can isolate strategy divergences from state divergences.

Full design: `docs/features/0029_PLAN.md`.

## Phases

- **Phase 1** (`08e8dbf`) — data layer: `Order.reduce_only` column, `PositionSnapshot.run_id` + `WalletSnapshot.run_id` (FK runs), three run-scoped indexes; recorder writers accept `run_id`; `OrderUpdateEvent.reduce_only`; bbu2-adapter populates `reduceOnly` from WS frame; `BacktestPositionTracker.PositionState.liquidation_price`; three new repository methods (`get_latest_before` × 2, `get_active_at`).
- **Phase 2A** (`18bf680`) — `apps/replay/src/replay/snapshot_loader.py`: seed dataclasses + 4 loader functions + 4-class exception hierarchy (SeedError base + SchemaError / ConfigMismatchError / DataQualityError).
- **Phase 2B** (`18bf680`) — backtest seeding: `BacktestPositionTracker.seed_state`, `BacktestOrderManager.seed_active_orders`, `BacktestRunner.__init__` extended with `restored_grid` and `seeded_active_orders`; risk-state mirroring into `gridcore.Position` so the early-imbalance gate (D-3 from feature 0028) sees seeded state on tick 1.
- **Phase 3** (`d43defd`) — `ReplayConfig.SeedConfig` + `ReplayEngine` orchestration + Phase 4 pre-check (`MIN(exchange_ts)` on wallet+positions; orders excluded since empty open orders is a valid happy path).

## Cross-cutting (also in scope, all in `d43defd`)

- **#1 — Live executor sends `orderLinkId`** so post-seed live fills land in `private_executions` with a non-NULL `order_link_id` matching replay's deterministic `client_order_id`.
- **#2 — Comparator `client_id` fallback** (`order_link_id or order_id`) so seeded / pre-fix-#1 executions still join.
- **#3 — `Order.reduce_only` schema + writer** persists in scope (Phase 1).
- **#4 — Recorder initial REST snapshot** at private-stream connect: writes wallet (per-coin), positions (always BOTH sides per symbol incl. zero-size), open orders. The "always two rows per symbol" invariant is what lets the loader treat exactly-one-side-missing as `SeedDataQualityError` rather than silently zero.

## Why these decisions

- **Single seed source = recorder DB** (no `from_files` mode). Adds surface, no clear use case while recorder is the only realistic capture path.
- **Grid seeded as full level list, not `anchor_price`**. Post-feature-0021 `GridStateStore.save(grid, grid_step, grid_count)`. Replay routes through `Grid.restore_grid(...)` same as live (`runner.py:248-263`).
- **`liquidation_price` overwritten by estimator after first risk update** (accepted, documented). Backtest's `_estimate_liquidation_price` differs from Bybit's `liqPrice`; seeded value lives until `_update_risk_multipliers` runs.
- **No global `seed_max_staleness_seconds`**. Private streams are event-driven on Bybit; quiet wallets/positions sit unchanged for many minutes. Pre-check on the initial-REST-snapshot timestamp + dimension-specific policy replaces a single threshold.
- **One-side-missing position → `SeedDataQualityError`**, not silent zero. Initial-snapshot contract guarantees both sides; absence of one means a corrupt run.
- **Live executor `orderLinkId` is mandatory** for any post-seed parity. Seed-only `client_id` fallback covers pre-existing orders only.

## Schema migration

`shared/db/` has no migration framework; new DBs get the columns via `Base.metadata.create_all()`. Existing SQLite/Postgres deploys need (no DEFAULT — old rows stay NULL, loader treats NULL as `SeedSchemaError` for `reduce_only` / excluded from run-scoped lookups for `run_id`):

```sql
ALTER TABLE orders ADD COLUMN reduce_only BOOLEAN;
ALTER TABLE position_snapshots ADD COLUMN run_id VARCHAR(36) REFERENCES runs(run_id) ON DELETE CASCADE;
ALTER TABLE wallet_snapshots ADD COLUMN run_id VARCHAR(36) REFERENCES runs(run_id) ON DELETE CASCADE;
```

Existing recordings with NULL on these columns cannot be used for seeding; `private_executions` from those recordings remain queryable for trade-comparison.

## Test plan

- [x] `uv run pytest shared/db/tests/ packages/gridcore/tests/ packages/bybit_adapter/tests/ apps/event_saver/tests/ apps/recorder/tests/ apps/backtest/tests/ apps/gridbot/tests/ apps/replay/tests/ apps/comparator/tests/ -q` → **1796 passed**, 3 skipped, 3 pre-existing fails in `test_risk_limit_info.py` (unrelated to this PR).
- [x] `uv run ruff check` clean on all modified paths.
- [x] **50+ new tests** across 8 test files: 6 repository tests, 20 snapshot-loader tests, 4 replay-engine seed tests, 5 backtest-runner seed tests, 3 comparator fallback tests, 1 live-executor `orderLinkId` test, 4 recorder initial-REST-snapshot tests, plus updated existing assertions.
- [ ] **Phase 4 — comparator parity smoke** (operational, deferred): requires fresh live + recorder run with private streams ≥10 min on a build that includes this PR's cross-cutting #3 + #4. Not a code deliverable.

## Out of scope

- Phase 4 operational smoke (above).
- `GridStateStore` `saved_at` timestamp metadata (separate small change to detect stale grid files between snapshot and `at_ts`).
- Live `db/grid_anchor.json` is currently in legacy anchor-only format on the running session — replay treats this with a tolerant info-log + fresh-build fallback (matches live `runner.py:248-263`); root cause of why live persistence hasn't produced a full-grid save is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)