### PR TITLE
fix(0036): coerce empty-string Bybit balances to Decimal("0") in wallet writer

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -2054,6 +2054,7 @@ All risk config thresholds (`max_margin=8`, `min_total_margin=0.15`) are ratios.
 17. **`asyncio.CancelledError`**: Is `BaseException`, passes through `except Exception`
 18. **Logging style**: Use `%s`-style in hot-path loops; f-strings elsewhere acceptable
 19. **PlaceLimitIntent constructor**: Requires `qty` and `grid_level` positional args
+20. **`Decimal("")` raises `decimal.InvalidOperation`**: Bybit may send empty strings for unused/dust numeric fields on mainnet UTA (e.g. `walletBalance`, `availableToWithdraw`). `d.get(key, "0")` only handles *missing* keys, not present-but-empty. For non-nullable Decimal columns use a `_decimal_or_zero(value)` helper (predicate `value in (None, "")`, fallback `Decimal("0")`); for nullable columns use the 0034 recorder pattern `Decimal(str(v)) if v not in (None, "") else None`. See `apps/event_saver/src/event_saver/writers/wallet_writer.py:17-34` and `apps/recorder/src/recorder/recorder.py:450-453`. Truthiness checks (`if v:`) are wrong here because they conflate legitimate `"0"` with empty.
 
 ## Dynamic Risk Limit Tiers (Feature/dynamic risk limit tiers)
 

--- a/apps/event_saver/src/event_saver/writers/wallet_writer.py
+++ b/apps/event_saver/src/event_saver/writers/wallet_writer.py
@@ -14,6 +14,26 @@ from grid_db import DatabaseFactory, WalletSnapshot, WalletSnapshotRepository
 logger = logging.getLogger(__name__)
 
 
+def _decimal_or_zero(value: object) -> Decimal:
+    """Coerce a Bybit numeric field to Decimal, mapping missing/empty to zero.
+
+    Bybit private wallet payloads can carry ``""`` for ``walletBalance`` /
+    ``availableToWithdraw`` on unused dust coins in a mainnet UTA account.
+    A plain ``Decimal(str(""))`` raises ``decimal.InvalidOperation``, which
+    the broad ``except`` in ``_messages_to_models`` then drops along with
+    every later coin in the same update. Map both ``None`` and ``""`` to
+    ``Decimal("0")``; let real numeric strings parse normally; let truly
+    malformed values still raise so the caller's warning path still fires.
+
+    The predicate is ``value in (None, "")`` rather than truthiness so a
+    legitimate ``"0"`` round-trips via the direct ``Decimal(str(...))``
+    path and is not coerced via the fallback.
+    """
+    if value in (None, ""):
+        return Decimal("0")
+    return Decimal(str(value))
+
+
 class WalletWriter:
     """Buffers and bulk-inserts wallet balance snapshots.
 
@@ -211,11 +231,11 @@ class WalletWriter:
                                 exchange_ts=exchange_ts,
                                 local_ts=local_ts,
                                 coin=coin_data.get("coin", ""),
-                                wallet_balance=Decimal(
-                                    str(coin_data.get("walletBalance", "0"))
+                                wallet_balance=_decimal_or_zero(
+                                    coin_data.get("walletBalance")
                                 ),
-                                available_balance=Decimal(
-                                    str(coin_data.get("availableToWithdraw", "0"))
+                                available_balance=_decimal_or_zero(
+                                    coin_data.get("availableToWithdraw")
                                 ),
                                 raw_json=coin_data,
                             )

--- a/apps/event_saver/tests/test_writers.py
+++ b/apps/event_saver/tests/test_writers.py
@@ -19,7 +19,7 @@ from event_saver.writers import TradeWriter, ExecutionWriter
 from event_saver.writers.ticker_writer import TickerWriter
 from event_saver.writers.order_writer import OrderWriter
 from event_saver.writers.position_writer import PositionWriter
-from event_saver.writers.wallet_writer import WalletWriter
+from event_saver.writers.wallet_writer import WalletWriter, _decimal_or_zero
 
 
 @pytest.fixture
@@ -941,3 +941,161 @@ class TestWalletWriter:
 
             await writer.flush()
             assert len(writer._buffer) == 0
+
+    def test_decimal_or_zero_helper(self):
+        """0036: helper maps None/'' to Decimal('0'), passes real values through."""
+        from decimal import InvalidOperation
+
+        assert _decimal_or_zero(None) == Decimal("0")
+        assert _decimal_or_zero("") == Decimal("0")
+        assert _decimal_or_zero("1.5") == Decimal("1.5")
+        # Legit "0" round-trips via direct path, not via fallback.
+        assert _decimal_or_zero("0") == Decimal("0")
+        # Truly malformed values still raise so the caller's broad except
+        # still drops the row and emits its existing warning.
+        with pytest.raises(InvalidOperation):
+            _decimal_or_zero("not-a-number")
+
+    @pytest.mark.asyncio
+    async def test_empty_string_wallet_balance_writes_zero(self, mock_db, caplog):
+        """0036: walletBalance='' writes Decimal('0') and emits no parse warning."""
+        import logging
+
+        writer = WalletWriter(db=mock_db, batch_size=100)
+        messages = [
+            {
+                "data": [
+                    {
+                        "accountType": "UNIFIED",
+                        "coin": [
+                            {
+                                "coin": "BTC",
+                                "walletBalance": "",
+                                "availableToWithdraw": "",
+                            }
+                        ],
+                        "updateTime": "1700000000000",
+                    }
+                ]
+            }
+        ]
+
+        with caplog.at_level(logging.WARNING, logger="event_saver.writers.wallet_writer"):
+            await writer.write(uuid4(), messages)
+
+        assert len(writer._buffer) == 1
+        snap = writer._buffer[0]
+        assert snap.coin == "BTC"
+        assert snap.wallet_balance == Decimal("0")
+        assert snap.available_balance == Decimal("0")
+        assert not any(
+            "Error parsing wallet snapshot" in r.message for r in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_missing_wallet_balance_writes_zero(self, mock_db):
+        """0036: missing walletBalance key still writes Decimal('0')."""
+        writer = WalletWriter(db=mock_db, batch_size=100)
+        messages = [
+            {
+                "data": [
+                    {
+                        "accountType": "UNIFIED",
+                        "coin": [
+                            {
+                                "coin": "USDC",
+                            }
+                        ],
+                        "updateTime": "1700000000000",
+                    }
+                ]
+            }
+        ]
+
+        await writer.write(uuid4(), messages)
+
+        assert len(writer._buffer) == 1
+        snap = writer._buffer[0]
+        assert snap.wallet_balance == Decimal("0")
+        assert snap.available_balance == Decimal("0")
+
+    @pytest.mark.asyncio
+    async def test_malformed_wallet_balance_drops_row_and_warns(self, mock_db, caplog):
+        """0036: 'not-a-number' walletBalance drops row and warns exactly once."""
+        import logging
+
+        writer = WalletWriter(db=mock_db, batch_size=100)
+        messages = [
+            {
+                "data": [
+                    {
+                        "accountType": "UNIFIED",
+                        "coin": [
+                            {
+                                "coin": "FOO",
+                                "walletBalance": "not-a-number",
+                                "availableToWithdraw": "1.0",
+                            }
+                        ],
+                        "updateTime": "1700000000000",
+                    }
+                ]
+            }
+        ]
+
+        with caplog.at_level(logging.WARNING, logger="event_saver.writers.wallet_writer"):
+            await writer.write(uuid4(), messages)
+
+        assert len(writer._buffer) == 0
+        warnings = [
+            r for r in caplog.records if "Error parsing wallet snapshot" in r.message
+        ]
+        assert len(warnings) == 1
+
+    @pytest.mark.asyncio
+    async def test_mixed_payload_blast_radius(self, mock_db, caplog):
+        """0036: bad coin drops itself and later coins in the same update.
+
+        Coins appended before the bad one survive because the try/except
+        wraps the per-wallet_data block but snapshots.append runs inside
+        the inner coin loop. This pins the known blast radius until the
+        broader 0037 per-coin isolation fix lands.
+        """
+        import logging
+
+        writer = WalletWriter(db=mock_db, batch_size=100)
+        messages = [
+            {
+                "data": [
+                    {
+                        "accountType": "UNIFIED",
+                        "coin": [
+                            {
+                                "coin": "USDT",
+                                "walletBalance": "10000.00",
+                                "availableToWithdraw": "9500.00",
+                            },
+                            {
+                                "coin": "FOO",
+                                "walletBalance": "not-a-number",
+                                "availableToWithdraw": "1.0",
+                            },
+                            {
+                                "coin": "BAR",
+                                "walletBalance": "1.0",
+                                "availableToWithdraw": "1.0",
+                            },
+                        ],
+                        "updateTime": "1700000000000",
+                    }
+                ]
+            }
+        ]
+
+        with caplog.at_level(logging.WARNING, logger="event_saver.writers.wallet_writer"):
+            await writer.write(uuid4(), messages)
+
+        # USDT (before bad coin) survives. FOO raises; BAR is collateral
+        # damage from the current try/except scope.
+        assert len(writer._buffer) == 1
+        assert writer._buffer[0].coin == "USDT"

--- a/docs/features/0036_PLAN.md
+++ b/docs/features/0036_PLAN.md
@@ -1,0 +1,140 @@
+# Feature 0036 — Wallet writer empty-string balances
+
+Branch: `feature/0036-wallet-writer-empty-string-decimal` (already created).
+
+## Context
+
+Bybit private wallet stream coin rows can use `""` for
+`walletBalance` or `availableToWithdraw` on unused/dust coins in a
+mainnet UTA account. `WalletWriter` currently does
+`Decimal(str(coin_data.get("walletBalance", "0")))`
+(`apps/event_saver/src/event_saver/writers/wallet_writer.py:215,218`),
+so the `"0"` fallback only handles *missing* keys. Present-but-empty
+values raise `decimal.ConversionSyntax`, get caught by the broad parse
+handler at lines 199–225, and the bad coin **plus every later coin in
+the same `data[]` update** is dropped (coins already appended earlier
+in the same update survive — `snapshots.append(...)` runs inside the
+inner coin loop). On mainnet the bad coin is typically dust at index
+0, so this effectively drops every coin every update and
+`wallet_snapshots` stays empty. `raw_json=coin_data` (line 220)
+preserves the original empty strings, so the fix is non-lossy: typed
+columns get `Decimal("0")`, audit trail keeps the truth.
+
+This breaks Phase 4 seed-aware replay because the seed pre-check
+requires `MIN(exchange_ts)` on `wallet_snapshots` to be non-NULL for
+the recorder run. `wallet_snapshots` staying empty makes otherwise
+valid mainnet recorder runs unusable. Testnet payloads were clean, so
+the bug only manifests against mainnet UTA — which is why feature
+0029 shipped green and this regressed later.
+
+## Change
+
+Add a module-level private helper in
+`apps/event_saver/src/event_saver/writers/wallet_writer.py`,
+immediately after `logger = logging.getLogger(__name__)` (line 14):
+
+```python
+def _decimal_or_zero(value: object) -> Decimal:
+    if value in (None, ""):
+        return Decimal("0")
+    return Decimal(str(value))
+```
+
+Predicate is `in (None, "")` (matching the feature 0034 recorder
+precedent at `apps/recorder/src/recorder/recorder.py:451-452`), not
+truthiness (`if value:`). Truthiness would conflate `"0"` and `"0.0"`
+with missing, which is wrong for non-nullable balance columns — a
+legitimate zero balance must round-trip as `Decimal("0")` via the
+direct path, not via the fallback.
+
+Use the helper at the two call sites — `walletBalance` (line 215) and
+`availableToWithdraw` (line 218). Drop the now-redundant `"0"`
+defaults at the call sites:
+
+```python
+wallet_balance=_decimal_or_zero(coin_data.get("walletBalance")),
+available_balance=_decimal_or_zero(coin_data.get("availableToWithdraw")),
+```
+
+The helper is the single source of truth for the fallback. Do not
+change the `WalletSnapshot` schema: `wallet_balance` and
+`available_balance` are intentionally `nullable=False`
+(`shared/db/src/grid_db/models.py:438-439`), so `None` is not the
+right fallback.
+
+## Tests
+
+File: `apps/event_saver/tests/test_writers.py`, class
+`TestWalletWriter` (currently lines 828–943).
+
+Pure-helper unit tests (cheap, pin the contract):
+
+- `_decimal_or_zero(None) == Decimal("0")`
+- `_decimal_or_zero("") == Decimal("0")`
+- `_decimal_or_zero("1.5") == Decimal("1.5")`
+- `_decimal_or_zero("0") == Decimal("0")` — round-trip, not via fallback
+- `_decimal_or_zero("not-a-number")` raises `decimal.InvalidOperation`
+
+Writer-level tests (mirror existing async style with `mock_db`):
+
+1. `walletBalance=""` writes one snapshot with
+   `wallet_balance == Decimal("0")` and emits **no**
+   `Error parsing wallet snapshot` warning (assert via `caplog`).
+2. Missing `walletBalance` key still writes one snapshot with
+   `wallet_balance == Decimal("0")`.
+3. Single-coin payload with `walletBalance="not-a-number"` produces
+   **zero** snapshots and emits the existing
+   `Error parsing wallet snapshot` warning exactly once (assert via
+   `caplog`).
+4. Mixed payload `[{coin: "USDT", ...valid}, {coin: "FOO", walletBalance: "not-a-number"}, {coin: "BAR", ...valid}]`
+   in a single `data[]` update produces exactly **one** snapshot
+   (USDT). FOO raises, BAR is collateral damage from the current
+   try/except scope. This pins the known blast radius until the 0037
+   per-coin isolation fix.
+
+## Verification
+
+1. Fast inner loop:
+   `uv run pytest apps/event_saver/tests/test_writers.py -k TestWalletWriter -q`
+2. Full regression:
+   `uv run pytest apps/event_saver/ -q`
+3. `uv run ruff check apps/event_saver/`
+4. Operator smoke: rerun recorder against the mainnet account. Confirm
+   `SELECT COUNT(*) FROM wallet_snapshots WHERE run_id = '<run>'`
+   becomes > 0 within ~5 minutes and no `Error parsing wallet
+   snapshot` warnings appear for empty-string coin payloads. Truly
+   malformed (non-empty-string) payloads may still warn — that path is
+   intentionally unchanged.
+5. Update `RULES.md` with a one-line pitfall: `Decimal("")` raises
+   `decimal.InvalidOperation`; for Bybit numeric fields that can be
+   present-but-empty, use a `_decimal_or_zero`-style helper rather
+   than relying on `dict.get(..., "0")` defaults.
+
+## Out of Scope
+
+Do not audit or change the other writers in this feature. Feature
+0037 should handle the wider sweep. Known suspects with the same
+`Decimal(str(d.get(k, "0")))` shape (raises on present-but-empty,
+broad except drops the row):
+
+- `apps/event_saver/src/event_saver/writers/position_writer.py:214`
+  (`size`), `:215` (`entryPrice`) — non-nullable columns, same blast
+  radius as wallet. Position snapshots would silently stop landing if
+  Bybit ever sent an empty `size` or `entryPrice`.
+- `apps/event_saver/src/event_saver/reconciler.py:332-333` (`price`,
+  `size` for trades) and `:382-385` (`execPrice`, `execQty`,
+  `execFee`, `closedPnl` for executions) — 6 sites. `execFee=""` for
+  maker-rebate or zero-fee executions is plausible.
+- `wallet_writer.py:213` `coin=coin_data.get("coin", "")` — schema is
+  `String(20), nullable=False`, so this tolerates an empty string but
+  is semantically wrong. Flag, do not fix in 0036.
+
+When 0037 lands, move `_decimal_or_zero` out of `wallet_writer.py`
+into a shared module (e.g.,
+`apps/event_saver/src/event_saver/writers/_parsing.py`) so the other
+writers can import it. For 0036 keep it private to `wallet_writer.py`
+to keep the diff minimal.
+
+Optional 0037 stretch: move the broad `try/except` *inside* each
+writer's inner coin/position/execution loop so one truly malformed
+row no longer takes out later rows in the same update.

--- a/docs/features/0036_REVIEW.md
+++ b/docs/features/0036_REVIEW.md
@@ -1,0 +1,68 @@
+# 0036 Review - Wallet writer empty-string balances
+
+## Summary
+
+No blocking findings.
+
+The implementation matches `docs/features/0036_PLAN.md`:
+
+- Adds private `_decimal_or_zero(value)` in `wallet_writer.py`.
+- Maps only `None` and `""` to `Decimal("0")`.
+- Leaves normal numeric strings, including `"0"`, on the direct `Decimal(str(value))` path.
+- Lets malformed non-empty values raise and flow through the existing wallet parse warning path.
+- Uses the helper for both `walletBalance` and `availableToWithdraw`.
+- Keeps `WalletSnapshot` schema behavior unchanged and preserves original payload values in `raw_json`.
+- Adds the requested `RULES.md` pitfall entry.
+
+## Findings
+
+None.
+
+## Review Notes
+
+- No data-shape alignment issue was introduced. The writer still reads the existing Bybit shape `message["data"][].coin[]` and the changed fields remain camelCase (`walletBalance`, `availableToWithdraw`) as expected by current tests and production parsing.
+- The change is appropriately scoped. It does not audit or alter the other writers called out for feature 0037, and it does not move parsing into a shared module prematurely.
+- The known broad `try/except` blast radius remains unchanged and is pinned by a test: coins before a malformed coin survive, while the malformed coin and later coins in the same wallet update are dropped.
+- Style is consistent enough for this codebase. The helper is small, module-private, and close to its call sites.
+
+## Test Review
+
+Coverage added for the new behavior:
+
+- Helper maps `None` and `""` to zero.
+- Helper parses `"1.5"` and `"0"` as normal Decimal values.
+- Helper raises `decimal.InvalidOperation` for `"not-a-number"`.
+- Writer accepts empty-string balances without emitting `Error parsing wallet snapshot`.
+- Writer preserves missing-key fallback behavior.
+- Writer drops and warns for malformed non-empty balance values.
+- Writer pins the current mixed-payload blast radius.
+
+The tests are isolated, fast, and follow the existing `TestWalletWriter` async style with `mock_db` and direct buffer assertions.
+
+## Verification
+
+```bash
+uv run pytest apps/event_saver/tests/test_writers.py -k TestWalletWriter -q
+# 9 passed, 34 deselected in 0.24s
+```
+
+```bash
+uv run pytest apps/event_saver/ -q
+# 149 passed in 1.73s
+```
+
+```bash
+uv run ruff check apps/event_saver/src/event_saver/writers/wallet_writer.py apps/event_saver/tests/test_writers.py
+# All checks passed!
+```
+
+The broader plan lint command currently fails on unrelated pre-existing lint issues outside this feature's changed files:
+
+```bash
+uv run ruff check apps/event_saver/
+```
+
+- `apps/event_saver/src/event_saver/collectors/public_collector.py`: unused `UTC`
+- `apps/event_saver/src/event_saver/main.py`: f-string without placeholders
+- `apps/event_saver/tests/test_config.py`: unused `pytest`
+- `apps/event_saver/tests/test_reconciler.py`: unused `patch`


### PR DESCRIPTION
## Summary

- Adds module-level `_decimal_or_zero(value)` helper in `wallet_writer.py` and wires it into the `walletBalance`/`availableToWithdraw` call sites, eliminating the `decimal.InvalidOperation` raised when Bybit sends `""` for unused/dust coin balances on mainnet UTA.
- Predicate is `value in (None, "")` (mirrors feature 0034 recorder precedent at `apps/recorder/src/recorder/recorder.py:450-453`); preserves legitimate `"0"` via the direct path and lets truly malformed values still raise so the existing parse warning fires.
- Adds 5 tests under `TestWalletWriter`: helper unit test plus 4 writer-level scenarios (empty-string, missing key, malformed value, mixed-payload blast-radius pin).
- Documents the pitfall in `RULES.md` (#20) and ships the plan + review docs under `docs/features/0036_*.md`.
- Out of scope (deferred to 0037): same `Decimal(str(d.get(k, "0")))` shape exists in `position_writer.py:214-215`, `reconciler.py:332-333,382-385`, plus the `coin=…get("coin", "")` empty-default in `wallet_writer.py:213`.

## Why

`wallet_snapshots` was staying empty on the mainnet recorder, blocking Phase 4 seed-aware replay (`MIN(exchange_ts)` pre-check is `nullable=False`). Bug only manifests on mainnet UTA — testnet payloads were clean, which is why feature 0029 shipped green.

## Test plan

- [x] `uv run pytest apps/event_saver/tests/test_writers.py -k TestWalletWriter -q` — 9 passed (4 existing + 5 new).
- [x] `uv run pytest apps/event_saver/ -q` — 149 passed, no regressions.
- [x] `uv run ruff check` scoped to changed files — clean. (Pre-existing ruff errors in `public_collector.py`, `main.py`, `test_config.py`, `test_reconciler.py` are untouched here.)
- [ ] Operator smoke: rerun recorder against mainnet account; confirm `SELECT COUNT(*) FROM wallet_snapshots WHERE run_id = '<run>'` > 0 within ~5 min and no `Error parsing wallet snapshot` warnings for empty-string coin payloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)