### PR TITLE
fix(comparator): strip orderLinkId suffix on live-trade load

### DIFF
--- a/apps/comparator/src/comparator/loader.py
+++ b/apps/comparator/src/comparator/loader.py
@@ -15,6 +15,7 @@ from typing import Optional
 from sqlalchemy.orm import Session
 
 from grid_db import PrivateExecution, PrivateExecutionRepository
+from gridcore.intents import extract_client_order_prefix
 from gridcore.position import DirectionType, SideType
 
 _ZERO = Decimal("0")
@@ -109,15 +110,18 @@ class LiveTradeLoader:
         # (aggregate). Same client_id + different order_id = ID reuse
         # (separate trades).
         #
-        # 0029: client_id = order_link_id or order_id. Live didn't always send
-        # orderLinkId before cross-cutting #1; rows with NULL order_link_id are
-        # joined via the Bybit-assigned order_id instead. The previous
-        # skip-on-NULL behaviour silently dropped those executions.
+        # 0029: client_id = prefix(order_link_id) or order_id. Live didn't
+        # always send orderLinkId before cross-cutting #1; rows with NULL
+        # order_link_id are joined via the Bybit-assigned order_id instead.
+        # Post-hotfix 2026-05-08, orderLinkId on the wire carries a
+        # `-{millis}` suffix; _extract_client_order_prefix strips it so the
+        # join key matches replay's deterministic prefix.
         grouped: dict[tuple[str, str], list[PrivateExecution]] = defaultdict(list)
         fallback_hits = 0
         for ex in executions:
-            client_id = ex.order_link_id or ex.order_id
-            if not ex.order_link_id:
+            link_prefix = extract_client_order_prefix(ex.order_link_id)
+            client_id = link_prefix or ex.order_id
+            if link_prefix is None:
                 fallback_hits += 1
             grouped[(client_id, ex.order_id)].append(ex)
 

--- a/apps/comparator/tests/test_loader.py
+++ b/apps/comparator/tests/test_loader.py
@@ -168,7 +168,7 @@ class TestLiveTradeLoader:
         ts = datetime(2025, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
 
         self._add_execution(
-            db, run_id, "e1", "LX-1", "Buy",
+            db, run_id, "e1", "LX1", "Buy",
             Decimal("100000"), Decimal("0.001"), Decimal("0.02"), Decimal("0"),
             ts, order_id="ORD-A",
         )
@@ -178,7 +178,7 @@ class TestLiveTradeLoader:
             trades = loader.load(run_id, ts - timedelta(hours=1), ts + timedelta(hours=1))
 
         assert len(trades) == 1
-        assert trades[0].client_order_id == "LX-1"
+        assert trades[0].client_order_id == "LX1"
 
     def test_loader_falls_back_to_order_id_when_link_id_null(self, db):
         """When order_link_id is NULL, order_id is used as the client_order_id (0029)."""
@@ -400,6 +400,129 @@ class TestLiveTradeLoader:
         assert len(trades) == 1
         assert trades[0].qty == Decimal("0.001")
         assert trades[0].occurrence == 0
+
+    # --- orderLinkId suffix handling (gridbot HOTFIX 2026-05-08) ---
+
+    def test_unsuffixed_order_link_id_unchanged(self, db):
+        """Pre-hotfix orderLinkId (no `-` suffix) is preserved as-is."""
+        run_id = self._seed_data(db)
+        ts = datetime(2025, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        self._add_execution(
+            db, run_id, "e1", "cffab542de0a6295", "Buy",
+            Decimal("100000"), Decimal("0.001"), Decimal("0.02"), Decimal("0"),
+            ts,
+        )
+
+        with db.get_session() as session:
+            loader = LiveTradeLoader(session)
+            trades = loader.load(run_id, ts - timedelta(hours=1), ts + timedelta(hours=1))
+
+        assert len(trades) == 1
+        assert trades[0].client_order_id == "cffab542de0a6295"
+
+    def test_suffixed_order_link_id_strips_to_prefix(self, db):
+        """Post-hotfix suffixed orderLinkId is normalized to its prefix."""
+        run_id = self._seed_data(db)
+        ts = datetime(2025, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        self._add_execution(
+            db, run_id, "e1", "cffab542de0a6295-1715170800000", "Buy",
+            Decimal("100000"), Decimal("0.001"), Decimal("0.02"), Decimal("0"),
+            ts,
+        )
+
+        with db.get_session() as session:
+            loader = LiveTradeLoader(session)
+            trades = loader.load(run_id, ts - timedelta(hours=1), ts + timedelta(hours=1))
+
+        assert len(trades) == 1
+        assert trades[0].client_order_id == "cffab542de0a6295"
+
+    def test_null_order_link_id_logs_fallback(self, db, caplog):
+        """NULL order_link_id falls back to order_id and logs a fallback hit."""
+        import logging
+
+        run_id = self._seed_data(db)
+        ts = datetime(2025, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        self._add_execution(
+            db, run_id, "e1", None, "Buy",
+            Decimal("100000"), Decimal("0.001"), Decimal("0.02"), Decimal("0"),
+            ts, order_id="ORD-FALLBACK",
+        )
+
+        with db.get_session() as session:
+            loader = LiveTradeLoader(session)
+            with caplog.at_level(logging.INFO, logger="comparator.loader"):
+                trades = loader.load(run_id, ts - timedelta(hours=1), ts + timedelta(hours=1))
+
+        assert len(trades) == 1
+        assert trades[0].client_order_id == "ORD-FALLBACK"
+        assert any(
+            "order_id fallback for 1 executions" in record.getMessage()
+            for record in caplog.records
+        )
+
+    def test_suffixed_reuse_same_prefix_different_order_id(self, db):
+        """Two suffixed placements sharing a prefix but different order_ids
+        produce two trades with the same client_order_id and sequential
+        occurrence indices — the ID-reuse path under the hotfix."""
+        run_id = self._seed_data(db)
+        ts = datetime(2025, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+        # Older placement first
+        self._add_execution(
+            db, run_id, "e1", "cffab542de0a6295-1000", "Buy",
+            Decimal("100000"), Decimal("0.001"), Decimal("0.02"), Decimal("0"),
+            ts, order_id="ORD-A",
+        )
+        # Newer placement, same logical intent → same prefix, different order
+        self._add_execution(
+            db, run_id, "e2", "cffab542de0a6295-2000", "Buy",
+            Decimal("100100"), Decimal("0.001"), Decimal("0.02"), Decimal("0"),
+            ts + timedelta(seconds=1), order_id="ORD-B",
+        )
+
+        with db.get_session() as session:
+            loader = LiveTradeLoader(session)
+            trades = loader.load(run_id, ts - timedelta(hours=1), ts + timedelta(hours=1))
+
+        assert len(trades) == 2
+        assert all(t.client_order_id == "cffab542de0a6295" for t in trades)
+        # Sort ensures deterministic occurrence assignment by (timestamp, ...)
+        sorted_trades = sorted(trades, key=lambda t: t.timestamp)
+        assert sorted_trades[0].occurrence == 0
+        assert sorted_trades[1].occurrence == 1
+
+    def test_suffixed_partial_fills_same_order_id_aggregated(self, db):
+        """Two suffixed rows with the SAME suffixed orderLinkId and SAME
+        order_id are partial fills of one placement and aggregate to one
+        trade (VWAP price, summed qty/fee)."""
+        run_id = self._seed_data(db)
+        ts = datetime(2025, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+        suffixed = "cffab542de0a6295-1715170800000"
+        self._add_execution(
+            db, run_id, "e1", suffixed, "Buy",
+            Decimal("100000"), Decimal("0.0005"), Decimal("0.01"), Decimal("0"),
+            ts, order_id="ORD-SHARED",
+        )
+        self._add_execution(
+            db, run_id, "e2", suffixed, "Buy",
+            Decimal("100002"), Decimal("0.0005"), Decimal("0.01"), Decimal("0"),
+            ts + timedelta(seconds=1), order_id="ORD-SHARED",
+        )
+
+        with db.get_session() as session:
+            loader = LiveTradeLoader(session)
+            trades = loader.load(run_id, ts - timedelta(hours=1), ts + timedelta(hours=1))
+
+        assert len(trades) == 1
+        t = trades[0]
+        assert t.client_order_id == "cffab542de0a6295"
+        assert t.qty == Decimal("0.001")
+        assert t.fee == Decimal("0.02")
+        # VWAP: (100000 * 0.0005 + 100002 * 0.0005) / 0.001 = 100001
+        assert t.price == Decimal("100001")
+        assert t.occurrence == 0
 
 
 # --- BacktestTradeLoader ---

--- a/docs/features/0029_PLAN.md
+++ b/docs/features/0029_PLAN.md
@@ -125,6 +125,18 @@ log + fresh-build fallback (matches live's behaviour at
   change) closes this. Same `client_id = order_link_id or order_id`
   logic also lands in `apps/comparator/src/comparator/loader.py` so
   pre-fix executions still join.
+- **Post-hotfix 2026-05-08, `orderLinkId` on the wire carries a
+  `-{millis}` suffix.** `apps/gridbot/src/gridbot/executor.py` now
+  appends a millisecond timestamp to every placement to dodge Bybit
+  ErrCode 110072 ("OrderLinkedID is duplicate") on re-placements of
+  the same logical intent. The full suffixed value is persisted in
+  `private_executions.order_link_id` (and `orders.order_link_id`)
+  for forensics. The comparator's `LiveTradeLoader` strips the
+  first `-` and everything after it via
+  `_extract_client_order_prefix`, so the join key becomes
+  `client_order_id = prefix(order_link_id) or order_id`. Replay
+  continues to emit the deterministic prefix unchanged; both sides
+  rejoin on the prefix.
 - **Position direction policy is governed by the initial REST
   snapshot contract.** Bybit hedge-mode only emits per-side updates
   on activity, but the recorder's initial REST snapshot at run


### PR DESCRIPTION
## Summary

- Comparator's `LiveTradeLoader` now normalizes `private_executions.order_link_id` to its deterministic prefix via `gridcore.intents.extract_client_order_prefix` before using it as the join key.
- 5 new tests in `test_loader.py` covering pre-hotfix backward-compat, suffix stripping, NULL fallback, ID-reuse with shared prefix, and partial-fill aggregation under the hotfix.
- Contract note added to `docs/features/0029_PLAN.md`.

## Why

Stacked on top of #69 (executor hotfix). After 2026-05-08, live `orderLinkId` on the wire carries a `-{millis}` suffix. Replay/backtest still emit the deterministic prefix as `client_order_id`. Without this fix the comparator's join key diverges and any post-hotfix window reports ~100% match rate loss.

## Stacking

**Base branch:** `hotfix/orderlinkid-suffix-2026-05-08` (PR #69), not `main`.

#69 must merge first, after which GitHub will auto-retarget this PR's base to `main`. The comparator helper imports from `gridcore.intents.extract_client_order_prefix` which lives in #69 — merging this PR before #69 would break the import.

## Test plan

- [x] `uv run pytest apps/comparator/tests/test_loader.py -v` — 29/29 pass (24 prior + 5 new).
- [x] `uv run ruff check apps/comparator/src/comparator/loader.py` — clean.
- [ ] End-to-end on a recent post-hotfix recorder window: comparator produces a non-empty match list where the pre-fix code reported 100% divergence.

## Out-of-scope follow-up

`apps/replay/src/replay/snapshot_loader.py:390` uses the same `client_id = row.order_link_id or row.order_id` pattern for seeded replays. Same class of bug after the hotfix. Tracked separately — not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)