### PR TITLE
fix: bidirectional window in position pairing

### DIFF
--- a/apps/comparator/src/comparator/position_metrics.py
+++ b/apps/comparator/src/comparator/position_metrics.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from datetime import timedelta
 from decimal import Decimal
 from typing import Optional
 
@@ -128,11 +129,11 @@ class PositionComparator:
         live_snapshots: list[PositionSnapshot],
         bt_snapshots: list[PositionSnapshot],
     ) -> list[PositionComparisonPair]:
-        """Pair backtest snapshots with the next live snapshot within tolerance.
+        """Pair backtest snapshots with the first live snapshot within tolerance.
 
         Per-side monotonic two-pointer with explicit consume step: each
         live row is claimed by at most one backtest row. Bt rows that
-        do not find a live row within ``pair_tolerance_s`` increment
+        do not find a live row within ``+/-pair_tolerance_s`` increment
         ``position_pairs_unmatched_bt`` (counted by ``fold_metrics_into``).
         """
         pairs: list[PositionComparisonPair] = []
@@ -149,21 +150,24 @@ class PositionComparator:
     ) -> list[PositionComparisonPair]:
         out: list[PositionComparisonPair] = []
         live_idx = 0
+        tolerance = timedelta(seconds=self._tolerance_s)
         for bt_row in bt:
             bt_ts = bt_row.exchange_ts
-            # Advance live_idx to the first live row with ts >= bt_ts.
-            while live_idx < len(live) and live[live_idx].exchange_ts < bt_ts:
+            lower_bound = bt_ts - tolerance
+            upper_bound = bt_ts + tolerance
+
+            # Drop stale live rows that cannot match this or any future bt row.
+            while live_idx < len(live) and live[live_idx].exchange_ts < lower_bound:
                 live_idx += 1
             if live_idx >= len(live):
-                # No future live row to claim — bt unmatched.
+                # No unclaimed live row remains — bt unmatched.
                 out.append(_unmatched_bt_marker(bt_row))
                 continue
+
             live_row = live[live_idx]
-            gap = (live_row.exchange_ts - bt_ts).total_seconds()
-            if gap > self._tolerance_s:
-                # Within tolerance check failed; bt unmatched. Do NOT
-                # advance live_idx — the next bt row may legitimately
-                # claim this live row.
+            if live_row.exchange_ts > upper_bound:
+                # No live row inside the bidirectional tolerance window. Do
+                # not advance live_idx; the next bt row may claim this live row.
                 out.append(_unmatched_bt_marker(bt_row))
                 continue
             out.append(_build_pair(live_row, bt_row))

--- a/apps/comparator/tests/test_position_metrics.py
+++ b/apps/comparator/tests/test_position_metrics.py
@@ -66,6 +66,24 @@ def test_pair_within_tolerance(base_ts):
     assert pairs[0].backtest is bt[0]
 
 
+def test_pair_live_before_backtest_within_tolerance(base_ts):
+    """Live may arrive before replay's simulated fill time and still pair."""
+    bt_ts = base_ts.replace(hour=12, minute=30, second=26, microsecond=112000)
+    live_ts = base_ts.replace(hour=12, minute=30, second=26, microsecond=73000)
+    live = [_snap("Buy", live_ts, source="live")]
+    bt = [_snap("Buy", bt_ts, source="backtest")]
+
+    pairs = PositionComparator().pair_and_compare(live, bt)
+
+    metrics = ValidationMetrics()
+    PositionComparator().fold_metrics_into(metrics, pairs)
+    assert len(pairs) == 1
+    assert pairs[0].live is live[0]
+    assert pairs[0].backtest is bt[0]
+    assert metrics.position_pairs_compared == 1
+    assert metrics.position_pairs_unmatched_bt == 0
+
+
 def test_pair_outside_tolerance_unmatched(base_ts):
     """Bt with no live in tolerance window counts as unmatched, no consume."""
     live = [_snap("Buy", base_ts + timedelta(seconds=PAIR_TOLERANCE_S + 5), source="live")]


### PR DESCRIPTION
## Summary
- Fixes pairing flaw where `_pair_side` only matched `live_ts >= bt_ts`, dropping live rows that arrived even slightly before the replay-simulated bt timestamp.
- Real-world impact: live @ 12:30:26.073 vs bt @ 12:30:26.112 (39ms earlier) → next candidate was 2 min away → all 50 bt rows in unmatched.
- Replaces forward-only window with bidirectional `|live_ts - bt_ts| <= pair_tolerance_s`, preserving the monotonic two-pointer and one-to-one consume invariant.

## Algorithm Notes
- Lives more than tolerance BEFORE bt are dropped as stale (no future bt can claim them either, since bts are monotonic).
- Lives more than tolerance AFTER bt leave `live_idx` in place so a later bt may still pair with them.
- Complexity stays O(n+m).

## Test plan
- [x] Added `test_pair_live_before_backtest_within_tolerance` — fails on old algorithm, passes on new.
- [x] All 12 existing tests in `test_position_metrics.py` still pass.
- [ ] Re-run comparator against the session that originally produced 50 unmatched bt rows; expect non-zero `position_pairs_compared`.

## Follow-ups (non-blocking, from review)
- Add tests for stale-live-drop branch (`live < lower_bound`), stale-then-fresh pairing, and consecutive-bt-with-earlier-lives consume invariant.
- Tighten docstring wording on the new bidirectional window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)