### PR TITLE
fix(0038): keep position pairing inside session to avoid DetachedInstanceError

### DIFF
--- a/apps/comparator/src/comparator/main.py
+++ b/apps/comparator/src/comparator/main.py
@@ -263,6 +263,11 @@ def run(
     from comparator.position_loader import load_position_snapshots
     from comparator.position_metrics import PositionComparator
 
+    # 0038: pairing and telemetry fold must run INSIDE the session so
+    # attribute access happens while rows are still attached;
+    # `expunge_all()` then detaches the rows so commit()'s expiration
+    # sweep on __exit__ leaves them readable for ComparatorReporter's
+    # CSV export below.
     with db.get_session() as session:
         live_snaps = load_position_snapshots(
             session,
@@ -281,16 +286,17 @@ def run(
             end_ts=config.end_ts,
         )
 
-    if live_snaps and bt_snaps:
-        pc = PositionComparator()
-        position_pairs = pc.pair_and_compare(live_snaps, bt_snaps)
-        pc.fold_metrics_into(metrics, position_pairs)
-    else:
-        position_pairs = []
-        logger.info(
-            "Position comparison skipped: live_snaps=%d, bt_snaps=%d",
-            len(live_snaps), len(bt_snaps),
-        )
+        if live_snaps and bt_snaps:
+            pc = PositionComparator()
+            position_pairs = pc.pair_and_compare(live_snaps, bt_snaps)
+            pc.fold_metrics_into(metrics, position_pairs)
+        else:
+            position_pairs = []
+            logger.info(
+                "Position comparison skipped: live_snaps=%d, bt_snaps=%d",
+                len(live_snaps), len(bt_snaps),
+            )
+        session.expunge_all()
 
     # Report (equity data and position pairs passed to reporter for export_all)
     reporter = ComparatorReporter(

--- a/apps/comparator/tests/test_main.py
+++ b/apps/comparator/tests/test_main.py
@@ -16,6 +16,7 @@ from grid_db import (
     Run,
     WalletSnapshot,
 )
+from grid_db.models import PositionSnapshot
 
 from gridcore.position import DirectionType, SideType
 
@@ -609,3 +610,79 @@ class TestRun:
             rows = {r["metric"]: r["value"] for r in csv_mod.DictReader(f)}
         # ETH trade filtered out, so no phantom backtest-only count from it
         assert rows["backtest_only_count"] == "0"
+
+    def test_run_position_telemetry_survives_session_close(self, db, tmp_path):
+        """Regression for feature 0038: pairing must not raise after session close.
+
+        Before the fix, `comparator.main.run` loaded `PositionSnapshot` ORM
+        rows inside a `with db.get_session()` block but called
+        `PositionComparator.pair_and_compare` AFTER the block exited.
+        SQLAlchemy's exit-time commit() expired every attribute on the
+        loaded rows; the first attribute read raised
+        `DetachedInstanceError` and propagated out of `run(...)` because
+        `run()` does not catch exceptions itself.
+
+        The CSV `position_comparison.csv` must be written with at least
+        one data row. Either failure mode (raised exception OR missing
+        CSV) catches the regression.
+        """
+        ts = self._seed_live_data(db)
+        ts_naive = ts.replace(tzinfo=None)
+
+        # Seed matching live/backtest position snapshots
+        with db.get_session() as session:
+            session.add(PositionSnapshot(
+                run_id="run_1", account_id="acc1", symbol="BTCUSDT",
+                exchange_ts=ts_naive, local_ts=ts_naive,
+                side="Buy", size=Decimal("0.001"),
+                entry_price=Decimal("100000"),
+                liq_price=Decimal("0"), unrealised_pnl=Decimal("0"),
+                source="live",
+                mark_price=Decimal("100000"),
+                position_im=Decimal("0"), position_mm=Decimal("0"),
+                cum_realised_pnl=Decimal("0"),
+            ))
+            session.add(PositionSnapshot(
+                run_id="run_1", account_id="acc1", symbol="BTCUSDT",
+                exchange_ts=ts_naive, local_ts=ts_naive,
+                side="Buy", size=Decimal("0.001"),
+                entry_price=Decimal("100000"),
+                liq_price=Decimal("0"), unrealised_pnl=Decimal("0"),
+                source="backtest",
+                mark_price=Decimal("100000"),
+                position_im=Decimal("0"), position_mm=Decimal("0"),
+                cum_realised_pnl=Decimal("0"),
+            ))
+
+        config = ComparatorConfig(
+            run_id="run_1",
+            database_url="sqlite:///:memory:",
+            start_ts=ts_naive - timedelta(hours=1),
+            end_ts=ts_naive + timedelta(hours=2),
+            symbol="BTCUSDT",
+            output_dir=str(tmp_path),
+        )
+        bt_trades = [
+            NormalizedTrade(
+                client_order_id="order_a", symbol="BTCUSDT", side=SideType.BUY,
+                price=Decimal("100000"), qty=Decimal("0.001"),
+                fee=Decimal("0.02"), realized_pnl=Decimal("0"),
+                timestamp=ts_naive, source="backtest", direction=DirectionType.LONG,
+            ),
+        ]
+
+        with patch("comparator.main.DatabaseFactory", return_value=db):
+            # If the regression returns, this raises DetachedInstanceError
+            # — `run()` does not catch exceptions itself.
+            result = run(config, bt_trades)
+
+        assert result == 0
+        position_csv = tmp_path / "position_comparison.csv"
+        assert position_csv.exists()
+        # At least one data row beyond the header.
+        with open(position_csv) as f:
+            lines = f.readlines()
+        assert len(lines) >= 2, (
+            f"position_comparison.csv has {len(lines)} lines; expected ≥2 "
+            "(header + at least one pair)."
+        )

--- a/apps/replay/src/replay/engine.py
+++ b/apps/replay/src/replay/engine.py
@@ -349,7 +349,12 @@ class ReplayEngine:
         )
 
         # 11. 0034: pair live/backtest position snapshots and fold telemetry
-        # parity metrics into the same ValidationMetrics object.
+        # parity metrics into the same ValidationMetrics object. 0038:
+        # pairing and telemetry fold must run INSIDE the session so attribute
+        # access (`.side`, `.exchange_ts`, telemetry columns) happens while
+        # rows are still attached; `expunge_all()` then detaches the rows so
+        # `commit()`'s expiration sweep on __exit__ leaves them readable for
+        # downstream consumers (ComparatorReporter CSV export).
         position_pairs: list = []
         with self._db.get_session() as db_session:
             live_snaps = load_position_snapshot_rows(
@@ -368,21 +373,22 @@ class ReplayEngine:
                 start_ts=start_ts,
                 end_ts=end_ts,
             )
-        if live_snaps and bt_snaps:
-            pc = PositionComparator()
-            position_pairs = pc.pair_and_compare(live_snaps, bt_snaps)
-            pc.fold_metrics_into(metrics, position_pairs)
-            logger.info(
-                "Position telemetry: %d pairs compared, %d unmatched bt, %d missing telemetry",
-                metrics.position_pairs_compared,
-                metrics.position_pairs_unmatched_bt,
-                metrics.position_pairs_missing_telemetry,
-            )
-        else:
-            logger.info(
-                "Position telemetry: skipped (live_snaps=%d, bt_snaps=%d)",
-                len(live_snaps), len(bt_snaps),
-            )
+            if live_snaps and bt_snaps:
+                pc = PositionComparator()
+                position_pairs = pc.pair_and_compare(live_snaps, bt_snaps)
+                pc.fold_metrics_into(metrics, position_pairs)
+                logger.info(
+                    "Position telemetry: %d pairs compared, %d unmatched bt, %d missing telemetry",
+                    metrics.position_pairs_compared,
+                    metrics.position_pairs_unmatched_bt,
+                    metrics.position_pairs_missing_telemetry,
+                )
+            else:
+                logger.info(
+                    "Position telemetry: skipped (live_snaps=%d, bt_snaps=%d)",
+                    len(live_snaps), len(bt_snaps),
+                )
+            db_session.expunge_all()
 
         return ReplayResult(
             session=session,

--- a/apps/replay/tests/test_engine.py
+++ b/apps/replay/tests/test_engine.py
@@ -8,6 +8,7 @@ import pytest
 
 from gridcore import TickerEvent, EventType
 from grid_db import Run, User, BybitAccount, Strategy
+from grid_db.models import PositionSnapshot
 
 from backtest.data_provider import InMemoryDataProvider
 from backtest.fill_simulator import FillMode
@@ -476,3 +477,88 @@ class TestPositionTelemetryWriter0034:
                 strategy_config, session,
                 run_id="test-run-id", account_id=None,
             )
+
+
+class TestPositionPairsSurviveSessionClose:
+    """Regression for feature 0038: DetachedInstanceError in position pairing.
+
+    Before the fix, `ReplayEngine.run` loaded `PositionSnapshot` ORM rows
+    inside a `with db.get_session()` block but called
+    `PositionComparator.pair_and_compare` (and the downstream attribute
+    reads) AFTER the block exited. The session manager's exit-time
+    `commit()` expired every attribute on the loaded instances; the next
+    attribute read raised `DetachedInstanceError`.
+    """
+
+    @patch("replay.engine.InstrumentInfoProvider")
+    def test_position_pairs_accessible_after_run(
+        self, mock_provider_cls, db, seeded_run_account, replay_config, ticker_events,
+    ):
+        """Column attributes on returned pairs must remain readable.
+
+        Seeds one live/backtest pair at matching exchange_ts so step 11
+        produces a non-empty `result.position_pairs`. Asserting any column
+        attribute access on the pair (`.live.side`, `.backtest.entry_price`)
+        is sufficient — the regression is a thrown `DetachedInstanceError`,
+        not a wrong value.
+        """
+        mock_info = MagicMock()
+        mock_info.qty_step = Decimal("0.001")
+        mock_info.tick_size = Decimal("0.1")
+        mock_info.round_qty = lambda q: max(Decimal("0.001"), q.quantize(Decimal("0.001")))
+        mock_provider_cls.return_value.get.return_value = mock_info
+
+        snap_ts = replay_config.start_ts + timedelta(minutes=1)
+        with db.get_session() as session:
+            session.add(PositionSnapshot(
+                run_id="test-run-id",
+                account_id=seeded_run_account.account_id,
+                symbol="BTCUSDT",
+                exchange_ts=snap_ts,
+                local_ts=snap_ts,
+                side="Buy",
+                size=Decimal("0.001"),
+                entry_price=Decimal("100000"),
+                liq_price=Decimal("0"),
+                unrealised_pnl=Decimal("0"),
+                source="live",
+                mark_price=Decimal("100000"),
+                position_im=Decimal("0"),
+                position_mm=Decimal("0"),
+                cum_realised_pnl=Decimal("0"),
+            ))
+            session.add(PositionSnapshot(
+                run_id="test-run-id",
+                account_id=seeded_run_account.account_id,
+                symbol="BTCUSDT",
+                exchange_ts=snap_ts,
+                local_ts=snap_ts,
+                side="Buy",
+                size=Decimal("0.001"),
+                entry_price=Decimal("100000"),
+                liq_price=Decimal("0"),
+                unrealised_pnl=Decimal("0"),
+                source="backtest",
+                mark_price=Decimal("100000"),
+                position_im=Decimal("0"),
+                position_mm=Decimal("0"),
+                cum_realised_pnl=Decimal("0"),
+            ))
+            session.commit()
+
+        engine = ReplayEngine(config=replay_config, db=db)
+        provider = InMemoryDataProvider(ticker_events)
+
+        result = engine.run(data_provider=provider)
+
+        assert len(result.position_pairs) > 0, (
+            "Seeded a matching live/backtest pair; expected pair_and_compare "
+            "to produce at least one pair."
+        )
+        pair = result.position_pairs[0]
+        # If the regression returns, these attribute reads raise
+        # sqlalchemy.orm.exc.DetachedInstanceError before reaching the assert.
+        assert pair.live.side == "Buy"
+        assert pair.backtest.side == "Buy"
+        assert pair.live.entry_price == Decimal("100000")
+        assert pair.backtest.entry_price == Decimal("100000")

--- a/docs/features/0038_PLAN.md
+++ b/docs/features/0038_PLAN.md
@@ -1,0 +1,160 @@
+# Feature 0038 — Fix `DetachedInstanceError` in position pairing
+
+## Context
+
+Feature 0034 introduced a step in both the replay engine and the
+standalone comparator CLI that pairs live and backtest `PositionSnapshot`
+ORM rows and folds parity telemetry into the run's `ValidationMetrics`.
+In both call sites, the two snapshot lists are loaded inside a
+`with db.get_session() as session:` block, but the pairing call
+(`PositionComparator.pair_and_compare`) and the subsequent
+`fold_metrics_into` run **outside** that block.
+
+`load_position_snapshots` returns SQLAlchemy ORM instances. When the
+`with` block exits, the session manager commits and closes; SQLAlchemy's
+default `expire_on_commit=True` marks every ORM attribute on those rows
+as expired before close. The first attribute read after exit
+(`.side`, `.exchange_ts`, telemetry columns inside the comparator) tries
+to refresh from a now-closed session and raises
+`sqlalchemy.orm.exc.DetachedInstanceError`, aborting the run before the
+report stage.
+
+Downstream, `ComparatorReporter` (constructed in
+`apps/replay/src/replay/main.py:169-173` for replay and in
+`apps/comparator/src/comparator/main.py:294-298` for the comparator CLI)
+writes a CSV that also touches column attrs on those instances, so the
+pairs must remain readable after the loader's session is gone.
+
+## Relevant Files
+
+- `apps/replay/src/replay/engine.py`
+  - `ReplayEngine.run` — step 11 "0034: pair live/backtest position
+    snapshots and fold telemetry parity metrics", around lines 349-394.
+  - The pre-existing `with self._db.get_session() as db_session:` block
+    that wraps both `load_position_snapshots(...)` calls.
+  - `ReplayResult.position_pairs` (dataclass field, line 147) — return
+    path that must hold the comparator output for `ComparatorReporter`.
+- `apps/comparator/src/comparator/main.py`
+  - `run(...)` — position telemetry block around lines 263-290.
+  - The pre-existing `with db.get_session() as session:` block that
+    wraps both `load_position_snapshots(...)` calls.
+  - The local `position_pairs` variable consumed by
+    `ComparatorReporter(...)` at lines 294-298.
+- `apps/replay/src/replay/main.py`
+  - `ComparatorReporter` construction at lines 169-173 — read-only
+    dependency; confirms callers continue to access column attrs on
+    `result.position_pairs` after `ReplayEngine.run` returns.
+- `comparator/position_metrics.py`
+  - `PositionComparator.pair_and_compare`,
+    `PositionComparator.fold_metrics_into` — read-only dependency. The
+    attributes they touch (`side`, `exchange_ts`, telemetry columns)
+    are the ones that get expired-then-detached.
+- `apps/replay/tests/test_engine.py`
+  - Existing in-memory SQLite fixture pattern (`database_url="sqlite:///:memory:"`,
+    used at lines 59, 168, 193, 208, 250, 302) — the regression test
+    described in the Tests section attaches here.
+
+No schema changes. No new files.
+
+## Change
+
+Apply the same shape of fix to both call sites:
+
+1. Keep the existing two `load_position_snapshots(...)` calls inside the
+   `with` block, unchanged.
+2. Move the `if live_snaps and bt_snaps: ... else: ...` branch (the
+   `PositionComparator()` construction, `pair_and_compare`,
+   `fold_metrics_into`, and the `logger.info` calls) **into** the same
+   `with` block, so every comparator attribute access happens while the
+   session is still open.
+3. As the last statement inside the `with` block, call
+   `session.expunge_all()`. This detaches all loaded instances from the
+   session **before** the manager's exit-time `commit()` runs, so the
+   expiration step skips them and the rows keep the column values that
+   `pair_and_compare` already materialized. After this point, no
+   downstream code (here or in `ComparatorReporter`) may trigger a fresh
+   lazy-load — `pair_and_compare` has already pulled everything it
+   needs into the `position_pairs` payload.
+4. In `ReplayEngine.run`, the outer scope retains the
+   `position_pairs: list = []` initializer and the return-time wiring
+   into `ReplayResult` exactly as today. In `comparator/main.py`, the
+   outer scope retains the `position_pairs = []` else-branch initializer
+   exactly as today, but moved inside the `with` for consistency with
+   the engine fix.
+
+## Failure Algorithm (for future regression awareness)
+
+The original failure path, present in both `ReplayEngine.run` and
+`comparator.main.run`:
+
+1. `with db.get_session() as session:` opens a session.
+2. `load_position_snapshots(...)` returns ORM rows attached to that
+   session, with column attributes populated.
+3. `with` exits: `__exit__` runs `session.commit()` (default
+   `expire_on_commit=True` marks every attribute on every tracked
+   instance as expired), then `session.close()`.
+4. Outside the block, `pair_and_compare(live_snaps, bt_snaps)` reads an
+   attribute on one of the rows.
+5. SQLAlchemy sees the attribute is expired, attempts to refresh from
+   the session, finds it closed, raises `DetachedInstanceError`.
+
+The fix breaks the path at step 3 by calling `expunge_all()` just
+**before** `__exit__` runs `commit()`. Detached instances are not in the
+session's identity map, so `commit()`'s expiration sweep does not touch
+them; their column values remain readable indefinitely.
+
+## Out of Scope
+
+- `apps/replay/conf/replay_ltcusdt_phase4.yaml` (new `run_id`,
+  `start_ts`/`end_ts`, `output_dir`) is a separate working-tree change.
+  It is unrelated to the bug fix and will be committed separately as a
+  chore.
+- Any change to `comparator.position_metrics.PositionComparator` itself,
+  to `comparator.position_loader.load_position_snapshots`, or to the
+  `PositionSnapshot` ORM model. Eager-loading at load time, or setting
+  `expire_on_commit=False` globally on the session factory, would also
+  fix the bug but each touches a broader surface and is not justified
+  for a localized session-scope mistake.
+
+## Tests
+
+Add one regression test under `apps/replay/tests/test_engine.py` (using
+the existing `sqlite:///:memory:` fixture pattern from lines 59-302):
+
+- Seed two `PositionSnapshot` rows for the same `run_id` and `symbol`,
+  one with `source="live"` and one with `source="backtest"`, at matching
+  `exchange_ts`.
+- Drive `ReplayEngine.run` end-to-end with the minimum config needed for
+  step 11 to fire.
+- After `run()` returns, access at least one column attribute on the
+  first element of `result.position_pairs` (e.g. `.live.side` or
+  whichever shape `pair_and_compare` returns). Asserting non-raising
+  attribute access is sufficient — the regression is a thrown
+  `DetachedInstanceError`, not a wrong value.
+
+A second, smaller test under `apps/comparator/tests/test_main.py` (or
+the nearest existing test of `comparator.main.run`) covers the
+comparator CLI path. Because `comparator.main.run` consumes
+`position_pairs` locally and hands it directly to `ComparatorReporter`
+without returning it, the assertion shape is different: invoke
+`run(...)` end-to-end against an in-memory DB seeded with one
+`live` / `backtest` snapshot pair, then assert that
+`position_comparison.csv` was written under the configured output
+directory with at least one data row. `comparator.main.run` does not
+catch exceptions itself — only the `main(...)` wrapper at line 310
+does — so a `DetachedInstanceError` during `pair_and_compare` or
+during the reporter's CSV export will propagate out of `run(...)` and
+fail the test before the CSV assertion runs. Either failure mode
+catches the regression. The in-memory SQLite fixture from
+`apps/comparator/tests/conftest.py` (if present) or a fresh
+`DatabaseFactory(sqlite:///:memory:)` is sufficient — no Phase 4
+recorder DB needed.
+
+Both tests guard against this specific regression and against a future
+`expire_on_commit` change that re-introduces it.
+
+Manual verification (still required because the test fixtures cannot
+exercise the full CSV export path): run the existing replay invocation
+against `apps/replay/conf/replay_ltcusdt_phase4.yaml`, confirm the run
+completes through step 11 without `DetachedInstanceError`, and that the
+CSV output by `ComparatorReporter` is non-empty.

--- a/docs/features/0038_REVIEW.md
+++ b/docs/features/0038_REVIEW.md
@@ -1,0 +1,62 @@
+# Feature 0038 Review - Fix `DetachedInstanceError` in position pairing
+
+## Summary
+
+No blocking issues found.
+
+The implementation matches the plan:
+
+- `ReplayEngine.run` now performs `PositionComparator.pair_and_compare(...)`
+  and `fold_metrics_into(...)` inside the same database session that loaded the
+  `PositionSnapshot` ORM rows.
+- `comparator.main.run` applies the same session-scope fix.
+- Both call sites call `expunge_all()` before the context manager exits, so the
+  rows are detached before SQLAlchemy's exit-time `commit()` can expire loaded
+  attributes.
+- The paired snapshot rows remain available to downstream CSV export through
+  `ComparatorReporter`.
+
+## Findings
+
+None.
+
+## Test Review
+
+The added regression coverage is appropriate for the bug:
+
+- `apps/replay/tests/test_engine.py::TestPositionPairsSurviveSessionClose::test_position_pairs_accessible_after_run`
+  seeds matching live/backtest `PositionSnapshot` rows, runs the replay engine,
+  and verifies returned pair attributes are readable after `ReplayEngine.run`
+  returns.
+- `apps/comparator/tests/test_main.py::TestRun::test_run_position_telemetry_survives_session_close`
+  seeds matching snapshots, runs the comparator path, and verifies
+  `position_comparison.csv` is written with data rows.
+
+The tests follow existing in-memory SQLite patterns and are isolated from
+external services. They cover the failure mode from the plan: ORM column
+attribute access after the loader session has closed.
+
+## Verification
+
+Commands run:
+
+```bash
+uv run pytest -q apps/replay/tests/test_engine.py::TestPositionPairsSurviveSessionClose::test_position_pairs_accessible_after_run
+uv run pytest -q apps/comparator/tests/test_main.py::TestRun::test_run_position_telemetry_survives_session_close
+uv run pytest -q apps/comparator/tests/test_main.py apps/comparator/tests/test_reporter.py apps/comparator/tests/test_position_metrics.py apps/comparator/tests/test_loader.py
+uv run pytest -q apps/replay/tests/test_engine.py
+uv run ruff check apps/replay/src/replay/engine.py apps/replay/tests/test_engine.py apps/comparator/src/comparator/main.py apps/comparator/tests/test_main.py
+```
+
+Results:
+
+- Targeted regression tests: passed.
+- Comparator relevant test suite: `86 passed`.
+- Replay engine test suite: `14 passed`.
+- Ruff: passed.
+
+## Residual Notes
+
+The manual replay invocation mentioned in the plan was not run during this
+review. The automated regression coverage exercises the ORM expiration failure
+path and the comparator CSV export path, but not the full Phase 4 replay config.


### PR DESCRIPTION
## Summary
- `ReplayEngine.run` and `comparator.main.run` loaded `PositionSnapshot` ORM rows inside a `with db.get_session()` block but ran `PositionComparator.pair_and_compare` after the block exited; SQLAlchemy's exit-time `commit()` expired every attribute and the next read raised `DetachedInstanceError`, aborting before report stage.
- Moved `pair_and_compare` + `fold_metrics_into` inside the same `with` block and call `session.expunge_all()` before exit, so the expiration sweep skips the loaded rows and `ComparatorReporter` CSV export still has readable column values.
- Added regression tests at both call sites (verified RED → GREEN against the original `DetachedInstanceError`).

## Test plan
- [x] `apps/replay/tests/test_engine.py::TestPositionPairsSurviveSessionClose` — 14/14 replay tests pass
- [x] `apps/comparator/tests/test_main.py::TestRun::test_run_position_telemetry_survives_session_close` — 26/26 comparator main tests pass; full comparator suite 135/135 pass
- [ ] Manual replay against `apps/replay/conf/replay_ltcusdt_phase4.yaml` — run completes through step 11 without `DetachedInstanceError` and `position_comparison.csv` non-empty (separate working-tree chore commit holds the Phase 4 yaml refresh)

🤖 Generated with [Claude Code](https://claude.com/claude-code)