### PR TITLE
feat(0037): recorder private WS TCP health reconciliation

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -753,9 +753,9 @@ See `docs/features/0003_LOW_PRIORITY_CLEANUP.md` for detailed documentation.
 
 **Feature 0035 — private WS message-gap watchdog disabled on recorder side**:
 - **Parity with gridbot feature 0026**: pybit ping/pong frames bypass business-event handler, so the 30s message-gap watchdog produces false-positive disconnects on a healthy quiet private WS. Recorder now passes `message_gap_watchdog_enabled=False` to `PrivateWebSocketClient`, matching `gridbot.orchestrator._init_account`.
-- **Side effect**: `PrivateCollector._handle_disconnect` and the `on_gap_detected` callback wired through `_handle_reconnect` become dormant — the watchdog was their sole trigger. Kept wired for symmetry / reversibility (same call as gridbot).
-- **Gap**: Recorder has no TCP-level health probe equivalent to gridbot's `_ws_health_check_once` (feature 0024). After 0035 the recorder relies entirely on pybit's internal reconnect for private WS recovery. A separate future feature can port the probe.
-- File: `apps/event_saver/src/event_saver/collectors/private_collector.py:128-139`
+- **Feature 0037 follow-up**: Recorder keeps a private TCP-level health probe in `PrivateCollector` while the message-gap watchdog stays disabled. On a dead private socket it resets the client and invokes the existing private gap callback so REST execution reconciliation runs for the outage window.
+- **Invariant**: Do not remove both private disconnect detectors. Message silence is not a private-stream failure signal, but the recorder still needs TCP-level liveness checks so real private WS outages do not silently skip execution backfill.
+- File: `apps/event_saver/src/event_saver/collectors/private_collector.py`
 
 ### Test Commands
 ```bash

--- a/apps/event_saver/src/event_saver/collectors/private_collector.py
+++ b/apps/event_saver/src/event_saver/collectors/private_collector.py
@@ -1,8 +1,10 @@
 """Collect private account data (executions, orders, positions, wallet)."""
 
+import asyncio
+import contextlib
 import logging
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Callable, Optional
 from uuid import UUID
 
@@ -12,6 +14,8 @@ from gridcore.events import ExecutionEvent, OrderUpdateEvent
 
 
 logger = logging.getLogger(__name__)
+
+_PRIVATE_WS_HEALTH_CHECK_INTERVAL = 10.0
 
 
 @dataclass
@@ -79,6 +83,7 @@ class PrivateCollector:
         on_position: Optional[Callable[[dict], None]] = None,
         on_wallet: Optional[Callable[[dict], None]] = None,
         on_gap_detected: Optional[Callable[[datetime, datetime], None]] = None,
+        ws_health_check_interval: float = _PRIVATE_WS_HEALTH_CHECK_INTERVAL,
     ):
         """Initialize private collector for an account.
 
@@ -89,6 +94,7 @@ class PrivateCollector:
             on_position: Callback for position snapshots (raw dict).
             on_wallet: Callback for wallet snapshots (raw dict).
             on_gap_detected: Callback when gap is detected (start, end).
+            ws_health_check_interval: TCP socket health-check interval in seconds.
         """
         self.context = context
         self._on_execution = on_execution
@@ -108,6 +114,9 @@ class PrivateCollector:
         self._ws_client: Optional[PrivateWebSocketClient] = None
         self._running = False
         self._symbols_set = set(context.symbols) if context.symbols else set()
+        self._ws_health_check_interval = ws_health_check_interval
+        self._ws_health_task: Optional[asyncio.Task[None]] = None
+        self._ws_health_stop_event: Optional[asyncio.Event] = None
 
     async def start(self) -> None:
         """Start collecting private data for this account.
@@ -139,6 +148,8 @@ class PrivateCollector:
         )
 
         self._ws_client.connect()
+        self._ws_health_stop_event = asyncio.Event()
+        self._ws_health_task = asyncio.create_task(self._ws_health_check_loop())
         logger.info(f"PrivateCollector started for account {self.context.account_id}")
 
     async def stop(self) -> None:
@@ -151,6 +162,15 @@ class PrivateCollector:
 
         logger.info(f"Stopping PrivateCollector for account {self.context.account_id}")
         self._running = False
+
+        if self._ws_health_stop_event:
+            self._ws_health_stop_event.set()
+
+        if self._ws_health_task:
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._ws_health_task
+            self._ws_health_task = None
+            self._ws_health_stop_event = None
 
         if self._ws_client:
             self._ws_client.disconnect()
@@ -167,6 +187,54 @@ class PrivateCollector:
         if self._ws_client:
             return self._ws_client.get_connection_state()
         return None
+
+    async def _ws_health_check_loop(self) -> None:
+        """Reset dead private sockets and trigger REST reconciliation."""
+        while self._running:
+            stop_event = self._ws_health_stop_event
+            if stop_event is None:
+                return
+            try:
+                await asyncio.wait_for(
+                    stop_event.wait(),
+                    timeout=self._ws_health_check_interval,
+                )
+                return
+            except TimeoutError:
+                pass
+            await self._ws_health_check_once()
+
+    async def _ws_health_check_once(self) -> None:
+        """Perform one TCP-level private WebSocket health check."""
+        client = self._ws_client
+        if not self._running or client is None:
+            return
+
+        try:
+            if client.is_socket_alive():
+                return
+
+            state = client.get_connection_state()
+            disconnected_at = (
+                state.last_message_ts
+                or state.disconnected_at
+                or datetime.now(UTC)
+            )
+            self._handle_disconnect(disconnected_at)
+
+            logger.warning(
+                "Private WebSocket socket dead for account %s; resetting",
+                self.context.account_id,
+            )
+            await asyncio.to_thread(client.reset)
+            self._handle_reconnect(disconnected_at, datetime.now(UTC))
+        except Exception as e:
+            logger.error(
+                "Private WebSocket health check failed for account %s: %s",
+                self.context.account_id,
+                e,
+                exc_info=True,
+            )
 
     def update_run_id(self, run_id: Optional[UUID]) -> None:
         """Update the run_id for subsequent events.

--- a/apps/event_saver/tests/test_private_collector.py
+++ b/apps/event_saver/tests/test_private_collector.py
@@ -1,10 +1,13 @@
 """Tests for PrivateCollector."""
 
+import asyncio
+import threading
 import pytest
-from datetime import datetime
+from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
+from bybit_adapter.ws_client import ConnectionState
 from event_saver.collectors.private_collector import PrivateCollector, AccountContext
 from gridcore.events import ExecutionEvent, OrderUpdateEvent
 
@@ -93,19 +96,23 @@ class TestLifecycle:
             MockWS.return_value = mock_ws
 
             await collector.start()
-
-            assert collector.is_running() is True
-            mock_ws.connect.assert_called_once()
+            try:
+                assert collector.is_running() is True
+                mock_ws.connect.assert_called_once()
+            finally:
+                await collector.stop()
 
     @pytest.mark.asyncio
     async def test_start_uses_correct_testnet_flag(self, collector, context):
         with patch("event_saver.collectors.private_collector.PrivateWebSocketClient") as MockWS:
             MockWS.return_value = MagicMock()
             await collector.start()
-
-            call_kwargs = MockWS.call_args[1]
-            assert call_kwargs["testnet"] is True
-            assert call_kwargs["api_key"] == "test_key"
+            try:
+                call_kwargs = MockWS.call_args[1]
+                assert call_kwargs["testnet"] is True
+                assert call_kwargs["api_key"] == "test_key"
+            finally:
+                await collector.stop()
 
     @pytest.mark.asyncio
     async def test_start_disables_private_message_gap_watchdog(self, collector):
@@ -115,9 +122,11 @@ class TestLifecycle:
         with patch("event_saver.collectors.private_collector.PrivateWebSocketClient") as MockWS:
             MockWS.return_value = MagicMock()
             await collector.start()
-
-            call_kwargs = MockWS.call_args[1]
-            assert call_kwargs["message_gap_watchdog_enabled"] is False
+            try:
+                call_kwargs = MockWS.call_args[1]
+                assert call_kwargs["message_gap_watchdog_enabled"] is False
+            finally:
+                await collector.stop()
 
     @pytest.mark.asyncio
     async def test_start_does_not_spawn_private_heartbeat_thread(self, collector):
@@ -152,11 +161,13 @@ class TestLifecycle:
         with patch("event_saver.collectors.private_collector.PrivateWebSocketClient") as MockWS:
             MockWS.return_value = MagicMock()
             await collector.start()
+            try:
+                MockWS.reset_mock()
+                await collector.start()
 
-            MockWS.reset_mock()
-            await collector.start()
-
-            MockWS.assert_not_called()
+                MockWS.assert_not_called()
+            finally:
+                await collector.stop()
 
     @pytest.mark.asyncio
     async def test_stop_disconnects(self, collector):
@@ -174,6 +185,75 @@ class TestLifecycle:
     @pytest.mark.asyncio
     async def test_stop_noop_if_not_running(self, collector):
         await collector.stop()
+
+    @pytest.mark.asyncio
+    async def test_private_ws_health_resets_dead_socket_and_reconciles(self, context, on_gap):
+        disconnected_at = datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC)
+        collector = PrivateCollector(
+            context=context,
+            on_gap_detected=on_gap,
+        )
+        mock_ws = MagicMock()
+        mock_ws.is_socket_alive.return_value = False
+        mock_ws.get_connection_state.return_value = ConnectionState(
+            last_message_ts=disconnected_at,
+            is_connected=True,
+        )
+        collector._running = True
+        collector._ws_client = mock_ws
+
+        await collector._ws_health_check_once()
+
+        mock_ws.reset.assert_called_once()
+        on_gap.assert_called_once()
+        assert on_gap.call_args[0][0] == disconnected_at
+        assert on_gap.call_args[0][1] >= disconnected_at
+
+    @pytest.mark.asyncio
+    async def test_stop_waits_for_in_flight_health_reset_before_disconnect(
+        self, context, on_gap
+    ):
+        disconnected_at = datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC)
+        collector = PrivateCollector(
+            context=context,
+            on_gap_detected=on_gap,
+        )
+        reset_started = threading.Event()
+        allow_reset_finish = threading.Event()
+        events: list[str] = []
+
+        def reset() -> None:
+            events.append("reset_start")
+            reset_started.set()
+            assert allow_reset_finish.wait(timeout=1.0)
+            events.append("reset_done")
+
+        mock_ws = MagicMock()
+        mock_ws.is_socket_alive.return_value = False
+        mock_ws.get_connection_state.return_value = ConnectionState(
+            last_message_ts=disconnected_at,
+            is_connected=True,
+        )
+        mock_ws.reset.side_effect = reset
+        mock_ws.disconnect.side_effect = lambda: events.append("disconnect")
+        collector._running = True
+        collector._ws_client = mock_ws
+        collector._ws_health_stop_event = asyncio.Event()
+        collector._ws_health_task = asyncio.create_task(
+            collector._ws_health_check_once()
+        )
+
+        assert await asyncio.to_thread(reset_started.wait, 1.0)
+        stop_task = asyncio.create_task(collector.stop())
+        await asyncio.sleep(0.01)
+
+        assert stop_task.done() is False
+        assert "disconnect" not in events
+
+        allow_reset_finish.set()
+        await stop_task
+
+        assert events == ["reset_start", "reset_done", "disconnect"]
 
     def test_get_connection_state_none_without_client(self, collector):
         assert collector.get_connection_state() is None

--- a/docs/features/0037_PLAN.md
+++ b/docs/features/0037_PLAN.md
@@ -1,0 +1,103 @@
+# Feature 0037 — Recorder private WS TCP health reconciliation
+
+## Context
+
+Feature 0035 disabled the recorder-side private WebSocket message-gap
+watchdog because a healthy quiet private stream can legitimately emit no
+business messages for longer than 30 seconds. That fixed false disconnects, but
+it also made the existing private gap reconciliation path dormant: the recorder
+still wires `PrivateCollector._handle_reconnect()` to
+`Recorder._handle_private_gap()`, but no recorder-side detector now calls it.
+
+The user wants to keep PR #80 as ignored/superseded context and implement the
+same class of fix through this feature plan in a separate branch and separate
+PR.
+
+Without a replacement detector, a dead private socket can recover/reset without
+the recorder scheduling REST execution backfill, which risks missing private
+execution rows in recordings.
+
+## Relevant Files
+
+- `apps/event_saver/src/event_saver/collectors/private_collector.py`
+  - `PrivateCollector.__init__`
+  - `PrivateCollector.start`
+  - `PrivateCollector.stop`
+  - `PrivateCollector._handle_disconnect`
+  - `PrivateCollector._handle_reconnect`
+- `apps/event_saver/tests/test_private_collector.py`
+  - lifecycle tests that call `start()`
+  - new focused health-check test for dead private sockets
+- `packages/bybit_adapter/src/bybit_adapter/ws_client.py`
+  - `PrivateWebSocketClient.is_socket_alive`
+  - `PrivateWebSocketClient.reset`
+  - read-only dependency; no adapter change expected
+- `apps/recorder/src/recorder/recorder.py`
+  - `Recorder._handle_private_gap`
+  - read-only dependency; confirms the callback schedules
+    `GapReconciler.reconcile_executions()`
+- `RULES.md`
+  - update the Feature 0035 note so it no longer says the recorder has no
+    TCP-level private WS probe
+
+## Change
+
+Add a recorder-owned private WebSocket health loop to `PrivateCollector`.
+
+The loop must keep `message_gap_watchdog_enabled=False` on
+`PrivateWebSocketClient`; message silence is still normal for private streams
+and must not be used as a disconnect signal.
+
+Add a configurable health-check interval to `PrivateCollector.__init__`, with a
+module-level default of 10 seconds to match the existing gridbot TCP probe
+cadence.
+
+When `PrivateCollector.start()` successfully connects the private WebSocket, it
+creates a stop event and starts one asyncio task for the TCP health loop.
+
+When `PrivateCollector.stop()` runs, it clears `_running`, signals the stop
+event, and awaits the task before disconnecting the WebSocket client. This
+lets an idle loop wake up immediately while still allowing an in-flight reset
+running in a worker thread to finish before `disconnect()` closes the socket.
+
+## Health Algorithm
+
+1. While the collector is running, wait for either the stop event or the
+   configured TCP health interval.
+2. Read the current private WebSocket client.
+3. If the collector stopped or the client is absent, return without action.
+4. Ask the client whether the underlying socket is alive.
+5. If the socket is alive, return without action.
+6. If the socket is dead, read the connection state and choose the gap start as
+   the latest available timestamp in this order:
+   - last message timestamp
+   - disconnected timestamp
+   - current UTC time
+7. Log the disconnect through the existing private disconnect handler.
+8. Reset the WebSocket client in a worker thread so TCP teardown/reconnect does
+   not block the recorder event loop; subscriptions are recreated by the reset.
+9. Invoke the existing private reconnect handler with the chosen gap start and
+   current UTC time, preserving the existing path into recorder REST execution
+   reconciliation.
+10. Catch and log health-check exceptions so one failed probe does not kill the
+    background loop.
+
+## Tests
+
+Update lifecycle tests that call `PrivateCollector.start()` so they stop the
+collector before the test exits.
+
+Add a focused test in `apps/event_saver/tests/test_private_collector.py` that:
+
+- creates a collector with `on_gap_detected`
+- installs a mock private WebSocket client whose socket is dead
+- returns a `ConnectionState` with a known `last_message_ts`
+- awaits one health-check pass
+- asserts that the client reset was called
+- asserts that `on_gap_detected` was called with the known gap start
+
+Run:
+
+- `uv run pytest apps/event_saver/tests/test_private_collector.py packages/bybit_adapter/tests/test_ws_client.py -q`
+- `uv run pytest apps/event_saver/tests -q`
+- `uv run ruff check apps/event_saver packages/bybit_adapter`

--- a/docs/features/0037_REVIEW.md
+++ b/docs/features/0037_REVIEW.md
@@ -1,0 +1,242 @@
+# 0037 Review — Recorder private WS TCP health reconciliation (second pass)
+
+## Summary
+
+The latest commit on `feature/0037-private-ws-health-reconciliation` addresses
+the most impactful finding from the first review (**F3 — event-loop blocking
+during reset**) and adds a dedicated test for the stop-during-reset race.
+
+No blocking findings. Two non-blocking design notes from the first review
+(F1, F2) remain valid as future follow-ups; they were not in scope for this
+change and the recorder behaves correctly without them. Tests, lint, and the
+event_saver + recorder suites all pass.
+
+## What changed since the first review
+
+- `client.reset()` is now offloaded to a worker thread:
+  `await asyncio.to_thread(client.reset)` at
+  `private_collector.py:229`. The event loop no longer stalls during the
+  TCP teardown + WS handshake + 4-stream re-subscribe sequence. **F3
+  resolved.**
+- Shutdown switched from `task.cancel()` to cooperative shutdown via an
+  `asyncio.Event` (`_ws_health_stop_event`). The loop races
+  `stop_event.wait()` against the sleep interval through
+  `asyncio.wait_for(stop_event.wait(), timeout=...)`
+  (`private_collector.py:191-205`). On `stop()`, the event is set, the loop
+  observes it on the next iteration, and exits without raising
+  `CancelledError`.
+- `stop()` ordering hardened: flips `_running = False`, sets the event,
+  awaits the in-flight task to completion, then disconnects the WS client
+  (`private_collector.py:160-179`). This guarantees `reset()` (which may be
+  running in `asyncio.to_thread`) finishes before `disconnect()` runs — no
+  pybit-state corruption from interleaved teardown.
+- New test
+  `TestLifecycle.test_stop_waits_for_in_flight_health_reset_before_disconnect`
+  (`test_private_collector.py:212-256`) injects a real
+  `threading.Event` gate into the mocked `reset()` and asserts the strict
+  event order `["reset_start", "reset_done", "disconnect"]` plus that
+  `stop()` does not complete while reset is in flight.
+- Existing focused test converted to `async` to match the now-async
+  `_ws_health_check_once`
+  (`test_private_collector.py:189-210`).
+
+## Implementation vs Plan
+
+All plan items still satisfied, with the algorithm reading as follows:
+
+- `message_gap_watchdog_enabled=False` preserved → `private_collector.py:147`.
+- `ws_health_check_interval` kwarg with module default
+  `_PRIVATE_WS_HEALTH_CHECK_INTERVAL = 10.0` → `private_collector.py:18, 86,
+  97, 117`.
+- `start()` creates the `asyncio.Event`, spawns the loop task, in that order,
+  after `connect()` succeeds → `private_collector.py:150-152`.
+- `stop()` flips `_running`, signals the event, awaits the task, nulls the
+  event + task, then disconnects → `private_collector.py:164-177`.
+- Health algorithm steps 1–10 are present and async-correct
+  → `_ws_health_check_loop` and `_ws_health_check_once` at
+  `private_collector.py:191-237`.
+- Gap-start fallback chain `last_message_ts → disconnected_at → now(UTC)` →
+  `private_collector.py:218-222`.
+- `_handle_disconnect` → off-loop `reset()` → `_handle_reconnect` ordering →
+  `private_collector.py:223-230`.
+- `try / except Exception` around the whole check protects the loop →
+  `private_collector.py:231-237`.
+
+Recorder-side integration is unchanged (`Recorder._handle_private_gap` still
+schedules `reconcile_executions` per symbol via
+`asyncio.run_coroutine_threadsafe`).
+
+## Findings
+
+### Resolved
+
+- **F3 — `client.reset()` blocking the event loop. RESOLVED.** Now executed
+  via `asyncio.to_thread`. Verified by inspection and by the new
+  stop-during-reset test, which exercises a real `threading.Event` gate and
+  confirms the event loop continues to run while the worker thread is held
+  inside `reset()` (`stop_task` is created, `await asyncio.sleep(0.01)`
+  proceeds, `stop_task.done()` is `False`, and `"disconnect"` is not yet in
+  the trace).
+
+### Still open (non-blocking, deferred follow-ups)
+
+- **F1 — `gap_start` can be arbitrarily stale on a quiet account.** With the
+  message-gap watchdog disabled, `state.last_message_ts` is only refreshed
+  by business messages. If the channel is quiet for an hour and the socket
+  then dies, the gap window passed to `reconcile_executions` is an hour
+  wide. Cost is REST work, not correctness (writer is idempotent on
+  `exec_id`). Mitigation when needed: stash the last "socket alive"
+  timestamp inside the probe and use it as the lower bound.
+- **F2 — Sustained outage causes per-tick reconciliation.** If `reset()`
+  cannot restore the socket within one interval, every subsequent tick
+  re-runs `_handle_disconnect → reset → _handle_reconnect`. Each iteration
+  increments `Recorder._gap_count` (`recorder.py:854-855`) and schedules
+  one reconcile per configured symbol. Idempotent at DB level, but the
+  metric and the REST call rate inflate. Mitigation when needed: track the
+  last reconciled `gap_start` and skip when unchanged, or only call
+  `_handle_reconnect` when `is_socket_alive()` is true *after* reset.
+- **F4 — `Recorder._handle_private_gap` is now called from inside its own
+  event loop.** `asyncio.run_coroutine_threadsafe(coro, self._event_loop)`
+  works in-loop because `.result()` is never invoked on the returned
+  future, but the natural API for in-loop scheduling is
+  `asyncio.create_task` / `asyncio.ensure_future`. Cosmetic; refactor if
+  the callback ever grows a `result()` call.
+
+### New observations
+
+- **N1 — `stop()` has no timeout on the awaited task.** If `client.reset()`
+  truly hangs (e.g., pybit's `connect()` gets stuck on a half-open TCP
+  handshake without surfacing an error), `await self._ws_health_task` will
+  block forever and so will the recorder's shutdown path. Low likelihood;
+  worth knowing for SIGTERM behavior. If observed, wrap the await with
+  `asyncio.wait_for(..., timeout=...)` and fall back to canceling /
+  abandoning the task.
+- **N2 — `contextlib.suppress(asyncio.CancelledError)` in `stop()` is
+  defensive only.** The new design removed the explicit `cancel()` call, so
+  the loop should now exit cleanly via the stop event. Keeping `suppress`
+  is harmless and protects against external cancellation, but the comment
+  trail (it used to be the primary shutdown signal) is now stale.
+- **N3 — The `_ws_health_check_loop` checks `while self._running` and also
+  `if stop_event is None: return`.** Two redundant exit conditions in the
+  same loop. Not a bug, but a single source of truth (the stop event)
+  would be tidier.
+
+## Subtle points worth knowing (non-issues)
+
+- The new test bypasses `start()` and constructs the task directly with
+  `asyncio.create_task(collector._ws_health_check_once())`. This is the
+  right level for testing the interlock semantics, since `start()` would
+  immediately spawn the regular loop and create extra timing variables.
+- `_ws_health_check_once` catches `Exception`, not `BaseException`, so
+  `asyncio.CancelledError` is correctly excluded. Combined with the new
+  no-cancel shutdown, the only way the task surfaces an unexpected
+  `CancelledError` is via outside-the-collector cancellation, which the
+  `suppress` in `stop()` handles.
+- The `disconnected_at` fallback chain still produces a "best-effort"
+  timestamp; `now(UTC)` is only reached if both `last_message_ts` and
+  `disconnected_at` are `None`, which only happens if the socket dies
+  immediately after connect with no prior detected disconnect.
+- Logging style remains mixed (`_handle_*` use f-strings; the new probe uses
+  lazy `%s`). Cosmetic.
+
+## Test Review
+
+### New / updated tests
+
+- `test_private_ws_health_resets_dead_socket_and_reconciles`
+  (`test_private_collector.py:189-210`) — now async; awaits
+  `collector._ws_health_check_once()`. Asserts `reset` called once and
+  `on_gap_detected` called with `gap_start == last_message_ts` and
+  `gap_end ≥ gap_start`.
+- `test_stop_waits_for_in_flight_health_reset_before_disconnect`
+  (`test_private_collector.py:212-256`) — new. Uses two `threading.Event`s
+  to gate `reset()` start/finish. Asserts that while `reset()` is blocked
+  in the worker thread:
+  - `stop()` does not return,
+  - `disconnect()` has not been called,
+  - the event loop is still responsive (the test's own `await
+    asyncio.sleep(0.01)` resolves),
+  and that after releasing the gate the order is
+  `["reset_start", "reset_done", "disconnect"]`.
+
+This second test is the most valuable addition: it directly exercises the
+F3/N1 boundary (loop responsiveness during reset) and the stop-ordering
+invariant.
+
+### Coverage gaps still open (not blocking)
+
+- Alive-socket short-circuit: `is_socket_alive() → True` should produce no
+  `reset`, no `on_gap_detected`. Trivial async test.
+- Fallback chain: `last_message_ts=None` → `disconnected_at`; both `None` →
+  `datetime.now(UTC)`. Currently only the `last_message_ts` branch is
+  pinned.
+- Exception isolation: have `is_socket_alive` or `reset` raise; assert the
+  task does not propagate and a subsequent call still works.
+- Loop integration: set `ws_health_check_interval=0.01`, run one or two
+  ticks, then `stop()` — verifies the wait_for/timeout path *and* the
+  stop-event exit path end-to-end.
+
+### Placement
+
+The two probe tests sit inside `TestLifecycle` but are about the health
+check, not the start/stop API. A `TestHealthCheck` class (consistent with
+the file's behavior-grouped layout) would make the file easier to navigate.
+Cosmetic.
+
+## Data alignment
+
+- `ConnectionState` field names (`last_message_ts`, `disconnected_at`)
+  match the dataclass at `ws_client.py:34-51`. No camelCase confusion.
+- `_handle_reconnect(disconnected_at, reconnected_at)` argument order
+  matches `Recorder._handle_private_gap(gap_start, gap_end)`
+  (`recorder.py:849-851`).
+- `asyncio.to_thread(client.reset)` passes the bound method; no positional
+  arguments needed — `reset()` takes none.
+
+## Over-engineering / file size
+
+None. Net change vs the previous round adds ~10 lines (the `Event`, the
+`wait_for`/timeout pattern, the `to_thread` call) plus one focused
+asyncio test. No new abstractions or files beyond PLAN / REVIEW.
+
+## Verification
+
+```
+uv run pytest apps/event_saver/tests/test_private_collector.py packages/bybit_adapter/tests/test_ws_client.py -q
+# 68 passed in 4.77s
+
+uv run pytest apps/event_saver/tests -q
+# 151 passed in 1.90s
+
+uv run pytest apps/recorder/tests -q
+# 76 passed, 2 skipped in 0.82s
+
+uv run ruff check apps/event_saver/src/event_saver/collectors/private_collector.py apps/event_saver/tests/test_private_collector.py
+# All checks passed!
+```
+
+`uv run ruff check apps/event_saver packages/bybit_adapter` still surfaces
+7 unrelated pre-existing F401 warnings in `test_rate_limiter.py`,
+`test_rest_client.py`, etc. — not introduced by this branch.
+
+## Branch hygiene
+
+- Branch: `feature/0037-private-ws-health-reconciliation`, one commit
+  (`6ea3aa4 Add recorder private WS health reconciliation`).
+- `git status` still shows uncommitted changes to:
+  - `apps/replay/conf/replay_ltcusdt_phase4.yaml`
+  - `apps/replay/src/replay/engine.py`
+  These are unrelated to 0037 and must not be included in the PR. Stash,
+  revert, or commit on a separate branch.
+- PR #80 (`cursor/critical-bug-inspection-0c30`) remains intentionally
+  superseded by this branch per `0037_PLAN.md` Context. Close it after
+  merge.
+
+## Recommendation
+
+Ship. The F3 fix removes the only "likely to surprise in production"
+behavior. F1, F2, and N1 are bounded risks worth tracking as follow-ups
+but do not block merging this PR; the recorder's REST reconciliation is
+idempotent and the event loop is no longer stalled by reset. The new
+stop-during-reset test is a strong correctness guarantee for the shutdown
+path.


### PR DESCRIPTION
## Summary
- Add a recorder-owned private WebSocket TCP health probe in `PrivateCollector` that resets dead sockets and routes the resulting gap window into the existing `Recorder._handle_private_gap` → `GapReconciler.reconcile_executions()` path
- Keep `message_gap_watchdog_enabled=False` (Feature 0035 stays intact); use `asyncio.to_thread(client.reset)` so the reset never blocks the event loop, and use a cooperative `asyncio.Event` for graceful shutdown that waits for an in-flight reset before disconnecting
- Supersedes PR #80 per `docs/features/0037_PLAN.md` Context

## Why
Feature 0035 disabled the private message-gap watchdog to stop false-positive disconnects on quiet streams, which silently disabled the only path into private REST execution backfill. Without a replacement detector, a dead private socket can recover (or fail to recover) without scheduling reconciliation, risking missing execution rows in recordings.

## Implementation notes
- `_ws_health_check_loop` races a sleep against `_ws_health_stop_event` via `asyncio.wait_for`; the loop exits cleanly on stop without raising `CancelledError`.
- `_ws_health_check_once` is async, snapshots the client, returns early if the socket is alive, otherwise picks `gap_start` from `last_message_ts → disconnected_at → now(UTC)`, logs the disconnect, runs `await asyncio.to_thread(client.reset)`, then fires `_handle_reconnect`.
- `stop()` flips `_running`, sets the stop event, awaits the task to completion (so an in-flight reset finishes before `disconnect()`), then disconnects.
- RULES.md note for Feature 0035 rewritten to reflect the new TCP probe and the "do not remove both detectors" invariant.

## Review
See `docs/features/0037_REVIEW.md` for the full plan-vs-implementation audit, open follow-ups (F1 — stale `gap_start` on quiet accounts, F2 — per-tick reconciliation during sustained outage, N1 — no timeout on stop's awaited task), and verification output.

## Test plan
- [x] `uv run pytest apps/event_saver/tests/test_private_collector.py packages/bybit_adapter/tests/test_ws_client.py -q` → 68 passed
- [x] `uv run pytest apps/event_saver/tests -q` → 151 passed
- [x] `uv run pytest apps/recorder/tests -q` → 76 passed, 2 skipped
- [x] `uv run ruff check apps/event_saver/src/event_saver/collectors/private_collector.py apps/event_saver/tests/test_private_collector.py` → clean
- [ ] Manual: deploy recorder, force a private WS outage, confirm `Private WebSocket socket dead ... resetting` log and a subsequent `reconcile_executions` REST call window

🤖 Generated with [Claude Code](https://claude.com/claude-code)