### PR TITLE
feat(0034): position telemetry parity (live vs backtest)

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -1986,6 +1986,13 @@ Reads recorded data, feeds through GridEngine + simulated order book, compares a
 - `RunRepository.get_latest_by_type()` has `statuses` filter (default: completed + running)
 - `datetime.fromisoformat()` requires Python 3.11+ for full timezone support
 - Config search: `--config` → `REPLAY_CONFIG_PATH` env → `conf/replay.yaml` → `replay.yaml`
+- **Position telemetry parity (feature 0034)**: backtest emits `position_snapshots` rows with `source='backtest'` on every fill (including wind-down close-outs). Comparator pairs them per-side with `source='live'` rows (monotonic two-pointer, 5s tolerance, one-to-one consume invariant) and recomputes unrealized PnL from `live.mark_price` so the delta is apples-to-apples. Twelve metrics added to `ValidationMetrics`; `position_comparison.csv` emitted when at least one pair exists. Un-migrated DBs raise loudly at load time — do NOT silently mask as zero-pair.
+
+### Position telemetry repository contract (feature 0034)
+
+- `PositionSnapshotRepository` read methods accept a `source: str | None = 'live'` parameter. **When adding a new read method, default to `'live'`** so legacy callers never silently mix in backtest rows. Pass `'backtest'` for backtest rows or `None` for the union (the comparator is the only legitimate `None` caller).
+- `position_snapshots` has a CHECK constraint `source IN ('live', 'backtest')` (Postgres) plus a B-tree index `(run_id, account_id, symbol, side, source, exchange_ts)`. Equality predicates precede the `exchange_ts` range — do not reorder.
+- One-off SQL migration for existing DBs: `scripts/migrate_0034_position_telemetry.py --database-url ...`. Fresh DBs get the columns via `Base.metadata.create_all()`.
 
 ---
 

--- a/apps/backtest/src/backtest/position_tracker.py
+++ b/apps/backtest/src/backtest/position_tracker.py
@@ -48,6 +48,13 @@ class PositionState:
     # (the same sentinel `Position.liquidation_price` uses).
     liquidation_price: Decimal = field(default_factory=lambda: Decimal("0"))
 
+    # 0034: Bybit-style running total of realized PnL since position open.
+    # Distinct from ``realized_pnl`` above, which is window-scoped (zeroed
+    # in ``seed_state`` to start replay accounting fresh). This field is
+    # seeded from ``PositionSnapshot.cum_realised_pnl`` and is NOT zeroed
+    # in ``seed_state`` — it represents the absolute exchange-side total.
+    cum_realised_pnl: Decimal = field(default_factory=lambda: Decimal("0"))
+
 
 class BacktestPositionTracker:
     """Track position and calculate PnL for backtest.
@@ -123,6 +130,13 @@ class BacktestPositionTracker:
         self.state.realized_pnl = Decimal("0")
         self.state.commission_paid = Decimal("0")
         self.state.funding_paid = Decimal("0")
+        # 0034: copy the cumulative running total from the seed so the
+        # backtest's cum_realised_pnl stays in lockstep with live's
+        # absolute Bybit-side total. Defaults to 0 when the seed object
+        # lacks the attribute (legacy seeds).
+        self.state.cum_realised_pnl = getattr(
+            seed, "cum_realised_pnl", Decimal("0")
+        )
 
     def process_fill(
         self,
@@ -151,9 +165,16 @@ class BacktestPositionTracker:
         is_opening = self._is_opening_fill(side)
 
         if is_opening:
-            return self._add_to_position(qty, price)
+            realized = self._add_to_position(qty, price)
         else:
-            return self._reduce_position(qty, price)
+            realized = self._reduce_position(qty, price)
+
+        # 0034: maintain Bybit-style running total of realized PnL since
+        # position open. Window-scoped `realized_pnl` lives on `state` and
+        # is zeroed by seed_state; `cum_realised_pnl` is NOT zeroed and
+        # carries the absolute total used for parity comparison.
+        self.state.cum_realised_pnl += realized
+        return realized
 
     def _is_opening_fill(self, side: str) -> bool:
         """Determine if fill opens/adds to position or reduces it.

--- a/apps/backtest/src/backtest/runner.py
+++ b/apps/backtest/src/backtest/runner.py
@@ -7,9 +7,10 @@ The runner is responsible for:
 """
 
 import logging
+from datetime import datetime
 from decimal import Decimal
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
 from gridcore import (
     GridEngine,
@@ -26,7 +27,17 @@ from gridcore import (
     apply_early_imbalance,
 )
 from gridcore.instrument_info import InstrumentInfo
-from gridcore.pnl import calc_position_value, calc_margin_ratio, calc_maintenance_margin, MMTiers, MM_TIERS, MM_TIERS_DEFAULT
+from gridcore.pnl import (
+    calc_position_value,
+    calc_margin_ratio,
+    calc_maintenance_margin,
+    calc_initial_margin,
+    calc_unrealised_pnl,
+    MMTiers,
+    MM_TIERS,
+    MM_TIERS_DEFAULT,
+)
+from grid_db.models import PositionSnapshot
 
 from backtest.config import BacktestStrategyConfig
 from backtest.executor import BacktestExecutor
@@ -173,8 +184,21 @@ class BacktestRunner:
         # Last price seen (needed for multiplier recalculation)
         self._last_price: Optional[Decimal] = None
 
+        # 0034: track Bybit-style mark separately so the emitted
+        # PositionSnapshot.mark_price is semantically the mark price (matches
+        # the recorder), not last_price. Falls back to event.price at the
+        # emission site when no ticker mark is available.
+        self._last_mark_price: Optional[Decimal] = None
+
         # Track whether grid has been built
         self._grid_built = False
+
+        # 0034: position telemetry parity emission hook. Replay engine wires
+        # a synchronous writer here. Standalone backtest leaves it None and
+        # emits nothing — keeps existing call sites unchanged.
+        self.position_snapshot_callback: Optional[
+            Callable[[PositionSnapshot], None]
+        ] = None
 
     def _copy_seeded_state_to_positions(self) -> None:
         """Mirror seeded tracker state into gridcore.Position instances.
@@ -322,6 +346,9 @@ class BacktestRunner:
             List of intents generated from fills.
         """
         self._last_price = event.last_price
+        # 0034: cache the ticker mark so backtest snapshots store the mark
+        # in PositionSnapshot.mark_price (matches recorder semantics).
+        self._last_mark_price = event.mark_price
         intents: list[PlaceLimitIntent | CancelIntent] = []
 
         # Check for fills
@@ -526,6 +553,86 @@ class BacktestRunner:
             and self._short_position is not None
         ):
             self._update_risk_multipliers(float(self._last_price))
+
+        # 0034: emit a parity-checkable position snapshot for the just-mutated
+        # direction. Done AFTER _update_risk_multipliers so any multiplier-
+        # driven liq_price update is reflected in the same row.
+        # Use the ticker mark (matches Bybit/recorder semantics for the
+        # mark_price column), not last_price. Fall back to event.price only
+        # when no ticker mark has been seen yet.
+        if self.position_snapshot_callback is not None:
+            mark_price = (
+                self._last_mark_price
+                if self._last_mark_price is not None
+                else event.price
+            )
+            snap = self._emit_position_snapshot(direction, event.exchange_ts, mark_price)
+            self.position_snapshot_callback(snap)
+
+    def _emit_position_snapshot(
+        self,
+        direction: str,
+        timestamp: datetime,
+        mark_price: Decimal,
+    ) -> PositionSnapshot:
+        """Build a parity-checkable position snapshot for the just-mutated direction.
+
+        ``direction`` (LONG/SHORT) — NOT fill side. In hedge mode a close-long
+        fill arrives as Sell but the snapshot row stays side='Buy'. Passing
+        fill side here would flip the snapshot's side column on every close
+        fill and break pairing.
+
+        Margin amounts come from ``calc_initial_margin`` / ``calc_maintenance_margin``
+        (both return tuples — first element is the amount). Unrealized PnL is
+        computed via ``calc_unrealised_pnl`` so the short-side sign is correct
+        (the naive ``(mark-entry)*size`` formula is wrong for shorts).
+
+        ``run_id`` / ``account_id`` are NOT set here — the caller (writer)
+        owns those fields per the run context.
+        """
+        tracker = (
+            self._long_tracker
+            if direction == DirectionType.LONG
+            else self._short_tracker
+        )
+        snap_side = "Buy" if direction == DirectionType.LONG else "Sell"
+
+        size = tracker.state.size
+        entry_price = tracker.state.avg_entry_price
+
+        if size > 0 and entry_price > 0:
+            position_value = calc_position_value(size, entry_price)
+            unrealised = calc_unrealised_pnl(direction, entry_price, mark_price, size)
+            position_im, _imr = calc_initial_margin(
+                position_value, self._leverage, self.symbol, tiers=self._mm_tiers
+            )
+            position_mm, _mmr = calc_maintenance_margin(
+                position_value, self.symbol, tiers=self._mm_tiers
+            )
+            liq_price = self._estimate_liquidation_price(
+                entry_price, direction, position_value, self._session.current_balance,
+            )
+        else:
+            unrealised = Decimal("0")
+            position_im = Decimal("0")
+            position_mm = Decimal("0")
+            liq_price = Decimal("0")
+
+        return PositionSnapshot(
+            # run_id / account_id / source filled by the writer.
+            symbol=self.symbol,
+            exchange_ts=timestamp,
+            local_ts=timestamp,
+            side=snap_side,
+            size=size,
+            entry_price=entry_price,
+            liq_price=liq_price,
+            unrealised_pnl=unrealised,
+            mark_price=mark_price,
+            position_im=position_im,
+            position_mm=position_mm,
+            cum_realised_pnl=tracker.state.cum_realised_pnl,
+        )
 
     def _build_position_state(
         self,

--- a/apps/backtest/tests/test_runner.py
+++ b/apps/backtest/tests/test_runner.py
@@ -1546,3 +1546,149 @@ class TestSeedAwareConstruction:
         # Short was not seeded → remains zero on the gridcore side.
         assert runner._short_position.size == Decimal("0")
         assert runner._short_position.liquidation_price == Decimal("0")
+
+
+class TestPositionSnapshotEmission:
+    """Feature 0034 — backtest emits parity-checkable PositionSnapshots."""
+
+    @pytest.fixture
+    def runner(self, sample_strategy_config, session):
+        fill_simulator = TradeThroughFillSimulator()
+        order_manager = BacktestOrderManager(
+            fill_simulator=fill_simulator,
+            commission_rate=sample_strategy_config.commission_rate,
+        )
+        executor = BacktestExecutor(order_manager=order_manager, qty_calculator=None)
+        return BacktestRunner(
+            strategy_config=sample_strategy_config,
+            executor=executor,
+            session=session,
+        )
+
+    def test_emits_after_long_fill(self, runner, sample_timestamp):
+        # Manually drive a fill via the long tracker, then emit.
+        runner.long_tracker.process_fill(
+            side="Buy", qty=Decimal("0.01"), price=Decimal("100"),
+        )
+        runner._last_price = Decimal("101")
+        snap = runner._emit_position_snapshot(
+            DirectionType.LONG, sample_timestamp, Decimal("101"),
+        )
+        assert snap.side == "Buy"
+        assert snap.size == Decimal("0.01")
+        assert snap.entry_price == Decimal("100")
+        # Unrealized = (101 - 100) * 0.01 = 0.01
+        assert snap.unrealised_pnl == Decimal("0.01")
+        assert snap.cum_realised_pnl == Decimal("0")  # opening fill
+        assert snap.mark_price == Decimal("101")
+
+    def test_emits_after_short_fill_correct_sign(self, runner, sample_timestamp):
+        runner.short_tracker.process_fill(
+            side="Sell", qty=Decimal("0.01"), price=Decimal("100"),
+        )
+        snap = runner._emit_position_snapshot(
+            DirectionType.SHORT, sample_timestamp, Decimal("90"),
+        )
+        assert snap.side == "Sell"
+        # Short: (entry - mark) * size = (100 - 90) * 0.01 = 0.1 (positive!)
+        assert snap.unrealised_pnl == Decimal("0.1")
+
+    def test_cum_realised_pnl_accumulates(self, runner, sample_timestamp):
+        # Open at 100, close at 110 → realized = 10 * 0.01 = 0.1
+        runner.long_tracker.process_fill("Buy", Decimal("0.01"), Decimal("100"))
+        runner.long_tracker.process_fill("Sell", Decimal("0.01"), Decimal("110"))
+        snap = runner._emit_position_snapshot(
+            DirectionType.LONG, sample_timestamp, Decimal("110"),
+        )
+        assert snap.cum_realised_pnl == Decimal("0.1")
+
+        # Second cycle adds another 0.1
+        runner.long_tracker.process_fill("Buy", Decimal("0.01"), Decimal("100"))
+        runner.long_tracker.process_fill("Sell", Decimal("0.01"), Decimal("110"))
+        snap2 = runner._emit_position_snapshot(
+            DirectionType.LONG, sample_timestamp, Decimal("110"),
+        )
+        assert snap2.cum_realised_pnl == Decimal("0.2")
+
+    def test_no_callback_no_emission(self, runner, sample_ticker_event):
+        """Default callback=None → no error, no emission."""
+        assert runner.position_snapshot_callback is None
+        # Process a tick that builds grid + might fill — should not raise.
+        runner.process_tick(sample_ticker_event)
+
+    def test_seeded_cum_realised_pnl_initial(self):
+        from backtest.position_tracker import BacktestPositionTracker
+        from dataclasses import dataclass
+
+        @dataclass
+        class _Seed:
+            size: Decimal
+            entry_price: Decimal
+            liquidation_price: Decimal
+            cum_realised_pnl: Decimal
+
+        tracker = BacktestPositionTracker(direction="long")
+        tracker.seed_state(_Seed(
+            size=Decimal("1"),
+            entry_price=Decimal("100"),
+            liquidation_price=Decimal("0"),
+            cum_realised_pnl=Decimal("42.5"),
+        ))
+        assert tracker.state.cum_realised_pnl == Decimal("42.5")
+        # And realized_pnl (window-scoped) is zeroed
+        assert tracker.state.realized_pnl == Decimal("0")
+
+    def test_emission_uses_ticker_mark_not_last_price(
+        self, sample_strategy_config, session, sample_timestamp,
+    ):
+        """Regression: emitted snapshot.mark_price must equal ticker.mark_price,
+        not ticker.last_price. The PositionSnapshot.mark_price column holds
+        Bybit's markPrice on the live side; if backtest writes last_price
+        there, the comparator's apples-to-apples recomputation drifts.
+        """
+        captured: list = []
+
+        fill_simulator = TradeThroughFillSimulator(mode=FillMode.BOOK_TOUCH)
+        order_manager = BacktestOrderManager(
+            fill_simulator=fill_simulator,
+            commission_rate=sample_strategy_config.commission_rate,
+        )
+        executor = BacktestExecutor(order_manager=order_manager, qty_calculator=None)
+        runner = BacktestRunner(
+            strategy_config=sample_strategy_config,
+            executor=executor,
+            session=session,
+        )
+        runner.position_snapshot_callback = captured.append
+
+        # Place a buy order that will fill when bid touches it.
+        order_manager.place_order(
+            client_order_id="mark-vs-last",
+            symbol="BTCUSDT",
+            side="Buy",
+            price=Decimal("100.0"),
+            qty=Decimal("0.1"),
+            direction="long",
+            grid_level=0,
+            timestamp=sample_timestamp,
+        )
+
+        # Ticker where last_price diverges from mark_price.
+        tick = TickerEvent(
+            event_type=EventType.TICKER,
+            symbol="BTCUSDT",
+            exchange_ts=sample_timestamp,
+            local_ts=sample_timestamp,
+            last_price=Decimal("99.0"),   # below order → fills
+            mark_price=Decimal("103.5"),  # deliberately different
+            bid1_price=Decimal("100.0"),
+            ask1_price=Decimal("99.5"),
+            funding_rate=Decimal("0"),
+        )
+        runner.process_fills(tick)
+
+        assert len(captured) == 1, "expected exactly one snapshot emission"
+        assert captured[0].mark_price == Decimal("103.5"), (
+            "snapshot.mark_price should reflect ticker.mark_price, "
+            f"not last_price (got {captured[0].mark_price})"
+        )

--- a/apps/comparator/src/comparator/main.py
+++ b/apps/comparator/src/comparator/main.py
@@ -257,8 +257,47 @@ def run(
             else:
                 logger.warning("Run %s not found, skipping equity comparison", config.run_id)
 
-    # Report (equity data passed to reporter for inclusion in export_all)
-    reporter = ComparatorReporter(match_result, metrics, equity_data=resampled_equity)
+    # 0034: Position telemetry comparison. Independent of equity — runs
+    # whenever both live and backtest snapshots exist for this run. The
+    # un-migrated-DB case raises here (loud failure, not silent skip).
+    from comparator.position_loader import load_position_snapshots
+    from comparator.position_metrics import PositionComparator
+
+    with db.get_session() as session:
+        live_snaps = load_position_snapshots(
+            session,
+            run_id=config.run_id,
+            symbol=config.symbol,
+            source="live",
+            start_ts=config.start_ts,
+            end_ts=config.end_ts,
+        )
+        bt_snaps = load_position_snapshots(
+            session,
+            run_id=config.run_id,
+            symbol=config.symbol,
+            source="backtest",
+            start_ts=config.start_ts,
+            end_ts=config.end_ts,
+        )
+
+    if live_snaps and bt_snaps:
+        pc = PositionComparator()
+        position_pairs = pc.pair_and_compare(live_snaps, bt_snaps)
+        pc.fold_metrics_into(metrics, position_pairs)
+    else:
+        position_pairs = []
+        logger.info(
+            "Position comparison skipped: live_snaps=%d, bt_snaps=%d",
+            len(live_snaps), len(bt_snaps),
+        )
+
+    # Report (equity data and position pairs passed to reporter for export_all)
+    reporter = ComparatorReporter(
+        match_result, metrics,
+        equity_data=resampled_equity,
+        position_pairs=position_pairs,
+    )
     reporter.print_summary()
     paths = reporter.export_all(config.output_dir)
 

--- a/apps/comparator/src/comparator/metrics.py
+++ b/apps/comparator/src/comparator/metrics.py
@@ -87,6 +87,22 @@ class ValidationMetrics:
     # Per-trade deltas (for detailed export)
     trade_deltas: list[TradeDelta] = field(default_factory=list)
 
+    # 0034: position telemetry parity (live vs backtest position snapshots).
+    # Sign convention: backtest minus live. Positive = backtest over-estimates.
+    # NULL telemetry fields are skipped per-field, never treated as zero.
+    position_im_mean_abs_delta: Decimal = field(default_factory=lambda: Decimal("0"))
+    position_im_max_abs_delta: Decimal = field(default_factory=lambda: Decimal("0"))
+    position_mm_mean_abs_delta: Decimal = field(default_factory=lambda: Decimal("0"))
+    position_mm_max_abs_delta: Decimal = field(default_factory=lambda: Decimal("0"))
+    liq_price_mean_abs_delta: Decimal = field(default_factory=lambda: Decimal("0"))
+    liq_price_max_abs_delta: Decimal = field(default_factory=lambda: Decimal("0"))
+    unrealised_pnl_mean_abs_delta: Decimal = field(default_factory=lambda: Decimal("0"))
+    unrealised_pnl_max_abs_delta: Decimal = field(default_factory=lambda: Decimal("0"))
+    cum_realised_pnl_final_delta: Decimal = field(default_factory=lambda: Decimal("0"))
+    position_pairs_compared: int = 0
+    position_pairs_unmatched_bt: int = 0
+    position_pairs_missing_telemetry: int = 0
+
 
 def _compute_trade_delta(pair: MatchedTrade) -> TradeDelta:
     """Compute delta between a matched pair."""

--- a/apps/comparator/src/comparator/position_loader.py
+++ b/apps/comparator/src/comparator/position_loader.py
@@ -1,0 +1,102 @@
+"""Position telemetry loader (feature 0034).
+
+Reads ``position_snapshots`` rows filtered by ``source`` (``'live'`` or
+``'backtest'``) for a given run and symbol. Returns the rows sorted by
+``(side, exchange_ts)`` so the pairing pass can stream them per-side
+with a monotonic two-pointer.
+
+Raises ``PositionTelemetryNotMigratedError`` when the ``source`` column
+is missing — that is the only signal that the operator forgot to apply
+the 0034 schema migration. We never silently mask un-migrated DBs as
+zero-pair scenarios.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy.exc import OperationalError, ProgrammingError
+from sqlalchemy.orm import Session
+
+from grid_db.models import PositionSnapshot
+
+
+class PositionTelemetryNotMigratedError(RuntimeError):
+    """The DB has ``position_snapshots`` but the 0034 columns are missing.
+
+    Raised at the start of ``load_position_snapshots`` so the operator
+    sees the migration message before any comparison runs.
+    """
+
+
+def _probe_schema(session: Session) -> None:
+    """Raise ``PositionTelemetryNotMigratedError`` if the 0034 columns are missing.
+
+    Uses a trivial ``SELECT source FROM position_snapshots LIMIT 1`` —
+    cheap on any backend, and fails loudly with ``OperationalError``
+    (SQLite) or ``ProgrammingError`` (Postgres) when the column does
+    not exist.
+    """
+    try:
+        session.execute(
+            PositionSnapshot.__table__.select()
+            .with_only_columns(PositionSnapshot.source)
+            .limit(1)
+        ).first()
+    except (OperationalError, ProgrammingError) as exc:
+        msg = str(exc).lower()
+        if "source" in msg and ("no such column" in msg or "does not exist" in msg):
+            raise PositionTelemetryNotMigratedError(
+                "Run the 0034 schema migration before comparing position "
+                "telemetry. Position_snapshots is missing the 'source' column. "
+                "See scripts/migrate_0034_position_telemetry.py."
+            ) from exc
+        raise
+
+
+def load_position_snapshots(
+    session: Session,
+    run_id: str,
+    symbol: str,
+    source: str,
+    start_ts: Optional[datetime] = None,
+    end_ts: Optional[datetime] = None,
+) -> list[PositionSnapshot]:
+    """Load position snapshots filtered by source, sorted by (side, exchange_ts).
+
+    Args:
+        session: Open DB session.
+        run_id: Recorder run identifier (scoped per-run; cross-run mixing
+            is a separate parity story).
+        symbol: Trading symbol, e.g. ``'LTCUSDT'``.
+        source: ``'live'`` or ``'backtest'`` — never ``None``. The
+            comparator deliberately always loads one source at a time so
+            the pairing pass operates on two clean per-side streams.
+        start_ts: Optional inclusive lower bound on ``exchange_ts``.
+        end_ts: Optional inclusive upper bound on ``exchange_ts``.
+
+    Returns:
+        List of :class:`PositionSnapshot` ordered by ``(side, exchange_ts)``.
+
+    Raises:
+        PositionTelemetryNotMigratedError: If 0034 columns are absent.
+    """
+    _probe_schema(session)
+
+    query = session.query(PositionSnapshot).filter(
+        PositionSnapshot.run_id == run_id,
+        PositionSnapshot.symbol == symbol,
+        PositionSnapshot.source == source,
+    )
+    if start_ts is not None:
+        query = query.filter(PositionSnapshot.exchange_ts >= start_ts)
+    if end_ts is not None:
+        query = query.filter(PositionSnapshot.exchange_ts <= end_ts)
+    return query.order_by(
+        PositionSnapshot.side.asc(),
+        PositionSnapshot.exchange_ts.asc(),
+    ).all()
+
+
+__all__ = ["PositionTelemetryNotMigratedError", "load_position_snapshots"]

--- a/apps/comparator/src/comparator/position_metrics.py
+++ b/apps/comparator/src/comparator/position_metrics.py
@@ -1,0 +1,260 @@
+"""Position telemetry pairing and delta metrics (feature 0034).
+
+Pairs ``source='live'`` and ``source='backtest'`` position snapshots
+with a per-side monotonic two-pointer:
+
+* Live snapshots are event-driven (every Bybit position change).
+* Backtest snapshots are fill-driven.
+* Each live row pairs with at most one backtest row.
+
+For each pair, computes per-field deltas and recomputes ``unrealised_pnl``
+on both sides against ``live.mark_price`` so the delta is apples-to-apples
+(each side's own ``size, entry_price``, the same mark).
+
+NULL telemetry is handled per-field: a pair with ``live.position_im=None``
+still emits per-pair deltas for the other fields and increments
+``position_pairs_missing_telemetry``.
+"""
+
+from __future__ import annotations
+
+import logging
+import statistics
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Optional
+
+from gridcore.pnl import calc_unrealised_pnl
+
+from grid_db.models import PositionSnapshot
+
+from comparator.metrics import ValidationMetrics
+
+
+logger = logging.getLogger(__name__)
+
+
+PAIR_TOLERANCE_S = 5
+"""Maximum exchange_ts gap allowed between paired live/backtest snapshots."""
+
+
+@dataclass
+class PositionComparisonPair:
+    """One paired live/backtest position snapshot with computed deltas."""
+
+    side: str  # 'Buy' (long) or 'Sell' (short)
+    live: PositionSnapshot
+    backtest: PositionSnapshot
+
+    # Recomputed unrealized against live.mark_price for apples-to-apples.
+    # None when live.mark_price is missing (the recomputation has no anchor).
+    unrealised_pnl_recomputed_live: Optional[Decimal] = None
+    unrealised_pnl_recomputed_bt: Optional[Decimal] = None
+
+    # Per-field deltas. Decimal when both sides non-NULL; None otherwise.
+    # Sign convention: backtest minus live.
+    position_im_delta: Optional[Decimal] = None
+    position_mm_delta: Optional[Decimal] = None
+    liq_price_delta: Optional[Decimal] = None
+    unrealised_pnl_delta: Optional[Decimal] = None
+    cum_realised_pnl_delta: Optional[Decimal] = None
+
+    # True when any per-field delta is None due to NULL telemetry on either
+    # side (other fields may still have populated deltas).
+    has_missing_telemetry: bool = False
+
+
+def _safe_sub(a: Optional[Decimal], b: Optional[Decimal]) -> Optional[Decimal]:
+    """``a - b`` returning None if either operand is None."""
+    if a is None or b is None:
+        return None
+    return a - b
+
+
+def _direction_for_side(side: str) -> str:
+    """Map Bybit position side ('Buy'/'Sell') to gridcore direction string."""
+    return "long" if side == "Buy" else "short"
+
+
+def _build_pair(
+    live: PositionSnapshot, bt: PositionSnapshot
+) -> PositionComparisonPair:
+    direction = _direction_for_side(live.side)
+    mark = live.mark_price
+
+    pair = PositionComparisonPair(
+        side=live.side,
+        live=live,
+        backtest=bt,
+        position_im_delta=_safe_sub(bt.position_im, live.position_im),
+        position_mm_delta=_safe_sub(bt.position_mm, live.position_mm),
+        liq_price_delta=_safe_sub(bt.liq_price, live.liq_price),
+        cum_realised_pnl_delta=_safe_sub(bt.cum_realised_pnl, live.cum_realised_pnl),
+    )
+
+    if mark is not None:
+        pair.unrealised_pnl_recomputed_live = calc_unrealised_pnl(
+            direction, live.entry_price, mark, live.size,
+        )
+        pair.unrealised_pnl_recomputed_bt = calc_unrealised_pnl(
+            direction, bt.entry_price, mark, bt.size,
+        )
+        pair.unrealised_pnl_delta = (
+            pair.unrealised_pnl_recomputed_bt - pair.unrealised_pnl_recomputed_live
+        )
+    else:
+        # mark_price missing → recomputation impossible; mark the row.
+        pair.has_missing_telemetry = True
+
+    # Field-by-field NULL detection (any None delta where both should be Decimal).
+    if (
+        pair.position_im_delta is None
+        or pair.position_mm_delta is None
+        or pair.liq_price_delta is None
+        or pair.cum_realised_pnl_delta is None
+    ):
+        pair.has_missing_telemetry = True
+
+    return pair
+
+
+class PositionComparator:
+    """Pairs live/backtest snapshots per-side and computes aggregate metrics."""
+
+    def __init__(self, pair_tolerance_s: int = PAIR_TOLERANCE_S):
+        self._tolerance_s = pair_tolerance_s
+
+    def pair_and_compare(
+        self,
+        live_snapshots: list[PositionSnapshot],
+        bt_snapshots: list[PositionSnapshot],
+    ) -> list[PositionComparisonPair]:
+        """Pair backtest snapshots with the next live snapshot within tolerance.
+
+        Per-side monotonic two-pointer with explicit consume step: each
+        live row is claimed by at most one backtest row. Bt rows that
+        do not find a live row within ``pair_tolerance_s`` increment
+        ``position_pairs_unmatched_bt`` (counted by ``fold_metrics_into``).
+        """
+        pairs: list[PositionComparisonPair] = []
+        for side in ("Buy", "Sell"):
+            live_side = [s for s in live_snapshots if s.side == side]
+            bt_side = [s for s in bt_snapshots if s.side == side]
+            pairs.extend(self._pair_side(live_side, bt_side))
+        return pairs
+
+    def _pair_side(
+        self,
+        live: list[PositionSnapshot],
+        bt: list[PositionSnapshot],
+    ) -> list[PositionComparisonPair]:
+        out: list[PositionComparisonPair] = []
+        live_idx = 0
+        for bt_row in bt:
+            bt_ts = bt_row.exchange_ts
+            # Advance live_idx to the first live row with ts >= bt_ts.
+            while live_idx < len(live) and live[live_idx].exchange_ts < bt_ts:
+                live_idx += 1
+            if live_idx >= len(live):
+                # No future live row to claim — bt unmatched.
+                out.append(_unmatched_bt_marker(bt_row))
+                continue
+            live_row = live[live_idx]
+            gap = (live_row.exchange_ts - bt_ts).total_seconds()
+            if gap > self._tolerance_s:
+                # Within tolerance check failed; bt unmatched. Do NOT
+                # advance live_idx — the next bt row may legitimately
+                # claim this live row.
+                out.append(_unmatched_bt_marker(bt_row))
+                continue
+            out.append(_build_pair(live_row, bt_row))
+            live_idx += 1  # Consume: one-to-one invariant.
+        return out
+
+    def fold_metrics_into(
+        self,
+        metrics: ValidationMetrics,
+        pairs: list[PositionComparisonPair],
+    ) -> None:
+        """Mutate ``metrics`` with the 12 new aggregate fields (idempotent)."""
+        matched = [p for p in pairs if p.backtest is not None and p.live is not None]
+        unmatched = [p for p in pairs if p.backtest is not None and p.live is None]
+
+        metrics.position_pairs_compared = len(matched)
+        metrics.position_pairs_unmatched_bt = len(unmatched)
+        metrics.position_pairs_missing_telemetry = sum(
+            1 for p in matched if p.has_missing_telemetry
+        )
+
+        def _agg(field_name: str) -> tuple[Decimal, Decimal]:
+            """Mean abs / max abs over matched pairs, skipping None per-field."""
+            vals = [
+                abs(getattr(p, field_name))
+                for p in matched
+                if getattr(p, field_name) is not None
+            ]
+            if not vals:
+                return Decimal("0"), Decimal("0")
+            mean = Decimal(str(statistics.mean([float(v) for v in vals])))
+            return mean, max(vals)
+
+        metrics.position_im_mean_abs_delta, metrics.position_im_max_abs_delta = _agg(
+            "position_im_delta"
+        )
+        metrics.position_mm_mean_abs_delta, metrics.position_mm_max_abs_delta = _agg(
+            "position_mm_delta"
+        )
+        metrics.liq_price_mean_abs_delta, metrics.liq_price_max_abs_delta = _agg(
+            "liq_price_delta"
+        )
+        metrics.unrealised_pnl_mean_abs_delta, metrics.unrealised_pnl_max_abs_delta = _agg(
+            "unrealised_pnl_delta"
+        )
+
+        # cum_realised_pnl: compare the FINAL value delta only (per Step 4
+        # design — per-pair rounding noise accumulates over long sessions).
+        # In hedge mode `cum_realised_pnl` is per-direction, so aggregate
+        # the last-pair delta for EACH side. Without per-side aggregation,
+        # `matched[-1]` would always be "last Sell pair" (Buy pairs are
+        # appended first), masking long-only divergence.
+        per_side_final: dict[str, Decimal] = {}
+        for pair in matched:
+            if pair.cum_realised_pnl_delta is None:
+                continue
+            per_side_final[pair.side] = pair.cum_realised_pnl_delta
+        metrics.cum_realised_pnl_final_delta = sum(
+            per_side_final.values(), Decimal("0"),
+        )
+
+
+def _unmatched_bt_marker(bt: PositionSnapshot) -> PositionComparisonPair:
+    """Sentinel pair for an unmatched backtest snapshot.
+
+    ``live`` is filled with ``None`` via the ``backtest=bt, live=None``
+    sentinel pattern — but the dataclass requires a ``PositionSnapshot``;
+    use a separate flag instead. We model this as a pair with the backtest
+    side set, the live side None, and ``has_missing_telemetry=True``.
+    """
+    # The dataclass demands ``live: PositionSnapshot``; we use an attribute
+    # override pattern via ``object.__setattr__`` to allow None on the
+    # mutable dataclass without rewriting the type hint.
+    pair = PositionComparisonPair.__new__(PositionComparisonPair)
+    pair.side = bt.side
+    pair.live = None  # type: ignore[assignment]
+    pair.backtest = bt
+    pair.unrealised_pnl_recomputed_live = None
+    pair.unrealised_pnl_recomputed_bt = None
+    pair.position_im_delta = None
+    pair.position_mm_delta = None
+    pair.liq_price_delta = None
+    pair.unrealised_pnl_delta = None
+    pair.cum_realised_pnl_delta = None
+    pair.has_missing_telemetry = True
+    return pair
+
+
+__all__ = [
+    "PAIR_TOLERANCE_S",
+    "PositionComparator",
+    "PositionComparisonPair",
+]

--- a/apps/comparator/src/comparator/position_metrics.py
+++ b/apps/comparator/src/comparator/position_metrics.py
@@ -19,7 +19,6 @@ still emits per-pair deltas for the other fields and increments
 from __future__ import annotations
 
 import logging
-import statistics
 from dataclasses import dataclass
 from decimal import Decimal
 from typing import Optional
@@ -187,7 +186,13 @@ class PositionComparator:
         )
 
         def _agg(field_name: str) -> tuple[Decimal, Decimal]:
-            """Mean abs / max abs over matched pairs, skipping None per-field."""
+            """Mean abs / max abs over matched pairs, skipping None per-field.
+
+            Pure Decimal arithmetic — no float roundtrip — so cumulative
+            rounding from many small deltas stays exact. Important because
+            `position_im` / `position_mm` deltas can be 1e-8 USDT per pair
+            and the acceptance gate is set at 0.05 USDT total.
+            """
             vals = [
                 abs(getattr(p, field_name))
                 for p in matched
@@ -195,7 +200,7 @@ class PositionComparator:
             ]
             if not vals:
                 return Decimal("0"), Decimal("0")
-            mean = Decimal(str(statistics.mean([float(v) for v in vals])))
+            mean = sum(vals, Decimal("0")) / Decimal(len(vals))
             return mean, max(vals)
 
         metrics.position_im_mean_abs_delta, metrics.position_im_max_abs_delta = _agg(

--- a/apps/comparator/src/comparator/reporter.py
+++ b/apps/comparator/src/comparator/reporter.py
@@ -13,6 +13,7 @@ from typing import Optional, Union
 
 from comparator.matcher import MatchResult
 from comparator.metrics import ValidationMetrics
+from comparator.position_metrics import PositionComparisonPair
 
 logger = logging.getLogger(__name__)
 
@@ -33,11 +34,13 @@ class ComparatorReporter:
         metrics: ValidationMetrics,
         equity_data: list[ResampledRow] | None = None,
         metadata: dict[str, str] | None = None,
+        position_pairs: list[PositionComparisonPair] | None = None,
     ):
         self._match_result = match_result
         self._metrics = metrics
         self._equity_data = equity_data
         self._metadata = metadata or {}
+        self._position_pairs = position_pairs or []
 
     def _ensure_path(self, path: Union[str, Path]) -> Path:
         """Convert to Path and create parent directories."""
@@ -198,6 +201,19 @@ class ComparatorReporter:
             ("equity_max_divergence", str(m.equity_max_divergence)),
             ("equity_mean_divergence", str(m.equity_mean_divergence)),
             ("equity_correlation", f"{m.equity_correlation:.6f}"),
+            # 0034: position telemetry parity metrics.
+            ("position_im_mean_abs_delta", str(m.position_im_mean_abs_delta)),
+            ("position_im_max_abs_delta", str(m.position_im_max_abs_delta)),
+            ("position_mm_mean_abs_delta", str(m.position_mm_mean_abs_delta)),
+            ("position_mm_max_abs_delta", str(m.position_mm_max_abs_delta)),
+            ("liq_price_mean_abs_delta", str(m.liq_price_mean_abs_delta)),
+            ("liq_price_max_abs_delta", str(m.liq_price_max_abs_delta)),
+            ("unrealised_pnl_mean_abs_delta", str(m.unrealised_pnl_mean_abs_delta)),
+            ("unrealised_pnl_max_abs_delta", str(m.unrealised_pnl_max_abs_delta)),
+            ("cum_realised_pnl_final_delta", str(m.cum_realised_pnl_final_delta)),
+            ("position_pairs_compared", str(m.position_pairs_compared)),
+            ("position_pairs_unmatched_bt", str(m.position_pairs_unmatched_bt)),
+            ("position_pairs_missing_telemetry", str(m.position_pairs_missing_telemetry)),
         ]
 
         with open(path, "w", newline="") as f:
@@ -239,6 +255,77 @@ class ComparatorReporter:
 
         logger.info("Exported equity comparison (%d points) to %s", len(self._equity_data), path)
 
+    def export_position_comparison(self, path: Union[str, Path]) -> None:
+        """Export per-pair position telemetry deltas to CSV (0034).
+
+        Columns mirror the plan: per-side, live and backtest sides plus
+        the recomputed unrealized PnL (apples-to-apples against
+        live.mark_price) and absolute deltas.
+        """
+        path = self._ensure_path(path)
+
+        with open(path, "w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow([
+                "side",
+                "live_ts",
+                "backtest_ts",
+                "live_size",
+                "bt_size",
+                "live_entry",
+                "bt_entry",
+                "mark_price",
+                "live_im",
+                "bt_im",
+                "im_delta",
+                "live_mm",
+                "bt_mm",
+                "mm_delta",
+                "live_liq",
+                "bt_liq",
+                "liq_delta",
+                "live_unrealised_recomp",
+                "bt_unrealised_recomp",
+                "unrealised_delta",
+                "live_cum_realised",
+                "bt_cum_realised",
+                "cum_realised_delta",
+            ])
+
+            for pair in self._position_pairs:
+                if pair.live is None:
+                    continue  # unmatched-bt sentinel; counted but not emitted
+                live = pair.live
+                bt = pair.backtest
+                writer.writerow([
+                    pair.side,
+                    live.exchange_ts.isoformat(),
+                    bt.exchange_ts.isoformat(),
+                    str(live.size),
+                    str(bt.size),
+                    str(live.entry_price),
+                    str(bt.entry_price),
+                    str(live.mark_price) if live.mark_price is not None else "",
+                    str(live.position_im) if live.position_im is not None else "",
+                    str(bt.position_im) if bt.position_im is not None else "",
+                    str(pair.position_im_delta) if pair.position_im_delta is not None else "",
+                    str(live.position_mm) if live.position_mm is not None else "",
+                    str(bt.position_mm) if bt.position_mm is not None else "",
+                    str(pair.position_mm_delta) if pair.position_mm_delta is not None else "",
+                    str(live.liq_price) if live.liq_price is not None else "",
+                    str(bt.liq_price) if bt.liq_price is not None else "",
+                    str(pair.liq_price_delta) if pair.liq_price_delta is not None else "",
+                    str(pair.unrealised_pnl_recomputed_live) if pair.unrealised_pnl_recomputed_live is not None else "",
+                    str(pair.unrealised_pnl_recomputed_bt) if pair.unrealised_pnl_recomputed_bt is not None else "",
+                    str(pair.unrealised_pnl_delta) if pair.unrealised_pnl_delta is not None else "",
+                    str(live.cum_realised_pnl) if live.cum_realised_pnl is not None else "",
+                    str(bt.cum_realised_pnl) if bt.cum_realised_pnl is not None else "",
+                    str(pair.cum_realised_pnl_delta) if pair.cum_realised_pnl_delta is not None else "",
+                ])
+
+        emitted = sum(1 for p in self._position_pairs if p.live is not None)
+        logger.info("Exported %d position pairs to %s", emitted, path)
+
     def export_all(self, output_dir: Union[str, Path]) -> dict[str, Path]:
         """Export all reports to a directory.
 
@@ -262,6 +349,15 @@ class ComparatorReporter:
             equity_path = output_dir / "equity_comparison.csv"
             self.export_equity(equity_path)
             paths["equity_comparison"] = equity_path
+
+        # 0034: emit position_comparison.csv only when at least one paired
+        # row exists. Migrated DB with no backtest rows yet → no file
+        # (this is the only intentional silent path; un-migrated DBs raise
+        # at load time in position_loader.py).
+        if any(p.live is not None for p in self._position_pairs):
+            position_path = output_dir / "position_comparison.csv"
+            self.export_position_comparison(position_path)
+            paths["position_comparison"] = position_path
 
         return paths
 
@@ -322,6 +418,20 @@ class ComparatorReporter:
             f"    Max divergence: {m.equity_max_divergence}",
             f"    Mean divergence:{m.equity_mean_divergence}",
             f"    Correlation:    {m.equity_correlation:.4f}",
+            "",
+            "  POSITION TELEMETRY",
+            f"    Pairs compared:        {m.position_pairs_compared}",
+            f"    Unmatched (bt):        {m.position_pairs_unmatched_bt}",
+            f"    Missing telemetry:     {m.position_pairs_missing_telemetry}",
+            f"    IM mean |delta|:       {m.position_im_mean_abs_delta}",
+            f"    IM max |delta|:        {m.position_im_max_abs_delta}",
+            f"    MM mean |delta|:       {m.position_mm_mean_abs_delta}",
+            f"    MM max |delta|:        {m.position_mm_max_abs_delta}",
+            f"    Liq price mean:        {m.liq_price_mean_abs_delta}",
+            f"    Liq price max:         {m.liq_price_max_abs_delta}",
+            f"    Unrealised mean:       {m.unrealised_pnl_mean_abs_delta}",
+            f"    Unrealised max:        {m.unrealised_pnl_max_abs_delta}",
+            f"    Cum realised final:    {m.cum_realised_pnl_final_delta}",
             "",
             "=" * 60,
         ]

--- a/apps/comparator/tests/test_position_metrics.py
+++ b/apps/comparator/tests/test_position_metrics.py
@@ -1,0 +1,270 @@
+"""Tests for position telemetry pairing and metrics (feature 0034)."""
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+
+from grid_db.models import PositionSnapshot
+
+from comparator.metrics import ValidationMetrics
+from comparator.position_loader import (
+    PositionTelemetryNotMigratedError,
+    load_position_snapshots,
+)
+from comparator.position_metrics import (
+    PAIR_TOLERANCE_S,
+    PositionComparator,
+)
+
+
+@pytest.fixture
+def base_ts():
+    return datetime(2026, 5, 11, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _snap(
+    side: str,
+    ts: datetime,
+    size: Decimal = Decimal("1"),
+    entry_price: Decimal = Decimal("100"),
+    mark_price: Decimal = Decimal("101"),
+    liq_price: Decimal = Decimal("90"),
+    position_im: Decimal = Decimal("10"),
+    position_mm: Decimal = Decimal("0.5"),
+    cum_realised_pnl: Decimal = Decimal("0"),
+    source: str = "live",
+) -> PositionSnapshot:
+    return PositionSnapshot(
+        run_id="run-test",
+        account_id="acct-1",
+        symbol="LTCUSDT",
+        exchange_ts=ts,
+        local_ts=ts,
+        side=side,
+        size=size,
+        entry_price=entry_price,
+        liq_price=liq_price,
+        unrealised_pnl=Decimal("0"),
+        source=source,
+        mark_price=mark_price,
+        position_im=position_im,
+        position_mm=position_mm,
+        cum_realised_pnl=cum_realised_pnl,
+    )
+
+
+def test_pair_within_tolerance(base_ts):
+    """Backtest at T pairs with first live at >= T within 5s."""
+    live = [_snap("Buy", base_ts + timedelta(seconds=2), source="live")]
+    bt = [_snap("Buy", base_ts, source="backtest")]
+
+    pairs = PositionComparator().pair_and_compare(live, bt)
+
+    assert len(pairs) == 1
+    assert pairs[0].live is live[0]
+    assert pairs[0].backtest is bt[0]
+
+
+def test_pair_outside_tolerance_unmatched(base_ts):
+    """Bt with no live in tolerance window counts as unmatched, no consume."""
+    live = [_snap("Buy", base_ts + timedelta(seconds=PAIR_TOLERANCE_S + 5), source="live")]
+    bt = [_snap("Buy", base_ts, source="backtest")]
+
+    pairs = PositionComparator().pair_and_compare(live, bt)
+
+    metrics = ValidationMetrics()
+    PositionComparator().fold_metrics_into(metrics, pairs)
+    assert metrics.position_pairs_compared == 0
+    assert metrics.position_pairs_unmatched_bt == 1
+
+
+def test_monotonic_consume_invariant(base_ts):
+    """Two bt rows before a single live row: first pairs, second unmatched.
+
+    Without the consume step, both bt rows would pair to the same live row
+    and inflate position_pairs_compared.
+    """
+    live = [_snap("Buy", base_ts + timedelta(seconds=2), source="live")]
+    bt = [
+        _snap("Buy", base_ts, source="backtest"),
+        _snap("Buy", base_ts + timedelta(seconds=1), source="backtest"),
+    ]
+
+    pairs = PositionComparator().pair_and_compare(live, bt)
+
+    matched = [p for p in pairs if p.live is not None]
+    unmatched = [p for p in pairs if p.live is None]
+    assert len(matched) == 1
+    assert len(unmatched) == 1
+
+    metrics = ValidationMetrics()
+    PositionComparator().fold_metrics_into(metrics, pairs)
+    assert metrics.position_pairs_compared == 1
+    assert metrics.position_pairs_unmatched_bt == 1
+
+
+def test_zero_deltas_when_equal(base_ts):
+    """Trivial all-equal pair → all per-field deltas zero."""
+    live = [_snap("Buy", base_ts, source="live")]
+    bt = [_snap("Buy", base_ts, source="backtest")]
+
+    pairs = PositionComparator().pair_and_compare(live, bt)
+    pair = pairs[0]
+
+    assert pair.position_im_delta == Decimal("0")
+    assert pair.position_mm_delta == Decimal("0")
+    assert pair.liq_price_delta == Decimal("0")
+    assert pair.unrealised_pnl_delta == Decimal("0")
+    assert pair.cum_realised_pnl_delta == Decimal("0")
+
+
+def test_unrealised_recomputation_divergent_entry(base_ts):
+    """Backtest entry diverges from live → unrealised_pnl_delta picks it up."""
+    # Long, mark=110, live entry=100 (pnl=10), bt entry=105 (pnl=5)
+    live = [_snap(
+        "Buy", base_ts, size=Decimal("1"),
+        entry_price=Decimal("100"), mark_price=Decimal("110"),
+        source="live",
+    )]
+    bt = [_snap(
+        "Buy", base_ts, size=Decimal("1"),
+        entry_price=Decimal("105"), mark_price=Decimal("110"),
+        source="backtest",
+    )]
+
+    pair = PositionComparator().pair_and_compare(live, bt)[0]
+
+    # bt minus live: 5 - 10 = -5
+    assert pair.unrealised_pnl_recomputed_live == Decimal("10")
+    assert pair.unrealised_pnl_recomputed_bt == Decimal("5")
+    assert pair.unrealised_pnl_delta == Decimal("-5")
+
+
+def test_short_side_recomputation_correct_sign(base_ts):
+    """Short pair: mark < entry → positive unrealized (long-only formula gives wrong sign)."""
+    # Short, entry=100, mark=90, size=1 → unrealized = (100-90)*1 = +10
+    live = [_snap(
+        "Sell", base_ts, size=Decimal("1"),
+        entry_price=Decimal("100"), mark_price=Decimal("90"),
+        source="live",
+    )]
+    bt = [_snap(
+        "Sell", base_ts, size=Decimal("1"),
+        entry_price=Decimal("100"), mark_price=Decimal("90"),
+        source="backtest",
+    )]
+
+    pair = PositionComparator().pair_and_compare(live, bt)[0]
+
+    assert pair.unrealised_pnl_recomputed_live == Decimal("10")
+    assert pair.unrealised_pnl_recomputed_bt == Decimal("10")
+    assert pair.unrealised_pnl_delta == Decimal("0")
+
+
+def test_null_telemetry_per_field(base_ts):
+    """Live row with NULL position_im → im_delta None, other deltas present."""
+    live = [_snap("Buy", base_ts, source="live")]
+    live[0].position_im = None  # simulate partial Bybit payload
+    bt = [_snap("Buy", base_ts, source="backtest")]
+
+    pair = PositionComparator().pair_and_compare(live, bt)[0]
+
+    assert pair.position_im_delta is None
+    assert pair.position_mm_delta == Decimal("0")
+    assert pair.liq_price_delta == Decimal("0")
+    assert pair.has_missing_telemetry is True
+
+    metrics = ValidationMetrics()
+    PositionComparator().fold_metrics_into(metrics, [pair])
+    assert metrics.position_pairs_compared == 1
+    assert metrics.position_pairs_missing_telemetry == 1
+
+
+def test_cum_realised_pnl_final_delta_aggregates_both_sides(base_ts):
+    """Both-side: final delta sums per-side last-pair deltas.
+
+    Without per-side aggregation, matched[-1] would always be "last Sell pair"
+    and a long-only divergence would be silently masked when any Sell pair
+    exists. Regression test for P2 finding in the 0034 code review.
+    """
+    # Long final delta = +5 (live cum=10, bt cum=15), short final = 0.
+    live = [
+        _snap("Buy", base_ts, cum_realised_pnl=Decimal("10"), source="live"),
+        _snap("Sell", base_ts + timedelta(seconds=1), cum_realised_pnl=Decimal("3"), source="live"),
+    ]
+    bt = [
+        _snap("Buy", base_ts, cum_realised_pnl=Decimal("15"), source="backtest"),
+        _snap("Sell", base_ts + timedelta(seconds=1), cum_realised_pnl=Decimal("3"), source="backtest"),
+    ]
+    pairs = PositionComparator().pair_and_compare(live, bt)
+    metrics = ValidationMetrics()
+    PositionComparator().fold_metrics_into(metrics, pairs)
+    assert metrics.cum_realised_pnl_final_delta == Decimal("5")
+
+
+def test_cum_realised_pnl_final_delta_only_short_diverges(base_ts):
+    """Short-only divergence: short delta surfaces in aggregate."""
+    live = [
+        _snap("Buy", base_ts, cum_realised_pnl=Decimal("0"), source="live"),
+        _snap("Sell", base_ts + timedelta(seconds=1), cum_realised_pnl=Decimal("0"), source="live"),
+    ]
+    bt = [
+        _snap("Buy", base_ts, cum_realised_pnl=Decimal("0"), source="backtest"),
+        _snap("Sell", base_ts + timedelta(seconds=1), cum_realised_pnl=Decimal("-2"), source="backtest"),
+    ]
+    pairs = PositionComparator().pair_and_compare(live, bt)
+    metrics = ValidationMetrics()
+    PositionComparator().fold_metrics_into(metrics, pairs)
+    assert metrics.cum_realised_pnl_final_delta == Decimal("-2")
+
+
+def test_fold_metrics_idempotent(base_ts):
+    """Calling fold_metrics_into twice yields the same final values."""
+    live = [_snap("Buy", base_ts, source="live")]
+    bt = [_snap("Buy", base_ts, source="backtest", position_im=Decimal("11"))]
+
+    pairs = PositionComparator().pair_and_compare(live, bt)
+    metrics = ValidationMetrics()
+    PositionComparator().fold_metrics_into(metrics, pairs)
+    snapshot1 = metrics.position_im_max_abs_delta
+
+    PositionComparator().fold_metrics_into(metrics, pairs)
+    snapshot2 = metrics.position_im_max_abs_delta
+    assert snapshot1 == snapshot2
+
+
+def test_un_migrated_db_raises():
+    """Load_position_snapshots raises on missing source column.
+
+    Simulates an un-migrated DB by creating a position_snapshots table
+    without the 0034 columns and the source-aware index.
+    """
+    from sqlalchemy import create_engine, text
+    from sqlalchemy.orm import sessionmaker
+
+    engine = create_engine("sqlite:///:memory:")
+    with engine.begin() as conn:
+        conn.execute(text(
+            "CREATE TABLE position_snapshots ("
+            "  id INTEGER PRIMARY KEY,"
+            "  run_id TEXT,"
+            "  account_id TEXT NOT NULL,"
+            "  symbol TEXT NOT NULL,"
+            "  exchange_ts TIMESTAMP NOT NULL,"
+            "  local_ts TIMESTAMP NOT NULL,"
+            "  side TEXT NOT NULL,"
+            "  size NUMERIC NOT NULL,"
+            "  entry_price NUMERIC NOT NULL,"
+            "  liq_price NUMERIC,"
+            "  unrealised_pnl NUMERIC,"
+            "  raw_json TEXT"
+            ")"
+        ))
+
+    Session = sessionmaker(bind=engine)
+    with Session() as session:
+        with pytest.raises(PositionTelemetryNotMigratedError):
+            load_position_snapshots(
+                session, run_id="r", symbol="LTCUSDT", source="live",
+            )

--- a/apps/comparator/tests/test_reporter.py
+++ b/apps/comparator/tests/test_reporter.py
@@ -142,6 +142,94 @@ class TestComparatorReporter:
 
         assert "equity_comparison" not in paths
 
+    def test_export_position_comparison_writes_expected_columns(
+        self, sample_match_result, tmp_path,
+    ):
+        """0034: export_position_comparison writes the documented columns."""
+        from grid_db.models import PositionSnapshot
+        from comparator.position_metrics import PositionComparator
+
+        metrics = calculate_metrics(sample_match_result)
+        ts = datetime(2025, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+        def _snap(side, source):
+            return PositionSnapshot(
+                run_id="r", account_id="a", symbol="BTCUSDT",
+                exchange_ts=ts, local_ts=ts, side=side,
+                size=Decimal("1"), entry_price=Decimal("100"),
+                liq_price=Decimal("90"), unrealised_pnl=Decimal("0"),
+                source=source, mark_price=Decimal("101"),
+                position_im=Decimal("10"), position_mm=Decimal("0.5"),
+                cum_realised_pnl=Decimal("5"),
+            )
+
+        pairs = PositionComparator().pair_and_compare(
+            [_snap("Buy", "live")], [_snap("Buy", "backtest")],
+        )
+        reporter = ComparatorReporter(
+            sample_match_result, metrics, position_pairs=pairs,
+        )
+        out = tmp_path / "position_comparison.csv"
+        reporter.export_position_comparison(out)
+
+        with open(out) as f:
+            reader = csv.DictReader(f)
+            header = reader.fieldnames
+            rows = list(reader)
+        assert "im_delta" in header
+        assert "mm_delta" in header
+        assert "liq_delta" in header
+        assert "unrealised_delta" in header
+        assert "cum_realised_delta" in header
+        assert len(rows) == 1
+        assert rows[0]["side"] == "Buy"
+
+    def test_export_all_includes_position_comparison_when_pairs_present(
+        self, sample_match_result, tmp_path,
+    ):
+        """0034: export_all adds position_comparison.csv when pairs exist."""
+        from grid_db.models import PositionSnapshot
+        from comparator.position_metrics import PositionComparator
+
+        metrics = calculate_metrics(sample_match_result)
+        ts = datetime(2025, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        snap = PositionSnapshot(
+            run_id="r", account_id="a", symbol="BTCUSDT",
+            exchange_ts=ts, local_ts=ts, side="Buy",
+            size=Decimal("1"), entry_price=Decimal("100"),
+            liq_price=Decimal("90"), unrealised_pnl=Decimal("0"),
+            source="live", mark_price=Decimal("101"),
+            position_im=Decimal("10"), position_mm=Decimal("0.5"),
+            cum_realised_pnl=Decimal("5"),
+        )
+        snap_bt = PositionSnapshot(
+            run_id="r", account_id="a", symbol="BTCUSDT",
+            exchange_ts=ts, local_ts=ts, side="Buy",
+            size=Decimal("1"), entry_price=Decimal("100"),
+            liq_price=Decimal("90"), unrealised_pnl=Decimal("0"),
+            source="backtest", mark_price=Decimal("101"),
+            position_im=Decimal("10"), position_mm=Decimal("0.5"),
+            cum_realised_pnl=Decimal("5"),
+        )
+        pairs = PositionComparator().pair_and_compare([snap], [snap_bt])
+        reporter = ComparatorReporter(
+            sample_match_result, metrics, position_pairs=pairs,
+        )
+        paths = reporter.export_all(tmp_path)
+        assert "position_comparison" in paths
+        assert paths["position_comparison"].exists()
+
+    def test_export_all_omits_position_comparison_when_no_pairs(
+        self, sample_match_result, tmp_path,
+    ):
+        """0034: export_all omits position_comparison.csv when no matched pairs."""
+        metrics = calculate_metrics(sample_match_result)
+        reporter = ComparatorReporter(
+            sample_match_result, metrics, position_pairs=[],
+        )
+        paths = reporter.export_all(tmp_path)
+        assert "position_comparison" not in paths
+
     def test_export_matched_trades_with_reused_ids(self, make_trade, ts, tmp_path):
         """Reused client_order_id rows each get their correct delta in CSV."""
         # Two matched pairs with the same client_order_id but different occurrences

--- a/apps/event_saver/src/event_saver/writers/position_writer.py
+++ b/apps/event_saver/src/event_saver/writers/position_writer.py
@@ -223,6 +223,30 @@ class PositionWriter:
                                 if pos.get("unrealisedPnl")
                                 else None
                             ),
+                            # 0034: position telemetry parity columns.
+                            # `source` is recorder-side metadata not present
+                            # on the Bybit payload — do NOT copy into raw_json.
+                            source="live",
+                            mark_price=(
+                                Decimal(str(pos.get("markPrice")))
+                                if pos.get("markPrice")
+                                else None
+                            ),
+                            position_im=(
+                                Decimal(str(pos.get("positionIM")))
+                                if pos.get("positionIM")
+                                else None
+                            ),
+                            position_mm=(
+                                Decimal(str(pos.get("positionMM")))
+                                if pos.get("positionMM")
+                                else None
+                            ),
+                            cum_realised_pnl=(
+                                Decimal(str(pos.get("cumRealisedPnl")))
+                                if pos.get("cumRealisedPnl")
+                                else None
+                            ),
                             raw_json=pos,
                         )
                     )

--- a/apps/event_saver/tests/test_writers.py
+++ b/apps/event_saver/tests/test_writers.py
@@ -772,6 +772,58 @@ class TestPositionWriter:
             await writer.flush()
             assert len(writer._buffer) == 0
 
+    @pytest.mark.asyncio
+    async def test_parses_0034_telemetry_fields(self, mock_db):
+        """0034: markPrice/positionIM/positionMM/cumRealisedPnl land in the right cols."""
+        from decimal import Decimal
+
+        writer = PositionWriter(db=mock_db, batch_size=100)
+        messages = [{
+            "data": [{
+                "symbol": "LTCUSDT",
+                "side": "Buy",
+                "size": "1.0",
+                "entryPrice": "100.0",
+                "liqPrice": "90.0",
+                "unrealisedPnl": "1.0",
+                "markPrice": "101.0",
+                "positionIM": "10.5",
+                "positionMM": "0.55",
+                "cumRealisedPnl": "12.34",
+                "updatedTime": "1700000000000",
+            }]
+        }]
+        await writer.write(uuid4(), messages)
+        snap = writer._buffer[0]
+        assert snap.source == "live"
+        assert snap.mark_price == Decimal("101.0")
+        assert snap.position_im == Decimal("10.5")
+        assert snap.position_mm == Decimal("0.55")
+        assert snap.cum_realised_pnl == Decimal("12.34")
+
+    @pytest.mark.asyncio
+    async def test_backward_compat_missing_0034_fields(self, mock_db):
+        """Rows missing new fields parse cleanly with None telemetry."""
+        writer = PositionWriter(db=mock_db, batch_size=100)
+        messages = [{
+            "data": [{
+                "symbol": "LTCUSDT",
+                "side": "Buy",
+                "size": "1.0",
+                "entryPrice": "100.0",
+                "liqPrice": "90.0",
+                "unrealisedPnl": "1.0",
+                "updatedTime": "1700000000000",
+            }]
+        }]
+        await writer.write(uuid4(), messages)
+        snap = writer._buffer[0]
+        assert snap.mark_price is None
+        assert snap.position_im is None
+        assert snap.position_mm is None
+        assert snap.cum_realised_pnl is None
+        assert snap.source == "live"
+
 
 class TestWalletWriter:
     """Test WalletWriter buffering and bulk insert."""

--- a/apps/recorder/src/recorder/recorder.py
+++ b/apps/recorder/src/recorder/recorder.py
@@ -441,6 +441,32 @@ class Recorder:
                                     if pos.get("unrealisedPnl") not in (None, "")
                                     else None
                                 ),
+                                # 0034: position telemetry parity columns.
+                                # mark_price guard matches the WS path
+                                # (position_writer.py): only None/"" → NULL.
+                                # A genuine 0 mark is rare but valid and
+                                # must be preserved for parity recomputation.
+                                source="live",
+                                mark_price=(
+                                    Decimal(str(pos.get("markPrice")))
+                                    if pos.get("markPrice") not in (None, "")
+                                    else None
+                                ),
+                                position_im=(
+                                    Decimal(str(pos.get("positionIM")))
+                                    if pos.get("positionIM") not in (None, "")
+                                    else None
+                                ),
+                                position_mm=(
+                                    Decimal(str(pos.get("positionMM")))
+                                    if pos.get("positionMM") not in (None, "")
+                                    else None
+                                ),
+                                cum_realised_pnl=(
+                                    Decimal(str(pos.get("cumRealisedPnl")))
+                                    if pos.get("cumRealisedPnl") not in (None, "")
+                                    else None
+                                ),
                                 raw_json=pos,
                             )
                         )
@@ -463,6 +489,12 @@ class Recorder:
                         entry_price=Decimal("0"),
                         liq_price=None,
                         unrealised_pnl=None,
+                        # 0034: zero-row stays NULL for telemetry; source=live.
+                        source="live",
+                        mark_price=None,
+                        position_im=None,
+                        position_mm=None,
+                        cum_realised_pnl=None,
                         raw_json=None,
                     )
                 )

--- a/apps/replay/src/replay/engine.py
+++ b/apps/replay/src/replay/engine.py
@@ -10,7 +10,7 @@ Orchestrates:
 
 import logging
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from decimal import Decimal
 from typing import Optional
 
@@ -21,6 +21,7 @@ from sqlalchemy import func
 from grid_db import (
     DatabaseFactory,
     PositionSnapshot,
+    PositionSnapshotRepository,
     Run,
     RunRepository,
     WalletSnapshot,
@@ -49,6 +50,10 @@ from comparator import (
     MatchResult,
     ValidationMetrics,
 )
+from comparator.position_loader import (
+    load_position_snapshots as load_position_snapshot_rows,
+)
+from comparator.position_metrics import PositionComparator
 
 from replay.config import ReplayConfig, SeedConfig
 from replay.snapshot_loader import (
@@ -73,6 +78,58 @@ logger = logging.getLogger(__name__)
 _SEED_PRE_CHECK_MARGIN = timedelta(seconds=5)
 
 
+class _BatchPositionSnapshotWriter:
+    """Synchronous writer for backtest position snapshots (0034).
+
+    Buffers snapshots emitted by ``BacktestRunner._emit_position_snapshot``
+    and flushes in bulk at end-of-run. Synchronous because replay is
+    single-threaded — no auto-flush loop, no asyncio coupling.
+
+    Stamps ``run_id``, ``account_id``, and ``source='backtest'`` on every
+    row. The runner only fills the symbol/side/size/entry/etc.
+    """
+
+    def __init__(
+        self,
+        db: DatabaseFactory,
+        run_id: str,
+        account_id: str,
+        source: str = "backtest",
+        flush_batch_size: int = 500,
+    ):
+        self._db = db
+        self._run_id = run_id
+        self._account_id = account_id
+        self._source = source
+        self._flush_batch_size = flush_batch_size
+        self._buffer: list[PositionSnapshot] = []
+        self._total_written = 0
+
+    def write(self, snapshot: PositionSnapshot) -> None:
+        """Stamp run-context fields and buffer for flush."""
+        snapshot.run_id = self._run_id
+        snapshot.account_id = self._account_id
+        snapshot.source = self._source
+        self._buffer.append(snapshot)
+        if len(self._buffer) >= self._flush_batch_size:
+            self.flush()
+
+    def flush(self) -> int:
+        """Bulk-insert any buffered snapshots; returns rowcount."""
+        if not self._buffer:
+            return 0
+        with self._db.get_session() as session:
+            repo = PositionSnapshotRepository(session)
+            inserted = repo.bulk_insert(self._buffer)
+        self._total_written += inserted
+        self._buffer.clear()
+        return inserted
+
+    @property
+    def total_written(self) -> int:
+        return self._total_written
+
+
 @dataclass
 class ReplayResult:
     """Result of a replay run."""
@@ -85,6 +142,9 @@ class ReplayResult:
     start_ts: datetime
     end_ts: datetime
     fill_mode: FillMode
+    # 0034: paired live/backtest position snapshots for the CSV export.
+    # Empty list when no pairs found OR comparator not run.
+    position_pairs: list = field(default_factory=list)
 
 
 class ReplayEngine:
@@ -121,8 +181,8 @@ class ReplayEngine:
         """
         config = self._config
 
-        # 1. Resolve run_id and time range
-        run_id, start_ts, end_ts = self._resolve_run(config)
+        # 1. Resolve run_id, account_id and time range
+        run_id, account_id, start_ts, end_ts = self._resolve_run(config)
         fill_mode = FillMode(config.fill_simulator.mode)
 
         logger.info(
@@ -166,6 +226,8 @@ class ReplayEngine:
             grid_seed=grid_seed,
             order_seeds=order_seeds,
             fill_mode=fill_mode,
+            run_id=run_id,
+            account_id=account_id,
         )
 
         if config.seed.enabled:
@@ -241,6 +303,16 @@ class ReplayEngine:
         if config.wind_down_mode == WindDownMode.CLOSE_ALL and last_price > 0:
             self._wind_down(runner, session, last_price, last_timestamp)
 
+        # 6b. 0034: flush buffered backtest position snapshots so the
+        # comparator (and the pair_and_compare call below) can read them.
+        position_writer = getattr(runner, "_position_writer", None)
+        if position_writer is not None:
+            position_writer.flush()
+            logger.info(
+                "Position telemetry: wrote %d backtest snapshots to DB",
+                position_writer.total_written,
+            )
+
         # 7. Finalize session
         final_unrealized = (
             runner.long_tracker.calculate_unrealized_pnl(last_price)
@@ -276,6 +348,42 @@ class ReplayEngine:
             qty_tolerance=config.qty_tolerance,
         )
 
+        # 11. 0034: pair live/backtest position snapshots and fold telemetry
+        # parity metrics into the same ValidationMetrics object.
+        position_pairs: list = []
+        with self._db.get_session() as db_session:
+            live_snaps = load_position_snapshot_rows(
+                db_session,
+                run_id=run_id,
+                symbol=config.symbol,
+                source="live",
+                start_ts=start_ts,
+                end_ts=end_ts,
+            )
+            bt_snaps = load_position_snapshot_rows(
+                db_session,
+                run_id=run_id,
+                symbol=config.symbol,
+                source="backtest",
+                start_ts=start_ts,
+                end_ts=end_ts,
+            )
+        if live_snaps and bt_snaps:
+            pc = PositionComparator()
+            position_pairs = pc.pair_and_compare(live_snaps, bt_snaps)
+            pc.fold_metrics_into(metrics, position_pairs)
+            logger.info(
+                "Position telemetry: %d pairs compared, %d unmatched bt, %d missing telemetry",
+                metrics.position_pairs_compared,
+                metrics.position_pairs_unmatched_bt,
+                metrics.position_pairs_missing_telemetry,
+            )
+        else:
+            logger.info(
+                "Position telemetry: skipped (live_snaps=%d, bt_snaps=%d)",
+                len(live_snaps), len(bt_snaps),
+            )
+
         return ReplayResult(
             session=session,
             metrics=metrics,
@@ -285,13 +393,16 @@ class ReplayEngine:
             start_ts=start_ts,
             end_ts=end_ts,
             fill_mode=fill_mode,
+            position_pairs=position_pairs,
         )
 
     def _resolve_run(self, config: ReplayConfig):
-        """Resolve run_id and time range from config or database.
+        """Resolve run_id, account_id and time range from config or database.
 
         Returns:
-            Tuple of (run_id, start_ts, end_ts).
+            Tuple of (run_id, account_id, start_ts, end_ts). ``account_id``
+            is the ``Run.account_id`` column — used by the 0034 position
+            telemetry writer. May be ``None`` on legacy pre-0029 runs.
         """
         run_id = config.run_id
 
@@ -308,6 +419,7 @@ class ReplayEngine:
                     )
                 # Extract values while still in session scope
                 run_id = run.run_id
+                run_account_id = run.account_id
                 run_start = run.start_ts
                 run_end = run.end_ts
 
@@ -315,19 +427,21 @@ class ReplayEngine:
 
             start_ts = config.start_ts or run_start
             end_ts = config.end_ts or run_end
+            account_id = run_account_id
         else:
             start_ts = config.start_ts
             end_ts = config.end_ts
-            # Fetch Run row if either timestamp is missing
-            if start_ts is None or end_ts is None:
-                with self._db.get_session() as session:
-                    run = session.get(Run, run_id)
-                    if run is None:
-                        raise ValueError(f"Run '{run_id}' not found in database")
-                    if start_ts is None:
-                        start_ts = run.start_ts
-                    if end_ts is None:
-                        end_ts = run.end_ts
+            # 0034: always load the Run row so account_id is available, even
+            # when both timestamps were supplied in the config. One PK lookup.
+            with self._db.get_session() as session:
+                run = session.get(Run, run_id)
+                if run is None:
+                    raise ValueError(f"Run '{run_id}' not found in database")
+                if start_ts is None:
+                    start_ts = run.start_ts
+                if end_ts is None:
+                    end_ts = run.end_ts
+                account_id = run.account_id
 
         # Handle active runs (end_ts still None → use utcnow)
         if end_ts is None:
@@ -343,7 +457,7 @@ class ReplayEngine:
                 f"Invalid time range: start_ts ({start_ts}) must be before end_ts ({end_ts})"
             )
 
-        return run_id, start_ts, end_ts
+        return run_id, account_id, start_ts, end_ts
 
     def _init_runner(
         self,
@@ -354,6 +468,8 @@ class ReplayEngine:
         grid_seed: Optional[GridStateSeed] = None,
         order_seeds: Optional[list[ActiveOrderSeed]] = None,
         fill_mode: FillMode = FillMode.STRICT_CROSS,
+        run_id: Optional[str] = None,
+        account_id: Optional[str] = None,
     ) -> BacktestRunner:
         """Initialize a BacktestRunner for the replay.
 
@@ -415,7 +531,7 @@ class ReplayEngine:
         if short_seed is not None:
             short_tracker.seed_state(short_seed)
 
-        return BacktestRunner(
+        runner = BacktestRunner(
             strategy_config=strategy_config,
             executor=executor,
             session=session,
@@ -425,6 +541,33 @@ class ReplayEngine:
             restored_grid=grid_seed.grid if grid_seed is not None else None,
             seeded_active_orders=order_seeds,
         )
+
+        # 0034: wire the position telemetry writer. Replay always emits to
+        # the recorder DB so the comparator can read both live and backtest
+        # rows from the same table (filtered by `source`).
+        if run_id is not None:
+            if account_id is None:
+                # Pre-0029 legacy data: Run.account_id is NULL. Don't
+                # silently fall back — surface the issue so the operator
+                # re-records with the current writer. A broken pre-0029
+                # run would otherwise look identical to a healthy empty
+                # data run (comparator would just see zero backtest rows).
+                raise ValueError(
+                    f"Run {run_id} has no account_id; cannot emit backtest "
+                    "position snapshots. Re-record after the 0029+0034 "
+                    "migrations to populate Run.account_id."
+                )
+            position_writer = _BatchPositionSnapshotWriter(
+                db=self._db,
+                run_id=run_id,
+                account_id=account_id,
+                source="backtest",
+            )
+            runner.position_snapshot_callback = position_writer.write
+            # Stash on runner so the engine can call .flush() at end-of-run.
+            runner._position_writer = position_writer  # type: ignore[attr-defined]
+
+        return runner
 
     def _load_seed(
         self,
@@ -618,3 +761,21 @@ class ReplayEngine:
                 strat_id=runner.strat_id,
             )
             session.record_trade(trade)
+
+            # 0034: wind_down bypasses runner._process_fill, so emit the
+            # snapshot explicitly. Without this, backtest cum_realised_pnl
+            # drifts behind live by the close-out PnL.
+            # Use the runner's cached ticker mark (same semantics as
+            # _process_fill's emission) so the mark_price column matches
+            # the recorder. Fall back to last_price only when no ticker
+            # mark was seen during the run.
+            if runner.position_snapshot_callback is not None and last_timestamp is not None:
+                mark = (
+                    runner._last_mark_price
+                    if runner._last_mark_price is not None
+                    else last_price
+                )
+                snap = runner._emit_position_snapshot(
+                    direction, last_timestamp, mark,
+                )
+                runner.position_snapshot_callback(snap)

--- a/apps/replay/src/replay/main.py
+++ b/apps/replay/src/replay/main.py
@@ -170,6 +170,7 @@ def main(argv=None) -> int:
             match_result=result.match_result,
             metrics=result.metrics,
             metadata={"fill_mode": result.fill_mode.value},
+            position_pairs=result.position_pairs,
         )
         exported = reporter.export_all(output_dir)
         summary_path = output_dir / "summary.json"

--- a/apps/replay/src/replay/snapshot_loader.py
+++ b/apps/replay/src/replay/snapshot_loader.py
@@ -84,12 +84,20 @@ class PositionStateSeed:
     ``DirectionType`` string values). ``leverage`` is NOT seeded —
     ``PositionSnapshot`` does not store it; replay reads leverage from
     its strategy config at tracker init time.
+
+    ``cum_realised_pnl`` (0034) is the Bybit ``cumRealisedPnl`` value at
+    ``at_ts`` — the cumulative realized PnL since position open. Seeded
+    into the tracker so backtest ``cum_realised_pnl`` parity is measured
+    against the same absolute baseline as live, not against a zero-start.
+    Defaults to ``Decimal('0')`` for snapshots with ``NULL`` telemetry or
+    pre-0034 recorder DBs.
     """
 
     direction: str
     size: Decimal
     entry_price: Decimal
     liquidation_price: Decimal
+    cum_realised_pnl: Decimal = Decimal("0")
 
 
 @dataclass(frozen=True)
@@ -294,12 +302,18 @@ def load_position_snapshots(
         size=buy_snap.size,
         entry_price=buy_snap.entry_price,
         liquidation_price=buy_snap.liq_price if buy_snap.liq_price is not None else Decimal("0"),
+        cum_realised_pnl=(
+            buy_snap.cum_realised_pnl if buy_snap.cum_realised_pnl is not None else Decimal("0")
+        ),
     )
     short_seed = PositionStateSeed(
         direction="short",
         size=sell_snap.size,
         entry_price=sell_snap.entry_price,
         liquidation_price=sell_snap.liq_price if sell_snap.liq_price is not None else Decimal("0"),
+        cum_realised_pnl=(
+            sell_snap.cum_realised_pnl if sell_snap.cum_realised_pnl is not None else Decimal("0")
+        ),
     )
     return long_seed, short_seed
 

--- a/apps/replay/tests/conftest.py
+++ b/apps/replay/tests/conftest.py
@@ -7,6 +7,7 @@ import pytest
 
 from gridcore import TickerEvent, EventType
 from grid_db import DatabaseFactory, DatabaseSettings
+from grid_db.models import BybitAccount, Run, Strategy, User
 
 from replay.config import ReplayConfig, ReplayStrategyConfig
 
@@ -28,6 +29,50 @@ def db(db_settings):
     database.create_tables()
     yield database
     database.drop_tables()
+
+
+@pytest.fixture
+def seeded_run_account(db, ts):
+    """Insert User → BybitAccount → Strategy → Run for the standard test-run-id.
+
+    Required by engine tests after feature 0034 — `_resolve_run` and the
+    0034 backtest writer require a real `Run.account_id`. Returns a simple
+    namespace with the account_id string so callers can reach the UUID
+    without holding an ORM session.
+    """
+    from types import SimpleNamespace
+
+    with db.get_session() as session:
+        user = User(username="testuser", email="t@example.com")
+        session.add(user)
+        session.flush()
+        account = BybitAccount(
+            user_id=user.user_id,
+            account_name="test_account",
+            environment="testnet",
+        )
+        session.add(account)
+        session.flush()
+        account_id = str(account.account_id)
+        strategy = Strategy(
+            account_id=account.account_id,
+            strategy_type="GridStrategy",
+            symbol="BTCUSDT",
+            config_json={},
+        )
+        session.add(strategy)
+        session.flush()
+        run = Run(
+            run_id="test-run-id",
+            user_id=user.user_id,
+            account_id=account_id,
+            strategy_id=strategy.strategy_id,
+            run_type="live",
+            start_ts=ts,
+        )
+        session.add(run)
+        session.commit()
+    return SimpleNamespace(account_id=account_id)
 
 
 @pytest.fixture

--- a/apps/replay/tests/test_engine.py
+++ b/apps/replay/tests/test_engine.py
@@ -72,7 +72,7 @@ class TestReplayEngine:
     """Tests for ReplayEngine."""
 
     @patch("replay.engine.InstrumentInfoProvider")
-    def test_replay_produces_result(self, mock_provider_cls, db, replay_config, ticker_events):
+    def test_replay_produces_result(self, mock_provider_cls, db, seeded_run_account, replay_config, ticker_events):
         """Replay with price movement produces a ReplayResult."""
         # Mock instrument info
         mock_info = MagicMock()
@@ -97,7 +97,7 @@ class TestReplayEngine:
         assert result.fill_mode == FillMode.BOOK_TOUCH
 
     @patch("replay.engine.InstrumentInfoProvider")
-    def test_replay_empty_data(self, mock_provider_cls, db, replay_config):
+    def test_replay_empty_data(self, mock_provider_cls, db, seeded_run_account, replay_config):
         """Replay with no data produces empty result."""
         mock_info = MagicMock()
         mock_info.qty_step = Decimal("0.001")
@@ -116,7 +116,7 @@ class TestReplayEngine:
         assert result.metrics.total_backtest_trades == 0
 
     @patch("replay.engine.InstrumentInfoProvider")
-    def test_replay_session_has_equity_curve(self, mock_provider_cls, db, replay_config, ticker_events):
+    def test_replay_session_has_equity_curve(self, mock_provider_cls, db, seeded_run_account, replay_config, ticker_events):
         """Session equity curve is populated during replay."""
         mock_info = MagicMock()
         mock_info.qty_step = Decimal("0.001")
@@ -325,7 +325,7 @@ class TestWindDown:
     """Tests for wind-down behavior."""
 
     @patch("replay.engine.InstrumentInfoProvider")
-    def test_leave_open_preserves_positions(self, mock_provider_cls, db, replay_config, ticker_events):
+    def test_leave_open_preserves_positions(self, mock_provider_cls, db, seeded_run_account, replay_config, ticker_events):
         """leave_open mode does not create wind-down trades."""
         mock_info = MagicMock()
         mock_info.qty_step = Decimal("0.001")
@@ -344,7 +344,7 @@ class TestWindDown:
         assert len(wind_down_trades) == 0
 
     @patch("replay.engine.InstrumentInfoProvider")
-    def test_close_all_creates_wind_down_trades(self, mock_provider_cls, db, replay_config, ticker_events):
+    def test_close_all_creates_wind_down_trades(self, mock_provider_cls, db, seeded_run_account, replay_config, ticker_events):
         """close_all mode creates wind-down trades for open positions."""
         mock_info = MagicMock()
         mock_info.qty_step = Decimal("0.001")
@@ -362,3 +362,117 @@ class TestWindDown:
         if any(t for t in result.session.trades if "wind_down" not in t.client_order_id):
             wind_down_trades = [t for t in result.session.trades if "wind_down" in t.client_order_id]
             assert len(wind_down_trades) > 0
+
+
+class TestPositionTelemetryWriter0034:
+    """Feature 0034 — replay writes backtest position_snapshots to DB."""
+
+    @patch("replay.engine.InstrumentInfoProvider")
+    def test_writes_backtest_source_rows(
+        self, mock_provider_cls, db, seeded_run_account, replay_config, ticker_events,
+    ):
+        """End-to-end: replay produces position_snapshots with source='backtest'."""
+        from grid_db.models import PositionSnapshot
+
+        mock_info = MagicMock()
+        mock_info.qty_step = Decimal("0.001")
+        mock_info.tick_size = Decimal("0.1")
+        mock_info.round_qty = lambda q: max(Decimal("0.001"), q.quantize(Decimal("0.001")))
+        mock_provider_cls.return_value.get.return_value = mock_info
+
+        engine = ReplayEngine(config=replay_config, db=db)
+        provider = InMemoryDataProvider(ticker_events)
+        result = engine.run(data_provider=provider)
+
+        with db.get_session() as session:
+            bt_rows = (
+                session.query(
+                    PositionSnapshot.source,
+                    PositionSnapshot.run_id,
+                    PositionSnapshot.account_id,
+                )
+                .filter(PositionSnapshot.source == "backtest")
+                .all()
+            )
+
+        # Either there were fills (rows exist) or no fills (no rows). When
+        # rows exist, each must carry the resolved account_id from Run.
+        if result.session.trades:
+            assert len(bt_rows) > 0
+            for source, run_id, account_id in bt_rows:
+                assert source == "backtest"
+                assert run_id == "test-run-id"
+                assert account_id == seeded_run_account.account_id
+
+    @patch("replay.engine.InstrumentInfoProvider")
+    def test_wind_down_emits_snapshot(
+        self, mock_provider_cls, db, seeded_run_account, replay_config, ticker_events,
+    ):
+        """Wind-down close_all path emits a backtest snapshot for each direction closed."""
+        from grid_db.models import PositionSnapshot
+
+        mock_info = MagicMock()
+        mock_info.qty_step = Decimal("0.001")
+        mock_info.tick_size = Decimal("0.1")
+        mock_info.round_qty = lambda q: max(Decimal("0.001"), q.quantize(Decimal("0.001")))
+        mock_provider_cls.return_value.get.return_value = mock_info
+
+        replay_config.wind_down_mode = "close_all"
+        engine = ReplayEngine(config=replay_config, db=db)
+        provider = InMemoryDataProvider(ticker_events)
+        result = engine.run(data_provider=provider)
+
+        wind_down_trades = [
+            t for t in result.session.trades if "wind_down" in t.client_order_id
+        ]
+        if not wind_down_trades:
+            pytest.skip("No positions to wind down in this ticker fixture.")
+
+        # Each wind-down trade should have a matching backtest snapshot
+        # written at its timestamp (engine._wind_down explicitly emits).
+        with db.get_session() as session:
+            bt_row_count = (
+                session.query(PositionSnapshot)
+                .filter(PositionSnapshot.source == "backtest")
+                .count()
+            )
+        assert bt_row_count >= len(wind_down_trades)
+
+    @patch("replay.engine.InstrumentInfoProvider")
+    def test_raises_on_null_run_account_id(
+        self, mock_provider_cls, db, seeded_run_account, replay_config,
+    ):
+        """Plan-mandated: a resolved run with NULL account_id must fail loudly.
+
+        The current schema enforces ``Run.account_id NOT NULL``, so to exercise
+        the protective path we mock ``_resolve_run`` to return ``account_id=None``
+        — the same shape a legacy pre-0029 DB row would have produced.
+        Without this safeguard a broken pre-migration run would look identical
+        to a healthy zero-data run.
+        """
+        from backtest.config import BacktestStrategyConfig
+        from backtest.session import BacktestSession
+
+        mock_info = MagicMock()
+        mock_info.qty_step = Decimal("0.001")
+        mock_info.tick_size = Decimal("0.1")
+        mock_info.round_qty = lambda q: max(Decimal("0.001"), q.quantize(Decimal("0.001")))
+        mock_provider_cls.return_value.get.return_value = mock_info
+
+        engine = ReplayEngine(config=replay_config, db=db)
+        strategy_config = BacktestStrategyConfig(
+            strat_id="replay_btcusdt",
+            symbol="BTCUSDT",
+            tick_size=Decimal("0.1"),
+            grid_count=20,
+            grid_step=0.2,
+            amount="x0.001",
+            commission_rate=Decimal("0.0002"),
+            enable_risk_multipliers=False,
+        )
+        session = BacktestSession(initial_balance=Decimal("10000"))
+        with pytest.raises(ValueError, match="has no account_id"):
+            engine._init_runner(
+                strategy_config, session,
+                run_id="test-run-id", account_id=None,
+            )

--- a/apps/replay/tests/test_engine_seed.py
+++ b/apps/replay/tests/test_engine_seed.py
@@ -235,7 +235,7 @@ class TestReplayEngineSeedingPipeline:
         engine = ReplayEngine(config=replay_config, db=seeded_db)
 
         # Mirror the run() call sequence: resolve run → load seed → build runner.
-        run_id, _start, _end = engine._resolve_run(replay_config)
+        run_id, _account_id, _start, _end = engine._resolve_run(replay_config)
         assert run_id == "seed-run"
 
         wallet_seed, long_seed, short_seed, grid_seed, order_seeds = engine._load_seed(

--- a/docs/features/0034_PLAN.md
+++ b/docs/features/0034_PLAN.md
@@ -1,0 +1,655 @@
+# Feature 0034 — Position telemetry parity
+
+## Goal
+
+Capture full position telemetry (`liq_price`, `unrealised_pnl`,
+`position_im`, `position_mm`, `cum_realised_pnl`, plus `mark_price` as
+an input) on the recorder side; have the backtest engine emit the
+same five derived fields on every fill; compare them in the comparator
+and surface divergences as new CSV/console metrics.
+
+Closes the parity gap that today's trade-level comparator hides: small
+qty/entry-price drift in matched trades compounds into IM/MM/liq_price
+divergence that nothing alerts on. Especially load-bearing for
+`early_imbalance_multiplier` (feature 0028 D-3) which gates on
+`liq_price == 0` — a few-cent divergence flips the trigger.
+
+## Decisions baked in (per discussion)
+
+1. **Fields v1**: `liq_price`, `unrealised_pnl`, `position_im`,
+   `position_mm`, `cum_realised_pnl`. `mark_price` recorded as a
+   sixth column for unrealized recomputation; not compared on its own.
+2. **Storage**: variant A — same `position_snapshots` table with a
+   new `source` column (`'live'` | `'backtest'`). Single migration,
+   indexes already cover the join keys. Mandatory rule: every read
+   query filters by `source` (default `'live'`).
+3. **Backtest emission cadence**: on every fill. No periodic snapshot;
+   the run-end "final" snapshot is also one fill-cycle's worth of
+   bookkeeping triggered by the wind-down path.
+4. **Unrealized comparison**: apples-to-apples — comparator recomputes
+   BOTH live and backtest unrealized from live's recorded `mark_price`
+   applied to each side's own `(size, entry_price)`. Each side's
+   reported `unrealised_pnl` is preserved in the CSV for forensic
+   value, but the divergence metric uses the recomputation.
+5. **MM risk-tier mismatch detection**: out of scope. Documented as
+   a follow-up because it lives in `risk_limit_info.py` correctness,
+   a different domain.
+
+## Approach
+
+### Step 1 — Schema migration
+
+Add to `shared/db/src/grid_db/models.py:PositionSnapshot`:
+
+| Column | Type | Nullable | Default | Purpose |
+|---|---|---|---|---|
+| `source` | `String(16)` | no | `'live'` | Distinguishes live snapshots from backtest. |
+| `mark_price` | `Numeric(20, 8)` | yes | NULL | Input for unrealized recomputation. |
+| `position_im` | `Numeric(20, 8)` | yes | NULL | Bybit `positionIM`. |
+| `position_mm` | `Numeric(20, 8)` | yes | NULL | Bybit `positionMM`. |
+| `cum_realised_pnl` | `Numeric(20, 8)` | yes | NULL | Bybit `cumRealisedPnl`. |
+
+Index update: replace existing
+`ix_position_snapshots_run_account_symbol_side_ts` with a new
+index covering
+`(run_id, account_id, symbol, side, source, exchange_ts)`.
+Equality predicates (run_id, account_id, symbol, side, source) MUST
+precede the range predicate (`exchange_ts <= at_ts`) for the B-tree
+to remain single-scan. Putting `source` after `exchange_ts` would
+make it a useless trailing column once the range predicate fires.
+
+CHECK constraint: `CHECK (source IN ('live', 'backtest'))` as
+defense-in-depth against a buggy writer slipping a wrong value.
+SQLite and Postgres both support it.
+
+Alembic migration:
+- `shared/db/alembic/versions/NNNN_0034_position_telemetry.py`
+- Forward: ADD COLUMN ×5, then `UPDATE position_snapshots SET source='live'`
+  (SQLite/Postgres-portable; rows are small in number even on production
+  recorder DB — ~10k rows after 12h of recording).
+- Backward: DROP COLUMN ×5. Single revision so it can be reverted
+  atomically if needed.
+
+### Step 1b — Repository read-path audit
+
+Every read method on `PositionSnapshotRepository` MUST grow a
+`source: str = 'live'` parameter so legacy consumers default to
+live data and never silently mix in backtest rows.
+
+Concrete grep (repositories.py):
+- `get_latest_by_account_symbol` (line 983) — used by seed loader
+  and any future "what's the current live position" caller.
+- `get_latest_before` (line 1007) — used by 0029 seed-aware replay
+  for `at_ts` lookup.
+- Any `get_by_*` / `find_*` method added in the future must follow
+  the same contract.
+
+Plus a code-review rule (RULES.md update): "When adding a new read
+method on PositionSnapshotRepository, accept a `source` parameter
+and default to `'live'`. Mixing sources without an explicit caller
+opt-in is a parity-leak."
+
+Tests:
+- Both methods, called without explicit source, return only
+  `source='live'` rows.
+- Explicit `source='backtest'` returns only backtest rows.
+- `source=None` (sentinel) returns the union — used by the
+  comparator's loader which deliberately wants both.
+
+### Step 2 — Recorder parser (live side)
+
+Extend `apps/event_saver/src/event_saver/writers/position_writer.py:166`
+(`_messages_to_models`) to also extract from `pos`:
+
+- `mark_price`: `pos.get("markPrice")`
+- `position_im`: `pos.get("positionIM")`
+- `position_mm`: `pos.get("positionMM")`
+- `cum_realised_pnl`: `pos.get("cumRealisedPnl")`
+
+Same nullable-Decimal guard as existing `liq_price` /
+`unrealised_pnl` blocks. Set `source='live'` explicitly (the column
+default would do, but explicit is cheaper to grep later).
+
+Same field extraction in `apps/recorder/src/recorder/recorder.py:423`
+(`_initial_rest_snapshot`) — REST `get_positions` returns the same
+keys.
+
+Do NOT copy `source` into `raw_json` — it's a recorder-side
+distinction not present on the Bybit payload, and duplicating it
+into the JSON blob would confuse future consumers.
+
+Update both code paths in one diff to keep them in lockstep.
+
+### Step 3 — Backtest emitter
+
+Backtest tracks IM/MM via `gridcore.pnl.calc_position_value`,
+`calc_maintenance_margin`, and the runner's `_estimate_liquidation_price`
+(`apps/backtest/src/backtest/runner.py:500`). All inputs are already
+on the tracker — we just need a write hook on each fill.
+
+New method on `BacktestRunner`:
+
+```python
+def _emit_position_snapshot(
+    self,
+    direction: DirectionType,           # LONG or SHORT, NOT fill side
+    timestamp: datetime,
+    mark_price: Decimal,
+) -> PositionSnapshot:
+    """Build a parity-checkable snapshot for the just-mutated direction."""
+```
+
+**Why `direction`, not `side`** (per review): in hedge mode a close-long
+fill arrives as `fill.side == 'Sell'`, but the corresponding position
+snapshot row must stay `side='Buy'` (Bybit's position side). Passing
+fill side here would silently flip the snapshot's `side` column on
+every close fill and break pairing.
+
+The method maps internally:
+- `DirectionType.LONG` → snapshot `side='Buy'`
+- `DirectionType.SHORT` → snapshot `side='Sell'`
+
+Both fill and wind-down call sites pass `direction` (the tracker
+already exposes it via `tracker.direction`), never the fill side.
+
+Computes:
+- `size`, `entry_price` from the tracker.
+- `unrealised_pnl` from
+  `gridcore.pnl.calc_unrealised_pnl(direction, entry_price, mark_price, size)`
+  (line 80) — side-aware: long is `(mark − entry) × size`, short is
+  `(entry − mark) × size`. The naive `(mark − entry) × size` formula
+  is wrong for shorts and would silently halve our parity signal.
+- `position_im, _imr_rate = gridcore.pnl.calc_initial_margin(
+     position_value, leverage, symbol=runner.symbol)`.
+- `position_mm, _mmr_rate = gridcore.pnl.calc_maintenance_margin(
+     position_value, symbol=runner.symbol)`.
+- Note: both `calc_initial_margin` (pnl.py:218) and
+  `calc_maintenance_margin` (pnl.py:289) return
+  `tuple[Decimal, Decimal]` — `(amount, rate)`. Direct assignment to a
+  `Decimal` snapshot column would store the tuple and break the insert.
+  Use the existing runner symbol so tier lookup matches what the
+  in-memory IM/MM calc already does at runtime.
+- `liq_price` from `_estimate_liquidation_price`.
+- `cum_realised_pnl`: running sum maintained on the tracker
+  (`tracker.cum_realised_pnl += realized_pnl` after each fill).
+  Initialized from `PositionStateSeed.cum_realised_pnl` when seeded;
+  defaults to `Decimal("0")` for non-seeded runs. See "Seed plumbing"
+  below.
+
+**Seed plumbing for `cum_realised_pnl`** (per review): Bybit's
+`cumRealisedPnl` is cumulative since position open. A seeded replay
+inherits a non-zero baseline. Without seeding into the backtest,
+`cum_realised_pnl_final_delta` collapses to "backtest is `live_baseline`
+units short" — a fake divergence.
+
+Changes required:
+- `apps/replay/src/replay/snapshot_loader.py` — extend
+  `PositionStateSeed` with `cum_realised_pnl: Decimal`, populated from
+  the live snapshot at `seed.at_ts`.
+- `apps/backtest/src/backtest/position_tracker.py:27 PositionState`
+  — add `cum_realised_pnl: Decimal = field(default_factory=lambda: Decimal("0"))`.
+  Distinct from the existing `realized_pnl` field (line 32), which
+  is window-scoped (zeroed in `seed_state` line 123 to start the
+  replay-window accounting fresh). `cum_realised_pnl` is the absolute
+  Bybit-style running total, **not** zeroed in `seed_state`.
+- `apps/backtest/src/backtest/position_tracker.py:98 seed_state(seed)`
+  — copy `seed.cum_realised_pnl` onto `self.state.cum_realised_pnl`
+  (do NOT zero it like `realized_pnl`).
+- `apps/backtest/src/backtest/position_tracker.py:process_fill` —
+  after computing `realized_pnl`, increment
+  `self.state.cum_realised_pnl += realized_pnl`. Keeps the running
+  sum local to the tracker, no external bookkeeping.
+
+**Do NOT add the field to `packages/gridcore/src/gridcore/position.py`**
+(per review): there are two `PositionState` dataclasses in the codebase
+— gridcore's (`position.py:33`) is for live-bot risk/multiplier inputs
+and is NOT what `BacktestPositionTracker.seed_state` mutates. Adding
+`cum_realised_pnl` to the wrong one would leave the seed propagation
+silently unimplemented.
+
+(My earlier plan referenced a `runner._apply_seed` method that does
+not exist — seed propagation actually flows through
+`BacktestPositionTracker.seed_state`. Corrected.)
+
+Alternative considered (and rejected for v1): "session-delta only" —
+compare `final − initial` on both sides instead of seeding. Simpler
+plumbing-wise, but loses absolute-number interpretability in CSV.
+Preferred path stays seeding.
+
+Call site: `apps/backtest/src/backtest/runner.py:466` right after
+`tracker.process_fill(...)` and right after the existing
+`_update_risk_multipliers` block, so multiplier-driven liq_price
+updates are reflected in the same snapshot.
+
+Sink: a lightweight injected `Optional[Callable[[PositionSnapshot], None]]`
+on the runner. Default `None` keeps standalone backtest behavior
+unchanged. Replay engine wires it to a `_BatchPositionSnapshotWriter`
+(analog of the live `PositionWriter`, but synchronous since replay
+is single-threaded).
+
+Required ORM fields on every emitted backtest snapshot:
+- `source='backtest'`
+- `run_id` = the **resolved** run_id, NOT the raw config field.
+  Replay supports `config.run_id=None` (auto-discovery via
+  `_resolve_run`). The writer must take the run_id resolved by the
+  engine, not `self._config.run_id` directly — otherwise auto-discovered
+  replays write `run_id=NULL`, breaking FK and run-scoped queries.
+- `account_id` from the extended `_resolve_run` return tuple (see
+  Step 6) — `(run_id, account_id, start_ts, end_ts)`. This is the
+  `account_id` column on the `Run` row, the canonical source.
+  If `Run.account_id` is NULL (pre-0029 legacy data), raise at
+  writer construction with "Run {run_id} has no account_id; cannot
+  emit backtest position snapshots". Do NOT silently fall back to
+  `seed.account_id`: it would only paper over the legacy-data case
+  and is unavailable when `seed.enabled=False`.
+- `exchange_ts` / `local_ts` = the fill timestamp.
+
+**Wind-down hook** (per review): replay's `_wind_down()`
+(`apps/replay/src/replay/engine.py:599`) calls
+`tracker.process_fill()` directly, bypassing
+`BacktestRunner._process_fill` and therefore the snapshot callback.
+The final wind-down fill would silently NOT emit a snapshot, leaving
+backtest cum_realised_pnl artificially behind live by the close-out
+PnL.
+
+Two options, pick (B):
+- (A) Route wind-down through `runner._process_fill` to inherit the
+  hook. Invasive: `_process_fill` is tightly coupled to GridEngine
+  intents which wind-down doesn't have.
+- (B) Wire the callback explicitly in `_wind_down()` after the
+  `tracker.process_fill(...)` line — small, surgical, local to the
+  engine. Mirror the same `_emit_position_snapshot` build path.
+
+Tests for both fill emission AND wind-down emission. Without the
+wind-down test, this regression is invisible.
+
+### Step 4 — Comparator: load and pair
+
+New module `apps/comparator/src/comparator/position_loader.py`:
+
+- `load_position_snapshots(db, run_id, symbol, source)` → list of
+  `PositionSnapshot` sorted by `(side, exchange_ts)`.
+- Two calls: `source='live'` and `source='backtest'`. Each returns
+  per-side sequences.
+
+New module `apps/comparator/src/comparator/position_metrics.py`:
+
+- **Pairing strategy** (per-side, monotonic two-pointer):
+  - Live snapshots are event-driven (fire on every Bybit position change).
+  - Backtest snapshots are fill-driven.
+  - Maintain a per-side moving live pointer `live_idx`, advance-only.
+    For each backtest snapshot `bt[i]`:
+    1. Advance `live_idx` to the first live row with
+       `live[live_idx].exchange_ts >= bt[i].exchange_ts`.
+    2. If found within `PAIR_TOLERANCE_S = 5`, **consume** it
+       (pair, then `live_idx += 1`).
+    3. Otherwise count as `position_pairs_unmatched_bt`, do NOT
+       advance the live pointer (give the next bt row a chance to
+       claim this live row if it's also after-but-within-window).
+  - **One-to-one invariant**: each live row pairs with at most one
+    backtest row. Without this, two close-together fills could
+    duplicate-pair to the same live row (dense fill bursts; delayed
+    live updates) and inflate `position_pairs_compared` while hiding
+    the divergence.
+  - This deliberately ignores live snapshots that have no matching
+    backtest snapshot (background mark-price ticks that didn't move
+    size/entry). They aren't a parity signal.
+  - Test case (Step 7): two backtest fills emitted before the next
+    live snapshot — first bt pairs with the next live row; second
+    bt counts as unmatched. Without the consume step, both would
+    pair to the same row.
+- **Per-pair deltas** computed via `calc_unrealised_pnl(direction, ...)`
+  for sign correctness:
+  - `liq_price_delta = bt.liq_price − live.liq_price`
+  - `position_im_delta`, `position_mm_delta`, `cum_realised_pnl_delta`
+  - `unrealised_pnl_recomputed_live = calc_unrealised_pnl(direction, live.entry_price, live.mark_price, live.size)`
+  - `unrealised_pnl_recomputed_bt = calc_unrealised_pnl(direction, bt.entry_price, live.mark_price, bt.size)`
+  - `unrealised_pnl_delta = recomputed_bt − recomputed_live`
+
+**NULL telemetry handling** (per review): three distinct conditions
+that must NOT be conflated:
+- **(a) Pair exists, telemetry NULL on live side**: occurs when the
+  recorder ran post-migration but the Bybit payload was partial, or
+  when historical rows were backfilled with NULL by the forward
+  migration. → counted in `position_pairs_missing_telemetry`. CSV
+  row is emitted with blank delta columns for the missing fields
+  only; other deltas in the same row are still computed.
+- **(b) No live snapshot in tolerance window**: → counted in
+  `position_pairs_unmatched_bt`. No CSV row. (Different number, do
+  not lump with (a).)
+- **(c) DB un-migrated to 0034**: the new columns don't exist in
+  schema. The comparator detects this at load time by attempting a
+  trivial `SELECT source FROM position_snapshots LIMIT 1`. On
+  `OperationalError: no such column`, raise with a clear "Run the
+  0034 schema migration before comparing position telemetry"
+  message. We do NOT silently mask un-migrated DBs as zero-pair
+  scenarios — that would hide the real problem (operator forgot to
+  migrate).
+
+The aggregate `*_mean_abs_delta` / `*_max_abs_delta` metrics skip
+NULL values per-field, never silently treat them as zero.
+- Aggregate metrics added to `ValidationMetrics`:
+
+  | Metric | Type |
+  |---|---|
+  | `position_im_mean_abs_delta` | Decimal |
+  | `position_im_max_abs_delta` | Decimal |
+  | `position_mm_mean_abs_delta` | Decimal |
+  | `position_mm_max_abs_delta` | Decimal |
+  | `liq_price_mean_abs_delta` | Decimal |
+  | `liq_price_max_abs_delta` | Decimal |
+  | `unrealised_pnl_mean_abs_delta` | Decimal |
+  | `unrealised_pnl_max_abs_delta` | Decimal |
+  | `cum_realised_pnl_final_delta` | Decimal |
+  | `position_pairs_compared` | int |
+  | `position_pairs_unmatched_bt` | int |
+  | `position_pairs_missing_telemetry` | int |
+
+  Sign convention: backtest minus live. Positive = backtest
+  over-estimates that metric.
+
+### Step 5 — Comparator: CSV + console
+
+`apps/comparator/src/comparator/reporter.py`:
+
+- New `export_position_comparison(path)` writing
+  `position_comparison.csv` with columns:
+  `(side, live_ts, backtest_ts, live_size, bt_size, live_entry, bt_entry,
+   mark_price, live_im, bt_im, im_delta, live_mm, bt_mm, mm_delta,
+   live_liq, bt_liq, liq_delta, live_unrealised_recomp,
+   bt_unrealised_recomp, unrealised_delta, live_cum_realised,
+   bt_cum_realised, cum_realised_delta)`.
+- `export_all` adds `position_comparison.csv` to the bundle when at
+  least one paired row exists for the run. The "empty result" case
+  (migrated DB but no backtest-source rows yet — e.g. fresh schema,
+  no replay ran) is the only silent-skip path; un-migrated DBs are
+  caught at load with an explicit error per Step 4 (c), never
+  silent-skipped.
+- `export_metrics` appends the 12 new metric rows from Step 4 (9 aggregate
+  deltas + 3 counters: `position_pairs_compared`,
+  `position_pairs_unmatched_bt`, `position_pairs_missing_telemetry`).
+- `print_summary` adds a `POSITION TELEMETRY` block after the
+  existing `EQUITY CURVE` block.
+
+CSV-injection sanitization (added in feature 0033) already covers
+the metadata path; the new columns are all Decimals and don't need
+sanitization.
+
+### Step 5b — Standalone comparator integration
+
+`apps/comparator/src/comparator/main.py` (the standalone CLI) runs
+its own pipeline today: trade match → `calculate_metrics` → equity
+comparison → `ComparatorReporter`. Without an explicit wiring step
+it would still ship trade + equity output and silently skip the new
+position metrics — a parity hole in the very tool whose job is parity.
+
+Add a position-comparison block right after the existing equity block
+in `main.py` (~line 256), structured to mirror equity:
+
+```python
+# Position telemetry comparison (0034)
+from comparator.position_loader import load_position_snapshots
+from comparator.position_metrics import PositionComparator
+
+with db.get_session() as session:
+    live_snaps = load_position_snapshots(
+        session, run_id=config.run_id, symbol=config.symbol, source="live"
+    )
+    bt_snaps = load_position_snapshots(
+        session, run_id=config.run_id, symbol=config.symbol, source="backtest"
+    )
+
+if live_snaps and bt_snaps:
+    pc = PositionComparator()
+    position_pairs = pc.pair_and_compare(live_snaps, bt_snaps)
+    pc.fold_metrics_into(metrics, position_pairs)  # mutates ValidationMetrics
+else:
+    position_pairs = []
+    logger.info("Position comparison skipped: no paired live/backtest snapshots")
+
+reporter = ComparatorReporter(
+    match_result, metrics,
+    equity_data=resampled_equity,
+    position_pairs=position_pairs,  # new ctor arg
+)
+```
+
+Contract:
+- `PositionComparator.fold_metrics_into(metrics, pairs)` mutates the
+  already-constructed `ValidationMetrics` with the 12 new fields
+  (9 aggregate deltas + 3 counters). Mutation over re-construction
+  because `ValidationMetrics` is a dataclass with many existing
+  fields and replay reuses the same flow.
+- If the un-migrated DB error from Step 4 (c) fires inside
+  `load_position_snapshots`, it propagates to the CLI — the operator
+  sees the migration message instead of a partial report. Tests
+  cover this path.
+- Same wiring applies to replay's `main.py:169` (which already
+  constructs `ComparatorReporter` from the engine's `ReplayResult`):
+  position_pairs flow from `result.position_pairs` (populated in
+  Step 6) into the same new ctor arg. Single contract, two consumers.
+
+### Step 6 — Replay wiring
+
+`apps/replay/src/replay/engine.py:_init_runner` (~line 389):
+
+**`_resolve_run` return-shape change** (per review): the current
+implementation at `engine.py:290-346` returns
+`(run_id, start_ts, end_ts)` — `account_id` is never plumbed out
+even though the Run row is already loaded inside the session in
+the auto-discover branch.
+
+Change the return tuple to `(run_id, account_id, start_ts, end_ts)`
+and update the existing call site at `engine.py:125`:
+- Auto-discover branch (lines 298-317): extract
+  `run_account_id = run.account_id` alongside the existing
+  `run.run_id` / `run.start_ts` / `run.end_ts`.
+- Explicit-run-id branch (lines 318-330): when start_ts/end_ts are
+  both provided today, the Run row is not loaded. After this change
+  the row is **always** loaded so `account_id` is available — one
+  cheap PK lookup, no perf concern.
+
+Then the writer wiring:
+
+```python
+run_id, account_id, start_ts, end_ts = self._resolve_run(config)
+...
+position_writer = _BatchPositionSnapshotWriter(
+    db=self._db,
+    run_id=run_id,
+    account_id=account_id,
+    source="backtest",
+)
+runner.position_snapshot_callback = position_writer.write
+```
+
+Alternative considered (and rejected): add a separate
+`_load_run(run_id) -> Run` helper called after `_resolve_run`. It
+keeps `_resolve_run`'s signature stable but doubles the DB read for
+the explicit-run-id path. The signature change is the smaller
+intrusion.
+
+Final flush at end of `_run` before metric calculation, and an
+explicit emission inside `_wind_down` (see Step 3 — wind-down hook).
+
+**ReplayResult plumbing for the comparator** (per review):
+`ComparatorReporter` today consumes `equity_data` as a constructor
+arg (`apps/comparator/src/comparator/reporter.py:30-40`). Mirror that
+pattern for positions — `ReplayResult` gets a new field:
+
+```python
+@dataclass
+class ReplayResult:
+    ...  # existing fields
+    position_pairs: list[PositionComparisonPair]
+```
+
+`engine._run` populates it by calling the new
+`PositionComparator.pair_and_compare(db, run_id, symbol)` after
+the backtest writer has flushed. `apps/replay/src/replay/main.py:169`
+then passes `position_pairs=result.position_pairs` to
+`ComparatorReporter`. Without this plumbing, replay computes DB
+rows but can't export `position_comparison.csv` — a silent gap in
+the otherwise-complete output bundle.
+
+### Step 7 — Tests
+
+`shared/db/tests/test_repositories.py`:
+- `PositionSnapshotRepository.get_latest_before` filters by source.
+- `bulk_insert` round-trips the five new columns.
+- Default `source='live'` on legacy rows.
+
+`apps/event_saver/tests/test_writers.py`:
+- `PositionWriter._messages_to_models` parses
+  `markPrice/positionIM/positionMM/cumRealisedPnl` into the right
+  columns; missing fields default to NULL (don't error).
+- Backward-compat: rows without those fields still parse.
+
+`apps/backtest/tests/test_runner.py`:
+- New `TestPositionSnapshotEmission` class.
+- After a long fill: snapshot has correct size, entry_price, IM, MM,
+  liq_price, cum_realised_pnl, source.
+- After a **short** fill: same shape, with correctly-signed unrealized
+  (long-only formula would give the wrong sign; this test guards it).
+- Multiple consecutive fills: `cum_realised_pnl` accumulates.
+- Snapshot callback not wired → no error, no emission.
+- Seeded run: tracker's `cum_realised_pnl` initialized from
+  `PositionStateSeed.cum_realised_pnl`, not from zero.
+
+`apps/comparator/tests/test_position_metrics.py` (new):
+- Pairing: backtest snapshot at T pairs with first live snapshot at
+  ≥ T within 5s; outside window → unmatched.
+- **Monotonic consume invariant** (per Step 4): two backtest snapshots
+  at T and T+1s, single live snapshot at T+2s. The first bt row
+  consumes the live row; the second bt row counts as
+  `position_pairs_unmatched_bt`, NOT a duplicate pair to the same
+  live row. Without the explicit consume step, both bt rows would
+  pair to the same live row — this test guards against that.
+- Metrics: trivial all-equal pair → all deltas zero.
+- Unrealized recomputation: divergent entry prices on matched size
+  → expected delta.
+- Short-side recomputation: `direction=SHORT` pair returns
+  correctly-signed unrealized (positive when mark < entry).
+- NULL telemetry: paired row with NULL `position_im` on live emits a
+  CSV row with blank im_delta but non-blank other deltas; counter
+  `position_pairs_missing_telemetry` increments.
+- Un-migrated DB: schema probe raises with the migration-required
+  message (Step 4 (c) contract).
+- `fold_metrics_into`: mutates an existing `ValidationMetrics`
+  instance with all 12 new fields; idempotent if called twice (last
+  call wins, no double-counting).
+
+`apps/comparator/tests/test_reporter.py`:
+- `export_position_comparison` writes expected columns.
+- `export_all` includes it when data present; excludes when absent.
+
+`apps/replay/tests/test_engine.py`:
+- End-to-end: replay run produces position_snapshots with
+  `source='backtest'` in DB, comparator finds non-zero
+  `position_pairs_compared`.
+- **Wind-down snapshot emission**: a replay with
+  `wind_down_mode=CLOSE_ALL` and a non-zero residual position emits
+  one additional backtest snapshot for the close-out, and its
+  `cum_realised_pnl` reflects the close-out PnL. Without this test
+  the wind-down regression (Step 3) is invisible.
+
+### Step 8 — Documentation
+
+- `RULES.md` § 3 (Replay) — add fourth bullet:
+  "Position telemetry parity: backtest emits position_snapshots with
+  source='backtest' on every fill; comparator recomputes unrealized
+  from live mark_price for apples-to-apples comparison."
+- `docs/features/0034_PLAN.md` (this file).
+- `docs/features/0034_RESULTS.md` after smoke validation (mirror
+  of 0033_RESULTS.md format).
+
+## Critical files to modify
+
+| File | Change |
+|---|---|
+| `shared/db/src/grid_db/models.py:356` | Add 5 columns to PositionSnapshot. |
+| `shared/db/alembic/versions/NNNN_0034_position_telemetry.py` | New migration. |
+| `shared/db/src/grid_db/repositories.py:983, 1007` | Both `get_latest_by_account_symbol` and `get_latest_before` gain `source: str = 'live'` param. |
+| `apps/replay/src/replay/snapshot_loader.py` | `PositionStateSeed` extended with `cum_realised_pnl`. |
+| `apps/backtest/src/backtest/position_tracker.py:98 seed_state` | Copy `seed.cum_realised_pnl` onto `tracker.state.cum_realised_pnl`. |
+| `apps/backtest/src/backtest/position_tracker.py:process_fill` | Increment `tracker.state.cum_realised_pnl += realized_pnl` after each fill. |
+| `apps/backtest/src/backtest/position_tracker.py:27 PositionState` | Add `cum_realised_pnl: Decimal` (distinct from existing window-scoped `realized_pnl`). NOT in gridcore's PositionState. |
+| `apps/replay/src/replay/engine.py:290-346` | `_resolve_run` return tuple extended to include `account_id`; explicit-run-id branch now always loads the Run row. Call site at line 125 updated. |
+| `apps/replay/src/replay/engine.py:599` | `_wind_down` calls snapshot callback after `tracker.process_fill`. |
+| `apps/replay/src/replay/engine.py:ReplayResult` | New `position_pairs` field. |
+| `apps/replay/src/replay/main.py:169` | Pass `position_pairs` to `ComparatorReporter`. |
+| `apps/event_saver/src/event_saver/writers/position_writer.py:166-228` | Parse 4 new fields from WS payload. |
+| `apps/recorder/src/recorder/recorder.py:423-446` | Same for REST snapshot path. |
+| `apps/backtest/src/backtest/runner.py:466+` | New `_emit_position_snapshot` hook on each fill. |
+| `apps/backtest/src/backtest/runner.py` | Maintain `cum_realised_pnl` running sum on tracker. |
+| `apps/comparator/src/comparator/position_loader.py` | NEW — load+filter by source. |
+| `apps/comparator/src/comparator/position_metrics.py` | NEW — pairing + delta metrics. |
+| `apps/comparator/src/comparator/metrics.py` | Extend `ValidationMetrics` with 12 fields (9 aggregate deltas + 3 counters). |
+| `apps/comparator/src/comparator/reporter.py` | New `export_position_comparison`; extend `export_metrics`; extend `print_summary`; new ctor arg `position_pairs`. |
+| `apps/comparator/src/comparator/main.py:256+` | Wire `PositionComparator.pair_and_compare` + `fold_metrics_into` after existing equity block; pass `position_pairs` into `ComparatorReporter`. Standalone CLI parity with replay flow. |
+| `apps/replay/src/replay/engine.py:389` | Wire `_BatchPositionSnapshotWriter` to runner. |
+
+## Verification
+
+1. `uv run pytest shared/db/ apps/event_saver/ apps/backtest/ apps/comparator/ apps/replay/ -q`
+   — all green including the new tests.
+2. `uv run pytest -q --ignore=apps/backtest/tests/test_risk_limit_info.py`
+   — full suite, only the 3 pre-existing unrelated failures remain.
+3. `uv run ruff check shared/db/ apps/` — clean.
+4. **Manual smoke**: rerun `apps/replay/conf/replay_ltcusdt_phase4.yaml`
+   against `data/recorder_ltcusdt_phase4.db` (will need a re-recorded
+   DB after deploying the recorder change, OR run migration + accept
+   that pre-existing rows have NULL telemetry columns and skip them).
+   Expect:
+   - `position_pairs_compared` ≈ matched_count = 135.
+   - `liq_price_max_abs_delta` ≤ 0.50 USDT (rough — bbu2 liq math
+     is heuristic; tighter bounds are a tuning exercise).
+   - `position_im_max_abs_delta` ≤ 0.05 USDT.
+   - `position_mm_max_abs_delta` ≤ 0.05 USDT.
+   - `cum_realised_pnl_final_delta` ≤ |cumulative_pnl_delta|
+     (existing trade-level metric; the two should agree within
+     rounding).
+5. `git status --short bbu_reference` empty; pinning still holds.
+
+## Out of scope
+
+- **MM risk-tier mismatch detection**: deferred. The fact that Bybit
+  switches MM% on tier transitions while the backtest may use a flat
+  rate is a separate correctness story belonging to
+  `apps/backtest/src/backtest/risk_limit_info.py`. Logged as a future
+  follow-up.
+- **Per-tick position snapshots** in backtest. Per decision (3) we
+  emit on fill only. If a long-running session has zero fills for
+  hours, comparator just sees zero pairs — that's acceptable for
+  smoke validation.
+- **Resampled position-curve plot**. The trade-curve plot from 0033
+  is enough for now; a side-by-side IM/MM time series can come later
+  if a real divergence shows up.
+- **Backward-compat shim for un-migrated DBs**: not provided. The
+  comparator detects missing `source` column at load time and raises
+  with a clear "Run the 0034 schema migration before comparing
+  position telemetry" message (Step 4 (c)). Hiding the un-migrated
+  case as a zero-pair scenario would mask operator mistakes.
+  Migrated DBs with no backtest-source rows yet (e.g. fresh schema,
+  no replay ran) silently produce zero pairs and no
+  `position_comparison.csv` — this is the only intentional silent
+  path.
+- **Live gridbot reading these columns**: this feature does not touch
+  the live trading loop. Gridbot still reads its own position state
+  from Bybit directly.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| `cum_realised_pnl` drift over long sessions accumulates rounding | Compare final-value delta only, not per-pair (per Step 4 design). Cross-check against existing `cumulative_pnl_delta` trade-level metric for sanity. |
+| `position_im` calc depends on leverage; backtest may use a stale leverage value | Document: bbu2's amount math implicitly assumes constant leverage per session; if a manual leverage change happens mid-session, IM diverges. Out of scope for v1. |
+| Replay against old recorder DBs (un-migrated to 0034) | Comparator detects missing schema column at load and raises "Run 0034 migration first". Migrated-but-NULL rows go into `position_pairs_missing_telemetry` (distinct counter from `position_pairs_unmatched_bt`). |
+| Same-table `source` mixing causes a read query to forget the filter | All read methods default `source='live'` (Step 1b). DB CHECK constraint enforces `source IN ('live', 'backtest')`. Tests assert default reads return live-only. RULES.md updated with rule for future methods. |
+| Wind-down close-out fill bypasses snapshot hook | Explicit callback invocation inside `_wind_down` (Step 3 — option B); test `wind_down_mode=CLOSE_ALL` asserts the close-out snapshot is emitted. |
+| Short-side unrealized recomputation uses wrong-sign formula | Use `gridcore.pnl.calc_unrealised_pnl(direction, ...)` everywhere; explicit short-fill test guards against regression. |
+| Seeded `cum_realised_pnl` not propagated | `PositionStateSeed.cum_realised_pnl` extended; `BacktestPositionTracker.seed_state` copies it onto `tracker.state.cum_realised_pnl`; seeded-run test asserts non-zero initial. |
+| Snapshot side written from fill side, flipping rows on every close | `_emit_position_snapshot` takes `direction: DirectionType`, never the fill side. Internal map `LONG→'Buy'`, `SHORT→'Sell'`. Close-fill emission test guards against the flip. |
+| Backtest writer uses unresolved `config.run_id` / `seed.account_id` | Writer accepts `run_id` and `account_id` from the engine's resolved `Run` record, not the raw config. Auto-discovery and non-seeded paths still produce valid rows. |
+| Pairing duplicates live row across multiple bt snapshots | Monotonic two-pointer with explicit live-row consume step. Test: two consecutive bt fills before next live snapshot — first pairs, second counts as unmatched. |
+| Margin-tuple return value silently corrupts snapshot fields | Plan and tests explicitly destructure `(amount, rate)` from `calc_initial_margin` / `calc_maintenance_margin`. |

--- a/docs/features/0034_REVIEW.md
+++ b/docs/features/0034_REVIEW.md
@@ -1,0 +1,25 @@
+# Feature 0034 Code Review — Position Telemetry Parity
+
+Review target: updated implementation of `docs/features/0034_PLAN.md`.
+
+Verification run:
+
+- `uv run pytest -q apps/comparator/tests/test_position_metrics.py apps/comparator/tests/test_reporter.py apps/replay/tests/test_engine.py apps/backtest/tests/test_runner.py shared/db/tests/test_repositories.py apps/event_saver/tests/test_writers.py apps/replay/tests/test_engine_seed.py` — **214 passed**
+- `uv run ruff check` on the changed implementation files — **passed**
+
+## Findings
+
+No blocking findings found in this pass.
+
+## Previously Reported Issues
+
+- `cum_realised_pnl_final_delta` now aggregates final deltas per side instead of using `matched[-1]`.
+- Missing `Run.account_id` now raises instead of silently disabling the backtest snapshot writer.
+- REST initial snapshots now preserve `markPrice="0"` consistently with the websocket writer.
+- Backtest snapshots now use cached `TickerEvent.mark_price` for `PositionSnapshot.mark_price`, with a regression test covering `last_price != mark_price`.
+- Reporter CSV/export tests and replay writer/wind-down coverage are present.
+
+## Notes
+
+- The implementation now matches the major plan requirements: schema/model changes, repository source filtering, live recorder parsing, backtest fill and wind-down emission, seed propagation for `cum_realised_pnl`, comparator pairing/metrics, standalone comparator wiring, and CSV/reporting export.
+- I did not rerun the entire repository test suite; the focused feature suite and changed-file lint checks passed.

--- a/scripts/migrate_0034_position_telemetry.py
+++ b/scripts/migrate_0034_position_telemetry.py
@@ -1,0 +1,122 @@
+"""One-off schema migration for feature 0034 (position telemetry parity).
+
+Adds five columns to `position_snapshots`:
+    source, mark_price, position_im, position_mm, cum_realised_pnl
+
+Replaces the 0029 index `ix_position_snapshots_run_account_symbol_side_ts`
+with the new 0034 index that includes `source` before `exchange_ts`.
+
+Adds a CHECK constraint on `source IN ('live', 'backtest')` where
+supported. SQLite cannot ADD CONSTRAINT post-hoc — for SQLite the CHECK
+is enforced at write time by the ORM `default='live'` and is implicit
+in the index-equality predicate.
+
+Idempotent: each step is gated on a probe.
+
+Usage:
+    uv run python scripts/migrate_0034_position_telemetry.py \\
+        --database-url "sqlite:///data/recorder_ltcusdt_phase4.db"
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+
+from sqlalchemy import create_engine, inspect, text
+
+logger = logging.getLogger("migrate_0034")
+
+
+NEW_COLUMNS: list[tuple[str, str]] = [
+    ("source", "VARCHAR(16) NOT NULL DEFAULT 'live'"),
+    ("mark_price", "NUMERIC(20, 8)"),
+    ("position_im", "NUMERIC(20, 8)"),
+    ("position_mm", "NUMERIC(20, 8)"),
+    ("cum_realised_pnl", "NUMERIC(20, 8)"),
+]
+
+OLD_INDEX = "ix_position_snapshots_run_account_symbol_side_ts"
+NEW_INDEX = "ix_position_snapshots_run_account_symbol_side_source_ts"
+
+
+def _column_exists(conn, table: str, column: str) -> bool:
+    inspector = inspect(conn)
+    return any(c["name"] == column for c in inspector.get_columns(table))
+
+
+def _index_exists(conn, table: str, index_name: str) -> bool:
+    inspector = inspect(conn)
+    return any(i["name"] == index_name for i in inspector.get_indexes(table))
+
+
+def migrate(database_url: str) -> None:
+    engine = create_engine(database_url)
+    dialect = engine.dialect.name
+    logger.info("Migrating %s (dialect=%s)", database_url, dialect)
+
+    with engine.begin() as conn:
+        added: list[str] = []
+        for col_name, col_def in NEW_COLUMNS:
+            if _column_exists(conn, "position_snapshots", col_name):
+                continue
+            conn.execute(
+                text(f"ALTER TABLE position_snapshots ADD COLUMN {col_name} {col_def}")
+            )
+            added.append(col_name)
+        if added:
+            logger.info("Added columns: %s", added)
+        else:
+            logger.info("All 0034 columns already present")
+
+        # Backfill source='live' on any pre-existing rows (server_default
+        # only applies to rows inserted after the column was added).
+        conn.execute(
+            text(
+                "UPDATE position_snapshots SET source='live' "
+                "WHERE source IS NULL"
+            )
+        )
+
+        if _index_exists(conn, "position_snapshots", OLD_INDEX):
+            conn.execute(text(f"DROP INDEX {OLD_INDEX}"))
+            logger.info("Dropped legacy index %s", OLD_INDEX)
+
+        if not _index_exists(conn, "position_snapshots", NEW_INDEX):
+            conn.execute(
+                text(
+                    f"CREATE INDEX {NEW_INDEX} ON position_snapshots "
+                    "(run_id, account_id, symbol, side, source, exchange_ts)"
+                )
+            )
+            logger.info("Created index %s", NEW_INDEX)
+
+        if dialect == "postgresql":
+            try:
+                conn.execute(
+                    text(
+                        "ALTER TABLE position_snapshots "
+                        "ADD CONSTRAINT ck_position_snapshots_source "
+                        "CHECK (source IN ('live', 'backtest'))"
+                    )
+                )
+                logger.info("Added CHECK constraint")
+            except Exception as exc:
+                if "already exists" in str(exc):
+                    logger.info("CHECK constraint already present")
+                else:
+                    raise
+
+    logger.info("Migration complete")
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--database-url", required=True)
+    args = parser.parse_args()
+    migrate(args.database_url)
+
+
+if __name__ == "__main__":
+    main()

--- a/shared/db/src/grid_db/models.py
+++ b/shared/db/src/grid_db/models.py
@@ -15,6 +15,7 @@ from sqlalchemy import (
     String,
     Text,
     Boolean,
+    CheckConstraint,
     DateTime,
     ForeignKey,
     Numeric,
@@ -384,15 +385,28 @@ class PositionSnapshot(Base):
     entry_price: Mapped[Decimal] = mapped_column(Numeric(20, 8), nullable=False)
     liq_price: Mapped[Optional[Decimal]] = mapped_column(Numeric(20, 8))
     unrealised_pnl: Mapped[Optional[Decimal]] = mapped_column(Numeric(20, 8))
+    # 0034: position telemetry parity (live vs backtest).
+    source: Mapped[str] = mapped_column(
+        String(16), nullable=False, default="live", server_default="live"
+    )
+    mark_price: Mapped[Optional[Decimal]] = mapped_column(Numeric(20, 8))
+    position_im: Mapped[Optional[Decimal]] = mapped_column(Numeric(20, 8))
+    position_mm: Mapped[Optional[Decimal]] = mapped_column(Numeric(20, 8))
+    cum_realised_pnl: Mapped[Optional[Decimal]] = mapped_column(Numeric(20, 8))
     raw_json: Mapped[Optional[dict[str, Any]]] = mapped_column(JSON)
 
     __table_args__ = (
         Index("ix_position_snapshots_account_ts", "account_id", "exchange_ts"),
-        # 0029: supports PositionSnapshotRepository.get_latest_before
-        # (run_id, account_id, symbol, side, at_ts).
+        # 0034: replaces 0029 index with source column so live/backtest reads
+        # remain single-scan. Equality predicates precede range predicate
+        # (exchange_ts).
         Index(
-            "ix_position_snapshots_run_account_symbol_side_ts",
-            "run_id", "account_id", "symbol", "side", "exchange_ts",
+            "ix_position_snapshots_run_account_symbol_side_source_ts",
+            "run_id", "account_id", "symbol", "side", "source", "exchange_ts",
+        ),
+        CheckConstraint(
+            "source IN ('live', 'backtest')",
+            name="ck_position_snapshots_source",
         ),
     )
 

--- a/shared/db/src/grid_db/repositories.py
+++ b/shared/db/src/grid_db/repositories.py
@@ -969,6 +969,12 @@ class PositionSnapshotRepository(BaseRepository[PositionSnapshot]):
                 "entry_price": s.entry_price,
                 "liq_price": s.liq_price,
                 "unrealised_pnl": s.unrealised_pnl,
+                # 0034: position telemetry parity columns.
+                "source": s.source if s.source is not None else "live",
+                "mark_price": s.mark_price,
+                "position_im": s.position_im,
+                "position_mm": s.position_mm,
+                "cum_realised_pnl": s.cum_realised_pnl,
                 "raw_json": s.raw_json,
             }
             for s in snapshots
@@ -984,25 +990,28 @@ class PositionSnapshotRepository(BaseRepository[PositionSnapshot]):
         self,
         account_id: str,
         symbol: str,
+        source: Optional[str] = "live",
     ) -> Optional[PositionSnapshot]:
         """Get the most recent position snapshot for an account/symbol.
 
         Args:
             account_id: Account ID.
             symbol: Trading symbol.
+            source: Snapshot source filter (0034). Defaults to ``'live'`` so
+                legacy callers never silently mix in backtest rows. Pass
+                ``'backtest'`` to read backtest rows, or ``None`` to read the
+                union (rare — used by the comparator).
 
         Returns:
             Latest PositionSnapshot or None.
         """
-        return (
-            self.session.query(PositionSnapshot)
-            .filter(
-                PositionSnapshot.account_id == account_id,
-                PositionSnapshot.symbol == symbol,
-            )
-            .order_by(PositionSnapshot.exchange_ts.desc())
-            .first()
+        query = self.session.query(PositionSnapshot).filter(
+            PositionSnapshot.account_id == account_id,
+            PositionSnapshot.symbol == symbol,
         )
+        if source is not None:
+            query = query.filter(PositionSnapshot.source == source)
+        return query.order_by(PositionSnapshot.exchange_ts.desc()).first()
 
     def get_latest_before(
         self,
@@ -1011,6 +1020,7 @@ class PositionSnapshotRepository(BaseRepository[PositionSnapshot]):
         symbol: str,
         side: str,
         at_ts: datetime,
+        source: Optional[str] = "live",
     ) -> Optional[PositionSnapshot]:
         """Get the latest snapshot for a run/account/symbol/side at-or-before at_ts.
 
@@ -1024,22 +1034,23 @@ class PositionSnapshotRepository(BaseRepository[PositionSnapshot]):
             symbol: Trading symbol.
             side: 'Buy' (long) or 'Sell' (short) — Bybit hedge-mode convention.
             at_ts: Inclusive upper bound on ``exchange_ts``.
+            source: Snapshot source filter (0034). Defaults to ``'live'``.
+                Pass ``'backtest'`` for backtest rows or ``None`` for the
+                union.
 
         Returns:
             Latest matching PositionSnapshot, or None if no row exists.
         """
-        return (
-            self.session.query(PositionSnapshot)
-            .filter(
-                PositionSnapshot.run_id == run_id,
-                PositionSnapshot.account_id == account_id,
-                PositionSnapshot.symbol == symbol,
-                PositionSnapshot.side == side,
-                PositionSnapshot.exchange_ts <= at_ts,
-            )
-            .order_by(PositionSnapshot.exchange_ts.desc())
-            .first()
+        query = self.session.query(PositionSnapshot).filter(
+            PositionSnapshot.run_id == run_id,
+            PositionSnapshot.account_id == account_id,
+            PositionSnapshot.symbol == symbol,
+            PositionSnapshot.side == side,
+            PositionSnapshot.exchange_ts <= at_ts,
         )
+        if source is not None:
+            query = query.filter(PositionSnapshot.source == source)
+        return query.order_by(PositionSnapshot.exchange_ts.desc()).first()
 
 
 class WalletSnapshotRepository(BaseRepository[WalletSnapshot]):

--- a/shared/db/tests/test_repositories.py
+++ b/shared/db/tests/test_repositories.py
@@ -1519,3 +1519,127 @@ class TestTickerSnapshotRepository:
         assert latest is not None
         assert latest.last_price == Decimal("51000.00")
         assert latest.exchange_ts.replace(tzinfo=None) == ts2.replace(tzinfo=None)
+
+
+class TestPositionSnapshotSourceFiltering0034:
+    """Feature 0034 — source-filtered reads on PositionSnapshotRepository."""
+
+    def _make_snap(self, account_id, ts, source, run_id=None, side="Buy"):
+        from grid_db import PositionSnapshot
+        from decimal import Decimal
+        return PositionSnapshot(
+            run_id=run_id,
+            account_id=str(account_id),
+            symbol="BTCUSDT",
+            exchange_ts=ts,
+            local_ts=ts,
+            side=side,
+            size=Decimal("1"),
+            entry_price=Decimal("100"),
+            liq_price=Decimal("90"),
+            unrealised_pnl=Decimal("0"),
+            source=source,
+            mark_price=Decimal("101"),
+            position_im=Decimal("10"),
+            position_mm=Decimal("0.5"),
+            cum_realised_pnl=Decimal("5"),
+        )
+
+    def test_bulk_insert_round_trips_new_columns(self, session, sample_account):
+        from grid_db import PositionSnapshotRepository, PositionSnapshot
+        from decimal import Decimal
+
+        ts = datetime.now(UTC)
+        repo = PositionSnapshotRepository(session)
+        repo.bulk_insert([self._make_snap(sample_account.account_id, ts, "backtest")])
+
+        loaded = session.query(PositionSnapshot).one()
+        assert loaded.source == "backtest"
+        assert loaded.mark_price == Decimal("101")
+        assert loaded.position_im == Decimal("10")
+        assert loaded.position_mm == Decimal("0.5")
+        assert loaded.cum_realised_pnl == Decimal("5")
+
+    def test_get_latest_by_account_symbol_defaults_live(self, session, sample_account):
+        from grid_db import PositionSnapshotRepository
+        import time
+        repo = PositionSnapshotRepository(session)
+        ts1 = datetime.now(UTC)
+        time.sleep(0.01)
+        ts2 = datetime.now(UTC)
+        repo.bulk_insert([
+            self._make_snap(sample_account.account_id, ts1, "live"),
+            self._make_snap(sample_account.account_id, ts2, "backtest"),
+        ])
+        latest = repo.get_latest_by_account_symbol(
+            str(sample_account.account_id), "BTCUSDT",
+        )
+        assert latest is not None
+        assert latest.source == "live"
+
+    def test_get_latest_by_account_symbol_explicit_backtest(self, session, sample_account):
+        from grid_db import PositionSnapshotRepository
+        import time
+        repo = PositionSnapshotRepository(session)
+        ts1 = datetime.now(UTC)
+        time.sleep(0.01)
+        ts2 = datetime.now(UTC)
+        repo.bulk_insert([
+            self._make_snap(sample_account.account_id, ts1, "live"),
+            self._make_snap(sample_account.account_id, ts2, "backtest"),
+        ])
+        latest = repo.get_latest_by_account_symbol(
+            str(sample_account.account_id), "BTCUSDT", source="backtest",
+        )
+        assert latest is not None
+        assert latest.source == "backtest"
+
+    def test_get_latest_by_account_symbol_source_none_union(self, session, sample_account):
+        from grid_db import PositionSnapshotRepository
+        import time
+        repo = PositionSnapshotRepository(session)
+        ts1 = datetime.now(UTC)
+        time.sleep(0.01)
+        ts2 = datetime.now(UTC)
+        repo.bulk_insert([
+            self._make_snap(sample_account.account_id, ts1, "live"),
+            self._make_snap(sample_account.account_id, ts2, "backtest"),
+        ])
+        latest = repo.get_latest_by_account_symbol(
+            str(sample_account.account_id), "BTCUSDT", source=None,
+        )
+        assert latest is not None
+        # union by timestamp → ts2 wins
+        assert latest.source == "backtest"
+
+    def test_get_latest_before_filters_source(self, session, sample_user, sample_account, sample_strategy):
+        """get_latest_before with explicit run_id filters by source."""
+        from grid_db import PositionSnapshotRepository, Run
+
+        # get_latest_before requires a run_id; create a Run record for FK.
+        run = Run(
+            run_id="r1",
+            user_id=sample_user.user_id,
+            run_type="live",
+            account_id=str(sample_account.account_id),
+            strategy_id=sample_strategy.strategy_id,
+            start_ts=datetime.now(UTC),
+        )
+        session.add(run)
+        session.commit()
+
+        repo = PositionSnapshotRepository(session)
+        ts = datetime.now(UTC)
+        repo.bulk_insert([
+            self._make_snap(sample_account.account_id, ts, "live", run_id="r1"),
+            self._make_snap(sample_account.account_id, ts, "backtest", run_id="r1"),
+        ])
+        # default = live
+        result = repo.get_latest_before("r1", str(sample_account.account_id), "BTCUSDT", "Buy", ts)
+        assert result is not None
+        assert result.source == "live"
+        result = repo.get_latest_before(
+            "r1", str(sample_account.account_id), "BTCUSDT", "Buy", ts, source="backtest"
+        )
+        assert result is not None
+        assert result.source == "backtest"


### PR DESCRIPTION
## Summary
- Adds 5 columns to `position_snapshots` (`source`, `mark_price`, `position_im`, `position_mm`, `cum_realised_pnl`) plus a source-aware index and CHECK constraint
- Recorder (WS + REST) extracts the new fields; backtest engine emits a parity-checkable snapshot on every fill and on wind-down close-outs
- Comparator pairs live/backtest snapshots per-side (monotonic two-pointer, 5s tolerance, one-to-one consume invariant) and recomputes unrealized PnL from `live.mark_price` against each side's own `(size, entry_price)` for apples-to-apples
- 12 new `ValidationMetrics` fields + `position_comparison.csv` + console summary block
- Standalone comparator CLI and replay both wire the new pipeline
- `cum_realised_pnl` seeded through `PositionStateSeed` → tracker so seeded replays don't show a fake baseline divergence
- One-off migration script at `scripts/migrate_0034_position_telemetry.py` for existing recorder DBs (project has no Alembic)

## Closes
Closes the parity gap where small qty/entry-price drift in matched trades compounds into IM/MM/liq_price divergence that the trade-level comparator hides — load-bearing for feature 0028 D-3 (`early_imbalance_multiplier`), which gates on `liq_price == 0`.

## Review history
Two review passes addressed in this branch:
- P2#1: `cum_realised_pnl_final_delta` now aggregates per-side final deltas (was masking long-only divergence by always picking the last Sell pair)
- P2#2: missing `Run.account_id` now raises at writer construction (was silently skipping the writer)
- P3: REST snapshot path now preserves `markPrice="0"` (matches WS writer)
- P2 (round 2): backtest snapshots now store ticker `mark_price`, not `last_price`, with regression test for `last_price ≠ mark_price`

Final review verdict: "No blocking findings."

## Test plan
- [x] `uv run pytest shared/db/ apps/event_saver/ apps/backtest/ apps/comparator/ apps/replay/ -q --ignore=apps/backtest/tests/test_risk_limit_info.py` → 778 passed
- [x] `uv run pytest apps/gridbot/ apps/recorder/ -q` → 502 passed, 2 skipped
- [x] `uv run ruff check` on all changed files → clean
- [ ] Manual smoke against `data/recorder_ltcusdt_phase4.db` after re-recording with the new schema (see plan §Verification step 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)