### PR TITLE
fix(0039): bound private WS reset/disconnect to keep recorder shutdown responsive

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -757,6 +757,16 @@ See `docs/features/0003_LOW_PRIORITY_CLEANUP.md` for detailed documentation.
 - **Invariant**: Do not remove both private disconnect detectors. Message silence is not a private-stream failure signal, but the recorder still needs TCP-level liveness checks so real private WS outages do not silently skip execution backfill.
 - File: `apps/event_saver/src/event_saver/collectors/private_collector.py`
 
+**Feature 0039 — bound private WS reset/disconnect with daemon thread + wait_for**:
+- **Why not `asyncio.to_thread` for pybit reset/disconnect**: the default `ThreadPoolExecutor` is joined by `concurrent.futures.thread._python_exit` at interpreter shutdown. A parked pybit call would block interpreter exit, moving the hang from `stop()` to `atexit` where it is also non-responsive to SIGTERM.
+- **Pattern**: wrap any potentially-hanging blocking call from a recorder collector path in `_run_in_daemon_thread(fn)` (a daemon `threading.Thread` bridged to the loop via `loop.create_future()` + `call_soon_threadsafe`) and bound it with `asyncio.wait_for(...)`. The daemon flag is load-bearing — daemon threads are not joined at interpreter exit.
+- **Cancellation safety**: the completer must guard on `fut.done()` before `set_result` / `set_exception` (so a late-returning abandoned worker does not raise `InvalidStateError`) and swallow `RuntimeError` from `call_soon_threadsafe` (so a worker that returns after the loop closed exits cleanly).
+- **Shutdown invariant**: if a prior `reset()` timed out, the worker is still holding `PrivateWebSocketClient._lock`; `stop()` must **skip** `disconnect()` (it would deadlock on the same lock) and clear the client reference — the daemon thread leaks until the process exits. This is the explicit "abandon" trade-off documented in `docs/features/0039_PLAN.md`.
+- **Don't touch an abandoned client from the event loop**: `PrivateWebSocketClient.is_socket_alive()` (`ws_client.py:504`) acquires the same `_lock` the parked reset worker holds. After `_ws_reset_abandoned` is set, `_ws_health_check_once()` must return early before any lock-taking method on the client runs — otherwise the next health tick blocks the event loop and reintroduces the SIGTERM hang.
+- **Pybit daemon verification**: pybit's `WebSocket` worker thread is started with `self.wst.daemon = True` (`.venv/lib/python3.12/site-packages/pybit/_websocket_stream.py:168-169`). Verified once for the abandon strategy — the OS reclaims the leaked thread at process exit. If the pybit version changes, re-check this line.
+- **Tests**: `try/finally` release of `threading.Event` gates is mandatory so parked worker threads do not leak between tests.
+- Files: `apps/event_saver/src/event_saver/collectors/private_collector.py:_run_in_daemon_thread`, `_ws_health_check_once`, `stop`.
+
 ### Test Commands
 ```bash
 # Run bybit_adapter tests

--- a/apps/event_saver/src/event_saver/collectors/private_collector.py
+++ b/apps/event_saver/src/event_saver/collectors/private_collector.py
@@ -3,9 +3,10 @@
 import asyncio
 import contextlib
 import logging
+import threading
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Callable, Optional
+from typing import Any, Callable, Optional
 from uuid import UUID
 
 from bybit_adapter.ws_client import PrivateWebSocketClient, ConnectionState
@@ -16,6 +17,52 @@ from gridcore.events import ExecutionEvent, OrderUpdateEvent
 logger = logging.getLogger(__name__)
 
 _PRIVATE_WS_HEALTH_CHECK_INTERVAL = 10.0
+_PRIVATE_WS_RESET_TIMEOUT = 30.0
+_PRIVATE_WS_DISCONNECT_TIMEOUT = 5.0
+
+
+def _run_in_daemon_thread(
+    fn: Callable[[], Any], *, name: Optional[str] = None
+) -> "asyncio.Future[Any]":
+    """Run ``fn`` on a dedicated daemon thread; return a future bound to the loop.
+
+    Used to wrap blocking pybit calls (``reset`` / ``disconnect``) so they can
+    be bounded by ``asyncio.wait_for`` and **abandoned** on timeout without
+    leaking into ``concurrent.futures.thread._python_exit`` at interpreter
+    shutdown (which would join the worker and re-introduce the hang).
+
+    Cancellation-safety: if ``wait_for`` cancels the future before the thread
+    returns, the completer guards on ``fut.done()`` so a late-returning worker
+    does not raise ``InvalidStateError`` on the loop. If the loop has been
+    closed by the time the worker returns, ``call_soon_threadsafe`` raises
+    ``RuntimeError`` which we swallow — the daemon thread exits quietly.
+    """
+    loop = asyncio.get_running_loop()
+    fut: "asyncio.Future[Any]" = loop.create_future()
+
+    def _complete(result: Any = None, exc: Optional[BaseException] = None) -> None:
+        if fut.done():
+            return
+        if exc is not None:
+            fut.set_exception(exc)
+        else:
+            fut.set_result(result)
+
+    def _target() -> None:
+        try:
+            result = fn()
+            exc: Optional[BaseException] = None
+        except BaseException as e:  # noqa: BLE001 — route to future
+            result = None
+            exc = e
+        try:
+            loop.call_soon_threadsafe(_complete, result, exc)
+        except RuntimeError:
+            # Loop already closed; daemon thread just exits.
+            pass
+
+    threading.Thread(target=_target, name=name, daemon=True).start()
+    return fut
 
 
 @dataclass
@@ -84,6 +131,8 @@ class PrivateCollector:
         on_wallet: Optional[Callable[[dict], None]] = None,
         on_gap_detected: Optional[Callable[[datetime, datetime], None]] = None,
         ws_health_check_interval: float = _PRIVATE_WS_HEALTH_CHECK_INTERVAL,
+        ws_reset_timeout: float = _PRIVATE_WS_RESET_TIMEOUT,
+        ws_disconnect_timeout: float = _PRIVATE_WS_DISCONNECT_TIMEOUT,
     ):
         """Initialize private collector for an account.
 
@@ -95,6 +144,12 @@ class PrivateCollector:
             on_wallet: Callback for wallet snapshots (raw dict).
             on_gap_detected: Callback when gap is detected (start, end).
             ws_health_check_interval: TCP socket health-check interval in seconds.
+            ws_reset_timeout: Bound on the blocking ``client.reset()`` call from
+                the TCP health loop. On timeout the worker is abandoned and
+                ``_handle_reconnect`` is skipped (no REST reconciliation on an
+                unconfirmed reset).
+            ws_disconnect_timeout: Bound on ``client.disconnect()`` during
+                ``stop()`` so shutdown stays responsive when pybit is wedged.
         """
         self.context = context
         self._on_execution = on_execution
@@ -115,8 +170,11 @@ class PrivateCollector:
         self._running = False
         self._symbols_set = set(context.symbols) if context.symbols else set()
         self._ws_health_check_interval = ws_health_check_interval
+        self._ws_reset_timeout = ws_reset_timeout
+        self._ws_disconnect_timeout = ws_disconnect_timeout
         self._ws_health_task: Optional[asyncio.Task[None]] = None
         self._ws_health_stop_event: Optional[asyncio.Event] = None
+        self._ws_reset_abandoned = False
 
     async def start(self) -> None:
         """Start collecting private data for this account.
@@ -146,6 +204,9 @@ class PrivateCollector:
             on_reconnect=self._handle_reconnect,
             message_gap_watchdog_enabled=False,
         )
+        # Fresh client; defensively clear any abandoned-flag inherited from a
+        # previous timed-out stop() so this collector is not crippled.
+        self._ws_reset_abandoned = False
 
         self._ws_client.connect()
         self._ws_health_stop_event = asyncio.Event()
@@ -172,8 +233,30 @@ class PrivateCollector:
             self._ws_health_task = None
             self._ws_health_stop_event = None
 
-        if self._ws_client:
-            self._ws_client.disconnect()
+        client = self._ws_client
+        if client is not None:
+            if self._ws_reset_abandoned:
+                logger.warning(
+                    "Skipping private WS disconnect for account %s — prior "
+                    "reset timed out and pybit is still parked; the worker "
+                    "thread is leaked until the process exits",
+                    self.context.account_id,
+                )
+            else:
+                try:
+                    await asyncio.wait_for(
+                        _run_in_daemon_thread(
+                            client.disconnect, name="ws-disconnect"
+                        ),
+                        timeout=self._ws_disconnect_timeout,
+                    )
+                except TimeoutError:
+                    logger.warning(
+                        "Private WS disconnect timed out after %.1fs for "
+                        "account %s; clearing client and continuing",
+                        self._ws_disconnect_timeout,
+                        self.context.account_id,
+                    )
             self._ws_client = None
 
         logger.info(f"PrivateCollector stopped for account {self.context.account_id}")
@@ -210,6 +293,14 @@ class PrivateCollector:
         if not self._running or client is None:
             return
 
+        if self._ws_reset_abandoned:
+            # A previous reset() timed out and the worker is still parked
+            # inside pybit holding PrivateWebSocketClient._lock. is_socket_alive
+            # also acquires that lock, so touching the client here would block
+            # the event loop and reintroduce the SIGTERM hang this feature is
+            # meant to fix. Stay out until start()/stop() resets the flag.
+            return
+
         try:
             if client.is_socket_alive():
                 return
@@ -226,7 +317,22 @@ class PrivateCollector:
                 "Private WebSocket socket dead for account %s; resetting",
                 self.context.account_id,
             )
-            await asyncio.to_thread(client.reset)
+            try:
+                await asyncio.wait_for(
+                    _run_in_daemon_thread(client.reset, name="ws-reset"),
+                    timeout=self._ws_reset_timeout,
+                )
+            except TimeoutError:
+                self._ws_reset_abandoned = True
+                logger.error(
+                    "Private WS reset timed out after %.1fs for account %s; "
+                    "abandoning worker thread and skipping REST gap "
+                    "reconciliation (reset unconfirmed)",
+                    self._ws_reset_timeout,
+                    self.context.account_id,
+                )
+                return
+            self._ws_reset_abandoned = False
             self._handle_reconnect(disconnected_at, datetime.now(UTC))
         except Exception as e:
             logger.error(

--- a/apps/event_saver/tests/test_private_collector.py
+++ b/apps/event_saver/tests/test_private_collector.py
@@ -1,6 +1,7 @@
 """Tests for PrivateCollector."""
 
 import asyncio
+import logging
 import threading
 import pytest
 from datetime import UTC, datetime
@@ -8,7 +9,11 @@ from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 from bybit_adapter.ws_client import ConnectionState
-from event_saver.collectors.private_collector import PrivateCollector, AccountContext
+from event_saver.collectors.private_collector import (
+    PrivateCollector,
+    AccountContext,
+    _run_in_daemon_thread,
+)
 from gridcore.events import ExecutionEvent, OrderUpdateEvent
 
 
@@ -493,3 +498,267 @@ class TestMisc:
         collector.update_run_id(new_run_id)
 
         assert context.run_id == new_run_id
+
+
+# ---------------------------------------------------------------------------
+# WS reset / disconnect timeout (Feature 0039)
+# ---------------------------------------------------------------------------
+
+
+class TestWsResetTimeout:
+    @pytest.mark.asyncio
+    async def test_private_ws_health_reset_timeout_skips_reconcile(
+        self, context, on_gap, caplog
+    ):
+        disconnected_at = datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC)
+        collector = PrivateCollector(
+            context=context,
+            on_gap_detected=on_gap,
+            ws_reset_timeout=0.05,
+        )
+        allow_reset_finish = threading.Event()
+
+        def reset() -> None:
+            assert allow_reset_finish.wait(timeout=2.0)
+
+        mock_ws = MagicMock()
+        mock_ws.is_socket_alive.return_value = False
+        mock_ws.get_connection_state.return_value = ConnectionState(
+            last_message_ts=disconnected_at,
+            is_connected=True,
+        )
+        mock_ws.reset.side_effect = reset
+        collector._running = True
+        collector._ws_client = mock_ws
+
+        try:
+            with caplog.at_level(logging.ERROR):
+                await collector._ws_health_check_once()
+
+            on_gap.assert_not_called()
+            assert collector._ws_reset_abandoned is True
+            assert any(
+                "timed out" in record.getMessage().lower()
+                and str(context.account_id) in record.getMessage()
+                for record in caplog.records
+            )
+        finally:
+            allow_reset_finish.set()
+
+    @pytest.mark.asyncio
+    async def test_stop_skips_disconnect_after_reset_timeout(self, context, on_gap):
+        ws_reset_timeout = 0.05
+        ws_disconnect_timeout = 0.05
+        disconnected_at = datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC)
+        collector = PrivateCollector(
+            context=context,
+            on_gap_detected=on_gap,
+            ws_reset_timeout=ws_reset_timeout,
+            ws_disconnect_timeout=ws_disconnect_timeout,
+        )
+        reset_started = threading.Event()
+        allow_reset_finish = threading.Event()
+
+        def reset() -> None:
+            reset_started.set()
+            assert allow_reset_finish.wait(timeout=2.0)
+
+        mock_ws = MagicMock()
+        mock_ws.is_socket_alive.return_value = False
+        mock_ws.get_connection_state.return_value = ConnectionState(
+            last_message_ts=disconnected_at,
+            is_connected=True,
+        )
+        mock_ws.reset.side_effect = reset
+        collector._running = True
+        collector._ws_client = mock_ws
+        collector._ws_health_stop_event = asyncio.Event()
+        collector._ws_health_task = asyncio.create_task(
+            collector._ws_health_check_once()
+        )
+
+        try:
+            assert await asyncio.to_thread(reset_started.wait, 2.0)
+
+            # Drive stop() while worker is STILL parked.
+            await asyncio.wait_for(
+                collector.stop(),
+                timeout=ws_reset_timeout + ws_disconnect_timeout + 0.5,
+            )
+
+            # Assert abandonment BEFORE releasing the event.
+            assert mock_ws.disconnect.call_count == 0
+            assert collector._ws_client is None
+            assert collector._ws_reset_abandoned is True
+        finally:
+            allow_reset_finish.set()
+
+    @pytest.mark.asyncio
+    async def test_subsequent_health_check_does_not_touch_abandoned_client(
+        self, context
+    ):
+        # Regression for review P1: after a reset timeout, the abandoned pybit
+        # worker is still holding PrivateWebSocketClient._lock. is_socket_alive
+        # acquires that same lock, so the next health tick must not call any
+        # lock-taking method on the client — otherwise the event loop blocks
+        # exactly when SIGTERM needs it.
+        collector = PrivateCollector(context=context)
+        collector._running = True
+
+        lock_held = threading.Event()
+        release_lock = threading.Event()
+
+        def is_socket_alive_blocks():
+            lock_held.set()
+            assert release_lock.wait(timeout=2.0)
+            return False
+
+        mock_ws = MagicMock()
+        mock_ws.is_socket_alive.side_effect = is_socket_alive_blocks
+        collector._ws_client = mock_ws
+        collector._ws_reset_abandoned = True
+
+        try:
+            # If the guard is missing, is_socket_alive will block forever and
+            # wait_for will fire.
+            await asyncio.wait_for(collector._ws_health_check_once(), timeout=0.2)
+
+            assert mock_ws.is_socket_alive.call_count == 0
+            assert mock_ws.reset.call_count == 0
+        finally:
+            release_lock.set()
+
+    @pytest.mark.asyncio
+    async def test_start_after_timed_out_stop_clears_abandoned_flag(self, context):
+        collector = PrivateCollector(context=context)
+        collector._ws_reset_abandoned = True
+
+        with patch(
+            "event_saver.collectors.private_collector.PrivateWebSocketClient"
+        ) as MockWS:
+            mock_ws = MagicMock()
+            MockWS.return_value = mock_ws
+
+            await collector.start()
+            try:
+                assert collector._ws_reset_abandoned is False
+            finally:
+                await collector.stop()
+
+            mock_ws.disconnect.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_stop_bounds_disconnect_when_no_prior_reset_timeout(
+        self, context, caplog
+    ):
+        ws_disconnect_timeout = 0.05
+        collector = PrivateCollector(
+            context=context,
+            ws_disconnect_timeout=ws_disconnect_timeout,
+        )
+        allow_disconnect_finish = threading.Event()
+
+        def disconnect() -> None:
+            assert allow_disconnect_finish.wait(timeout=2.0)
+
+        mock_ws = MagicMock()
+        mock_ws.disconnect.side_effect = disconnect
+        collector._running = True
+        collector._ws_client = mock_ws
+
+        try:
+            with caplog.at_level(logging.WARNING):
+                await asyncio.wait_for(
+                    collector.stop(),
+                    timeout=ws_disconnect_timeout + 0.5,
+                )
+
+            assert collector._ws_client is None
+            assert any(
+                "disconnect" in record.getMessage().lower()
+                and "timed out" in record.getMessage().lower()
+                for record in caplog.records
+            )
+        finally:
+            allow_disconnect_finish.set()
+
+
+class TestRunInDaemonThread:
+    @pytest.mark.asyncio
+    async def test_uses_daemon_true(self):
+        captured: dict = {}
+        original_thread = threading.Thread
+
+        def fake_thread(*args, **kwargs):
+            captured.update(kwargs)
+            return original_thread(*args, **kwargs)
+
+        done = threading.Event()
+
+        def fn() -> None:
+            done.set()
+
+        with patch(
+            "event_saver.collectors.private_collector.threading.Thread",
+            side_effect=fake_thread,
+        ):
+            fut = _run_in_daemon_thread(fn)
+            await fut
+
+        assert captured.get("daemon") is True
+        assert done.is_set()
+
+    @pytest.mark.asyncio
+    async def test_completion_after_cancel_does_not_raise(self):
+        loop = asyncio.get_running_loop()
+        exception_records: list[dict] = []
+        loop.set_exception_handler(lambda _loop, ctx: exception_records.append(ctx))
+
+        gate = threading.Event()
+
+        def fn() -> None:
+            assert gate.wait(timeout=2.0)
+
+        fut = _run_in_daemon_thread(fn)
+        fut.cancel()
+        # Wait for cancellation to propagate.
+        await asyncio.sleep(0.01)
+
+        try:
+            gate.set()
+            # Yield so the daemon thread's call_soon_threadsafe completer runs.
+            await asyncio.sleep(0.05)
+
+            assert exception_records == []
+        finally:
+            loop.set_exception_handler(None)
+
+    def test_completion_after_loop_closed_does_not_raise(self):
+        loop = asyncio.new_event_loop()
+        gate = threading.Event()
+        threads_before = {t.ident for t in threading.enumerate()}
+        try:
+            asyncio.set_event_loop(loop)
+
+            def fn() -> None:
+                assert gate.wait(timeout=2.0)
+
+            async def spawn():
+                return _run_in_daemon_thread(fn)
+
+            loop.run_until_complete(spawn())
+        finally:
+            loop.close()
+            asyncio.set_event_loop(None)
+
+        # Loop is now closed; daemon thread is still parked on the gate.
+        worker = next(
+            (t for t in threading.enumerate() if t.ident not in threads_before),
+            None,
+        )
+        assert worker is not None
+        assert worker.daemon is True
+
+        gate.set()
+        worker.join(timeout=2.0)
+        assert worker.is_alive() is False

--- a/docs/features/0037_REVIEW.md
+++ b/docs/features/0037_REVIEW.md
@@ -110,7 +110,9 @@ schedules `reconcile_executions` per symbol via
   block forever and so will the recorder's shutdown path. Low likelihood;
   worth knowing for SIGTERM behavior. If observed, wrap the await with
   `asyncio.wait_for(..., timeout=...)` and fall back to canceling /
-  abandoning the task.
+  abandoning the task. **Addressed by Feature 0039** — `reset()` and
+  `disconnect()` now run on a daemon thread bounded by `asyncio.wait_for`,
+  with abandonment-aware shutdown.
 - **N2 — `contextlib.suppress(asyncio.CancelledError)` in `stop()` is
   defensive only.** The new design removed the explicit `cancel()` call, so
   the loop should now exit cleanly via the stop event. Keeping `suppress`

--- a/docs/features/0039_PLAN.md
+++ b/docs/features/0039_PLAN.md
@@ -1,0 +1,291 @@
+# Feature 0039 — Bound private WS reset & disconnect to prevent recorder shutdown hang
+
+## Context
+
+Feature 0037 (PR #82, merged 2026-05-13) added a recorder-side private
+WebSocket TCP health probe that resets dead sockets via
+`await asyncio.to_thread(client.reset)` at
+`apps/event_saver/src/event_saver/collectors/private_collector.py:229`.
+
+`PrivateWebSocketClient.reset()`
+(`packages/bybit_adapter/src/bybit_adapter/ws_client.py:513`) is synchronous:
+
+1. `_stop_heartbeat_watchdog()` (outside lock)
+2. `with self._lock: self._disconnect_internal()` — pybit `WebSocket.exit()` may stall
+3. `self.connect()` — acquires `self._lock` again AND instantiates pybit
+   `WebSocket(...)` *while holding the lock* (`ws_client.py:404`–`418`); this is
+   where slow DNS / half-open TCP handshake parks the worker thread.
+
+`asyncio.to_thread` cannot cancel that worker. With
+`PrivateCollector.stop()` (a) awaiting `_ws_health_task` (`private_collector.py:170-171`)
+and then (b) calling `self._ws_client.disconnect()` synchronously on the event
+loop (`private_collector.py:175-176`), there are **two** shutdown blockers:
+
+- the awaited `_ws_health_task` itself, if reset is mid-flight,
+- `disconnect()`, which also acquires `_lock` (`ws_client.py:457`) — even if (a)
+  is bounded by `wait_for`, (b) still deadlocks on the same lock held by the
+  parked reset worker.
+
+A timeout on `to_thread(client.reset)` alone is therefore **not sufficient**.
+The shutdown path must also be bounded and must tolerate an abandoned worker.
+
+This bug was flagged as N1 in `docs/features/0037_REVIEW.md` and called out as
+the only P1 by the Claude Code Review bot on PR #82.
+
+## Design trade-off (explicit)
+
+If reset times out, the worker thread is still parked inside pybit holding
+`PrivateWebSocketClient._lock`. We have two real choices for shutdown:
+
+- **Abandon the client.** Skip / time-bound `disconnect()` and clear the
+  reference. The parked worker thread leaks until it returns from pybit
+  (or the OS reaps it at process exit). SIGTERM stays responsive.
+- **Keep waiting.** Block shutdown on the lock until reset returns. This is
+  the current behaviour and the bug we are fixing.
+
+**Decision: abandon, but only over a dedicated daemon thread.** SIGTERM
+responsiveness in the recorder takes priority over a tidy pybit close. We log
+the leak so it is visible in incident postmortems.
+
+### Why not `asyncio.to_thread`
+
+`asyncio.to_thread` schedules work on the default `ThreadPoolExecutor`.
+Python's interpreter shutdown registers
+`concurrent.futures.thread._python_exit` via `atexit`, which **joins** all
+running executor threads. A parked pybit `reset` (or `disconnect`) would
+therefore block interpreter shutdown even after `await saver.stop()` returns
+— moving the hang from `stop()` to `atexit`, which is also non-responsive to
+SIGTERM.
+
+We bypass this by running `client.reset` / `client.disconnect` on a dedicated
+**daemon** `threading.Thread`, bridged to the event loop with
+`loop.create_future()` + `loop.call_soon_threadsafe`. Daemon threads are not
+joined at interpreter exit; the OS reclaims them with the process. This gives
+us a real "abandon" option.
+
+### Residual risk
+
+Pybit's `WebSocket` internally spawns its own threads. Implementation must
+verify (one-time check during work) that pybit's worker threads are created
+with `daemon=True`; if not, document the residual hang risk and decide whether
+to escalate to a hard-exit-after-bounded-shutdown policy (e.g. `os._exit(0)`
+guarded by the recorder's signal handler). Do **not** add `os._exit` without
+that verification — it is the last-resort lever.
+
+## Relevant Files
+
+- `apps/event_saver/src/event_saver/collectors/private_collector.py`
+  - new private module-level helper `_run_in_daemon_thread(fn) -> asyncio.Future`
+    (see Algorithm below) — replaces `asyncio.to_thread` for the reset and
+    disconnect calls; await it via `asyncio.wait_for`
+  - `PrivateCollector.__init__` — add `ws_reset_timeout` and
+    `ws_disconnect_timeout` parameters, plus an internal
+    `_ws_reset_abandoned: bool` flag (initialised `False`)
+  - `PrivateCollector.start` — set `self._ws_reset_abandoned = False` when a
+    new client is created so a re-`start()` after a previous timed-out stop
+    does not inherit the stale flag
+  - `PrivateCollector._ws_health_check_once` — replace
+    `await asyncio.to_thread(client.reset)` with
+    `await asyncio.wait_for(_run_in_daemon_thread(client.reset), timeout=ws_reset_timeout)`;
+    on `TimeoutError` set `_ws_reset_abandoned = True`, log, and **do not**
+    call `_handle_reconnect`; on success set `_ws_reset_abandoned = False`
+    (defensive)
+  - `PrivateCollector.stop` — replace the synchronous `client.disconnect()`
+    call with
+    `await asyncio.wait_for(_run_in_daemon_thread(client.disconnect), timeout=ws_disconnect_timeout)`;
+    if `_ws_reset_abandoned` is already set, skip `disconnect()` entirely; on
+    `TimeoutError` log and continue (still set `_ws_client = None`)
+  - module-level constants `_PRIVATE_WS_RESET_TIMEOUT = 30.0`,
+    `_PRIVATE_WS_DISCONNECT_TIMEOUT = 5.0`
+- `apps/event_saver/tests/test_private_collector.py`
+  - existing `test_stop_waits_for_in_flight_health_reset_before_disconnect`
+    pattern: `threading.Event`-gated mock `reset`
+  - new tests (see below) — all use `try/finally` to release the event before
+    the test returns so worker threads do not leak between tests
+- `packages/bybit_adapter/src/bybit_adapter/ws_client.py`
+  - `PrivateWebSocketClient.reset` / `.disconnect` / `.connect` / `._lock`
+  - read-only dependency; no adapter change
+- `docs/features/0037_REVIEW.md`
+  - mark N1 as addressed by this feature (touch at end of work)
+- `RULES.md`
+  - add a note: any `asyncio.to_thread` call in a recorder collector path must
+    be wrapped in `asyncio.wait_for`, and shutdown paths that touch the same
+    lock must also be bounded + tolerate an abandoned worker
+
+## Change
+
+### Health loop (`_ws_health_check_once`)
+
+Replace the bare `await asyncio.to_thread(client.reset)` with
+`await asyncio.wait_for(_run_in_daemon_thread(client.reset), timeout=self._ws_reset_timeout)`.
+
+On `TimeoutError`:
+
+- set `self._ws_reset_abandoned = True`
+- log an error including the account id and the timeout value
+- return without calling `_handle_reconnect` — reset was not confirmed; REST
+  gap reconciliation must not run
+- the worker thread keeps running until pybit returns or the process exits
+
+The outer broad `except Exception` block stays; non-timeout errors continue to
+be logged and the loop continues on the next tick.
+
+### Shutdown (`stop`)
+
+After awaiting `_ws_health_task` (already correct — the task will resolve once
+`wait_for` fires the timeout), replace this block:
+
+```
+if self._ws_client:
+    self._ws_client.disconnect()
+    self._ws_client = None
+```
+
+with:
+
+- if `self._ws_reset_abandoned` is True: log a warning that disconnect is being
+  skipped because the prior reset is still parked inside pybit, leak-acknowledged;
+  set `self._ws_client = None` and return.
+- else: `await asyncio.wait_for(_run_in_daemon_thread(client.disconnect), timeout=self._ws_disconnect_timeout)`;
+  on `TimeoutError` log a warning and clear `self._ws_client` anyway (do not
+  re-raise).
+
+This keeps the happy path identical (a healthy client disconnects cleanly) and
+guarantees `stop()` resolves in bounded time even when pybit is wedged.
+
+## Algorithm
+
+### `_run_in_daemon_thread(fn) -> asyncio.Future`
+
+1. Capture the running loop via `asyncio.get_running_loop()`.
+2. Create an `asyncio.Future` on that loop.
+3. Define a target that calls `fn()`. On return / exception, schedule a small
+   **completer callback** onto the loop via `loop.call_soon_threadsafe(...)`.
+   The completer must be cancellation-safe:
+   ```
+   def _complete(result=None, exc=None):
+       if fut.done():        # cancelled by wait_for, or already set
+           return
+       if exc is not None:
+           fut.set_exception(exc)
+       else:
+           fut.set_result(result)
+   ```
+   Without the `fut.done()` guard, a late-returning daemon thread whose future
+   was already cancelled by `asyncio.wait_for` will raise `InvalidStateError`
+   inside `call_soon_threadsafe` and pollute the event loop.
+4. Wrap `loop.call_soon_threadsafe(...)` in `try: ... except RuntimeError: pass`.
+   If the loop has already been closed during shutdown (legitimate during
+   SIGTERM races), the daemon thread must not raise — it just exits quietly.
+5. Start a `threading.Thread(target=..., daemon=True, name="ws-reset"|"ws-disconnect")`.
+6. Return the future.
+
+Daemon = True is load-bearing: it lets the process exit even if the thread is
+parked inside pybit. The `fut.done()` guard and `RuntimeError` swallow together
+ensure that an abandoned worker which eventually returns cannot crash the
+recorder or its (closed) event loop.
+
+### Health loop
+
+1. Wake (`stop_event` or interval) — unchanged.
+2. `client = self._ws_client`; return if not running or absent — unchanged.
+3. If `client.is_socket_alive()`, return — unchanged.
+4. Compute `disconnected_at` — unchanged.
+5. `_handle_disconnect(disconnected_at)` — unchanged.
+6. Log dead-socket warning — unchanged.
+7. `await asyncio.wait_for(_run_in_daemon_thread(client.reset), timeout=ws_reset_timeout)`.
+8. On `TimeoutError`: set `_ws_reset_abandoned = True`, log error, return.
+9. On success: clear `_ws_reset_abandoned`; `_handle_reconnect(...)`.
+
+### Shutdown (`stop()`)
+
+10. Signal stop event, await health task (bounded by step 7).
+11. If `_ws_reset_abandoned`: log warning, clear `_ws_client`, return.
+12. Else:
+    `await asyncio.wait_for(_run_in_daemon_thread(client.disconnect), timeout=ws_disconnect_timeout)`;
+    on `TimeoutError` log warning + continue. Clear `_ws_client` either way.
+
+## Tests
+
+All new tests use **`try/finally`** to set the `allow_reset_finish` event
+before returning so the parked worker can exit and not leak across tests. Each
+new test takes `ws_reset_timeout=0.05` (or similar small value) to keep wall
+time low.
+
+- `test_private_ws_health_reset_timeout_skips_reconcile`
+  - mock client: `is_socket_alive=False`, `get_connection_state` returns a
+    `ConnectionState` with known `last_message_ts`
+  - `reset` blocks on `threading.Event` (released in `finally`)
+  - await one `_ws_health_check_once()`
+  - assert `on_gap_detected` was NOT called
+  - assert `_ws_reset_abandoned` is True
+  - assert an error was logged (`caplog`) mentioning timeout + account id
+
+- `test_stop_skips_disconnect_after_reset_timeout`
+  - reuse the event-gated pattern; start the health task, wait for
+    `reset_started`
+  - **Structure precisely:**
+    ```
+    try:
+        # 1. drive stop() while the worker is STILL parked
+        await asyncio.wait_for(collector.stop(), timeout=ws_reset_timeout + ws_disconnect_timeout + 0.5)
+        # 2. assert abandonment BEFORE releasing the event
+        assert mock_ws.disconnect.call_count == 0
+        assert collector._ws_client is None
+        assert collector._ws_reset_abandoned is True
+    finally:
+        allow_reset_finish.set()  # only released AFTER assertions
+    ```
+  - the rule: `allow_reset_finish.set()` must NOT be reachable until after the
+    abandonment assertions have run; otherwise the parked reset finishes
+    early, the abandoned branch is bypassed, and the test silently passes as
+    the happy path
+
+- `test_start_after_timed_out_stop_clears_abandoned_flag`
+  - simulate a prior timed-out reset by manually setting
+    `collector._ws_reset_abandoned = True` on a stopped collector
+  - call `start()` (mock `PrivateWebSocketClient` so no real socket opens)
+  - assert `collector._ws_reset_abandoned is False`
+  - call `stop()` — assert the (fresh) mock client's `disconnect` IS called
+
+- `test_stop_bounds_disconnect_when_no_prior_reset_timeout`
+  - happy-ish path: socket is alive, no reset, but `client.disconnect` blocks
+    on an event
+  - call `stop()` — must complete within ~`ws_disconnect_timeout`
+  - assert disconnect timeout was logged
+  - assert `self._ws_client is None`
+  - `finally`: release the disconnect event
+
+- existing `test_stop_waits_for_in_flight_health_reset_before_disconnect`
+  - keep its semantics intact for the **non-timeout** case: when reset finishes
+    quickly, stop still awaits it before disconnect (no behaviour change for
+    the happy path)
+
+- `test_run_in_daemon_thread_uses_daemon_true`
+  - direct unit test of the helper: monkeypatch `threading.Thread` to capture
+    the kwargs of the spawned thread and assert `daemon=True`. This locks the
+    load-bearing property and prevents a future refactor from quietly
+    regressing SIGTERM behaviour.
+
+- `test_run_in_daemon_thread_completion_after_cancel_does_not_raise`
+  - call the helper with a `fn` gated on a `threading.Event` (released in
+    `finally`)
+  - call `fut.cancel()` to simulate the `wait_for` timeout path
+  - release the event so the daemon target runs `_complete()`
+  - assert no exception is logged / raised by the loop (use
+    `caplog.records` + a custom default exception handler installed via
+    `loop.set_exception_handler` to catch `InvalidStateError`)
+  - asserts that the `fut.done()` guard is in place
+
+- `test_run_in_daemon_thread_completion_after_loop_closed_does_not_raise`
+  - run helper inside a temporary loop; close the loop while the thread is
+    still parked; release the gate
+  - assert the daemon thread exits cleanly with no uncaught `RuntimeError`
+    (run the thread to completion via `thread.join(timeout=...)` and assert
+    `is_alive() is False`)
+
+Run:
+
+- `uv run pytest apps/event_saver/tests/test_private_collector.py -q`
+- `uv run pytest apps/event_saver/tests -q`
+- `uv run ruff check apps/event_saver`

--- a/docs/features/0039_REVIEW.md
+++ b/docs/features/0039_REVIEW.md
@@ -1,0 +1,42 @@
+# Feature 0039 Review — Bound private WS reset & disconnect
+
+## Findings
+
+No blocking issues found in the updated implementation.
+
+The previous P1 is addressed: `_ws_health_check_once()` now returns early when
+`_ws_reset_abandoned` is set, before calling any lock-taking method on the
+abandoned `PrivateWebSocketClient`. This preserves the shutdown guarantee after
+a reset timeout because the next health tick cannot block the event loop on the
+adapter lock held by the parked daemon worker.
+
+The previous N1 is also addressed in `RULES.md`: the pybit daemon-thread
+verification is documented, including the installed pybit location where
+`self.wst.daemon = True` is set before `start()`.
+
+## Coverage
+
+- Reset timeout skips REST gap reconciliation and sets `_ws_reset_abandoned`.
+- `stop()` skips `disconnect()` after an abandoned reset and clears the client
+  reference.
+- A subsequent health check does not touch the abandoned client.
+- Restart clears the abandoned flag for a fresh client.
+- Disconnect is bounded when there was no prior reset timeout.
+- `_run_in_daemon_thread()` is covered for daemon creation, late completion
+  after cancellation, and late completion after loop close.
+- Existing happy-path reset ordering is still covered by
+  `test_stop_waits_for_in_flight_health_reset_before_disconnect`.
+
+## Verification
+
+- `uv run pytest apps/event_saver/tests/test_private_collector.py -q` — passed
+  (`39 passed`)
+- `uv run pytest apps/event_saver/tests -q` — passed (`159 passed`)
+- `git diff --check` — passed
+- `uv run ruff check apps/event_saver` — failed on pre-existing unrelated lint
+  issues:
+  - `apps/event_saver/src/event_saver/collectors/public_collector.py:4` unused
+    `UTC`
+  - `apps/event_saver/src/event_saver/main.py:504` f-string without placeholders
+  - `apps/event_saver/tests/test_config.py:3` unused `pytest`
+  - `apps/event_saver/tests/test_reconciler.py:7` unused `patch`


### PR DESCRIPTION
## Summary

- Wrap blocking `PrivateWebSocketClient.reset()` / `.disconnect()` in a dedicated **daemon** `threading.Thread` bridged to the event loop, bounded by `asyncio.wait_for` — fixes recorder shutdown hang when pybit parks on a half-open TCP handshake (issue #83, 0037 review N1).
- On reset timeout, set `_ws_reset_abandoned` and skip both the next health tick's `is_socket_alive()` (same lock the parked worker holds) and `stop()`'s `disconnect()` (same lock again); the daemon thread leaks until process exit (pybit's worker is also `daemon=True`, verified).
- 7 new tests: reset-timeout + skip-reconcile, stop-skips-disconnect-after-timeout, subsequent-health-check-doesn't-touch-abandoned-client (regression for review P1), start-clears-abandoned-flag, bounded-disconnect, daemon-thread invariant, cancellation- and loop-closed safety of the helper.

## Why not `asyncio.to_thread`

`asyncio.to_thread` schedules onto the default `ThreadPoolExecutor`, which `concurrent.futures.thread._python_exit` joins at interpreter shutdown. A parked pybit call would block `atexit`, moving the SIGTERM hang from `stop()` to interpreter exit. Daemon threads sidestep this — the OS reclaims them at process exit.

## Test plan

- [x] `uv run pytest apps/event_saver/tests apps/recorder/tests -q` — 235 passed, 2 skipped
- [x] `uv run ruff check apps/event_saver/src/event_saver/collectors/private_collector.py apps/event_saver/tests/test_private_collector.py` — clean
- [x] Verified pybit's `WebSocketApp.run_forever` thread uses `self.wst.daemon = True` (`.venv/lib/python3.12/site-packages/pybit/_websocket_stream.py:168-169`)
- [ ] Manual: recorder graceful SIGTERM during a healthy run still exits cleanly
- [ ] Manual: kill the underlying TCP connection out-of-band, send SIGTERM during reset, confirm recorder exits within `ws_reset_timeout + ws_disconnect_timeout`

🤖 Generated with [Claude Code](https://claude.com/claude-code)