### PR TITLE
feat(0033): configurable fill simulator with book_touch parity mode

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -1641,13 +1641,21 @@ Replay engine that reads recorded mainnet data from the recorder's database, fee
    - `ComparatorReporter` (comparator) — CSV + console report
    - Replay engine is a thin orchestrator wiring these together
 
-3. **Config Shape: Root-Level Replay Parameters**
+3. **Replay Fill Simulator Modes**
+   - `strict_cross` (default): existing conservative model. BUY fills only below limit; SELL fills only above limit.
+   - `trade_through_at_limit`: last-price model that includes exact limit touches (`<=` / `>=`).
+   - `book_touch`: replay parity mode using recorded L1 (`ask1 <= limit` for BUY, `bid1 >= limit` for SELL), falling back to `trade_through_at_limit` for legacy bare-price callers.
+   - `BacktestEngine` still instantiates the default `strict_cross` mode; replay config can opt into other modes via `fill_simulator.mode`.
+   - `BacktestOrderManager.check_fills(TickerEvent(...))` is always scoped to the ticker's own symbol; the legacy bare-Decimal path preserves all-symbol scanning when no `symbol` filter is supplied.
+   - Rationale: production backtests keep conservative semantics while recorder parity smoke can use the richer bid/ask already stored in `ticker_snapshots`.
+
+4. **Config Shape: Root-Level Replay Parameters**
    - `initial_balance`, `enable_funding`, `wind_down_mode` live at **root level** of `ReplayConfig`, NOT nested under `strategy`
    - They are backtest/replay parameters, not grid-strategy parameters
    - `strategy:` block only contains grid config (tick_size, grid_count, grid_step, amount, commission_rate)
    - File: `apps/replay/src/replay/config.py`
 
-4. **Run Resolution (`_resolve_run()`)**
+5. **Run Resolution (`_resolve_run()`)**
    - Auto-discover: queries `RunRepository.get_latest_by_type("recording")` — filters to `("completed", "running")` status by default
    - Explicit `run_id`: looks up Run row from DB if timestamps are missing (no hard-fail)
    - Active runs (`end_ts=None`): falls back to `datetime.now(timezone.utc)` instead of failing

--- a/apps/backtest/src/backtest/fill_simulator.py
+++ b/apps/backtest/src/backtest/fill_simulator.py
@@ -56,7 +56,13 @@ class TradeThroughFillSimulator:
     """
 
     def __init__(self, mode: FillMode = FillMode.STRICT_CROSS):
-        self._mode = FillMode(mode)
+        try:
+            self._mode = FillMode(mode)
+        except ValueError as exc:
+            valid = ", ".join(m.value for m in FillMode)
+            raise ValueError(
+                f"Invalid fill mode {mode!r}. Valid modes: {valid}"
+            ) from exc
 
     @property
     def mode(self) -> FillMode:
@@ -176,10 +182,12 @@ class TradeThroughFillSimulator:
             if snapshot.ask1_price is None:
                 return self._should_fill_at_limit(side, limit_price, snapshot.last_price)
             return snapshot.ask1_price <= limit_price
-
-        if snapshot.bid1_price is None:
-            return self._should_fill_at_limit(side, limit_price, snapshot.last_price)
-        return snapshot.bid1_price >= limit_price
+        elif side == SideType.SELL:
+            if snapshot.bid1_price is None:
+                return self._should_fill_at_limit(side, limit_price, snapshot.last_price)
+            return snapshot.bid1_price >= limit_price
+        else:
+            raise ValueError(f"Invalid order side: {side!r}")
 
     def get_fill_price(self, order: "SimulatedOrder") -> Decimal:
         """Get fill price for an order.

--- a/apps/backtest/src/backtest/fill_simulator.py
+++ b/apps/backtest/src/backtest/fill_simulator.py
@@ -5,12 +5,21 @@ Implements the fill logic: orders fill when price crosses their limit price.
 
 from dataclasses import dataclass
 from decimal import Decimal
+from enum import StrEnum
 from typing import TYPE_CHECKING
 
-from gridcore import SideType
+from gridcore import SideType, TickerEvent
 
 if TYPE_CHECKING:
     from backtest.order_manager import SimulatedOrder
+
+
+class FillMode(StrEnum):
+    """Supported simulated limit-order fill modes."""
+
+    STRICT_CROSS = "strict_cross"
+    TRADE_THROUGH_AT_LIMIT = "trade_through_at_limit"
+    BOOK_TOUCH = "book_touch"
 
 
 @dataclass(frozen=True)
@@ -21,57 +30,156 @@ class FillResult:
     fill_price: Decimal
 
 
+@dataclass(frozen=True)
+class MarketSnapshot:
+    """Internal normalized market data used for fill checks."""
+
+    last_price: Decimal
+    bid1_price: Decimal | None = None
+    ask1_price: Decimal | None = None
+
+
 class TradeThroughFillSimulator:
-    """Strict cross fill model for limit orders.
+    """Configurable fill model for simulated limit orders.
 
-    Fill logic (conservative):
-    - BUY limit orders fill when current_price < limit_price
-    - SELL limit orders fill when current_price > limit_price
-
-    At limit price (price == limit), order does NOT fill because:
-    - Queue position is unknown (others may be ahead)
-    - Volume at that level may be insufficient
-    - Conservative assumption is better for backtesting
+    Supported modes:
+    - strict_cross: conservative default; BUY below limit, SELL above limit.
+      Exact limit touches do not fill because queue position and volume are
+      unknown.
+    - trade_through_at_limit: last-price model that includes exact limit
+      touches.
+    - book_touch: L1-aware parity mode; BUY when ask touches/crosses limit,
+      SELL when bid touches/crosses limit, with last-price-at-limit fallback
+      only when L1 data is unavailable.
 
     Fill price is always the limit price.
     """
 
-    def check_fill(self, order: "SimulatedOrder", current_price: Decimal) -> FillResult:
-        """Check if order should fill based on price crossing.
+    def __init__(self, mode: FillMode = FillMode.STRICT_CROSS):
+        self._mode = FillMode(mode)
+
+    @property
+    def mode(self) -> FillMode:
+        """Fill mode used by this simulator."""
+        return self._mode
+
+    def check_fill(
+        self,
+        order: "SimulatedOrder",
+        market: TickerEvent | Decimal,
+    ) -> FillResult:
+        """Check if order should fill based on the configured fill mode.
 
         Args:
             order: The order to check
-            current_price: Current market price
+            market: TickerEvent for L1-aware modes, or legacy bare Decimal.
+                Bare Decimal is retained for backward compatibility; prefer
+                TickerEvent for new callers.
 
         Returns:
             FillResult with should_fill flag and fill_price
         """
-        should_fill = self._should_fill(order.side, order.price, current_price)
+        snapshot = self._to_snapshot(market)
+        should_fill = self._should_fill(order.side, order.price, snapshot)
         fill_price = order.price if should_fill else Decimal("0")
         return FillResult(should_fill=should_fill, fill_price=fill_price)
 
-    def _should_fill(self, side: str, limit_price: Decimal, current_price: Decimal) -> bool:
-        """Determine if order should fill based on strict price crossing.
+    def _to_snapshot(self, market: TickerEvent | Decimal) -> MarketSnapshot:
+        """Normalize supported market inputs to an internal snapshot."""
+        if isinstance(market, TickerEvent):
+            return MarketSnapshot(
+                last_price=market.last_price,
+                bid1_price=self._normalize_l1_price(market.bid1_price),
+                ask1_price=self._normalize_l1_price(market.ask1_price),
+            )
 
-        Strict cross model (conservative):
-        - BUY fills when market price drops BELOW limit price
-        - SELL fills when market price rises ABOVE limit price
-        - At limit price exactly, order does NOT fill
+        return MarketSnapshot(last_price=market)
+
+    def _normalize_l1_price(self, price: Decimal) -> Decimal | None:
+        """Treat non-positive L1 defaults as missing book data."""
+        return price if price > 0 else None
+
+    def _should_fill(
+        self,
+        side: str,
+        limit_price: Decimal,
+        snapshot: MarketSnapshot,
+    ) -> bool:
+        """Determine if order should fill based on configured mode.
+
+        Modes:
+        - strict_cross: BUY below limit, SELL above limit
+        - trade_through_at_limit: BUY at/below, SELL at/above
+        - book_touch: BUY ask at/below, SELL bid at/above; falls back to
+          trade_through_at_limit when L1 data is unavailable
 
         Args:
             side: 'Buy' or 'Sell'
             limit_price: Order's limit price
-            current_price: Current market price
+            snapshot: Normalized market snapshot
 
         Returns:
             True if order should fill
         """
+        match self._mode:
+            case FillMode.STRICT_CROSS:
+                return self._should_fill_strict_cross(
+                    side, limit_price, snapshot.last_price,
+                )
+            case FillMode.TRADE_THROUGH_AT_LIMIT:
+                return self._should_fill_at_limit(
+                    side, limit_price, snapshot.last_price,
+                )
+            case FillMode.BOOK_TOUCH:
+                return self._should_fill_book_touch(side, limit_price, snapshot)
+
+        raise ValueError(f"Unsupported fill mode: {self._mode}")
+
+    def _should_fill_strict_cross(
+        self,
+        side: str,
+        limit_price: Decimal,
+        current_price: Decimal,
+    ) -> bool:
+        """Strict conservative fill check."""
+        if current_price <= 0:
+            return False
         if side == SideType.BUY:
             # Buy limit fills when price crosses below limit
             return current_price < limit_price
         else:  # Sell
             # Sell limit fills when price crosses above limit
             return current_price > limit_price
+
+    def _should_fill_at_limit(
+        self,
+        side: str,
+        limit_price: Decimal,
+        current_price: Decimal,
+    ) -> bool:
+        """Trade-through fill check that includes exact limit touches."""
+        if current_price <= 0:
+            return False
+        if side == SideType.BUY:
+            return current_price <= limit_price
+        else:  # Sell
+            return current_price >= limit_price
+
+    def _should_fill_book_touch(
+        self,
+        side: str,
+        limit_price: Decimal,
+        snapshot: MarketSnapshot,
+    ) -> bool:
+        """L1-aware fill check with legacy last-price fallback."""
+        if side == SideType.BUY:
+            if snapshot.ask1_price is None:
+                return self._should_fill_at_limit(side, limit_price, snapshot.last_price)
+            return snapshot.ask1_price <= limit_price
+
+        if snapshot.bid1_price is None:
+            return self._should_fill_at_limit(side, limit_price, snapshot.last_price)
+        return snapshot.bid1_price >= limit_price
 
     def get_fill_price(self, order: "SimulatedOrder") -> Decimal:
         """Get fill price for an order.

--- a/apps/backtest/src/backtest/order_manager.py
+++ b/apps/backtest/src/backtest/order_manager.py
@@ -265,7 +265,10 @@ class BacktestOrderManager:
         """
         if market is None:
             if current_price is None:
-                raise ValueError("market is required")
+                raise ValueError(
+                    "Either 'market' (TickerEvent or Decimal) or 'current_price' "
+                    "keyword argument is required"
+                )
             market = current_price
 
         if isinstance(market, TickerEvent):

--- a/apps/backtest/src/backtest/order_manager.py
+++ b/apps/backtest/src/backtest/order_manager.py
@@ -8,9 +8,9 @@ import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
 from decimal import Decimal
-from typing import Optional
+from typing import Optional, overload
 
-from gridcore import ExecutionEvent, EventType
+from gridcore import ExecutionEvent, EventType, TickerEvent
 
 from backtest.fill_simulator import TradeThroughFillSimulator
 
@@ -134,11 +134,10 @@ class BacktestOrderManager:
 
         Subsequent ``check_fills`` calls iterate ``self.active_orders``
         and run the fill simulator on every order;
-        ``TradeThroughFillSimulator._should_fill`` reads only ``side``
-        / ``price`` / ``current_price`` (with strict ``<`` for Buy and
-        strict ``>`` for Sell — see ``fill_simulator.py``), so seeded
-        orders are eligible for fills as soon as price crosses the
-        limit strictly.
+        ``TradeThroughFillSimulator`` reads the configured market input
+        according to its fill mode (strict cross by default), so seeded
+        orders are eligible for fills under the same semantics as newly
+        placed simulated orders.
 
         ``grid_level`` is set to ``0`` for every seeded order: live
         active orders carry no level metadata, and the simulator does
@@ -216,36 +215,84 @@ class BacktestOrderManager:
                 return self.cancel_order(order_id, timestamp)
         return False
 
+    @overload
     def check_fills(
         self,
+        market: TickerEvent,
+        timestamp: Optional[datetime] = None,
+        symbol: Optional[str] = None,
+    ) -> list[ExecutionEvent]: ...
+
+    @overload
+    def check_fills(
+        self,
+        market: Decimal,
+        timestamp: datetime,
+        symbol: Optional[str] = None,
+    ) -> list[ExecutionEvent]: ...
+
+    @overload
+    def check_fills(
+        self,
+        *,
         current_price: Decimal,
         timestamp: datetime,
         symbol: Optional[str] = None,
+    ) -> list[ExecutionEvent]: ...
+
+    def check_fills(
+        self,
+        market: TickerEvent | Decimal | None = None,
+        timestamp: Optional[datetime] = None,
+        symbol: Optional[str] = None,
+        *,
+        current_price: Optional[Decimal] = None,
     ) -> list[ExecutionEvent]:
         """Check all active orders for fills.
 
         Args:
-            current_price: Current market price
-            timestamp: Current timestamp
-            symbol: Optional symbol filter
+            market: Current ticker event, or legacy bare market price.
+            timestamp: Fill timestamp. Defaults to ``market.exchange_ts`` for
+                TickerEvent input; required for legacy Decimal input.
+            symbol: Optional symbol filter. TickerEvent input is always scoped
+                to ``market.symbol``; Decimal input preserves the legacy
+                all-symbol scan when symbol is omitted.
+            current_price: Deprecated keyword-only alias for legacy bare
+                Decimal callers. Prefer ``market`` for new code.
 
         Returns:
             List of ExecutionEvent for filled orders
         """
+        if market is None:
+            if current_price is None:
+                raise ValueError("market is required")
+            market = current_price
+
+        if isinstance(market, TickerEvent):
+            fill_timestamp = timestamp or market.exchange_ts
+            symbol_filter = market.symbol
+        else:
+            if timestamp is None:
+                raise ValueError(
+                    "timestamp is required when checking fills with a bare Decimal price"
+                )
+            fill_timestamp = timestamp
+            symbol_filter = symbol
+
         fills: list[ExecutionEvent] = []
 
         for order_id, order in list(self.active_orders.items()):
             # Skip if symbol filter specified and doesn't match
-            if symbol is not None and order.symbol != symbol:
+            if symbol_filter is not None and order.symbol != symbol_filter:
                 continue
 
-            fill_result = self.fill_simulator.check_fill(order, current_price)
+            fill_result = self.fill_simulator.check_fill(order, market)
 
             if fill_result.should_fill:
                 # Move from active to filled
                 self.active_orders.pop(order_id)
                 order.status = "filled"
-                order.filled_ts = timestamp
+                order.filled_ts = fill_timestamp
                 self.filled_orders.append(order)
                 # Allow client_order_id to be reused
                 self._client_order_ids.discard(order.client_order_id)
@@ -257,8 +304,8 @@ class BacktestOrderManager:
                 exec_event = ExecutionEvent(
                     event_type=EventType.EXECUTION,
                     symbol=order.symbol,
-                    exchange_ts=timestamp,
-                    local_ts=timestamp,
+                    exchange_ts=fill_timestamp,
+                    local_ts=fill_timestamp,
                     exec_id=f"exec_{uuid.uuid4().hex[:8]}",
                     order_id=order.order_id,
                     order_link_id=order.client_order_id,

--- a/apps/backtest/src/backtest/runner.py
+++ b/apps/backtest/src/backtest/runner.py
@@ -326,9 +326,7 @@ class BacktestRunner:
 
         # Check for fills
         fills = self._executor.order_manager.check_fills(
-            current_price=event.last_price,
-            timestamp=event.exchange_ts,
-            symbol=event.symbol,
+            market=event,
         )
 
         # Process fills

--- a/apps/backtest/tests/test_fill_simulator.py
+++ b/apps/backtest/tests/test_fill_simulator.py
@@ -324,3 +324,26 @@ class TestFillModeMatrix:
 
         assert buy_result.should_fill is False
         assert sell_result.should_fill is False
+
+    def test_invalid_fill_mode_string_raises_with_valid_options(self):
+        """Construction with an unknown mode lists the valid options."""
+        with pytest.raises(ValueError, match="Valid modes: strict_cross"):
+            TradeThroughFillSimulator(mode="not_a_mode")
+
+    def test_book_touch_rejects_invalid_side(self):
+        """book_touch raises on side values outside SideType."""
+        simulator = TradeThroughFillSimulator(mode=FillMode.BOOK_TOUCH)
+        order = SimulatedOrder(
+            order_id="1",
+            client_order_id="c1",
+            symbol="LTCUSDT",
+            side="Invalid",
+            price=Decimal("58.60"),
+            qty=Decimal("0.1"),
+            direction="long",
+            grid_level=0,
+        )
+        ticker = _ticker(Decimal("58.60"), Decimal("58.60"), Decimal("58.60"))
+
+        with pytest.raises(ValueError, match="Invalid order side"):
+            simulator.check_fill(order, ticker)

--- a/apps/backtest/tests/test_fill_simulator.py
+++ b/apps/backtest/tests/test_fill_simulator.py
@@ -5,8 +5,42 @@ from decimal import Decimal
 
 import pytest
 
-from backtest.fill_simulator import TradeThroughFillSimulator, FillResult
+from gridcore import EventType, TickerEvent
+
+from backtest.fill_simulator import FillMode, TradeThroughFillSimulator
 from backtest.order_manager import SimulatedOrder
+
+
+def _order(side: str, price: Decimal = Decimal("58.60")) -> SimulatedOrder:
+    return SimulatedOrder(
+        order_id="1",
+        client_order_id="c1",
+        symbol="LTCUSDT",
+        side=side,
+        price=price,
+        qty=Decimal("0.1"),
+        direction="long" if side == "Buy" else "short",
+        grid_level=0,
+    )
+
+
+def _ticker(
+    last: Decimal,
+    bid: Decimal,
+    ask: Decimal,
+) -> TickerEvent:
+    ts = datetime(2026, 5, 11, 4, 49, 58, tzinfo=timezone.utc)
+    return TickerEvent(
+        event_type=EventType.TICKER,
+        symbol="LTCUSDT",
+        exchange_ts=ts,
+        local_ts=ts,
+        last_price=last,
+        mark_price=last,
+        bid1_price=bid,
+        ask1_price=ask,
+        funding_rate=Decimal("0"),
+    )
 
 
 class TestTradeThroughFillSimulator:
@@ -136,3 +170,157 @@ class TestTradeThroughFillSimulator:
         )
 
         assert fill_simulator.get_fill_price(order) == Decimal("99500.50")
+
+
+class TestFillModeMatrix:
+    """Mode matrix for strict, last-price-at-limit, and L1 touch fills."""
+
+    @pytest.mark.parametrize(
+        (
+            "market",
+            "buy_expected",
+            "sell_expected",
+        ),
+        [
+            (
+                _ticker(Decimal("58.59"), Decimal("58.58"), Decimal("58.59")),
+                {
+                    FillMode.STRICT_CROSS: True,
+                    FillMode.TRADE_THROUGH_AT_LIMIT: True,
+                    FillMode.BOOK_TOUCH: True,
+                },
+                {
+                    FillMode.STRICT_CROSS: False,
+                    FillMode.TRADE_THROUGH_AT_LIMIT: False,
+                    FillMode.BOOK_TOUCH: False,
+                },
+            ),
+            (
+                _ticker(Decimal("58.61"), Decimal("58.61"), Decimal("58.62")),
+                {
+                    FillMode.STRICT_CROSS: False,
+                    FillMode.TRADE_THROUGH_AT_LIMIT: False,
+                    FillMode.BOOK_TOUCH: False,
+                },
+                {
+                    FillMode.STRICT_CROSS: True,
+                    FillMode.TRADE_THROUGH_AT_LIMIT: True,
+                    FillMode.BOOK_TOUCH: True,
+                },
+            ),
+            (
+                _ticker(Decimal("58.60"), Decimal("58.59"), Decimal("58.61")),
+                {
+                    FillMode.STRICT_CROSS: False,
+                    FillMode.TRADE_THROUGH_AT_LIMIT: True,
+                    FillMode.BOOK_TOUCH: False,
+                },
+                {
+                    FillMode.STRICT_CROSS: False,
+                    FillMode.TRADE_THROUGH_AT_LIMIT: True,
+                    FillMode.BOOK_TOUCH: False,
+                },
+            ),
+            (
+                _ticker(Decimal("58.60"), Decimal("58.60"), Decimal("58.60")),
+                {
+                    FillMode.STRICT_CROSS: False,
+                    FillMode.TRADE_THROUGH_AT_LIMIT: True,
+                    FillMode.BOOK_TOUCH: True,
+                },
+                {
+                    FillMode.STRICT_CROSS: False,
+                    FillMode.TRADE_THROUGH_AT_LIMIT: True,
+                    FillMode.BOOK_TOUCH: True,
+                },
+            ),
+            (
+                _ticker(Decimal("58.61"), Decimal("58.60"), Decimal("58.60")),
+                {
+                    FillMode.STRICT_CROSS: False,
+                    FillMode.TRADE_THROUGH_AT_LIMIT: False,
+                    FillMode.BOOK_TOUCH: True,
+                },
+                {
+                    FillMode.STRICT_CROSS: True,
+                    FillMode.TRADE_THROUGH_AT_LIMIT: True,
+                    FillMode.BOOK_TOUCH: True,
+                },
+            ),
+            (
+                Decimal("58.60"),
+                {
+                    FillMode.STRICT_CROSS: False,
+                    FillMode.TRADE_THROUGH_AT_LIMIT: True,
+                    FillMode.BOOK_TOUCH: True,
+                },
+                {
+                    FillMode.STRICT_CROSS: False,
+                    FillMode.TRADE_THROUGH_AT_LIMIT: True,
+                    FillMode.BOOK_TOUCH: True,
+                },
+            ),
+        ],
+    )
+    @pytest.mark.parametrize("mode", list(FillMode))
+    def test_fill_mode_matrix(self, market, buy_expected, sell_expected, mode):
+        simulator = TradeThroughFillSimulator(mode=mode)
+
+        buy_result = simulator.check_fill(_order("Buy"), market)
+        sell_result = simulator.check_fill(_order("Sell"), market)
+
+        assert buy_result.should_fill is buy_expected[mode]
+        assert sell_result.should_fill is sell_expected[mode]
+
+    def test_book_touch_falls_back_to_trade_through_on_bare_decimal_buy(self):
+        simulator = TradeThroughFillSimulator(mode=FillMode.BOOK_TOUCH)
+
+        result = simulator.check_fill(_order("Buy"), Decimal("58.60"))
+
+        assert result.should_fill is True
+        assert result.fill_price == Decimal("58.60")
+
+    def test_book_touch_falls_back_to_trade_through_on_bare_decimal_sell(self):
+        simulator = TradeThroughFillSimulator(mode=FillMode.BOOK_TOUCH)
+
+        result = simulator.check_fill(_order("Sell"), Decimal("58.60"))
+
+        assert result.should_fill is True
+        assert result.fill_price == Decimal("58.60")
+
+    def test_book_touch_treats_default_zero_bid_ask_as_missing_l1(self):
+        """TickerEvent's default zero bid/ask must not trigger phantom fills."""
+        simulator = TradeThroughFillSimulator(mode=FillMode.BOOK_TOUCH)
+        ts = datetime(2026, 5, 11, 4, 49, 58, tzinfo=timezone.utc)
+        ticker = TickerEvent(
+            event_type=EventType.TICKER,
+            symbol="LTCUSDT",
+            exchange_ts=ts,
+            local_ts=ts,
+            last_price=Decimal("58.61"),
+            mark_price=Decimal("58.61"),
+        )
+
+        buy_result = simulator.check_fill(_order("Buy"), ticker)
+        sell_result = simulator.check_fill(_order("Sell"), ticker)
+
+        assert buy_result.should_fill is False
+        assert sell_result.should_fill is True
+
+    @pytest.mark.parametrize("mode", list(FillMode))
+    def test_non_positive_last_price_never_fills(self, mode):
+        """Default zero last_price is invalid market data, not a cross."""
+        simulator = TradeThroughFillSimulator(mode=mode)
+        ts = datetime(2026, 5, 11, 4, 49, 58, tzinfo=timezone.utc)
+        ticker = TickerEvent(
+            event_type=EventType.TICKER,
+            symbol="LTCUSDT",
+            exchange_ts=ts,
+            local_ts=ts,
+        )
+
+        buy_result = simulator.check_fill(_order("Buy"), ticker)
+        sell_result = simulator.check_fill(_order("Sell"), ticker)
+
+        assert buy_result.should_fill is False
+        assert sell_result.should_fill is False

--- a/apps/backtest/tests/test_order_manager.py
+++ b/apps/backtest/tests/test_order_manager.py
@@ -1,12 +1,12 @@
 """Tests for order manager."""
 
-from datetime import datetime, timezone
 from decimal import Decimal
 
 import pytest
 
-from backtest.order_manager import BacktestOrderManager, SimulatedOrder
-from backtest.fill_simulator import TradeThroughFillSimulator
+from gridcore import EventType, TickerEvent
+
+from backtest.fill_simulator import FillMode, TradeThroughFillSimulator
 
 
 class TestBacktestOrderManager:
@@ -258,6 +258,123 @@ class TestBacktestOrderManager:
         assert len(fills) == 1
         assert fills[0].symbol == "BTCUSDT"
         assert order_manager.total_active_orders == 1  # ETHUSDT still active
+
+    def test_check_fills_ticker_event_scopes_to_event_symbol(
+        self,
+        order_manager,
+        sample_timestamp,
+    ):
+        """TickerEvent input only checks orders for the event symbol."""
+        order_manager.place_order(
+            client_order_id="btc",
+            symbol="BTCUSDT",
+            side="Buy",
+            price=Decimal("100000"),
+            qty=Decimal("0.1"),
+            direction="long",
+            grid_level=0,
+            timestamp=sample_timestamp,
+        )
+        order_manager.place_order(
+            client_order_id="eth",
+            symbol="ETHUSDT",
+            side="Buy",
+            price=Decimal("100000"),
+            qty=Decimal("0.1"),
+            direction="long",
+            grid_level=0,
+            timestamp=sample_timestamp,
+        )
+        ticker = TickerEvent(
+            event_type=EventType.TICKER,
+            symbol="BTCUSDT",
+            exchange_ts=sample_timestamp,
+            local_ts=sample_timestamp,
+            last_price=Decimal("99000"),
+            mark_price=Decimal("99000"),
+            bid1_price=Decimal("98999"),
+            ask1_price=Decimal("99001"),
+            funding_rate=Decimal("0"),
+        )
+
+        fills = order_manager.check_fills(ticker)
+
+        assert len(fills) == 1
+        assert fills[0].symbol == "BTCUSDT"
+        assert order_manager.get_order_by_client_id("eth").status == "pending"
+
+    def test_check_fills_ticker_event_ignores_symbol_override(
+        self,
+        order_manager,
+        sample_timestamp,
+    ):
+        """TickerEvent input is always scoped to the event symbol."""
+        order_manager.place_order(
+            client_order_id="btc",
+            symbol="BTCUSDT",
+            side="Buy",
+            price=Decimal("100000"),
+            qty=Decimal("0.1"),
+            direction="long",
+            grid_level=0,
+            timestamp=sample_timestamp,
+        )
+        order_manager.place_order(
+            client_order_id="eth",
+            symbol="ETHUSDT",
+            side="Buy",
+            price=Decimal("3000"),
+            qty=Decimal("0.1"),
+            direction="long",
+            grid_level=0,
+            timestamp=sample_timestamp,
+        )
+        ticker = TickerEvent(
+            event_type=EventType.TICKER,
+            symbol="BTCUSDT",
+            exchange_ts=sample_timestamp,
+            local_ts=sample_timestamp,
+            last_price=Decimal("99000"),
+            mark_price=Decimal("99000"),
+            bid1_price=Decimal("98999"),
+            ask1_price=Decimal("99001"),
+            funding_rate=Decimal("0"),
+        )
+
+        fills = order_manager.check_fills(ticker, symbol="ETHUSDT")
+
+        assert len(fills) == 1
+        assert fills[0].symbol == "BTCUSDT"
+        assert order_manager.get_order_by_client_id("eth").status == "pending"
+
+    def test_check_fills_decimal_requires_timestamp(self, order_manager):
+        """Legacy bare-Decimal fill checks need an explicit timestamp."""
+        with pytest.raises(ValueError, match="timestamp is required"):
+            order_manager.check_fills(Decimal("99000"))
+
+    def test_book_touch_falls_back_through_order_manager_bare_decimal(
+        self,
+        order_manager,
+        sample_timestamp,
+    ):
+        """BOOK_TOUCH degrades to at-limit semantics for bare Decimal input."""
+        order_manager.fill_simulator = TradeThroughFillSimulator(mode=FillMode.BOOK_TOUCH)
+        order_manager.place_order(
+            client_order_id="ltc",
+            symbol="LTCUSDT",
+            side="Buy",
+            price=Decimal("58.60"),
+            qty=Decimal("0.1"),
+            direction="long",
+            grid_level=0,
+            timestamp=sample_timestamp,
+        )
+
+        fills = order_manager.check_fills(Decimal("58.60"), timestamp=sample_timestamp)
+
+        assert len(fills) == 1
+        assert fills[0].price == Decimal("58.60")
+        assert fills[0].side == "Buy"
 
     def test_fill_includes_commission(self, order_manager, sample_timestamp):
         """Execution event includes calculated commission."""

--- a/apps/backtest/tests/test_runner.py
+++ b/apps/backtest/tests/test_runner.py
@@ -13,7 +13,7 @@ from gridcore.pnl import calc_maintenance_margin
 
 from backtest.runner import BacktestRunner
 from backtest.config import BacktestStrategyConfig
-from backtest.fill_simulator import TradeThroughFillSimulator
+from backtest.fill_simulator import FillMode, TradeThroughFillSimulator
 from backtest.order_manager import BacktestOrderManager
 from backtest.executor import BacktestExecutor
 from backtest.session import BacktestSession
@@ -98,6 +98,53 @@ class TestBacktestRunner:
 
         # Should have recorded a trade
         assert len(runner._session.trades) >= 1
+
+    def test_book_touch_fills_on_ask_touch_without_last_penetration(
+        self,
+        sample_strategy_config,
+        session,
+        sample_timestamp,
+    ):
+        """Runner passes full ticker data to the fill simulator."""
+        fill_simulator = TradeThroughFillSimulator(mode=FillMode.BOOK_TOUCH)
+        order_manager = BacktestOrderManager(
+            fill_simulator=fill_simulator,
+            commission_rate=sample_strategy_config.commission_rate,
+        )
+        executor = BacktestExecutor(order_manager=order_manager, qty_calculator=None)
+        runner = BacktestRunner(
+            strategy_config=sample_strategy_config,
+            executor=executor,
+            session=session,
+        )
+        order_manager.place_order(
+            client_order_id="book-touch-buy",
+            symbol="BTCUSDT",
+            side="Buy",
+            price=Decimal("58.60"),
+            qty=Decimal("0.1"),
+            direction="long",
+            grid_level=0,
+            timestamp=sample_timestamp,
+        )
+        tick = TickerEvent(
+            event_type=EventType.TICKER,
+            symbol="BTCUSDT",
+            exchange_ts=sample_timestamp,
+            local_ts=sample_timestamp,
+            last_price=Decimal("58.61"),
+            mark_price=Decimal("58.61"),
+            bid1_price=Decimal("58.59"),
+            ask1_price=Decimal("58.60"),
+            funding_rate=Decimal("0"),
+        )
+
+        post_fill_intents = runner.process_fills(tick)
+
+        assert len(session.trades) == 1
+        assert session.trades[0].price == Decimal("58.60")
+        assert order_manager.total_active_orders == 0
+        assert post_fill_intents == []
 
     def test_apply_funding(self, runner, sample_ticker_event):
         """Funding is applied to positions."""

--- a/apps/comparator/src/comparator/reporter.py
+++ b/apps/comparator/src/comparator/reporter.py
@@ -22,6 +22,11 @@ ResampledRow = tuple[datetime, Optional[Decimal], Optional[Decimal]]
 class ComparatorReporter:
     """Export comparison results to CSV and console."""
 
+    # Characters that spreadsheet apps (Excel, Sheets, LibreOffice) interpret
+    # as formula triggers when a cell value starts with them. Prefixing with
+    # a single quote forces the cell to be read as a literal string.
+    _CSV_INJECTION_TRIGGERS = ("=", "+", "-", "@")
+
     def __init__(
         self,
         match_result: MatchResult,
@@ -39,6 +44,17 @@ class ComparatorReporter:
         path = Path(path)
         path.parent.mkdir(parents=True, exist_ok=True)
         return path
+
+    def _sanitize_csv_value(self, value: str) -> str:
+        """Defuse spreadsheet formula injection on cell values.
+
+        Spreadsheet apps interpret a cell starting with =, +, -, @ as a
+        formula. Prefix such values with a single quote so they're read as
+        literal text instead.
+        """
+        if value and value[0] in self._CSV_INJECTION_TRIGGERS:
+            return f"'{value}"
+        return value
 
     def export_matched_trades(self, path: Union[str, Path]) -> None:
         """Export matched trade pairs with deltas to CSV."""
@@ -190,7 +206,7 @@ class ComparatorReporter:
             for metric, value in rows:
                 writer.writerow([metric, value])
             for key, value in sorted(self._metadata.items()):
-                writer.writerow([f"meta.{key}", value])
+                writer.writerow([f"meta.{key}", self._sanitize_csv_value(value)])
 
         logger.info("Exported validation metrics to %s", path)
 

--- a/apps/comparator/src/comparator/reporter.py
+++ b/apps/comparator/src/comparator/reporter.py
@@ -27,10 +27,12 @@ class ComparatorReporter:
         match_result: MatchResult,
         metrics: ValidationMetrics,
         equity_data: list[ResampledRow] | None = None,
+        metadata: dict[str, str] | None = None,
     ):
         self._match_result = match_result
         self._metrics = metrics
         self._equity_data = equity_data
+        self._metadata = metadata or {}
 
     def _ensure_path(self, path: Union[str, Path]) -> Path:
         """Convert to Path and create parent directories."""
@@ -187,6 +189,8 @@ class ComparatorReporter:
             writer.writerow(["metric", "value"])
             for metric, value in rows:
                 writer.writerow([metric, value])
+            for key, value in sorted(self._metadata.items()):
+                writer.writerow([f"meta.{key}", value])
 
         logger.info("Exported validation metrics to %s", path)
 

--- a/apps/comparator/tests/test_reporter.py
+++ b/apps/comparator/tests/test_reporter.py
@@ -216,3 +216,36 @@ class TestComparatorReporter:
         assert len(rows) == 2
         assert rows[0]["occurrence"] == "0"
         assert rows[1]["occurrence"] == "1"
+
+
+class TestCsvInjectionSanitization:
+    """Metadata values that look like spreadsheet formulas must be neutered."""
+
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            ("=cmd|'/c calc'!A1", "'=cmd|'/c calc'!A1"),
+            ("+SUM(A1:A2)", "'+SUM(A1:A2)"),
+            ("-1+1", "'-1+1"),
+            ("@SUM(A1)", "'@SUM(A1)"),
+            ("strict_cross", "strict_cross"),  # unchanged
+            ("", ""),  # empty stays empty
+        ],
+    )
+    def test_meta_value_sanitization(
+        self, sample_match_result, tmp_path, raw, expected
+    ):
+        metrics = calculate_metrics(sample_match_result)
+        reporter = ComparatorReporter(
+            sample_match_result, metrics, metadata={"injected": raw}
+        )
+
+        path = tmp_path / "metrics.csv"
+        reporter.export_metrics(path)
+
+        with open(path) as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+
+        metrics_dict = {r["metric"]: r["value"] for r in rows}
+        assert metrics_dict["meta.injected"] == expected

--- a/apps/comparator/tests/test_reporter.py
+++ b/apps/comparator/tests/test_reporter.py
@@ -63,6 +63,26 @@ class TestComparatorReporter:
         assert metrics_dict["matched_count"] == "2"
         assert "match_rate" in metrics_dict
         assert "pnl_correlation" in metrics_dict
+        assert "meta.fill_mode" not in metrics_dict
+
+    def test_export_metrics_includes_metadata(self, sample_match_result, tmp_path):
+        """Metrics CSV includes optional metadata with meta. prefix."""
+        metrics = calculate_metrics(sample_match_result)
+        reporter = ComparatorReporter(
+            sample_match_result,
+            metrics,
+            metadata={"fill_mode": "book_touch"},
+        )
+        path = tmp_path / "metrics.csv"
+
+        reporter.export_metrics(path)
+
+        with open(path) as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+
+        metrics_dict = {r["metric"]: r["value"] for r in rows}
+        assert metrics_dict["meta.fill_mode"] == "book_touch"
 
     def test_export_all(self, reporter, tmp_path):
         """export_all creates all expected files."""

--- a/apps/replay/conf/replay.yaml.example
+++ b/apps/replay/conf/replay.yaml.example
@@ -19,6 +19,12 @@ strategy:
   amount: "x0.001"
   commission_rate: 0.0002
 
+# Optional fill simulator mode:
+#   strict_cross (default, conservative), trade_through_at_limit, or book_touch.
+#   Use book_touch for recorder parity smoke when ticker_snapshots include L1 bid/ask.
+# fill_simulator:
+#   mode: strict_cross
+
 initial_balance: 10000
 enable_funding: true
 funding_rate: 0.0001

--- a/apps/replay/conf/replay_ltcusdt_phase4.yaml
+++ b/apps/replay/conf/replay_ltcusdt_phase4.yaml
@@ -1,0 +1,36 @@
+database_url: "sqlite:///data/recorder_ltcusdt_phase4.db"
+run_id: "b1f5b867-0c1c-4504-b48e-cc1d7a395eaf"
+
+symbol: "LTCUSDT"
+start_ts: "2026-05-10T18:06:18Z"
+end_ts: "2026-05-11T06:04:23Z"
+
+strategy:
+  tick_size: "0.1"
+  grid_count: 20
+  grid_step: 0.3
+  amount: "x0.001"
+  commission_rate: "0.0002"
+  enable_risk_multipliers: true
+  early_imbalance_multiplier: 1.0
+
+seed:
+  enabled: true
+  at_ts: "2026-05-10T18:06:18Z"
+  account_id: "00000000-0000-0000-0000-000000000002"
+  strat_id: "ltcusdt_test"
+  grid_state_path: "db/grid_anchor.phase4.json"
+  wallet_coin: "USDT"
+
+fill_simulator:
+  mode: "book_touch"
+
+initial_balance: "10000"
+
+enable_funding: true
+funding_rate: "0.0001"
+wind_down_mode: "leave_open"
+
+output_dir: "results/replay_ltcusdt_phase4"
+price_tolerance: 0
+qty_tolerance: "0.001"

--- a/apps/replay/src/replay/config.py
+++ b/apps/replay/src/replay/config.py
@@ -7,7 +7,7 @@ import os
 from decimal import Decimal
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
+from typing import Literal, Optional
 
 import yaml
 from pydantic import BaseModel, Field, field_validator, model_validator
@@ -154,6 +154,15 @@ class SeedConfig(BaseModel):
         return self
 
 
+class FillSimulatorConfig(BaseModel):
+    """Replay fill simulator configuration."""
+
+    mode: Literal["strict_cross", "trade_through_at_limit", "book_touch"] = Field(
+        default="strict_cross",
+        description="Fill simulator mode for replay.",
+    )
+
+
 class ReplayConfig(BaseModel):
     """Root configuration for replay engine."""
 
@@ -185,6 +194,10 @@ class ReplayConfig(BaseModel):
     seed: SeedConfig = Field(
         default_factory=SeedConfig,
         description="Seed-from-recorder configuration (feature 0029); off by default.",
+    )
+    fill_simulator: FillSimulatorConfig = Field(
+        default_factory=FillSimulatorConfig,
+        description="Fill simulator configuration.",
     )
 
     # Backtest parameters

--- a/apps/replay/src/replay/engine.py
+++ b/apps/replay/src/replay/engine.py
@@ -34,7 +34,7 @@ from backtest.config import BacktestStrategyConfig, WindDownMode
 from backtest.data_provider import HistoricalDataProvider, InMemoryDataProvider
 from backtest.engine import FundingSimulator
 from backtest.executor import BacktestExecutor
-from backtest.fill_simulator import TradeThroughFillSimulator
+from backtest.fill_simulator import FillMode, TradeThroughFillSimulator
 from backtest.instrument_info import InstrumentInfoProvider
 from backtest.order_manager import BacktestOrderManager
 from backtest.position_tracker import BacktestPositionTracker
@@ -80,6 +80,11 @@ class ReplayResult:
     session: BacktestSession
     metrics: ValidationMetrics
     match_result: MatchResult
+    run_id: str
+    symbol: str
+    start_ts: datetime
+    end_ts: datetime
+    fill_mode: FillMode
 
 
 class ReplayEngine:
@@ -118,10 +123,11 @@ class ReplayEngine:
 
         # 1. Resolve run_id and time range
         run_id, start_ts, end_ts = self._resolve_run(config)
+        fill_mode = FillMode(config.fill_simulator.mode)
 
         logger.info(
             f"Replay: symbol={config.symbol}, run_id={run_id}, "
-            f"range={start_ts} to {end_ts}"
+            f"range={start_ts} to {end_ts}, fill_mode={fill_mode.value}"
         )
 
         # 2. Build backtest components
@@ -159,6 +165,7 @@ class ReplayEngine:
             short_seed=short_seed,
             grid_seed=grid_seed,
             order_seeds=order_seeds,
+            fill_mode=fill_mode,
         )
 
         if config.seed.enabled:
@@ -273,6 +280,11 @@ class ReplayEngine:
             session=session,
             metrics=metrics,
             match_result=match_result,
+            run_id=run_id,
+            symbol=config.symbol,
+            start_ts=start_ts,
+            end_ts=end_ts,
+            fill_mode=fill_mode,
         )
 
     def _resolve_run(self, config: ReplayConfig):
@@ -341,6 +353,7 @@ class ReplayEngine:
         short_seed: Optional[PositionStateSeed] = None,
         grid_seed: Optional[GridStateSeed] = None,
         order_seeds: Optional[list[ActiveOrderSeed]] = None,
+        fill_mode: FillMode = FillMode.STRICT_CROSS,
     ) -> BacktestRunner:
         """Initialize a BacktestRunner for the replay.
 
@@ -365,6 +378,7 @@ class ReplayEngine:
                 to ``BacktestRunner`` as ``seeded_active_orders``, which
                 pre-loads the ``BacktestOrderManager`` so they participate
                 in fill checks on the first tick.
+            fill_mode: Fill simulator mode for the replay runner.
         """
         instrument_info = self._instrument_provider.get(strategy_config.symbol)
         logger.info(
@@ -372,7 +386,7 @@ class ReplayEngine:
             f"qty_step={instrument_info.qty_step}, tick_size={instrument_info.tick_size}"
         )
 
-        fill_simulator = TradeThroughFillSimulator()
+        fill_simulator = TradeThroughFillSimulator(mode=fill_mode)
         order_manager = BacktestOrderManager(
             fill_simulator=fill_simulator,
             commission_rate=strategy_config.commission_rate,

--- a/apps/replay/src/replay/main.py
+++ b/apps/replay/src/replay/main.py
@@ -7,6 +7,7 @@ Usage:
 """
 
 import argparse
+import json
 import logging
 import sys
 from datetime import datetime
@@ -164,11 +165,28 @@ def main(argv=None) -> int:
 
         # Export comparison reports
         output_dir = Path(config.output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
         reporter = ComparatorReporter(
             match_result=result.match_result,
             metrics=result.metrics,
+            metadata={"fill_mode": result.fill_mode.value},
         )
         exported = reporter.export_all(output_dir)
+        summary_path = output_dir / "summary.json"
+        with open(summary_path, "w") as f:
+            json.dump(
+                {
+                    "run_id": result.run_id,
+                    "fill_mode": result.fill_mode.value,
+                    "start_ts": result.start_ts.isoformat(),
+                    "end_ts": result.end_ts.isoformat(),
+                    "symbol": result.symbol,
+                },
+                f,
+                indent=2,
+            )
+            f.write("\n")
+        exported["summary"] = summary_path
         reporter.print_summary()
 
         for report_type, path in exported.items():

--- a/apps/replay/tests/test_config.py
+++ b/apps/replay/tests/test_config.py
@@ -3,7 +3,12 @@
 import pytest
 from decimal import Decimal
 from pydantic import ValidationError
-from replay.config import load_config, ReplayConfig, ReplayStrategyConfig
+from replay.config import (
+    FillSimulatorConfig,
+    ReplayConfig,
+    ReplayStrategyConfig,
+    load_config,
+)
 
 
 class TestReplayStrategyConfig:
@@ -49,6 +54,7 @@ class TestReplayConfig:
         assert config.output_dir == "results/replay"
         assert config.price_tolerance == Decimal("0")
         assert config.qty_tolerance == Decimal("0.001")
+        assert config.fill_simulator.mode == "strict_cross"
 
     def test_initial_balance_string(self):
         config = ReplayConfig(
@@ -65,6 +71,44 @@ class TestReplayConfig:
             initial_balance=5000,
         )
         assert config.initial_balance == Decimal("5000")
+
+    def test_fill_simulator_omitted_defaults_to_strict_cross(self):
+        config = ReplayConfig(
+            symbol="BTCUSDT",
+            strategy=ReplayStrategyConfig(tick_size=Decimal("0.1")),
+        )
+
+        assert config.fill_simulator == FillSimulatorConfig(mode="strict_cross")
+
+    def test_fill_simulator_empty_block_defaults_to_strict_cross(self):
+        config = ReplayConfig(
+            symbol="BTCUSDT",
+            strategy=ReplayStrategyConfig(tick_size=Decimal("0.1")),
+            fill_simulator={},
+        )
+
+        assert config.fill_simulator.mode == "strict_cross"
+
+    @pytest.mark.parametrize(
+        "mode",
+        ["strict_cross", "trade_through_at_limit", "book_touch"],
+    )
+    def test_fill_simulator_explicit_modes(self, mode):
+        config = ReplayConfig(
+            symbol="BTCUSDT",
+            strategy=ReplayStrategyConfig(tick_size=Decimal("0.1")),
+            fill_simulator={"mode": mode},
+        )
+
+        assert config.fill_simulator.mode == mode
+
+    def test_fill_simulator_invalid_mode_rejected(self):
+        with pytest.raises(ValidationError):
+            ReplayConfig(
+                symbol="BTCUSDT",
+                strategy=ReplayStrategyConfig(tick_size=Decimal("0.1")),
+                fill_simulator={"mode": "invalid"},
+            )
 
 
 class TestLoadConfig:

--- a/apps/replay/tests/test_engine.py
+++ b/apps/replay/tests/test_engine.py
@@ -10,6 +10,7 @@ from gridcore import TickerEvent, EventType
 from grid_db import Run, User, BybitAccount, Strategy
 
 from backtest.data_provider import InMemoryDataProvider
+from backtest.fill_simulator import FillMode
 
 from replay.config import ReplayConfig, ReplayStrategyConfig
 from replay.engine import ReplayEngine, ReplayResult
@@ -89,6 +90,11 @@ class TestReplayEngine:
         assert result.session is not None
         assert result.metrics is not None
         assert result.match_result is not None
+        assert result.run_id == "test-run-id"
+        assert result.symbol == "BTCUSDT"
+        assert result.start_ts == replay_config.start_ts
+        assert result.end_ts == replay_config.end_ts
+        assert result.fill_mode == FillMode.STRICT_CROSS
 
     @patch("replay.engine.InstrumentInfoProvider")
     def test_replay_empty_data(self, mock_provider_cls, db, replay_config):

--- a/docs/features/0029_RUNBOOK.md
+++ b/docs/features/0029_RUNBOOK.md
@@ -328,6 +328,9 @@ seed:
   grid_state_path: "db/grid_anchor.phase4.json"
   wallet_coin: "USDT"
 
+fill_simulator:
+  mode: book_touch
+
 # Fallback when seed-wallet returns None (shouldn't happen if Step 4
 # succeeded with a non-empty wallet on the account)
 initial_balance: "10000"

--- a/docs/features/0033_PLAN.md
+++ b/docs/features/0033_PLAN.md
@@ -1,0 +1,573 @@
+# Feature 0033 — Configurable fill simulator: bid/ask-aware parity mode for replay
+
+## Brief
+
+The 0029 Phase 4 parity smoke shipped on `0d7a35f` (PR #68) and ran twice on
+LTCUSDT mainnet — once on 2026-05-08 (76 executions, 20h window) and once on
+2026-05-10/11 (138 executions, 12h window, after 0030+0031 merges). Both
+runs converged on the same result:
+
+| Metric | Run 1 | Run 2 (post 0030+0031) | Target |
+|---|---|---|---|
+| `match_rate` | 91.89% | 91.30% | ≥0.95 |
+| `price_max_abs_delta` | 0 | 0 | 0 |
+| `qty_median_abs_delta` | 0 | 0 | 0 |
+| `pnl_correlation` | 0.9958 | 0.9838 | high |
+| `live_only` | 6 (8.1%) | 12 (8.7%) | 0 |
+| `backtest_only` | 0 | 0 | 0 |
+
+The shortfall is structural, not a bug.
+`apps/backtest/src/backtest/fill_simulator.py:53-74` implements a strict-cross
+fill semantics for **all** consumers (`backtest`, `replay`, and the Phase 4
+parity smoke) — BUY fills only when `current_price < limit_price`, SELL only
+when `current_price > limit_price`. `current_price` is the ticker's
+`last_price`. This is conservative for production backtest (no phantom
+fills), but it **under-models exchange-observed fills** for parity smoke.
+Real fills involve a market or aggressing limit order crossing the
+resting side of the book (e.g. a BUY limit at 58.60 fills when an
+incoming sell reaches our bid), which `last_price < limit` does not
+capture when the trade prints exactly at the limit. A recorded L1
+touch/cross (`ask1 ≤ limit` for BUY, `bid1 ≥ limit` for SELL) is a much
+closer proxy — not a full microstructure model, but a measurable
+improvement over `last_price`-only. The observed ~9% match-rate gap in both runs
+is explained by **two compounding effects**: roughly half are direct
+at-limit misses (live filled while `last_price == limit` with no strict
+penetration; strict-cross sees `current < limit == False`); the rest are
+cascade artefacts — once strict-cross delays even one fill, comparator's
+`(client_order_id, occurrence)` matcher shifts subsequent live occurrences
+into `live_only` (see parallel-review finding below and Step 7).
+
+Concrete evidence — unmatched `b8ec692b2ae7d0d5` BUY @ 58.60 in run 2, filled
+in live at `2026-05-11T04:49:58.970`. Ticker history around the fill from
+`ticker_snapshots`:
+
+```
+04:49:55.216 → 04:49:58.516   last_price = 58.61   (above limit)
+04:49:59.016 → 04:50:01.316   last_price = 58.60   (== limit, no penetration)
+04:50:01.416 → 04:50:02.616   last_price = 58.61
+04:50:02.716 → ...            last_price = 58.60
+```
+
+`last_price` never drops below 58.60, yet live filled BUY @ 58.60 because the
+order book's BID @ 58.60 absorbed an incoming sell — Bybit reports that as
+`last_price = 58.60`. Strict-cross sees `58.60 < 58.60 == False` → no fill.
+
+A parallel independent investigation (2026-05-11) confirmed the diagnosis
+and added a second-order finding:
+
+- **6 of 12 `live_only` fills** are direct strict-cross misses (the pattern
+  above): `min(last_price) == limit` over the live execution window,
+  `strict_ticks=0`, `touch_ticks>0`. Examples: BUY 58.60 at 04:49:58.970,
+  BUY 58.40 at 03:36:55.834, BUY 58.00 at 20:50:01.324.
+- **6 of 12** are **cascade artefacts** — once an earlier strict-cross
+  miss delays a fill, comparator's `client_order_id + occurrence`
+  matching aligns the late replay fill against an *earlier* live
+  occurrence, shifting all subsequent occurrences and pushing the
+  original later-occurrence into `live_only`. A single missed fill can
+  produce two `live_only` records. Example: `0bffdc44677f4e83` live
+  occurrence 0 at 20:34 ended up matched with replay's fill at 22:14,
+  forcing live occurrence 1 at 22:14 into `live_only`.
+
+The cascade is a comparator-side concern, deferred (see Step 7). The
+strict-cross root cause is in `fill_simulator.py` and is the primary fix
+0033 addresses.
+
+Recorder writes `bid1_price` and `ask1_price` to `ticker_snapshots`
+(`apps/recorder/src/recorder/db.py` schema; verified via
+`PRAGMA table_info(ticker_snapshots)`), and `SQLiteDataProvider` populates
+them on `TickerEvent`. But the data is discarded at
+`apps/backtest/src/backtest/runner.py:328` where only `event.last_price` is
+forwarded into `order_manager.check_fills(...)`. The L1 book that lives in
+the database never reaches the fill decision.
+
+This feature plumbs the full `TickerEvent` through to the simulator and adds
+a configurable `mode` selector so production backtest keeps its conservative
+strict-cross semantics while replay parity smoke can request `book_touch`
+semantics — a **closer proxy** to live fills using recorded L1
+touch/cross, not a full exchange-microstructure model. Real resting BUY
+limits fill via an incoming sell crossing the bid; we approximate this by
+checking whether the recorded `ask1_price` ≤ limit, which captures most
+exchange-observed fills but does not model queue position, partial-volume
+contention, or sub-tick reorderings.
+
+Non-goals:
+
+- Changing `strict_cross` as the **default**. Existing backtest users rely
+  on conservative semantics; flipping the default would silently change
+  every historical backtest result (more fills, higher turnover, different
+  PnL/fees). Migration of defaults is a separate, audited decision.
+- Comparator-side occurrence-shift cascade. Tracked as 0033 follow-up
+  (Step 7).
+- Adding bid/ask to `TickerEvent` (already there; just unused downstream).
+- Modifying `apps/backtest/tests/test_fill_simulator.py:11`'s
+  "at limit does NOT fill" contract. That contract is correct for
+  `strict_cross` and stays as-is — new tests cover the new modes.
+- Modeling slippage. `book_touch` still fills at `order.price` (the limit
+  price). Modeling worse-than-limit fills is a separate concern.
+
+## Plan
+
+### Step 1 — Refactor `TradeThroughFillSimulator` to accept full `TickerEvent`
+
+`apps/backtest/src/backtest/fill_simulator.py`:
+
+1. Add `FillMode` enum (use `StrEnum` so YAML config strings round-trip):
+   ```python
+   class FillMode(StrEnum):
+       STRICT_CROSS = "strict_cross"                  # default; current behavior
+       TRADE_THROUGH_AT_LIMIT = "trade_through_at_limit"  # last_price <= / >= limit
+       BOOK_TOUCH = "book_touch"                      # ask1 <= limit / bid1 >= limit
+   ```
+2. Add internal normalized snapshot dataclass — keeps the `TickerEvent`
+   type contract clean (it currently types `bid1_price`/`ask1_price` as
+   non-Optional `Decimal`; we don't widen the cross-cutting type just for
+   the simulator). Backward-compat callers that pass bare `Decimal`
+   convert into this snapshot with `None` bid/ask:
+   ```python
+   @dataclass(frozen=True)
+   class MarketSnapshot:
+       last_price: Decimal
+       bid1_price: Decimal | None = None
+       ask1_price: Decimal | None = None
+   ```
+3. Change `__init__` to accept `mode: FillMode = FillMode.STRICT_CROSS`.
+4. Add new primary signature `check_fill(self, order, ticker: TickerEvent)
+   → FillResult` that normalizes to `MarketSnapshot` internally
+   (`last_price`, `bid1_price`, `ask1_price` from the event). The old
+   `check_fill(self, order, current_price: Decimal)` overload becomes a
+   thin adapter that constructs `MarketSnapshot(last_price=current_price)`
+   directly (no fake `TickerEvent`) and forwards. **No `@deprecated`
+   decorator** — `typing_extensions.deprecated` is not currently in the
+   project's dep tree, and adding it just for this is overkill.
+   Document the legacy status in the docstring (e.g.
+   `"Legacy bare-Decimal entry point — prefer the TickerEvent overload
+   for L1-aware fill modes."`). Optionally emit a one-line
+   `warnings.warn("...", DeprecationWarning, stacklevel=2)` ONLY if a
+   reviewer explicitly asks for it — quiet by default to avoid noise in
+   existing test runs that go through the bare-Decimal path.
+5. Branch internally on `self._mode`:
+   - `STRICT_CROSS`: existing `<` / `>` against `snapshot.last_price`.
+   - `TRADE_THROUGH_AT_LIMIT`: `<=` / `>=` against `snapshot.last_price`.
+   - `BOOK_TOUCH`: BUY fills when `snapshot.ask1_price is not None and
+     snapshot.ask1_price <= limit`; fallback to `last_price <= limit`
+     (i.e. behaves like `TRADE_THROUGH_AT_LIMIT`) if `ask1_price is None`
+     (legacy provider). SELL symmetric on `bid1_price >= limit`.
+6. `get_fill_price(order) → order.price` unchanged. All three modes use
+   the limit price as fill price (no slippage modeling — see Non-goals).
+
+### Step 2 — Plumb `TickerEvent` through the runner
+
+`apps/backtest/src/backtest/runner.py:328` currently:
+
+```python
+fill_events = self._executor.order_manager.check_fills(
+    event.last_price, timestamp=event.exchange_ts,
+)
+```
+
+Change `check_fills` signature in `apps/backtest/src/backtest/order_manager.py:219`
+to a union-typed primary signature:
+
+```python
+def check_fills(
+    self,
+    market: TickerEvent | Decimal,
+    timestamp: datetime | None = None,
+    symbol: str | None = None,
+) -> list[ExecutionEvent]:
+    ...
+```
+
+Return type stays `list[ExecutionEvent]` — same as today
+(`apps/backtest/src/backtest/order_manager.py:224`). 0033 does NOT
+introduce a new `FillEvent` type.
+
+Semantics:
+
+- **`market` is a `TickerEvent`**: `timestamp` defaults to
+  `market.exchange_ts` if not explicitly passed. Symbol filter is
+  **always scoped to `market.symbol`** — the `symbol` parameter is
+  ignored on this path (`TickerEvent` already carries a symbol, and
+  silently considering orders for OTHER symbols on a single-symbol
+  tick is almost always a bug). If a caller genuinely needs an
+  all-symbol scan, they MUST use the bare-`Decimal` legacy path.
+  No sentinel value is introduced on the TickerEvent path; the
+  API stays unambiguous.
+- **`market` is a bare `Decimal`** (legacy path): `timestamp` is
+  required — fail-fast `ValueError` if `timestamp is None`. Symbol
+  filter preserves today's behavior — when `symbol is None`, scan all
+  active orders across all symbols (this is what existing callers
+  rely on). When `symbol` is supplied, filter as today.
+
+The asymmetry is intentional and documented in the `check_fills`
+docstring: `TickerEvent` carries a symbol, so the safe-by-default
+behavior is to scope to it (no escape hatch on this path); the
+bare-Decimal legacy path has no symbol context, so the all-symbol
+default stays for backward compatibility.
+
+Inside `check_fills`, **no `MarketSnapshot` construction in
+`order_manager.py`** — the manager always forwards whatever it received
+(`TickerEvent` or `Decimal`) to `fill_simulator.check_fill(order,
+market)` and lets the simulator's adapter normalize internally. This
+keeps `MarketSnapshot` strictly internal to `fill_simulator.py` (not
+imported anywhere else; no cross-module leakage).
+
+The non-Optional `TickerEvent` type contract is preserved — we never
+build a fake `TickerEvent` with `None` bid/ask, because the legacy
+adapter inside the simulator builds `MarketSnapshot` directly from the
+bare `Decimal`.
+
+Preserves all existing test fixtures that pass bare `Decimal` — they
+keep working through the legacy adapter path.
+
+### Step 3 — Replay config exposes `fill_simulator.mode`
+
+`apps/replay/src/replay/config.py`:
+
+```python
+class FillSimulatorConfig(BaseModel):
+    mode: Literal["strict_cross", "trade_through_at_limit", "book_touch"] = "strict_cross"
+
+class ReplayConfig(BaseModel):
+    ...
+    fill_simulator: FillSimulatorConfig = Field(default_factory=FillSimulatorConfig)
+```
+
+`apps/replay/src/replay/engine.py:_init_runner` currently takes
+`(strategy_config, session, long_seed, short_seed, grid_seed,
+order_seeds)` — there is no `ReplayConfig` parameter. Pick **one** of:
+
+- (a) add `fill_mode: FillMode = FillMode.STRICT_CROSS` as a new
+  parameter to `_init_runner`. Callers (the `run()` method has
+  `self._config` available) resolve it from
+  `FillMode(self._config.fill_simulator.mode)` and pass through. The
+  default keeps the signature backward-compatible for any direct test
+  callers of `_init_runner`.
+- (b) pass the whole `ReplayConfig` into `_init_runner` and read
+  `config.fill_simulator.mode` inside. Heavier coupling, but matches
+  precedent if other config fields already leak in.
+
+Choose (a) — minimal surface change, explicit dependency, easier to
+unit-test the runner init independently of full config construction.
+
+Then inside `_init_runner`, the simulator is instantiated and passed
+into `BacktestRunner` via the existing `BacktestExecutor` /
+`BacktestOrderManager` constructor chain:
+
+```python
+fill_simulator = TradeThroughFillSimulator(mode=fill_mode)
+# ... wire into executor / order_manager as today
+```
+
+No changes required to `apps/backtest/conf/backtest.yaml.example` — the
+new field is replay-only (see Out of scope).
+
+### Step 4 — Tests
+
+**`apps/backtest/tests/test_fill_simulator.py`** — add a parameterized
+test class `TestFillModeMatrix` covering each `FillMode`:
+
+| Ticker state | BUY @ 58.60 expected fill in each mode | SELL @ 58.60 expected fill in each mode |
+|---|---|---|
+| `last=58.59` (below limit, strict cross down) | all 3: fill | all 3: no fill |
+| `last=58.61` (above limit, strict cross up) | all 3: no fill | all 3: fill |
+| `last=58.60, bid1=58.59, ask1=58.61` (at limit, no book touch) | strict_cross: no, trade_through: yes, book_touch: no | strict_cross: no, trade_through: yes, book_touch: no |
+| `last=58.60, bid1=58.60, ask1=58.60` (at limit, book touched both sides) | strict_cross: no, trade_through: yes, book_touch: yes | strict_cross: no, trade_through: yes, book_touch: yes |
+| `last=58.61, bid1=58.60, ask1=58.60` (book touched, last lagging) | strict_cross: no, trade_through: no, book_touch: yes | strict_cross: yes, trade_through: yes, book_touch: yes |
+| **Legacy bare-`Decimal` path:** `simulator.check_fill(order, Decimal("58.60"))` (adapter builds `MarketSnapshot(last=58.60, bid1=None, ask1=None)` internally) | strict_cross: no, trade_through: yes, book_touch: yes (falls back to last_price) | strict_cross: no, trade_through: yes, book_touch: yes (fallback) |
+
+Existing `test_fill_simulator.py:11` "at limit does NOT fill" stays
+unchanged — it runs only against `strict_cross` (the default).
+
+**`apps/backtest/tests/test_runner.py`** — integration test
+`test_book_touch_fills_on_ask_touch_without_last_penetration` that runs a
+synthetic 5-ticker sequence with one BUY limit at 58.60, ticker sequence:
+
+```
+[(last=59.0,  bid1=58.99, ask1=59.01),
+ (last=58.61, bid1=58.59, ask1=58.60),  # ask touches limit, last lags
+ (last=58.61, bid1=58.59, ask1=58.60),
+ (last=58.61, bid1=58.59, ask1=58.60),
+ (last=58.61, bid1=58.99, ask1=59.01)]
+```
+
+Assert: `book_touch` mode fills exactly once on tick 2 (`ask1 <= 58.60` is
+the trigger; `last_price = 58.61` would have failed strict-cross);
+`strict_cross` never fills.
+
+**Fallback coverage** — two more tests pinning the legacy bare-Decimal
+adapter path. **Important:** these tests do NOT construct
+`TickerEvent(bid1=None, ask1=None)` — that would violate the contract
+(`TickerEvent` keeps bid/ask as non-Optional `Decimal` from Step 1). The
+fallback is exercised by calling the simulator (or order_manager) with a
+bare `Decimal` instead of a `TickerEvent`:
+
+- `test_book_touch_falls_back_to_trade_through_on_bare_decimal_buy`:
+  BUY @ 58.60, call `simulator.check_fill(order, Decimal("58.60"))`
+  with `mode=BOOK_TOUCH`. Assert fills (legacy adapter constructs
+  `MarketSnapshot(last_price=58.60, bid1=None, ask1=None)` internally;
+  `book_touch` then degrades to `last_price <= limit` semantics).
+- `test_book_touch_falls_back_to_trade_through_on_bare_decimal_sell`:
+  SELL @ 58.60, call `simulator.check_fill(order, Decimal("58.60"))`
+  with `mode=BOOK_TOUCH`. Assert fills (mirror of the BUY case).
+
+Equivalent end-to-end check via `order_manager`:
+- `test_book_touch_falls_back_through_order_manager_bare_decimal`:
+  call `order_manager.check_fills(Decimal("58.60"),
+  timestamp=datetime(...))` with simulator mode `BOOK_TOUCH`. Assert
+  the resting BUY @ 58.60 in the order book gets an `ExecutionEvent`.
+  This pins the legacy Decimal path through both layers.
+
+Motivation explicit in test docstring: legacy bare-Decimal callers (and
+any consumer that doesn't have L1 bid/ask data) must not silently
+no-fill — that would be worse than current `strict_cross`. The
+`book_touch` mode explicitly degrades to `trade_through_at_limit`
+semantics when `MarketSnapshot.bid1_price`/`ask1_price` is `None`.
+
+**Symbol filter preservation** — add
+`test_check_fills_preserves_symbol_filter_after_ticker_event_refactor`:
+multi-symbol order book in `BacktestOrderManager`, single-symbol
+`TickerEvent`, assert only the matching-symbol order is considered for
+fill. Locks the existing semantic that `check_fills(..., symbol=...)`
+filters by symbol — protects against an accidental drop during the
+signature refactor.
+
+**`apps/replay/tests/test_config.py`** — config round-trip tests for the
+new `fill_simulator` block:
+1. Omitted block → `FillSimulatorConfig(mode="strict_cross")`.
+2. Empty block (`fill_simulator: {}`) → same default.
+3. Each of the three modes explicit → loads correctly.
+4. Invalid mode (`fill_simulator: {mode: invalid}`) → `ValidationError`.
+
+### Step 5 — Documentation
+
+- Update **`apps/replay/conf/replay.yaml.example`** only with a
+  commented-out `fill_simulator.mode` block + 2-line explanation of when
+  to use which mode. **`apps/backtest/conf/backtest.yaml.example` is NOT
+  updated in this feature** — see Out of scope (backtest engine
+  symmetry is deferred so we don't document a field that doesn't yet
+  wire through `BacktestEngine`).
+- Update `docs/features/0029_RUNBOOK.md` Step 8 (replay config template):
+  add `fill_simulator: {mode: book_touch}` to the parity-smoke config.
+- Add a short paragraph to `RULES.md` documenting the three modes, the
+  default rationale, and the fact that backtest engine currently always
+  uses `strict_cross` regardless of config (with a note pointing to the
+  follow-up ticket).
+
+### Step 5b — Emit `fill_mode` in run metadata
+
+State of the world today: the replay reporter writes `matched_trades.csv`,
+`unmatched_trades.csv`, and `validation_metrics.csv` only. There is no
+`summary.json`, and `validation_metrics.csv` is owned by
+`ComparatorReporter` which has no native concept of replay fill semantics
+(comparator works against any backtest-trades CSV). So neither plain
+"add a field to summary.json" nor "bake `fill_mode` into
+`ValidationMetrics`" is the right shape.
+
+Plan:
+
+1. **Extend `ReplayResult`** (`apps/replay/src/replay/engine.py:77` —
+   the dataclass currently lives in `engine.py`, not in a separate
+   `result.py`. It exposes only `session`,
+   `metrics`, `match_result`) with the run-context fields the engine
+   already resolves but does not propagate back to `main.py`:
+   ```python
+   @dataclass
+   class ReplayResult:
+       session: BacktestSession
+       metrics: ...
+       match_result: ...
+       # NEW fields:
+       run_id: str
+       symbol: str
+       start_ts: datetime
+       end_ts: datetime
+       fill_mode: FillMode
+   ```
+   `ReplayEngine.run()` sets these before returning. Without this,
+   `main.py` (which owns output writing) cannot reliably populate
+   `summary.json` when `run_id`/`start_ts`/`end_ts` come from
+   auto-discovery rather than the YAML config.
+
+2. **`apps/replay/src/replay/main.py` writes a new `summary.json`** in
+   the output dir (alongside the CSVs), serializing from the extended
+   `ReplayResult`:
+   ```json
+   {
+     "run_id": "b1f5b867-...",
+     "fill_mode": "book_touch",
+     "start_ts": "2026-05-10T18:06:18+00:00",
+     "end_ts":   "2026-05-11T06:04:23+00:00",
+     "symbol": "LTCUSDT"
+   }
+   ```
+   `main.py` is the right home because it already constructs
+   `ComparatorReporter` and calls `export_all(output_dir)` — the same
+   place where the CSVs are written.
+
+3. **Pass run metadata into `ComparatorReporter`** via an optional
+   `metadata: dict[str, str] | None = None` parameter on the export
+   method (and constructor where it makes sense). Replay's inline
+   comparator path supplies `{"fill_mode": <result.fill_mode.value>}`.
+   Standalone comparator CLI invocations pass nothing — `fill_mode` is
+   simply absent from `validation_metrics.csv` in those runs, which is
+   correct (the CLI doesn't know which simulator produced the input
+   trades.csv).
+
+4. `ComparatorReporter.export_metrics` writes the supplied `metadata`
+   entries as additional `metric,value` rows at the bottom of
+   `validation_metrics.csv`, prefixed (e.g. `meta.fill_mode,...`) to
+   keep them visually separate from numeric metrics.
+
+Rationale: months from now, comparing baseline metrics across runs needs
+to be unambiguous about which fill semantics produced them.
+strict_cross-baseline vs book_touch-baseline have qualitatively different
+expected ranges, and silent drift between them would be hard to debug.
+Pushing the metadata in via a generic `dict[str, str]` keeps comparator
+agnostic of replay-specific concepts.
+
+### Step 6 — Phase 4 re-validation
+
+Re-run the existing recording (`data/recorder_ltcusdt_phase4.db`,
+run_id `b1f5b867-0c1c-4504-b48e-cc1d7a395eaf`, 138 executions over 12h)
+with the new `fill_simulator.mode: book_touch` set in
+`apps/replay/conf/replay_ltcusdt_phase4.yaml`. Expected outcome:
+
+- `match_rate ≥ 0.95` (vs. 0.913 strict_cross baseline).
+- `live_only` count drops from 12 to ≤4 (residual is the cascade tail
+  — Step 7).
+- `backtest_only` **does not increase materially** relative to
+  `matched_count` (i.e., `backtest_only / matched_count ≤ 1-2%`). Hard
+  zero is not guaranteed — `book_touch` still has phantom risk from
+  queue position and volume effects (our BUY 0.1 @ 58.60 could phantom-
+  fill when the ask side shows only 0.05 at 58.60 because the simulator
+  doesn't model queue contention). If `backtest_only` grows, the
+  analysis goes in `0033_REVIEW.md` with the offending fills'
+  client_order_ids and ticker windows for diagnosis.
+- `pnl_correlation ≥ 0.99`.
+
+If the residual `live_only` stays high (>5), it's the cascade-shift
+problem (Step 7), not strict-cross. Document residual numbers in
+`docs/features/0033_REVIEW.md` and proceed.
+
+### Step 7 — Cascade follow-up (deferred, NOT in this feature)
+
+Even with the correct fill mode, comparator's
+`(client_order_id, occurrence)` matching can shift numbering once a
+single fill is delayed: a late-arriving replay fill gets paired with an
+earlier live occurrence, pushing the original later occurrence into
+`live_only`. A single missed fill produces two unmatched records.
+
+The naive fix — pair fills by
+`(client_order_id, abs(ts_live - ts_replay) ≤ TOL)` — is too loose: it
+can silently hide real missing occurrences when one `client_order_id` is
+reused heavily across cancel-replace cycles. The correct shape is a
+**stable bipartite matching** between live and replay fills sharing the
+same `client_order_id`, with:
+
+- one-to-one pairing constraint (each fill matched at most once);
+- side/price/qty equality required for a candidate match (rejects
+  accidental cross-pairings);
+- timestamp delta as a **tie-breaker / objective function** (minimize
+  sum of |Δt| across the matching), not a yes/no filter;
+- residual fills with no eligible partner go to
+  `live_only`/`backtest_only` as today.
+
+Track as a separate ticket (0034 candidate) — out of scope here.
+Reference: classical bipartite assignment (Hungarian / Kuhn-Munkres);
+practical greedy approximation acceptable since N per
+`client_order_id` is small (≤ 10 occurrences in our data).
+
+## Critical files to modify
+
+| File | Change |
+|---|---|
+| `apps/backtest/src/backtest/fill_simulator.py` | Add `FillMode` enum, accept `TickerEvent`, branch on mode. |
+| `apps/backtest/src/backtest/order_manager.py:219` | `check_fills(market: TickerEvent \| Decimal, timestamp=None, symbol=None)` union signature; `timestamp` required for Decimal path; asymmetric symbol-default (per Step 2). Forwards bare `Decimal` to simulator unchanged — no `MarketSnapshot` construction here. |
+| `apps/backtest/src/backtest/runner.py:328` | Pass full `event` instead of `event.last_price`. |
+| `apps/backtest/tests/test_fill_simulator.py` | Parameterized `TestFillModeMatrix` (6 cases × 3 modes × 2 sides). |
+| `apps/backtest/tests/test_runner.py` | Integration test for `book_touch` end-to-end. |
+| `apps/replay/src/replay/config.py` | New `FillSimulatorConfig` field. |
+| `apps/replay/src/replay/engine.py:_init_runner` | Read mode from config, pass to simulator. |
+| `apps/replay/tests/test_config.py` | Round-trip tests for new field. |
+| `apps/replay/conf/replay.yaml.example` | Document new optional field. (Backtest yaml NOT updated — see Out of scope.) |
+| `apps/replay/src/replay/engine.py:77` (`ReplayResult` dataclass) | Extend with `run_id`, `symbol`, `start_ts`, `end_ts`, `fill_mode`. |
+| `apps/replay/src/replay/engine.py` (`ReplayEngine.run`) | Populate the new `ReplayResult` fields before returning. |
+| `apps/replay/src/replay/main.py` | Write `summary.json` from the extended `ReplayResult`; pass `metadata={"fill_mode": ...}` into `ComparatorReporter`. |
+| `apps/comparator/src/comparator/reporter.py` (or wherever `ComparatorReporter` lives) | Accept `metadata: dict[str, str] \| None`; emit `meta.<key>,<value>` rows in `validation_metrics.csv`. |
+| `docs/features/0029_RUNBOOK.md` | Add `fill_simulator: {mode: book_touch}` to Step 8 template. |
+| `RULES.md` | Short paragraph on three modes + default rationale. |
+
+## Verification
+
+1. `uv run pytest apps/backtest/ apps/replay/ -q` — all green, including
+   new parameterized fill_simulator tests and the new runner integration
+   test.
+2. `uv run pytest packages/gridcore/ apps/gridbot/ apps/comparator/ -q`
+   — all green. `gridcore` and `gridbot` are untouched. `comparator`
+   gains the `metadata: dict[str, str] | None` parameter on
+   `ComparatorReporter` and `meta.<key>,<value>` row emission in
+   `validation_metrics.csv`; verification covers that **standalone**
+   comparator invocations (no `metadata` supplied) produce a
+   `validation_metrics.csv` byte-identical to today (no extra
+   `meta.*` rows when caller passes `None`), so existing test fixtures
+   and CLI users see no diff.
+3. `uv run ruff check apps/backtest/ apps/replay/` — clean.
+4. **Manual parity re-run**:
+   - Update `apps/replay/conf/replay_ltcusdt_phase4.yaml` with
+     `fill_simulator: {mode: book_touch}`.
+   - `uv run python -m replay.main --config apps/replay/conf/replay_ltcusdt_phase4.yaml`
+   - `cat results/replay_ltcusdt_phase4/validation_metrics.csv` — check
+     `match_rate ≥ 0.95`.
+5. **Backward-compat**: re-run the existing 0029 audit invocation (no
+   `fill_simulator` block in config). Confirm metrics match the run 2
+   baseline (`match_rate = 0.913`, `live_only = 12`, `backtest_only = 0`).
+   Proves default behavior is unchanged.
+6. Operational verification of bbu2 pinning still passes:
+   `git status --short bbu_reference` empty;
+   `git diff --exit-code -- bbu_reference` exits 0.
+
+## Out of scope
+
+- **Wiring `fill_simulator.mode` into `BacktestEngine`.** 0033 is
+  replay-only. `BacktestEngine._init_runner` continues to instantiate
+  `TradeThroughFillSimulator()` with the default `STRICT_CROSS` mode
+  regardless of any config field. A follow-up ticket adds symmetric
+  config support to `apps/backtest/src/backtest/config.py` and the
+  backtest engine. Until then, backtest users see no change.
+- Comparator-side cascade fix (stable bipartite matching). Tracked
+  separately; see Step 7 note.
+- Slippage modeling for fills. `book_touch` still fills at `order.price`
+  as before.
+- Changing `STRICT_CROSS` as the default. Migration audit required.
+- Removing the deprecated `check_fills(current_price)` overload.
+  Backward-compat shim stays through 0034+.
+- Exposing `FillMode` as a public symbol via `backtest.__init__`.
+  Importers go through `backtest.fill_simulator` directly; export is
+  added only after a concrete external consumer materializes.
+- Changes to recorder behavior or `ticker_snapshots` schema. Bid/ask are
+  already captured; 0033 is read-only on the recorder side.
+- Production backtest tuning / perf benchmarks for the new mode. All
+  three modes are O(1) per fill check — no perf regression expected.
+
+## Reference
+
+- 0029 Phase 4 run 1 metrics:
+  `results/replay_ltcusdt_phase4.run1/validation_metrics.csv`
+- 0029 Phase 4 run 2 metrics:
+  `results/replay_ltcusdt_phase4/validation_metrics.csv`
+- 0029 runbook: `docs/features/0029_RUNBOOK.md`
+- Recorder DB: `data/recorder_ltcusdt_phase4.db`
+  (run_id `b1f5b867-0c1c-4504-b48e-cc1d7a395eaf`, 138 execs, 12h)
+- Strict-cross logic: `apps/backtest/src/backtest/fill_simulator.py:53-74`
+- Conservative-fill rationale comment:
+  `apps/backtest/src/backtest/fill_simulator.py:27-37`
+- Existing "at limit does NOT fill" test contract:
+  `apps/backtest/tests/test_fill_simulator.py:11`
+- Recorder ticker schema with bid/ask:
+  `PRAGMA table_info(ticker_snapshots)` in `data/recorder_ltcusdt_phase4.db`
+- TickerEvent definition with `bid1_price`/`ask1_price`:
+  search `class TickerEvent` in `packages/`
+- Independent parallel-agent review confirming strict-cross root cause
+  + cascade hypothesis: inline in this branch's conversation log
+  (2026-05-11).

--- a/docs/features/0033_REVIEW.md
+++ b/docs/features/0033_REVIEW.md
@@ -1,0 +1,367 @@
+# Feature 0033 — Code review (Round 4, post-fix verification)
+
+## Summary
+
+Round 3 raised five P3 polish findings (N1–N5) and one RULES.md
+documentation gap. **All six are addressed in Round 4.** A fourth-pass
+re-read of the codebase did not surface any new P0/P1/P2 issues. The
+single net new observation is that the previously-flagged latent
+`last_price = Decimal('0')` phantom-fill (N2 in R3) is **now actively
+defended in code AND covered by a regression test**, going further than
+R3 even suggested.
+
+**Verdict:** Code is ready to ship pending the two manual parity
+smokes from the plan's verification block.
+
+**Test status:** 194 targeted tests pass (was 152 in R3; +42 from
+recent additions including the matrix expansion and defensive
+guards). Full suite: `3 failed, 574 passed` — the 3 failures are in
+`test_risk_limit_info.py` and pre-exist on `main` (verified). No new
+ruff debt (7 errors on `main`, 7 here, all pre-existing).
+
+---
+
+## Round-3 findings — all closed
+
+### N1 — Class docstring describes only strict_cross — ✅ **FIXED**
+
+**File:** `apps/backtest/src/backtest/fill_simulator.py:42-56`
+
+```python
+class TradeThroughFillSimulator:
+    """Configurable fill model for simulated limit orders.
+
+    Supported modes:
+    - strict_cross: conservative default; BUY below limit, SELL above limit.
+      Exact limit touches do not fill because queue position and volume are
+      unknown.
+    - trade_through_at_limit: last-price model that includes exact limit
+      touches.
+    - book_touch: L1-aware parity mode; BUY when ask touches/crosses limit,
+      SELL when bid touches/crosses limit, with last-price-at-limit fallback
+      only when L1 data is unavailable.
+
+    Fill price is always the limit price.
+    """
+```
+
+All three modes are now described accurately. The misleading
+"At limit price, order does NOT fill" universal claim is replaced with
+mode-specific bullets. Clean.
+
+### N2 — Latent `last_price = 0` phantom-fill — ✅ **FIXED (with regression test)**
+
+**Fix locations:**
+- `fill_simulator.py:145-146` (strict_cross guard)
+- `fill_simulator.py:161-162` (trade_through_at_limit guard)
+
+```python
+def _should_fill_strict_cross(self, side, limit_price, current_price):
+    if current_price <= 0:
+        return False
+    ...
+
+def _should_fill_at_limit(self, side, limit_price, current_price):
+    if current_price <= 0:
+        return False
+    ...
+```
+
+The book_touch fallback path goes through `_should_fill_at_limit`, so
+it inherits the guard transitively. All three modes now refuse to fill
+when `last_price <= 0`.
+
+**Regression test added:**
+`test_non_positive_last_price_never_fills`
+(`apps/backtest/tests/test_fill_simulator.py`), parameterized across
+all three modes:
+
+```python
+ticker = TickerEvent(
+    event_type=EventType.TICKER,
+    symbol="LTCUSDT",
+    exchange_ts=ts,
+    local_ts=ts,
+    # last_price OMITTED — defaults to Decimal('0')
+)
+buy_result = simulator.check_fill(_order("Buy"), ticker)
+sell_result = simulator.check_fill(_order("Sell"), ticker)
+assert buy_result.should_fill is False
+assert sell_result.should_fill is False
+```
+
+Pre-fix this would have flipped BUY to True for strict_cross /
+trade_through_at_limit (and book_touch via fallback). Symmetric to the
+P2 fix for bid/ask in Round 2. **0033 leaves the codebase strictly
+more correct than it found it on the strict_cross path** — a
+pre-existing latent bug is now closed as a side benefit.
+
+### N3 — Implicit fall-through in `_should_fill` mode dispatch — ✅ **FIXED**
+
+**File:** `apps/backtest/src/backtest/fill_simulator.py:124-136`
+
+```python
+match self._mode:
+    case FillMode.STRICT_CROSS:
+        return self._should_fill_strict_cross(
+            side, limit_price, snapshot.last_price,
+        )
+    case FillMode.TRADE_THROUGH_AT_LIMIT:
+        return self._should_fill_at_limit(
+            side, limit_price, snapshot.last_price,
+        )
+    case FillMode.BOOK_TOUCH:
+        return self._should_fill_book_touch(side, limit_price, snapshot)
+
+raise ValueError(f"Unsupported fill mode: {self._mode}")
+```
+
+Exact recommendation from R3 applied: `match` / `case` with all known
+modes enumerated, plus an explicit `raise ValueError` for any future
+mode that lands without dispatch coverage. Future contributors cannot
+silently fall through to `book_touch` semantics anymore. Clean.
+
+### N4 — Honest type signature for `check_fills` — ✅ **FIXED**
+
+**File:** `apps/backtest/src/backtest/order_manager.py:218-249`
+
+Three `@overload` decorators now document the legitimate call shapes
+for static analysis:
+
+```python
+@overload
+def check_fills(
+    self,
+    market: TickerEvent,
+    timestamp: Optional[datetime] = None,
+    symbol: Optional[str] = None,
+) -> list[ExecutionEvent]: ...
+
+@overload
+def check_fills(
+    self,
+    market: Decimal,
+    timestamp: datetime,                   # REQUIRED in this overload
+    symbol: Optional[str] = None,
+) -> list[ExecutionEvent]: ...
+
+@overload
+def check_fills(
+    self,
+    *,
+    current_price: Decimal,
+    timestamp: datetime,                   # REQUIRED in this overload
+    symbol: Optional[str] = None,
+) -> list[ExecutionEvent]: ...
+
+def check_fills(...):                       # runtime impl with Union+None
+    ...
+```
+
+Static type checkers now see three precise signatures: `TickerEvent`
+input (timestamp defaults to `market.exchange_ts`), `Decimal` input
+(timestamp required positionally), or legacy keyword `current_price`
+(timestamp required). The runtime impl is dispatch glue. This matches
+the standard Python pattern for backward-compatible signature
+evolution.
+
+### N5 — Test inconsistency in book_touch fallback test — ✅ **FIXED (different shape)**
+
+**File:** `apps/backtest/tests/test_order_manager.py:355-377`
+
+```python
+def test_book_touch_falls_back_through_order_manager_bare_decimal(
+    self,
+    order_manager,                          # uses shared fixture
+    sample_timestamp,
+):
+    """BOOK_TOUCH degrades to at-limit semantics for bare Decimal input."""
+    order_manager.fill_simulator = TradeThroughFillSimulator(mode=FillMode.BOOK_TOUCH)
+    ...
+```
+
+Resolution differs from R3's recommendation (no new `book_touch_order_manager`
+fixture introduced) but achieves the goal: the test now reuses the
+shared `order_manager` fixture and just swaps in the BOOK_TOUCH
+simulator inline. Less fixture proliferation, same test isolation.
+Reasonable trade-off — accept.
+
+### RULES.md gap — ✅ **FIXED**
+
+**File:** `RULES.md:1649`
+
+Added bullet under section 3:
+
+> `BacktestOrderManager.check_fills(TickerEvent(...))` is always scoped
+> to the ticker's own symbol; the legacy bare-Decimal path preserves
+> all-symbol scanning when no `symbol` filter is supplied.
+
+The asymmetric symbol-default contract from Step 2 of the plan is now
+documented in RULES.md as recommended in R3.
+
+---
+
+## Round-1 + Round-2 findings — confirmed still closed
+
+| Finding | Origin | Status |
+|---|---|---|
+| P2 phantom-fill on `TickerEvent(bid1=0, ask1=0)` | R1 | ✅ Fixed via `_normalize_l1_price`; regression test passes |
+| P3 `current_price` kwarg undocumented | R1 | ✅ Docstring explicitly marks as deprecated alias |
+| P3 redundant `mkdir` in `main.py` | R1 | ✅ Moved before `export_all` |
+| P3 misleading `fills` var name in test | R1 | ✅ Renamed to `post_fill_intents` |
+
+---
+
+## Round-4 deep re-pass — observations
+
+A fourth-pass re-read found **no new defects**. Notable observations:
+
+1. **`@overload` semantics consistency check.** The runtime impl accepts
+   `market: TickerEvent | Decimal | None = None` with a runtime `raise
+   ValueError` if both `market` and `current_price` are `None`. The
+   overloads don't expose this `None` shape — good, because it's an
+   error case, not a valid call form. Static type checkers will reject
+   `check_fills()` (no args) as ambiguous, which matches runtime
+   behavior.
+
+2. **Defense-in-depth on guard placement.** The `current_price <= 0`
+   guard is duplicated in `_should_fill_strict_cross` AND
+   `_should_fill_at_limit`. Could be lifted to the `_should_fill`
+   dispatcher for DRY, but the current placement is **safer**: it
+   protects each private helper against direct callers (current or
+   future). Acceptable redundancy.
+
+3. **`match` statement enforces exhaustiveness only at runtime.** Python
+   `match`/`case` doesn't have compile-time exhaustiveness checking like
+   Rust. The `raise ValueError` after the match is the correct
+   compensating pattern. No further hardening needed.
+
+4. **The book_touch fallback path has no explicit "L1 missing"
+   telemetry.** When `bid1`/`ask1` is normalized to `None` and the
+   simulator silently degrades to `trade_through_at_limit`, there is no
+   log line or counter. For replay parity smoke this is fine (callers
+   know they configured `book_touch`), but for production-style
+   diagnostic visibility it might be worth a `logger.debug(...)` in
+   `_should_fill_book_touch`. Not blocking; flag for follow-up if
+   parity-smoke results ever look suspicious for L1-missing reasons.
+
+5. **`_resolve_run` always returns concrete values.** `ReplayResult`
+   now requires non-Optional `run_id`, `start_ts`, `end_ts`. Verified:
+   `_resolve_run` raises if it can't resolve (e.g., no recording run
+   found, no time range available), so the contract is honored.
+
+6. **`fill_mode` serialization.** `summary.json` writes
+   `result.fill_mode.value` (the string), not the enum object. Correct —
+   JSON can't natively serialize enums.
+
+7. **Comparator metadata is read-once.** `ComparatorReporter.__init__`
+   stashes `metadata or {}`. If the caller mutates the dict after
+   construction, it'll be reflected in the export (defensive copy not
+   made). Not a concern in current callers — replay's `main.py` builds
+   the dict inline and never mutates — but worth a note if metadata
+   ever gets passed from a longer-lived owner.
+
+---
+
+## Test suite status
+
+```
+uv run pytest apps/backtest/tests/test_fill_simulator.py
+              apps/backtest/tests/test_order_manager.py
+              apps/backtest/tests/test_runner.py
+              apps/replay/tests/
+              apps/comparator/tests/test_reporter.py -q
+→ 194 passed in 0.30s    (was 152 in R3 → +42 from added matrix cases
+                          and the parameterized last_price=0 regression)
+```
+
+Full suite:
+```
+uv run pytest apps/backtest/ apps/replay/ apps/comparator/ -q
+→ 3 failed, 574 passed in 1.43s
+```
+
+The 3 failures in `test_risk_limit_info.py` pre-exist on `main`
+(confirmed in R2 via `git stash`).
+
+**Test growth on this branch:**
+
+| File | Tests added |
+|---|---|
+| `test_fill_simulator.py` | Matrix expansion (3 modes × 6 cases × 2 sides = 36), 2 bare-Decimal fallback, 1 zero-bid/ask regression, 1 zero-last-price regression × 3 modes |
+| `test_order_manager.py` | symbol-scope, symbol-kwarg-ignored, decimal-timestamp-required, book_touch via order_manager |
+| `test_runner.py` | book_touch end-to-end integration |
+| `test_config.py` | 4 round-trip cases for `fill_simulator` block |
+| `test_engine.py` | ReplayResult metadata assertions |
+| `test_reporter.py` | metadata-empty + metadata-with-fill_mode |
+
+Total new tests roughly: ~50, mostly parameterized.
+
+---
+
+## Lint status
+
+```
+uv run ruff check apps/backtest/src apps/replay/src apps/comparator/src
+→ Found 7 errors.   (all F401 unused imports in pre-existing files;
+                     verified zero new errors introduced by 0033)
+```
+
+---
+
+## Plan compliance — all 27 plan items verified
+
+(All items already enumerated and verified in R3 review; status
+unchanged in R4 — every plan-mandated change is present in code.)
+
+---
+
+## Pre-merge work remaining
+
+| Item | Status |
+|---|---|
+| P0/P1/P2 findings | ✅ 0 open |
+| R1 polish (P3 × 3) | ✅ all closed (R2) |
+| R3 polish (P3 × 5) | ✅ all closed (R4) |
+| R3 RULES.md gap | ✅ closed (R4) |
+| R4 fresh-pass review | ✅ no new defects |
+| `uv run pytest apps/backtest/ apps/replay/ apps/comparator/ -q` | ✅ 574 pass + 3 pre-existing failures |
+| `uv run ruff check apps/backtest/src apps/replay/src apps/comparator/src` | ✅ 7 pre-existing errors, 0 new |
+| `git diff --exit-code -- bbu_reference` | ✅ clean |
+| **Manual parity smoke: `mode: book_touch`** — target `match_rate ≥ 0.95`, `pnl_correlation ≥ 0.99`, `live_only ≤ 4`, `backtest_only / matched ≤ 1-2%` | ⏳ pending |
+| **Manual backward-compat parity smoke (default config)** — must reproduce Run 2 baseline (`match_rate = 0.913`, `live_only = 12`, `backtest_only = 0`) | ⏳ pending |
+
+---
+
+## TL;DR — findings across all four rounds
+
+| Severity | R1 | R2 | R3 | R4 |
+|---|---|---|---|---|
+| P0 | 0 | 0 | 0 | 0 |
+| P1 | 0 | 0 | 0 | 0 |
+| P2 | 1 (phantom-fill on default zero L1) | 0 (fixed) | 0 | 0 |
+| P3 | 3 | 0 (all closed) | 5 (docs, last_price=0, dispatch fall-through, type hint, fixture) | 0 (all closed) |
+| Docs | 0 | 0 | 1 (RULES.md asymmetric symbol) | 0 (closed) |
+
+**Cumulative cleanup:** 1 P2 + 8 P3 + 1 docs = 10 findings; all 10
+closed across R2 + R4. No findings remain open.
+
+**Implementation is functionally and stylistically ship-ready.** The
+codebase is in better shape than before this feature — the side-effect
+last_price=0 hardening (N2) closes a pre-existing latent bug that was
+unrelated to 0033's primary scope but uncovered during review.
+
+The only remaining work is the two manual parity smokes from the
+plan's verification block. Recommended execution:
+
+```bash
+# 1) book_touch parity (replay_ltcusdt_phase4.yaml already has mode: "book_touch")
+uv run python -m replay.main --config apps/replay/conf/replay_ltcusdt_phase4.yaml
+cat results/replay_ltcusdt_phase4/validation_metrics.csv
+
+# 2) backward-compat (comment out the fill_simulator block in the yaml, re-run)
+# Expected: match_rate = 0.913, live_only = 12 — same as Run 2 baseline.
+```
+
+Document both runs' metrics inline at the bottom of this file (or in
+`0033_RESULTS.md`) and the PR is ready.


### PR DESCRIPTION
## Summary

- Adds a `FillMode` enum (`strict_cross` default, `trade_through_at_limit`, `book_touch`) to `TradeThroughFillSimulator` and plumbs the full `TickerEvent` through `BacktestOrderManager.check_fills` so replay parity smoke can use recorded L1 bid/ask.
- Replay config gains `fill_simulator.mode`; `ReplayResult` carries `run_id` / `symbol` / `start_ts` / `end_ts` / `fill_mode` so `main.py` writes a new `summary.json` alongside the existing CSV reports.
- `ComparatorReporter` accepts an optional `metadata` dict and emits `meta.*` rows in `validation_metrics.csv` — backward-compatible for standalone CLI users (no `metadata` → byte-identical output).
- Defensive `<= 0` guards on `_should_fill_strict_cross` and `_should_fill_at_limit` close a pre-existing latent phantom-fill path for default-zero `last_price`; `MarketSnapshot` normalizes non-positive bid/ask to `None` to prevent the analogous phantom-fill on `book_touch`.
- Production backtest behavior is unchanged — `BacktestEngine` still instantiates `STRICT_CROSS` by default; the new field is replay-only (backtest engine symmetry is deferred).

Motivated by the 0029 Phase 4 parity smoke (`match_rate = 91.3%` over two runs) — strict-cross misses ~half of `live_only` fills directly when `last_price` lands exactly at the limit, with cascade artefacts accounting for the rest. `book_touch` is a closer L1-aware proxy. Full background in `docs/features/0033_PLAN.md`.

## Test plan

- [ ] `uv run pytest apps/backtest/ apps/replay/ apps/comparator/ -q` — all green except 3 pre-existing failures in `test_risk_limit_info.py` that also fail on `main`.
- [ ] `uv run ruff check apps/backtest/src apps/replay/src apps/comparator/src` — 7 errors, all pre-existing on `main`; 0 new lint debt.
- [ ] Manual parity smoke with `fill_simulator: {mode: book_touch}` against `data/recorder_ltcusdt_phase4.db` — target `match_rate ≥ 0.95`, `pnl_correlation ≥ 0.99`, `live_only ≤ 4`, `backtest_only / matched ≤ 1-2%`.
- [ ] Manual backward-compat parity smoke with default config (no `fill_simulator` block) — must reproduce Run 2 baseline `match_rate = 0.913`, `live_only = 12`, `backtest_only = 0`.
- [ ] `git diff --exit-code -- bbu_reference` — empty.

Plan and 4 rounds of code review in `docs/features/0033_PLAN.md` and `docs/features/0033_REVIEW.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)