### PR TITLE
feat(0040): wire increase_same_position_on_low_margin from YAML to RiskConfig

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -242,6 +242,7 @@ make test-integration
 - **SHORT position bug**: Reference code had incorrect liq risk logic (`<` instead of `>`). Higher ratio = closer to liquidation for shorts.
 - **Position.size**: Stored on `Position` object, updated in `StrategyRunner.on_position_update()` from both REST and WS paths. Used by `_is_good_to_place()` to validate reduce-only orders.
 - **Unknown market price**: REST/WS position updates can arrive before the first ticker. Pass `last_close=None` (or a queued ticker price if available), never `0.0`; `StrategyRunner.on_position_update()` updates wallet/position sizes but skips risk multiplier recalculation until a real positive price exists.
+- **`increase_same_position_on_low_margin` (feature 0040)**: YAML-wired in **gridbot only** via `StrategyConfig` → `RiskConfig` in `apps/gridbot/src/gridbot/runner.py`. Gates `Position._adjust_position_for_low_margin` (open-interval `0.94 < position_ratio < 1.05` AND `total_margin < min_total_margin`): `True` → boost own side `×2`; `False` (default) → suppress opposite side `×0.5`. Continuous boost (not one-shot) while the guard condition holds. **Deliberate divergence**: `apps/backtest` and `apps/pnl_checker` still construct `RiskConfig` with the 4-arg pattern and default the flag to `False`, so any YAML with the flag `true` makes live/backtest semantics diverge until a follow-up wires both apps. See `docs/features/0040_PLAN.md` "Out of scope".
 
 ### Pre-placement Validation (`_is_good_to_place`)
 

--- a/apps/gridbot/conf/gridbot.yaml.example
+++ b/apps/gridbot/conf/gridbot.yaml.example
@@ -20,6 +20,7 @@ strategies:
     min_liq_ratio: 0.8
     max_liq_ratio: 1.2
     min_total_margin: 0.15
+    increase_same_position_on_low_margin: false  # true = boost own side x2 on low margin; false = suppress opposite side x0.5
     shadow_mode: false  # Set to true to log without executing
 
   - strat_id: "ethusdt_main"

--- a/apps/gridbot/src/gridbot/config.py
+++ b/apps/gridbot/src/gridbot/config.py
@@ -52,6 +52,13 @@ class StrategyConfig(BaseModel):
     min_liq_ratio: float = Field(default=0.8, description="Minimum liquidation ratio")
     max_liq_ratio: float = Field(default=1.2, description="Maximum liquidation ratio")
     min_total_margin: float = Field(default=0.15, description="Minimum total margin")
+    increase_same_position_on_low_margin: bool = Field(
+        default=False,
+        description=(
+            "When equal positions AND total_margin < min_total_margin: "
+            "True = boost own side (x2), False = reduce opposite side (x0.5)"
+        ),
+    )
 
     # Mode
     shadow_mode: bool = Field(default=False, description="Log intents without executing")

--- a/apps/gridbot/src/gridbot/runner.py
+++ b/apps/gridbot/src/gridbot/runner.py
@@ -198,6 +198,9 @@ class StrategyRunner:
             max_liq_ratio=strategy_config.max_liq_ratio,
             max_margin=strategy_config.max_margin,
             min_total_margin=strategy_config.min_total_margin,
+            increase_same_position_on_low_margin=(
+                strategy_config.increase_same_position_on_low_margin
+            ),
         )
         self._long_position, self._short_position = Position.create_linked_pair(risk_config)
 

--- a/apps/gridbot/tests/test_config.py
+++ b/apps/gridbot/tests/test_config.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 import yaml
+from pydantic import ValidationError
 
 from gridbot.config import (
     AccountConfig,
@@ -59,6 +60,38 @@ class TestStrategyConfig:
         assert strategy.grid_count == 50  # default
         assert strategy.grid_step == 0.2  # default
         assert strategy.shadow_mode is False  # default
+
+    def test_increase_same_position_on_low_margin_defaults_false(self):
+        """Test low-margin equal-position boost flag defaults off."""
+        strategy = StrategyConfig(
+            strat_id="btc_main",
+            account="main",
+            symbol="BTCUSDT",
+            tick_size=Decimal("0.1"),
+        )
+        assert strategy.increase_same_position_on_low_margin is False
+
+    def test_increase_same_position_on_low_margin_explicit_true(self):
+        """Test low-margin equal-position boost flag can be enabled."""
+        strategy = StrategyConfig(
+            strat_id="btc_main",
+            account="main",
+            symbol="BTCUSDT",
+            tick_size=Decimal("0.1"),
+            increase_same_position_on_low_margin=True,
+        )
+        assert strategy.increase_same_position_on_low_margin is True
+
+    def test_increase_same_position_on_low_margin_invalid_type(self):
+        """Test non-coercible boost flag values are rejected."""
+        with pytest.raises(ValidationError):
+            StrategyConfig(
+                strat_id="btc_main",
+                account="main",
+                symbol="BTCUSDT",
+                tick_size=Decimal("0.1"),
+                increase_same_position_on_low_margin=[],
+            )
 
     def test_tick_size_from_string(self):
         """Test tick_size parsed from string."""
@@ -262,6 +295,7 @@ class TestLoadConfig:
                     "tick_size": "0.1",
                     "grid_count": 50,
                     "grid_step": 0.2,
+                    "increase_same_position_on_low_margin": True,
                 }
             ],
             "database_url": "sqlite:///test.db",
@@ -277,6 +311,7 @@ class TestLoadConfig:
             assert config.accounts[0].name == "test"
             assert len(config.strategies) == 1
             assert config.strategies[0].tick_size == Decimal("0.1")
+            assert config.strategies[0].increase_same_position_on_low_margin is True
             assert config.database_url == "sqlite:///test.db"
         finally:
             Path(config_path).unlink()

--- a/apps/gridbot/tests/test_notifier.py
+++ b/apps/gridbot/tests/test_notifier.py
@@ -2,7 +2,7 @@
 
 import time
 from datetime import datetime, UTC, timedelta
-from unittest.mock import Mock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 

--- a/apps/gridbot/tests/test_runner.py
+++ b/apps/gridbot/tests/test_runner.py
@@ -166,6 +166,39 @@ class TestStrategyRunnerProperties:
         )
         assert runner.shadow_mode is True
 
+    def test_low_margin_equal_position_boost_config_wired_true(
+        self, strategy_config, mock_executor, instrument_info
+    ):
+        """StrategyConfig flag is passed to both linked Position risk configs."""
+        strategy_config = strategy_config.model_copy(
+            update={"increase_same_position_on_low_margin": True}
+        )
+        runner = StrategyRunner(
+            strategy_config=strategy_config,
+            executor=mock_executor,
+            instrument_info=instrument_info,
+        )
+
+        assert (
+            runner._long_position.risk_config.increase_same_position_on_low_margin
+            is True
+        )
+        assert (
+            runner._short_position.risk_config.increase_same_position_on_low_margin
+            is True
+        )
+
+    def test_low_margin_equal_position_boost_config_defaults_false(self, runner):
+        """Default StrategyConfig flag keeps both linked Position risk configs off."""
+        assert (
+            runner._long_position.risk_config.increase_same_position_on_low_margin
+            is False
+        )
+        assert (
+            runner._short_position.risk_config.increase_same_position_on_low_margin
+            is False
+        )
+
 
 class TestStrategyRunnerTicker:
     """Tests for ticker event processing."""

--- a/conf/gridbot_test.yaml
+++ b/conf/gridbot_test.yaml
@@ -13,6 +13,9 @@ strategies:
     grid_step: 0.3
     amount: "x0.001"
     max_margin: 5.0
+    # Continuous own-side x2 boost while equal positions AND total_margin < 3.
+    min_total_margin: 3
+    increase_same_position_on_low_margin: true
     shadow_mode: false  # start with shadow mode to avoid real orders
 
 database_url: "${DATABASE_URL}"

--- a/docs/features/0040_PLAN.md
+++ b/docs/features/0040_PLAN.md
@@ -1,0 +1,220 @@
+# Feature 0040 — Wire `increase_same_position_on_low_margin` from YAML to RiskConfig
+
+Branch: `feature/0040-low-margin-equal-boost-config` (to be created from `main`).
+
+> Note: requested as "Feature 0036" in the spec, but `0036` is already
+> taken by the merged wallet-writer fix (PR #81). Renumbered to the next
+> available slot per `commands/plan_feature.md`.
+
+## Context
+
+`RiskConfig.increase_same_position_on_low_margin: bool`
+(`packages/gridcore/src/gridcore/position.py:61`) already exists and
+already gates two branches inside `Position._adjust_position_for_low_margin`
+(`packages/gridcore/src/gridcore/position.py:394-411`):
+
+- `True` → boost own side: `set_amount_multiplier(SIDE_BUY/SELL, 2.0)`
+- `False` → suppress opposite side: `set_amount_multiplier(<opposite>, 0.5)`
+
+The branch is exercised when `position_ratio` falls in the open
+interval `(0.94, 1.05)` *and* `total_margin < risk_config.min_total_margin`
+— the equal-positions low-margin guard implemented as the strict
+comparison `0.94 < self.position_ratio < 1.05` at
+`packages/gridcore/src/gridcore/position.py:251`. The boundaries
+`0.94` and `1.05` themselves do **not** trigger the branch.
+
+**Gap:** there is no wire-through from YAML. `StrategyConfig`
+(`apps/gridbot/src/gridbot/config.py:26-87`) has no
+`increase_same_position_on_low_margin` field, and
+`StrategyRunner.__init__` constructs `RiskConfig` with only four args
+(`apps/gridbot/src/gridbot/runner.py:196-201`):
+
+```
+RiskConfig(
+    min_liq_ratio=strategy_config.min_liq_ratio,
+    max_liq_ratio=strategy_config.max_liq_ratio,
+    max_margin=strategy_config.max_margin,
+    min_total_margin=strategy_config.min_total_margin,
+)
+```
+
+So the dataclass default `False` is the only reachable value — the
+`True` branch is dead code from a config standpoint. This plan wires
+the flag end-to-end so operators can opt in via YAML.
+
+`min_total_margin` itself is also currently absent from
+`conf/gridbot_test.yaml` (defaults to `0.15`). Bumping it to `3` is part
+of the live-config update so the boost branch actually fires given
+current `total_margin ≈ 2.55`.
+
+## Scope
+
+This is a wire-through only. No semantics change in `gridcore` —
+`_adjust_position_for_low_margin` is not modified, existing
+`packages/gridcore/tests/test_position.py` cases for both branches stay
+green untouched.
+
+## Files & changes
+
+### 1. `apps/gridbot/src/gridbot/config.py` — `StrategyConfig`
+
+Add a new field next to `min_total_margin` (line 54):
+
+```
+increase_same_position_on_low_margin: bool = Field(
+    default=False,
+    description=(
+        "When equal positions AND total_margin < min_total_margin: "
+        "True = boost own side (×2), False = reduce opposite side (×0.5)"
+    ),
+)
+```
+
+No validator needed — Pydantic enforces `bool` typing and rejects
+non-coercible values.
+
+### 2. `apps/gridbot/src/gridbot/runner.py` — `RiskConfig` instantiation
+
+`apps/gridbot/src/gridbot/runner.py:196-201` — add the kwarg:
+
+```
+risk_config = RiskConfig(
+    min_liq_ratio=strategy_config.min_liq_ratio,
+    max_liq_ratio=strategy_config.max_liq_ratio,
+    max_margin=strategy_config.max_margin,
+    min_total_margin=strategy_config.min_total_margin,
+    increase_same_position_on_low_margin=(
+        strategy_config.increase_same_position_on_low_margin
+    ),
+)
+```
+
+### 3. `conf/gridbot_test.yaml` — live ltcusdt_test strategy
+
+Inside `strategies[0]` (currently lines 8-16), append the two missing
+risk knobs:
+
+```
+min_total_margin: 3
+increase_same_position_on_low_margin: true
+```
+
+`min_total_margin` previously took the schema default `0.15`. Setting
+it to `3` is intentional — see "Behavioural caveat" below.
+
+### 4. `apps/gridbot/conf/gridbot.yaml.example` — example doc
+
+Under the existing `min_total_margin: 0.15` line in the
+`btcusdt_main` strategy block (line 22), add:
+
+```
+increase_same_position_on_low_margin: false  # true = boost own side ×2 on low margin; false = suppress opposite side ×0.5
+```
+
+Leave the second example strategy (`ethusdt_main`) untouched — it
+relies on defaults for the other risk knobs already.
+
+### 5. `apps/gridbot/tests/test_config.py` — `TestStrategyConfig`
+
+Add three tests next to the existing `test_basic_strategy` cluster
+(after line 131):
+
+- **default off** — `StrategyConfig(...minimal...)` has
+  `.increase_same_position_on_low_margin is False`.
+- **explicit true** — `StrategyConfig(..., increase_same_position_on_low_margin=True)`
+  exposes the field as `True`.
+- **invalid type** — passing a non-bool, non-coercible value (e.g. an
+  arbitrary `object()` or a string that isn't `"true"/"false"/0/1`)
+  raises `ValidationError`. Note: Pydantic v2 coerces `"true"`/`"false"`
+  and `0`/`1` to bool by default, so the invalid-type test must use a
+  genuinely uncoercible value such as a list `[]` or `object()`.
+
+### 6. `apps/gridbot/tests/test_runner.py` — runner construction
+
+Add one test verifying the wire-through to `RiskConfig`:
+
+- Build a `StrategyConfig` with `increase_same_position_on_low_margin=True`
+  using the existing `instrument_info` and `mock_executor` fixtures.
+- Construct `StrategyRunner(strategy_config=cfg, ...)` directly.
+- Assert `runner._long_position.risk_config.increase_same_position_on_low_margin is True`
+  and likewise for `_short_position`.
+- Mirror with a second test where the flag is False (or rely on the
+  existing `runner` fixture which already defaults to False).
+
+`StrategyRunner` holds `_long_position` / `_short_position` as
+attributes (see `runner.py:202`), and `Position` keeps a reference to
+its `risk_config` (used in `_adjust_position_for_low_margin`).
+No private-attribute hacks needed.
+
+## Algorithm
+
+No new algorithm. The wire-through is mechanical: Pydantic field →
+attribute access in `runner.py` → dataclass kwarg → existing
+`Position._adjust_position_for_low_margin` branch selector.
+
+## Behavioural caveat (must surface to user in final report)
+
+With `conf/gridbot_test.yaml` setting `min_total_margin: 3` and current
+live `total_margin ≈ 2.55`, the condition
+`total_margin < min_total_margin` will be **continuously true** until
+`total_margin` climbs above `3`.
+
+Combined with `increase_same_position_on_low_margin: true`, every time
+`position_ratio` falls in the open interval `(0.94, 1.05)` — frequent
+in mean-reversion regimes — one side's `amount_multiplier` flips to
+`2.0`, doubling the order size on that tick. With `amount: "x0.001"` this becomes effective
+`x0.002` of wallet per tick — a **continuous boost**, not a one-shot.
+On LTCUSDT mainnet this is a real exposure increase. The user has
+confirmed this is the intended behaviour.
+
+## Out of scope — follow-ups
+
+Two other call sites construct `RiskConfig` from a YAML-driven config
+with the same 4-arg pattern and would keep defaulting
+`increase_same_position_on_low_margin=False` after this feature lands.
+They are **deliberately deferred** to keep this PR focused on the live
+gridbot wire-through:
+
+1. **Backtest** — `apps/backtest/src/backtest/config.py:50`
+   (`StrategyConfig.min_total_margin`) and
+   `apps/backtest/src/backtest/runner.py:151-155`
+   (`RiskConfig(min_liq_ratio=..., max_liq_ratio=..., max_margin=...,
+   min_total_margin=...)`). Until a follow-up wires the flag here,
+   backtests run on `conf/gridbot_test.yaml` (or any YAML with the
+   flag set to `true`) will silently fall through the False branch
+   (`set_amount_multiplier(<opposite>, 0.5)`) instead of the True
+   branch (`×2` own side). **Live and backtest risk semantics will
+   diverge** for any strategy that enables the flag, so replay /
+   validation results will not reproduce live boost behaviour until
+   the follow-up lands.
+
+2. **PnL checker** — `apps/pnl_checker/src/pnl_checker/config.py:83`
+   (same default-`0.15` `min_total_margin` field) and
+   `apps/pnl_checker/src/pnl_checker/main.py:82-86` (4-arg
+   `RiskConfig(...)` construction). The PnL checker is read-only
+   analysis tooling, so the divergence is less load-bearing than the
+   backtest gap but still real: any margin-driven `amount_multiplier`
+   inspection it performs will use the False branch.
+
+Both should be tracked as separate tickets immediately after 0040
+merges. Suggested follow-up scope: mirror the StrategyConfig field +
+RiskConfig kwarg + a single regression test per app — the wire-through
+is mechanical and the gridcore semantics are unchanged.
+
+## Verification
+
+- `uv run pytest apps/gridbot/ packages/gridcore/ -q` — all green.
+- `uv run ruff check apps/gridbot/` — clean.
+- `git diff main...HEAD --stat` — five files: `config.py`, `runner.py`,
+  `conf/gridbot_test.yaml`, `apps/gridbot/conf/gridbot.yaml.example`,
+  `apps/gridbot/tests/test_config.py`, plus `apps/gridbot/tests/test_runner.py`
+  (six in practice; ≤6 is fine).
+- Show final `git diff` of the two YAML configs.
+
+## Workflow constraints
+
+- Branch from `main`, **not** from the current
+  `feature/0039-private-ws-reset-timeout` branch.
+- No commit, no push, no PR until the user explicitly says so.
+- No live-bot run for validation — unit tests only.
+- Do not delete the branch after any future merge (user convention).

--- a/docs/features/0040_REVIEW.md
+++ b/docs/features/0040_REVIEW.md
@@ -1,0 +1,66 @@
+# Feature 0040 — Code Review (Round 2)
+
+Branch: `feature/0040-low-margin-equal-boost-config`
+Plan: `docs/features/0040_PLAN.md`
+Scope: wire `increase_same_position_on_low_margin` from YAML → `StrategyConfig` → `RiskConfig`. Mechanical pass-through only; no `gridcore` semantics changed.
+
+## What changed since Round 1
+
+- ✅ **End-to-end YAML coverage added** — `apps/gridbot/tests/test_config.py:298,314` now sets `increase_same_position_on_low_margin: True` in `config_data` and asserts on the loaded strategy.
+- ✅ **ASCII/Unicode reconciled** — `apps/gridbot/src/gridbot/config.py:59` description now uses ASCII `x2` / `x0.5`, matching `apps/gridbot/conf/gridbot.yaml.example:23`.
+- ✅ **Operator comment added** — `conf/gridbot_test.yaml:16` now carries `# Continuous own-side x2 boost while equal positions AND total_margin < 3.` above the flag.
+- ✅ **RULES.md entry added** — bullet appended to `### Position Risk Module (`position.py`)` documenting the gridbot-only wire-through and the deliberate live↔backtest divergence.
+
+## Verification
+
+- `uv run pytest apps/gridbot/tests/test_config.py apps/gridbot/tests/test_runner.py -q` — **176 passed in 0.16s**.
+- `git diff --stat` — 7 files, +83/-1 lines. Matches plan scope.
+
+## Summary
+
+No **Critical**, no **Warning**, no remaining **Suggestion**. Implementation complete and reviewed.
+
+### Operator-risk note (not a vulnerability, unchanged from Round 1)
+
+`conf/gridbot_test.yaml:16-18` flips the **live mainnet** LTCUSDT bot into the 2x-on-low-margin boost regime. With `min_total_margin: 3` and current `total_margin ≈ 2.55`, the condition is continuously true; every time `position_ratio` lands in the open interval `(0.94, 1.05)` one side's `amount_multiplier` flips to `2.0`. The new inline comment now makes this visible to operators reading the file. The plan's "Behavioural caveat" documents intent; `max_margin: 5.0` is the only remaining brake on continuous boosting.
+
+## Per-category findings
+
+### 1. Code Quality — clean
+
+- `apps/gridbot/src/gridbot/config.py:55-61` — Pydantic Field placed correctly after `min_total_margin`, follows the `Field(default=..., description=...)` pattern of adjacent fields.
+- `apps/gridbot/src/gridbot/runner.py:201-203` — kwarg added in same order as the `RiskConfig` constructor's field order; multi-line wrap style matches surrounding code.
+- `apps/gridbot/tests/test_notifier.py:5` — unused `Mock` import removed; only `MagicMock` is referenced. Acceptable one-line lint cleanup in a touched test suite.
+
+### 2. Security — clean
+
+- No shell/SQL/HTML user-input sinks introduced. No new endpoints/handlers.
+- No hardcoded secrets. `${DATABASE_URL}` interpolation unchanged.
+- Pydantic strictly validates `bool`; `test_config.py:86-94` covers rejection of non-coercible types.
+- Trust boundary unchanged (YAML loaded by operator, not network input).
+
+### 3. Performance — clean
+
+- One-time Pydantic field construction and one-time kwarg pass-through at runner init.
+- Hot-path impact in `packages/gridcore/src/gridcore/position.py:400`: a single attribute read on `self.risk_config` selecting between two pre-existing `set_amount_multiplier(...)` branches. No new allocations, queries, async calls, or I/O.
+
+### 4. Testing — strong
+
+- `apps/gridbot/tests/test_config.py:64-94` — three direct-construction tests: default off, explicit true, invalid type (`[]`, Pydantic v2 rejects).
+- `apps/gridbot/tests/test_config.py:298,314` — YAML round-trip now covered via `load_config()` path.
+- `apps/gridbot/tests/test_runner.py:169-200` — both `_long_position` and `_short_position` asserted in both True and default-False states. Uses `model_copy(update=...)` (correct for Pydantic v2 convention).
+- All three layers of the wire-through (YAML key → StrategyConfig field → runner kwarg → RiskConfig attr) are now tested.
+
+### 5. Documentation — consistent
+
+- `config.py:59` description and `gridbot.yaml.example:23` comment both ASCII now — consistent.
+- `conf/gridbot_test.yaml:16` carries an operator-facing comment explaining the continuous-boost regime.
+- `default=False` preserves prior behaviour; existing YAMLs without the field remain green. No migration note required.
+- RULES.md updated with a bullet under `### Position Risk Module (`position.py`)`.
+
+## Out-of-scope follow-ups (documented in plan, deliberately deferred)
+
+1. `apps/backtest/src/backtest/config.py:50` + `apps/backtest/src/backtest/runner.py:151-155` — same 4-arg `RiskConfig` pattern; live↔backtest semantic divergence until wired.
+2. `apps/pnl_checker/src/pnl_checker/config.py:83` + `apps/pnl_checker/src/pnl_checker/main.py:82-86` — same pattern; read-only analysis tool.
+
+Both should be tracked as separate tickets immediately after 0040 merges.


### PR DESCRIPTION
## Summary

- Adds `StrategyConfig.increase_same_position_on_low_margin: bool` (default `False`) and passes it through to `RiskConfig` in `StrategyRunner.__init__`, so operators can opt into the existing `Position._adjust_position_for_low_margin` `True` branch via YAML. No `gridcore` semantics changed.
- Enables the flag on the live `ltcusdt_test` strategy (`conf/gridbot_test.yaml`) with `min_total_margin: 3`. Combined with `total_margin ≈ 2.55`, this puts the bot into a continuous own-side `x2` boost regime whenever `position_ratio ∈ (0.94, 1.05)` — intended per plan's "Behavioural caveat".
- `apps/backtest` and `apps/pnl_checker` still construct `RiskConfig` with the 4-arg pattern and default the flag to `False`. Deliberate divergence documented in `docs/features/0040_PLAN.md` "Out of scope" and `RULES.md`. Follow-up tickets recommended.

## Test plan

- [x] `uv run pytest apps/gridbot/ -q` — 431 passed
- [x] New unit tests: `StrategyConfig` default off / explicit true / non-coercible type rejected; YAML round-trip via `test_load_from_yaml`
- [x] New runner tests: flag propagates to both `_long_position.risk_config` and `_short_position.risk_config` (True and default-False)
- [x] Code review documented in `docs/features/0040_REVIEW.md` (zero CRITICAL / zero blocking WARNING after 2 rounds)
- [ ] Manual: observe `amount_multiplier` flips on live during equal-position low-margin windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)