### PR TITLE
feat(0035): disable private WS message-gap watchdog in recorder

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -751,6 +751,12 @@ See `docs/features/0003_LOW_PRIORITY_CLEANUP.md` for detailed documentation.
 - **Behavior**: Executions/orders REQUIRE `run_id` for persistence; position/wallet snapshots do NOT
 - Files: `apps/event_saver/src/event_saver/collectors/private_collector.py:24-28`, `main.py:86-90`
 
+**Feature 0035 — private WS message-gap watchdog disabled on recorder side**:
+- **Parity with gridbot feature 0026**: pybit ping/pong frames bypass business-event handler, so the 30s message-gap watchdog produces false-positive disconnects on a healthy quiet private WS. Recorder now passes `message_gap_watchdog_enabled=False` to `PrivateWebSocketClient`, matching `gridbot.orchestrator._init_account`.
+- **Side effect**: `PrivateCollector._handle_disconnect` and the `on_gap_detected` callback wired through `_handle_reconnect` become dormant — the watchdog was their sole trigger. Kept wired for symmetry / reversibility (same call as gridbot).
+- **Gap**: Recorder has no TCP-level health probe equivalent to gridbot's `_ws_health_check_once` (feature 0024). After 0035 the recorder relies entirely on pybit's internal reconnect for private WS recovery. A separate future feature can port the probe.
+- File: `apps/event_saver/src/event_saver/collectors/private_collector.py:128-139`
+
 ### Test Commands
 ```bash
 # Run bybit_adapter tests

--- a/apps/event_saver/src/event_saver/collectors/private_collector.py
+++ b/apps/event_saver/src/event_saver/collectors/private_collector.py
@@ -135,6 +135,7 @@ class PrivateCollector:
             on_wallet=self._handle_wallet if self._on_wallet else None,
             on_disconnect=self._handle_disconnect,
             on_reconnect=self._handle_reconnect,
+            message_gap_watchdog_enabled=False,
         )
 
         self._ws_client.connect()

--- a/apps/event_saver/tests/test_private_collector.py
+++ b/apps/event_saver/tests/test_private_collector.py
@@ -127,11 +127,23 @@ class TestLifecycle:
         # test_ws_client.py::test_private_watchdog_disabled_skips_heartbeat_thread
         # but goes through the recorder's collector path so a regression in
         # private_collector.py is caught here too.
-        with patch("bybit_adapter.ws_client.WebSocket"):
+        with patch("bybit_adapter.ws_client.WebSocket") as MockWebSocket:
+            mock_ws = MagicMock()
+            MockWebSocket.return_value = mock_ws
+
             await collector.start()
             try:
                 assert collector._ws_client is not None
+                # Heartbeat thread must not be started when the watchdog is off.
                 assert collector._ws_client._heartbeat_thread is None
+                # connect() did not short-circuit before the gate — connection
+                # is logically up and all four stream subscriptions were
+                # registered with the (mocked) pybit session.
+                assert collector._ws_client.is_connected() is True
+                mock_ws.execution_stream.assert_called_once()
+                mock_ws.order_stream.assert_called_once()
+                mock_ws.position_stream.assert_called_once()
+                mock_ws.wallet_stream.assert_called_once()
             finally:
                 await collector.stop()
 

--- a/apps/event_saver/tests/test_private_collector.py
+++ b/apps/event_saver/tests/test_private_collector.py
@@ -120,6 +120,22 @@ class TestLifecycle:
             assert call_kwargs["message_gap_watchdog_enabled"] is False
 
     @pytest.mark.asyncio
+    async def test_start_does_not_spawn_private_heartbeat_thread(self, collector):
+        # Feature 0035 defense-in-depth: prove end-to-end through the real
+        # PrivateWebSocketClient that the watchdog gate is honoured — the
+        # heartbeat thread must not start when the flag is False. Mirrors
+        # test_ws_client.py::test_private_watchdog_disabled_skips_heartbeat_thread
+        # but goes through the recorder's collector path so a regression in
+        # private_collector.py is caught here too.
+        with patch("bybit_adapter.ws_client.WebSocket"):
+            await collector.start()
+            try:
+                assert collector._ws_client is not None
+                assert collector._ws_client._heartbeat_thread is None
+            finally:
+                await collector.stop()
+
+    @pytest.mark.asyncio
     async def test_start_twice_warns(self, collector):
         with patch("event_saver.collectors.private_collector.PrivateWebSocketClient") as MockWS:
             MockWS.return_value = MagicMock()

--- a/apps/event_saver/tests/test_private_collector.py
+++ b/apps/event_saver/tests/test_private_collector.py
@@ -108,6 +108,18 @@ class TestLifecycle:
             assert call_kwargs["api_key"] == "test_key"
 
     @pytest.mark.asyncio
+    async def test_start_disables_private_message_gap_watchdog(self, collector):
+        # Feature 0035 — mirrors gridbot feature 0026: the message-gap watchdog
+        # produces false-positive disconnects on a healthy quiet private WS
+        # because pybit's ping/pong frames bypass the business-event handler.
+        with patch("event_saver.collectors.private_collector.PrivateWebSocketClient") as MockWS:
+            MockWS.return_value = MagicMock()
+            await collector.start()
+
+            call_kwargs = MockWS.call_args[1]
+            assert call_kwargs["message_gap_watchdog_enabled"] is False
+
+    @pytest.mark.asyncio
     async def test_start_twice_warns(self, collector):
         with patch("event_saver.collectors.private_collector.PrivateWebSocketClient") as MockWS:
             MockWS.return_value = MagicMock()

--- a/docs/features/0035_PLAN.md
+++ b/docs/features/0035_PLAN.md
@@ -1,0 +1,35 @@
+# Feature 0035 — Disable private WS message-gap watchdog in recorder
+
+**Parent:** [Feature 0026](./0026_PLAN.md) (same fix, gridbot side).
+
+## Context
+
+The live gridbot was emitting ~1249 false `Detected disconnection: no messages for 30.0s` warnings per night on its private WebSocket. Root cause: pybit's protocol-level ping/pong frames bypass the business-event handler, so a healthy quiet private socket looks silent to the message-gap watchdog and gets torn down.
+
+Feature 0026 fixed gridbot by adding `message_gap_watchdog_enabled: bool = True` to `PrivateWebSocketClient` and passing `False` from `gridbot.orchestrator._init_account` (commit `cc975da`). Stable in production ~6 days.
+
+The recorder (`apps/event_saver`) was missed. Its `PrivateCollector` (`apps/event_saver/src/event_saver/collectors/private_collector.py:128`) instantiates `PrivateWebSocketClient` directly without the flag, so a fresh recorder run today reproduced the false-positive at t+30s on `data/recorder_ltcusdt_phase4.db`.
+
+## Change
+
+One line: add `message_gap_watchdog_enabled=False` to the existing `PrivateWebSocketClient(...)` call in `private_collector.py`. The flag plumbing in `packages/bybit_adapter/src/bybit_adapter/ws_client.py:390` is already done by 0026; this is purely an opt-out at the call site.
+
+Default for the flag stays `True` in `ws_client.py` — only the two known callers (gridbot orchestrator and event_saver private collector) opt out explicitly.
+
+## Test
+
+One new test in `apps/event_saver/tests/test_private_collector.py::TestLifecycle::test_start_disables_private_message_gap_watchdog`, mirroring the gridbot-side `test_init_account_disables_private_message_gap_watchdog` but adapted to the event_saver test style (`MockWS.call_args[1]["..."]`). Patches `PrivateWebSocketClient`, calls `collector.start()`, asserts the kwarg.
+
+## Side effects (intentional, mirrors 0026)
+
+- `PrivateCollector._handle_disconnect` and the `on_gap_detected` callback wired through `_handle_reconnect` become dormant — the watchdog was their only trigger. Kept wired for symmetry and reversibility, same as gridbot's `_on_ws_disconnect`.
+
+## Out of scope (gap to document)
+
+After this change the recorder has **no active disconnect detection** for the private WS — it relies entirely on pybit's internal reconnect loop. Gridbot covers itself with the TCP-level probe `_ws_health_check_once` from feature 0024; the recorder has no equivalent. A separate future feature can port that probe to `event_saver` if recorder-side disconnect detection becomes important.
+
+## Verification
+
+1. `uv run pytest apps/event_saver/ packages/bybit_adapter/ -q` — green, including the new test and existing `test_start_creates_ws_and_connects` / `test_start_uses_correct_testnet_flag`.
+2. `uv run ruff check apps/event_saver/ packages/bybit_adapter/` — clean.
+3. Operator smoke: restart recorder, tail `/tmp/recorder*.log`, confirm no `Detected disconnection: no messages for 30.0s` warning in the first 5 minutes of a quiet private WS. Public WS watchdog remains active (intentionally untouched — public has a real, working message stream).


### PR DESCRIPTION
## Summary

- Apply the [feature 0026](https://github.com/erzhan12/grid-bot-validation/pull/64) private-WS watchdog opt-out to the **recorder** side (`apps/event_saver`), which was missed by 0026.
- One-line change: pass `message_gap_watchdog_enabled=False` to `PrivateWebSocketClient(...)` in `PrivateCollector.start()`. The flag plumbing already exists in `bybit_adapter` (default stays `True`; recorder + gridbot opt out explicitly).
- Eliminates ~1249 false `Detected disconnection: no messages for 30.0s` warnings per night caused by pybit's protocol-level ping/pong frames bypassing the business-event handler on a healthy quiet socket.

## Files changed

| Path | Change |
|---|---|
| `apps/event_saver/src/event_saver/collectors/private_collector.py` | +1 line at L138 (the kwarg) |
| `apps/event_saver/tests/test_private_collector.py` | +12 lines: new `test_start_disables_private_message_gap_watchdog` mirroring gridbot's `test_init_account_disables_private_message_gap_watchdog` from commit `cc975da`, adapted to event_saver's local mock-kwargs style |
| `docs/features/0035_PLAN.md` | New, ~30 lines, parent = 0026, documents the no-TCP-probe gap |
| `RULES.md` | One bullet under Phase D noting recorder-side parity with 0026 and the gap |

## Intentional side effects (mirrors gridbot 0026)

- `PrivateCollector._handle_disconnect` and the `on_gap_detected` callback wired through `_handle_reconnect` become dormant — the watchdog was their sole trigger. Kept wired for symmetry and reversibility.

## Documented gap (out of scope here)

After this merge the recorder has **no active disconnect detection** for the private WS — it relies on pybit's internal reconnect. Gridbot covers itself with the TCP-level `_ws_health_check_once` probe from feature 0024; the recorder has no equivalent. A separate future feature can port the probe.

## Non-goals (per the implementation prompt)

- No change to the public WS watchdog (public has a real, working message stream).
- No change to `PrivateWebSocketClient` itself or its default (`message_gap_watchdog_enabled: bool = True` stays — safe-by-default for any new consumer).
- No new abstractions / helpers.

## Test plan

- [x] `uv run pytest apps/event_saver/tests/test_private_collector.py -q` — 28 passed (was 27; one new test added)
- [x] `uv run pytest apps/event_saver/ packages/bybit_adapter/ -q` — 289 passed
- [x] `uv run ruff check apps/event_saver/src/event_saver/collectors/private_collector.py apps/event_saver/tests/test_private_collector.py` — clean (pre-existing F401/F541 lint warnings in unrelated files were not touched)
- [ ] Operator smoke: restart recorder, tail `/tmp/recorder*.log`, confirm no `Detected disconnection: no messages for 30.0s` warning within 5 min of private WS connect

🤖 Generated with [Claude Code](https://claude.com/claude-code)