### PR TITLE
fix(0041): refuse to persist truncated private execution backfills

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -693,8 +693,8 @@ See `docs/features/0003_LOW_PRIORITY_CLEANUP.md` for detailed documentation.
    - File: `apps/event_saver/src/event_saver/reconciler.py:203-210`
 
 4. **Private Reconciliation Pagination**
-   - **Issue**: Only fetched first 100 executions, ignored `next_cursor`
-   - **Fix**: Use `get_executions_all()` with pagination loop (max 10 pages)
+   - **Issue**: Only fetched first 100 executions, ignored `next_cursor`; later pagination could silently persist a truncated backfill and advance past missing executions
+   - **Fix**: Use `get_executions_all()` with pagination loop (max 100 pages), request `return_truncated=True`, and refuse to persist when the REST backfill is truncated
    - File: `apps/event_saver/src/event_saver/reconciler.py:217-227`
 
 5. **REST Calls Blocking Event Loop**

--- a/apps/event_saver/src/event_saver/collectors/public_collector.py
+++ b/apps/event_saver/src/event_saver/collectors/public_collector.py
@@ -1,7 +1,7 @@
 """Collect public market data (ticker + trades) for multiple symbols."""
 
 import logging
-from datetime import datetime, UTC
+from datetime import datetime
 from typing import Callable, Optional
 
 from bybit_adapter.ws_client import PublicWebSocketClient, ConnectionState

--- a/apps/event_saver/src/event_saver/main.py
+++ b/apps/event_saver/src/event_saver/main.py
@@ -501,7 +501,7 @@ async def main():
     # Load configuration
     config = EventSaverConfig()
 
-    logger.info(f"Event Saver Configuration:")
+    logger.info("Event Saver Configuration:")
     logger.info(f"  Symbols: {config.get_symbols()}")
     logger.info(f"  Testnet: {config.testnet}")
     logger.info(f"  Batch size: {config.batch_size}")

--- a/apps/event_saver/src/event_saver/reconciler.py
+++ b/apps/event_saver/src/event_saver/reconciler.py
@@ -19,6 +19,8 @@ from grid_db import (
 
 logger = logging.getLogger(__name__)
 
+_PRIVATE_EXECUTION_RECONCILE_MAX_PAGES = 100
+
 
 class GapReconciler:
     """Detects and fills gaps in captured data using REST API.
@@ -247,7 +249,6 @@ class GapReconciler:
 
             # Create authenticated REST client for this account
             # (cannot use shared client with empty credentials)
-            from bybit_adapter.rest_client import BybitRestClient
             authenticated_client = BybitRestClient(
                 api_key=api_key,
                 api_secret=api_secret,
@@ -260,13 +261,27 @@ class GapReconciler:
 
             # Run synchronous REST call in thread to avoid blocking event loop
             # Use get_executions_all to handle pagination automatically
-            executions_data = await asyncio.to_thread(
+            executions_data, truncated = await asyncio.to_thread(
                 authenticated_client.get_executions_all,
                 symbol=symbol,
                 start_time=start_ms,
                 end_time=end_ms,
-                max_pages=10,  # Safety limit
+                max_pages=_PRIVATE_EXECUTION_RECONCILE_MAX_PAGES,
+                return_truncated=True,
             )
+
+            if truncated:
+                logger.error(
+                    "Execution reconciliation for %s account %s was truncated "
+                    "after %d pages; refusing to persist a partial backfill for "
+                    "%s to %s",
+                    symbol,
+                    account_id,
+                    _PRIVATE_EXECUTION_RECONCILE_MAX_PAGES,
+                    datetime.fromtimestamp(start_ms / 1000, tz=UTC),
+                    datetime.fromtimestamp(end_ms / 1000, tz=UTC),
+                )
+                return 0
 
             if not executions_data:
                 logger.debug(f"No executions returned from REST API for {symbol}")

--- a/apps/event_saver/tests/test_config.py
+++ b/apps/event_saver/tests/test_config.py
@@ -1,7 +1,5 @@
 """Tests for EventSaverConfig."""
 
-import pytest
-
 from event_saver.config import EventSaverConfig
 
 

--- a/apps/event_saver/tests/test_reconciler.py
+++ b/apps/event_saver/tests/test_reconciler.py
@@ -4,13 +4,13 @@ import pytest
 import unittest.mock
 from datetime import datetime, UTC, timedelta
 from decimal import Decimal
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 from uuid import uuid4
 
 from bybit_adapter.rest_client import BybitRestClient
 from grid_db import DatabaseFactory
 
-from event_saver.reconciler import GapReconciler
+from event_saver.reconciler import GapReconciler, _PRIVATE_EXECUTION_RECONCILE_MAX_PAGES
 
 
 @pytest.fixture
@@ -222,7 +222,7 @@ class TestReconcileExecutions:
         mock_rest_client.get_executions.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_calls_rest_api(self, mock_db, mock_rest_client, monkeypatch):
+    async def test_calls_rest_api(self, mock_db, mock_rest_client):
         """Test that REST API is called for valid gaps."""
         reconciler = GapReconciler(
             db=mock_db,
@@ -247,7 +247,7 @@ class TestReconcileExecutions:
 
         # Mock the BybitRestClient constructor
         mock_client = MagicMock()
-        mock_client.get_executions_all.return_value = []
+        mock_client.get_executions_all.return_value = ([], False)
 
         # Patch BybitRestClient constructor, PrivateExecutionRepository, and asyncio.to_thread
         with unittest.mock.patch('event_saver.reconciler.PrivateExecutionRepository', return_value=mock_repo), \
@@ -268,6 +268,72 @@ class TestReconcileExecutions:
 
         # Verify reconciliation completed (would return 0 for empty list)
         assert count == 0
+        mock_client.get_executions_all.assert_called_once()
+        call_kwargs = mock_client.get_executions_all.call_args.kwargs
+        assert call_kwargs["max_pages"] == _PRIVATE_EXECUTION_RECONCILE_MAX_PAGES
+        assert call_kwargs["return_truncated"] is True
+
+    @pytest.mark.asyncio
+    async def test_truncated_rest_response_is_not_persisted(
+        self, mock_db, mock_rest_client, caplog
+    ):
+        """Test that truncated REST backfills are refused before DB writes."""
+        reconciler = GapReconciler(
+            db=mock_db,
+            rest_client=mock_rest_client,
+            gap_threshold_seconds=5.0,
+        )
+
+        gap_start = datetime.now(UTC)
+        gap_end = gap_start + timedelta(seconds=10)
+
+        mock_session = MagicMock()
+        mock_repo = MagicMock()
+        mock_repo.get_last_execution_ts.return_value = None
+        mock_db.get_session.return_value.__enter__.return_value = mock_session
+        mock_db.get_session.return_value.__exit__.return_value = None
+
+        async def mock_to_thread(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        mock_client = MagicMock()
+        mock_client.get_executions_all.return_value = (
+            [{"execId": "partial", "category": "linear", "execType": "Trade"}],
+            True,
+        )
+
+        conversion_spy = MagicMock(wraps=reconciler._executions_to_models)
+        with caplog.at_level("ERROR", logger="event_saver.reconciler"):
+            with unittest.mock.patch(
+                "event_saver.reconciler.PrivateExecutionRepository",
+                return_value=mock_repo,
+            ), unittest.mock.patch(
+                "event_saver.reconciler.asyncio.to_thread",
+                side_effect=mock_to_thread,
+            ), unittest.mock.patch(
+                "event_saver.reconciler.BybitRestClient",
+                return_value=mock_client,
+            ), unittest.mock.patch.object(
+                reconciler,
+                "_executions_to_models",
+                conversion_spy,
+            ):
+                count = await reconciler.reconcile_executions(
+                    user_id=uuid4(),
+                    account_id=uuid4(),
+                    run_id=uuid4(),
+                    symbol="BTCUSDT",
+                    gap_start=gap_start,
+                    gap_end=gap_end,
+                    api_key="test_key",
+                    api_secret="test_secret",
+                    testnet=True,
+                )
+
+        assert count == 0
+        conversion_spy.assert_not_called()
+        mock_repo.bulk_insert.assert_not_called()
+        assert any("truncated" in record.message for record in caplog.records)
 
 
 class TestTradesConversion:

--- a/docs/features/0041_PLAN.md
+++ b/docs/features/0041_PLAN.md
@@ -1,0 +1,265 @@
+# Feature 0041 — Refuse to persist truncated private execution backfills
+
+## Context
+
+`GapReconciler.reconcile_executions()` in
+`apps/event_saver/src/event_saver/reconciler.py:263-300` calls
+`BybitRestClient.get_executions_all(..., max_pages=10)` to backfill private
+executions across a detected gap, then bulk-inserts whatever it received.
+
+`BybitRestClient.get_executions_all()`
+(`packages/bybit_adapter/src/bybit_adapter/rest_client.py:211-253`) returns
+**only a list**. It loops `while page < max_pages`, breaks when Bybit hands
+back an empty cursor, and otherwise stops at the page cap. The caller cannot
+tell whether the loop exited because Bybit was exhausted or because the
+safety cap was reached *while Bybit still advertised another page*.
+
+Consequence: a private WebSocket outage with more than `max_pages * page_size`
+executions in the gap causes `reconcile_executions()` to bulk-insert only the
+first slice and return success. The next reconciliation pulls
+`get_last_execution_ts()` (now advanced to the last persisted row) and uses
+that as `reconcile_start` — so the **middle of the gap is silently treated
+as reconciled**. Replay and the live-vs-replay comparator then operate on
+ground truth that is missing executions, with no warning.
+
+This is the same correctness bug surfaced by `app/cursor` in PR #86
+(`cursor/critical-correctness-bugs-74d3`). We are re-implementing the fix on
+our own feature branch under our normal workflow and will close PR #86 once
+this lands.
+
+## Design trade-off (explicit)
+
+When a backfill is truncated we have two choices:
+
+- **Persist what we got, log a warning.** The next cycle will keep advancing
+  `last_execution_ts` through the partial data and will never re-fetch the
+  missing middle. This is the current behaviour — the bug.
+- **Refuse to persist anything; leave the gap open.** The next reconciliation
+  retries the same window. `last_execution_ts` does not advance past missing
+  data. Operator gets an ERROR log to investigate (raise cap, narrow window,
+  or escalate).
+
+**Decision: refuse and leave the gap open.** Correctness of replay ground
+truth dominates reconciliation throughput. Bumping the page cap to 100 gives
+~10,000 executions per cycle of headroom for LTCUSDT-scale traffic before
+truncation is even possible, so the refusal path should be exercised rarely
+in practice.
+
+Scope of the guarantee: **this code path will not advance `last_execution_ts`
+via partial REST data.** It does *not* guarantee the next reconciliation
+re-fetches the exact same window. `PrivateExecutionRepository.get_last_execution_ts()`
+(`shared/db/src/grid_db/repositories.py:642`) returns the
+**account-wide latest timestamp**, and the live execution writer
+(`apps/event_saver/src/event_saver/writers/execution_writer.py:96`) keeps
+writing post-gap executions through the live WebSocket path. Private gap
+reconciliation is scheduled asynchronously
+(`apps/event_saver/src/event_saver/main.py:442`), so a live row landing
+after the truncated window can still push `last_execution_ts` past the gap
+before the next retry runs. The middle of the gap can therefore still be
+lost to operator action if reconciliation is not re-driven manually after
+the ERROR.
+
+### Residual risk
+
+- No auto-retry, no auto-narrowing of the window — a chronically truncating
+  gap will keep logging ERROR every reconciliation tick until the operator
+  acts. Acceptable: a loud, observable failure is preferable to a silent
+  ground-truth corruption.
+- Because `get_last_execution_ts` is account-wide and the live writer keeps
+  advancing it, the refusal only protects against *this REST call* writing
+  partial rows. A delayed retry whose `reconcile_start` has been advanced by
+  live writes will skip the still-missing middle. Mitigation: monitor the
+  ERROR log and treat truncation as an incident, not a self-healing event.
+
+## Relevant Files
+
+- `packages/bybit_adapter/src/bybit_adapter/rest_client.py`
+  - `BybitRestClient.get_executions_all` (lines 211-253) — add an optional
+    `return_truncated: bool = False` parameter. Default behaviour
+    (`return_truncated=False`) keeps the bare `list[dict]` return so existing
+    callers do not break. When `True`, return
+    `tuple[list[dict], bool]` where the bool is `True` iff the loop exited
+    because the page cap was hit while Bybit still had a next cursor.
+  - Update the trailing `logger.info(...)` to include the truncated flag.
+- `apps/event_saver/src/event_saver/reconciler.py`
+  - Remove the redundant local `from bybit_adapter.rest_client import BybitRestClient`
+    at line 250; the module already imports it at the top
+    (line 10). Tests must be able to patch
+    `event_saver.reconciler.BybitRestClient`.
+  - Add a module-level constant
+    `_PRIVATE_EXECUTION_RECONCILE_MAX_PAGES = 100`. Replace the hardcoded
+    `max_pages=10` at line 268.
+  - Call `get_executions_all(..., return_truncated=True)` and unpack
+    `(executions_data, truncated)`.
+  - If `truncated` is `True`: log ERROR with symbol, account id, max-pages
+    constant, and the requested window (`start_ms` / `end_ms` as UTC
+    datetimes); `return 0` **before** any model conversion or repository
+    write.
+- `apps/event_saver/tests/test_reconciler.py`
+  - Existing `TestReconcileExecutions` empty-list test must update its mock
+    return value from `[]` to `([], False)` because the reconciler now
+    requests the tuple form. Add asserts that
+    `get_executions_all` was called with `return_truncated=True`.
+  - New test for the truncated-rejection path (see Tests below).
+- `packages/bybit_adapter/tests/test_rest_client.py`
+  - Existing `TestGetExecutionsAll.test_stops_at_max_pages` continues to assert
+    list-return behaviour for `return_truncated=False`.
+  - New tests for both the truncated-flag-True and the cursor-exhausted-False
+    cases (see Tests below).
+- `RULES.md`
+  - Update the existing stale note at `RULES.md:695-698` ("Private
+    Reconciliation Pagination") which currently states "max 10 pages":
+    bump to **max 100 pages** and add that the reconciler must request
+    `return_truncated=True` and **refuse to persist when truncated**. Do
+    not leave a duplicate or contradictory rule elsewhere in the file.
+
+## Change
+
+### `get_executions_all` signature
+
+```
+def get_executions_all(
+    self,
+    symbol: Optional[str] = None,
+    start_time: Optional[int] = None,
+    end_time: Optional[int] = None,
+    max_pages: int = 10,
+    return_truncated: bool = False,
+) -> list[dict] | tuple[list[dict], bool]:
+```
+
+Backward-compatible: every existing call site passes no flag and continues
+to receive `list[dict]`.
+
+### Truncation detection
+
+After the pagination loop, compute:
+
+```
+truncated = page >= max_pages and cursor is not None
+```
+
+This relies on the inner `get_executions()` method already normalising an
+empty `nextPageCursor` to `None` at
+`rest_client.py:209` (`return executions, next_cursor if next_cursor else None`).
+That normalisation is what makes `cursor is not None` a valid truncation
+signal — verify it is still in place during implementation. If it ever
+changes, this fix breaks silently.
+
+### Reconciler refusal
+
+In `reconcile_executions`, after the `await asyncio.to_thread(...)`:
+
+```
+executions_data, truncated = execution_result
+if truncated:
+    logger.error(
+        "Execution reconciliation for %s account %s was truncated "
+        "after %d pages; refusing to persist a partial backfill for "
+        "%s to %s",
+        symbol, account_id, _PRIVATE_EXECUTION_RECONCILE_MAX_PAGES,
+        datetime.fromtimestamp(start_ms / 1000, tz=UTC),
+        datetime.fromtimestamp(end_ms / 1000, tz=UTC),
+    )
+    return 0
+```
+
+Place the check **before** `_executions_to_models` and **before** any
+`PrivateExecutionRepository.bulk_insert` call. The early `return 0` ensures
+**this REST call does not advance `last_execution_ts` via partial data**.
+Whether the next reconciliation re-fetches the same window depends on what
+the live writer persists in the meantime — see the trade-off / residual
+risk section above.
+
+## Algorithm
+
+### `get_executions_all` (with truncation flag)
+
+1. `all_executions = []`; `cursor = None`; `page = 0`.
+2. While `page < max_pages`:
+   1. Call `self.get_executions(..., cursor=cursor)` → `(executions, cursor)`.
+   2. `all_executions.extend(executions)`; `page += 1`.
+   3. If `not executions`: break.
+   4. If `not cursor`: break.
+3. `truncated = page >= max_pages and cursor is not None`.
+4. Log `"Fetched N total executions across P pages (truncated=T)"`.
+5. If `return_truncated`: return `(all_executions, truncated)`.
+   Else: return `all_executions`.
+
+### `reconcile_executions` (with refusal)
+
+1. Compute `reconcile_start` from `get_last_execution_ts` or `gap_start` — unchanged.
+2. Build authenticated REST client — unchanged.
+3. `start_ms`, `end_ms` from window — unchanged.
+4. `await asyncio.to_thread(get_executions_all, ..., max_pages=_PRIVATE_EXECUTION_RECONCILE_MAX_PAGES, return_truncated=True)` → `(executions_data, truncated)`.
+5. **If `truncated`: log ERROR with symbol / account / max_pages / window;
+   `return 0`.** No model conversion, no DB write, no
+   `last_execution_ts` advance.
+6. If `not executions_data`: return 0 — unchanged.
+7. Convert to models, bulk insert, log success — unchanged.
+
+## Tests
+
+### `packages/bybit_adapter/tests/test_rest_client.py`
+
+Use the existing fixtures: `mock_session` (pybit HTTP mock at the session
+layer) and `client` (real `BybitRestClient` patched with that mock). Tests
+call `client.get_executions_all(...)` and assert against
+`mock_session.get_executions` — going through the real
+`client.get_executions()` wrapper is required because that wrapper performs
+the empty-cursor → `None` normalisation
+(`rest_client.py:209`) which the truncation check relies on.
+
+- `test_return_truncated_flag_when_max_pages_reached`
+  - `mock_session.get_executions.return_value = _ok_response({"list": [{"execId": "e"}], "nextPageCursor": "more"})`
+    (same value each call — non-empty cursor every page)
+  - call `client.get_executions_all(symbol="BTCUSDT", max_pages=3, return_truncated=True)`
+  - assert `len(result) == 3`, `truncated is True`,
+    `mock_session.get_executions.call_count == 3`
+- `test_return_truncated_false_when_cursor_exhausted_at_max_pages_boundary`
+  - `mock_session.get_executions.side_effect = [
+        _ok_response({"list": [{"execId": "e1"}], "nextPageCursor": "cursor2"}),
+        _ok_response({"list": [{"execId": "e2"}], "nextPageCursor": ""}),
+    ]`
+    (empty cursor on second page — the real `client.get_executions` wrapper
+    converts that to `None`, which is what makes the truncation check work
+    correctly at the exact-max-pages boundary)
+  - call `client.get_executions_all(symbol="BTCUSDT", max_pages=2, return_truncated=True)`
+    — `max_pages=2` is intentional: the loop hits `page == max_pages` AND
+    the last cursor is empty in the same iteration, which is the exact
+    boundary that would falsely report `truncated=True` if `cursor` were
+    not normalised to `None`
+  - assert both rows returned and `truncated is False`
+- Existing `test_stops_at_max_pages` keeps its list-return assertion (no flag
+  passed). This documents the backward-compatible default.
+
+### `apps/event_saver/tests/test_reconciler.py`
+
+- Update the existing empty-result test:
+  - `mock_client.get_executions_all.return_value = ([], False)` (tuple form)
+  - Add `mock_client.get_executions_all.assert_called_once()` and
+    `assert mock_client.get_executions_all.call_args.kwargs["return_truncated"] is True`
+- New `test_truncated_rest_response_is_not_persisted`
+  - Patch `event_saver.reconciler.BybitRestClient`,
+    `event_saver.reconciler.PrivateExecutionRepository`,
+    `event_saver.reconciler.asyncio.to_thread` (run inline).
+  - `mock_client.get_executions_all.return_value =
+    ([{"execId": "partial", "category": "linear", "execType": "Trade"}], True)`
+  - Call `reconciler.reconcile_executions(...)`.
+  - Assert `count == 0`.
+  - Assert `mock_repo.bulk_insert.assert_not_called()`.
+  - (Optional but recommended) assert an ERROR log was emitted mentioning
+    "truncated" via `caplog`.
+
+### Run
+
+- `uv run pytest packages/bybit_adapter/tests/test_rest_client.py::TestGetExecutionsAll apps/event_saver/tests/test_reconciler.py::TestReconcileExecutions -v`
+- `uv run pytest packages/bybit_adapter/tests apps/event_saver/tests -q`
+- `uv run ruff check packages/bybit_adapter apps/event_saver`
+
+## Follow-up
+
+- After this PR is merged, close PR #86 with a note pointing at the merged
+  feature/0041 commit so the duplicate-fix history is clear. Do **not**
+  delete the `cursor/critical-correctness-bugs-74d3` branch (memory rule:
+  no branch deletion on merge).

--- a/docs/features/0041_REVIEW.md
+++ b/docs/features/0041_REVIEW.md
@@ -1,0 +1,203 @@
+# Feature 0041 — Code Review
+
+**Scope.** Review the diff in PR #86 (`cursor/critical-correctness-bugs-74d3`)
+against `docs/features/0041_PLAN.md`. The PR was opened by `app/cursor` and
+proposes the same fix described in the plan; this review records whether
+the PR is a faithful implementation that we can merge as-is, or whether
+gaps justify re-implementing on `feature/0041-...` per the follow-up
+section of the plan.
+
+**Verdict.** PR #86 is **broadly correct** and matches the plan's
+architecture. There is **one Medium finding** (RULES.md stale rule left in
+place) and **two Low findings** (boundary test does not exercise the
+boundary, no ERROR-log assertion). No High findings — the core correctness
+fix (refuse to persist truncated backfills) is implemented and tested.
+
+---
+
+## 1. Plan implementation accuracy
+
+| Plan item | PR #86 status |
+|---|---|
+| `return_truncated: bool = False` parameter, default list return | ✓ implemented (`rest_client.py:215-217`) |
+| `truncated = page >= max_pages and cursor is not None` | ✓ implemented (post-loop) |
+| Trailing `logger.info` includes truncated flag | ✓ implemented |
+| Remove redundant local `from bybit_adapter.rest_client import BybitRestClient` | ✓ removed at the local-import site; module-level import at `reconciler.py:10` unchanged |
+| `_PRIVATE_EXECUTION_RECONCILE_MAX_PAGES = 100` constant | ✓ added at `reconciler.py:22` |
+| Reconciler unpacks `(executions_data, truncated)` and returns 0 on truncation **before** model conversion or bulk_insert | ✓ implemented |
+| ERROR log includes symbol, account, max_pages, window | ✓ implemented; window rendered as UTC datetimes |
+| RULES.md updated | ✗ **partially** — see Finding 1 |
+| Existing empty-list test updated to `([], False)` and asserts `return_truncated=True` | ✓ implemented |
+| New `test_truncated_rest_response_is_not_persisted` asserts `bulk_insert.assert_not_called()` | ✓ implemented |
+| New `test_return_truncated_flag_when_max_pages_reached` | ✓ implemented |
+| New cursor-exhausted-False boundary test | ✗ **gap** — see Finding 2 |
+
+---
+
+## 2. Findings
+
+### Finding 1 — Medium — RULES.md stale rule left in place
+
+PR #86 **adds** a new rule under section 5 at the top of the
+reconciliation block (`RULES.md:572-575`) describing the no-partial-backfill
+invariant. It does **not** touch the existing stale note at
+`RULES.md:695-698` which still says:
+
+> **Private Reconciliation Pagination**
+> - **Issue**: Only fetched first 100 executions, ignored `next_cursor`
+> - **Fix**: Use `get_executions_all()` with pagination loop (max 10 pages)
+
+After merge, the file would carry two reconciliation rules in conflict
+about the page cap (`max 10 pages` at line 697 vs. `max_pages=100` in the
+reconciler code). Future readers will reach for the older note, which is
+exactly what the plan's "Relevant Files → RULES.md" section called out
+must not happen.
+
+**Required fix before merge.** Either update lines 695-698 to "max 100
+pages, with `return_truncated=True` and refusal-on-truncation", or delete
+the stale note in favour of the new one — but the two notes cannot both
+stand.
+
+### Finding 2 — Low — boundary test does not exercise the boundary
+
+PR #86's `test_return_truncated_false_when_cursor_exhausted` mocks two
+pages (`"cursor2"` then `""`) and calls
+`client.get_executions_all(symbol="BTCUSDT", return_truncated=True)` with
+the **default `max_pages=10`**.
+
+The runtime path: after page 2 the inner `get_executions()` wrapper
+normalises `""` → `None`, the loop breaks via `if not cursor`, and the
+post-loop check evaluates `page >= max_pages` as `2 >= 10` → `False`, so
+`truncated` is False regardless of whether the `cursor is not None` guard
+is correct. **The test passes even if the empty-cursor → None
+normalisation is removed**, because `page >= max_pages` short-circuits the
+expression.
+
+The plan specified `max_pages=2` for this exact reason: with
+`max_pages=2`, `page == max_pages` becomes True at exit, and the
+correctness of `truncated=False` depends entirely on `cursor` being None
+rather than `""`. That is the boundary the plan asked the test to lock.
+
+**Recommended fix.** Change the call to
+`client.get_executions_all(symbol="BTCUSDT", max_pages=2, return_truncated=True)`.
+Same fixtures, same asserts; just the `max_pages=2` keyword.
+
+Severity is Low because the production code is correct (the inner wrapper
+does normalise empty cursor to None at `rest_client.py:209`). The risk is
+a future refactor silently removing that normalisation without the test
+catching it.
+
+### Finding 3 — Low — ERROR log not asserted in the reconciler refusal test
+
+`test_truncated_rest_response_is_not_persisted` asserts `count == 0` and
+`bulk_insert.assert_not_called()` but does not capture the ERROR log via
+`caplog`. The plan marked this as "optional but recommended."
+
+The ERROR log is the operator's only signal that a truncated backfill was
+refused (see the residual-risk section of the plan: chronically truncating
+gaps must be visible). Asserting on it pins the log line so a future log
+refactor (level change, message rewording) cannot quietly mute the alert.
+
+**Recommended fix.** Add `caplog.set_level(logging.ERROR)` at the start of
+the test and `assert any("truncated" in r.message for r in caplog.records)`
+at the end.
+
+---
+
+## 3. Bug-hunt sweep
+
+- **Truncation detection.** `truncated = page >= max_pages and cursor is not None`.
+  Verified the inner `get_executions()` returns `next_cursor if next_cursor else None`
+  at `rest_client.py:209`, so `cursor is not None` is a valid truncation signal
+  at the exact-max-pages boundary. No bug.
+- **Reconciler control flow.** `executions_data, truncated = execution_result`
+  unpacks unconditionally. Because the reconciler always passes
+  `return_truncated=True`, `get_executions_all` always returns a tuple in
+  this call site; the union return type cannot bite here. No bug.
+- **Backward compatibility.** All other call sites of `get_executions_all`
+  (none in this diff) continue to pass no flag and receive `list[dict]`.
+  `test_stops_at_max_pages` keeps its list-return assertion. No bug.
+- **Authenticated client import path.** Local `from bybit_adapter.rest_client import BybitRestClient`
+  removed; module-level import at `reconciler.py:10` already shadows it.
+  Tests patch `event_saver.reconciler.BybitRestClient`, which now reliably
+  resolves to the patched symbol. No bug.
+- **Page-cap raise.** 10 → 100 is in `_PRIVATE_EXECUTION_RECONCILE_MAX_PAGES`.
+  At Bybit's default page size of 100 executions, this is 10,000 rows per
+  reconciliation. For LTCUSDT-scale traffic this is several orders of
+  magnitude above realistic gap sizes. No DoS concern; truncation refusal
+  remains the safety net if the assumption is ever wrong.
+
+## 4. Data alignment
+
+- All execution dicts go through `_executions_to_models` which already
+  handles Bybit's camelCase keys (`execId`, `execType`, etc.). No change.
+- The truncated branch returns before `_executions_to_models`, so no
+  alignment risk on that path.
+- The `truncated` boolean is plain Python; no serialisation involved.
+
+## 5. Over-engineering / file size
+
+- `rest_client.py` net: +6 lines for the flag + post-loop computation. No
+  bloat.
+- `reconciler.py` net: -1 local import, +1 module constant, +1 unpack
+  line, +12 lines for the ERROR log + early return. No restructuring.
+- No helper module introduced. No abstractions beyond what the bug
+  demands. Matches the plan's terseness.
+
+## 6. Style consistency
+
+- The union return type `list[dict] | tuple[list[dict], bool]` is awkward
+  but consistent with the codebase's existing flag-driven return shapes
+  (no `@overload` pattern used elsewhere in this package). Acceptable as
+  written; not a finding.
+- Module-level constants in `reconciler.py` already use the `_FOO`
+  uppercase-with-leading-underscore convention; the new constant matches.
+- Log f-string vs. `%`-style: the new ERROR log uses `%`-style
+  (`logger.error("... %s ...", arg, ...)`), while the surrounding logs
+  use f-strings. Mild inconsistency; **not blocking**. Either rewrite as
+  f-string for visual consistency, or leave for the lazy-formatting perf
+  win. Note for the implementer.
+
+## 7. Unit tests
+
+- **Coverage.** Happy path (cursor exhausts), cap-hit (truncated=True),
+  reconciler refusal (truncated row not persisted), empty result with the
+  new tuple shape — all covered.
+- **Isolation.** Mocks are scoped via `unittest.mock.patch` context
+  managers; no shared global state. `asyncio.to_thread` is patched inline
+  so tests run synchronously. Good.
+- **Naming.** Matches existing `TestGetExecutionsAll` and
+  `TestReconcileExecutions` conventions.
+- **Edge cases missed.** Finding 2 above. Also: no test for
+  `return_truncated=False` with the page cap hit (i.e. confirm the list
+  return still works in the truncated case). Not strictly required —
+  existing `test_stops_at_max_pages` covers the no-flag path — but a
+  combined-case assertion would be tidy.
+- **Interaction verification.** `mock_repo.bulk_insert.assert_not_called()`
+  is the right assertion for the refusal path (locks behaviour, not
+  implementation). Good.
+
+---
+
+## 8. Recommendation
+
+**Block PR #86 until Finding 1 is addressed.** Findings 2 and 3 are
+nice-to-have; can be requested as follow-up commits on the same PR or
+deferred to a small patch after merge.
+
+If `app/cursor` will not iterate on the PR, our follow-up plan
+(implementing on `feature/0041-...` and closing #86) is the path. The
+re-implementation should incorporate all three findings before opening
+its own PR. The plan already specifies the correct RULES.md target lines
+(`RULES.md:695-698`) and the correct `max_pages=2` boundary test, so
+following the plan verbatim will produce a stronger fix than the current
+PR #86 diff.
+
+## 9. Tests run
+
+Not run — PR #86 has not been merged into the working tree. Per the plan,
+once we implement on `feature/0041-...` we will run:
+
+- `uv run pytest packages/bybit_adapter/tests/test_rest_client.py::TestGetExecutionsAll apps/event_saver/tests/test_reconciler.py::TestReconcileExecutions -v`
+- `uv run pytest packages/bybit_adapter/tests apps/event_saver/tests -q`
+- `uv run ruff check packages/bybit_adapter apps/event_saver`

--- a/packages/bybit_adapter/src/bybit_adapter/rest_client.py
+++ b/packages/bybit_adapter/src/bybit_adapter/rest_client.py
@@ -214,7 +214,8 @@ class BybitRestClient:
         start_time: Optional[int] = None,
         end_time: Optional[int] = None,
         max_pages: int = 10,
-    ) -> list[dict]:
+        return_truncated: bool = False,
+    ) -> list[dict] | tuple[list[dict], bool]:
         """Fetch all executions with automatic pagination.
 
         Args:
@@ -222,9 +223,12 @@ class BybitRestClient:
             start_time: Start time in milliseconds (optional)
             end_time: End time in milliseconds (optional)
             max_pages: Maximum number of pages to fetch (safety limit)
+            return_truncated: Return whether pagination stopped at the safety limit
+                while Bybit still advertised another page.
 
         Returns:
-            List of all executions across pages
+            List of all executions across pages. If ``return_truncated`` is True,
+            returns ``(executions, truncated)``.
 
         Raises:
             Exception: If API call fails
@@ -249,7 +253,13 @@ class BybitRestClient:
             if not cursor:
                 break
 
-        logger.info(f"Fetched {len(all_executions)} total executions across {page} pages")
+        truncated = page >= max_pages and cursor is not None
+        logger.info(
+            f"Fetched {len(all_executions)} total executions across {page} pages "
+            f"(truncated={truncated})"
+        )
+        if return_truncated:
+            return all_executions, truncated
         return all_executions
 
     def get_order_history(

--- a/packages/bybit_adapter/tests/test_normalizer.py
+++ b/packages/bybit_adapter/tests/test_normalizer.py
@@ -1,6 +1,4 @@
 """Tests for BybitNormalizer event conversion."""
-
-import pytest
 from datetime import datetime, UTC
 from decimal import Decimal
 from uuid import uuid4

--- a/packages/bybit_adapter/tests/test_rate_limiter.py
+++ b/packages/bybit_adapter/tests/test_rate_limiter.py
@@ -1,6 +1,4 @@
 """Tests for RateLimiter sliding window implementation."""
-
-import pytest
 from datetime import datetime, timedelta, UTC
 from unittest.mock import patch
 

--- a/packages/bybit_adapter/tests/test_rest_client.py
+++ b/packages/bybit_adapter/tests/test_rest_client.py
@@ -1,6 +1,4 @@
 """Tests for BybitRestClient."""
-
-import logging
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -182,6 +180,39 @@ class TestGetExecutionsAll:
 
         assert len(result) == 3
         assert mock_session.get_executions.call_count == 3
+
+    def test_return_truncated_flag_when_max_pages_reached(self, client, mock_session):
+        mock_session.get_executions.return_value = _ok_response(
+            {"list": [{"execId": "e"}], "nextPageCursor": "more"}
+        )
+
+        result, truncated = client.get_executions_all(
+            symbol="BTCUSDT",
+            max_pages=3,
+            return_truncated=True,
+        )
+
+        assert len(result) == 3
+        assert truncated is True
+        assert mock_session.get_executions.call_count == 3
+
+    def test_return_truncated_false_when_cursor_exhausted_at_max_pages_boundary(
+        self, client, mock_session
+    ):
+        mock_session.get_executions.side_effect = [
+            _ok_response({"list": [{"execId": "e1"}], "nextPageCursor": "cursor2"}),
+            _ok_response({"list": [{"execId": "e2"}], "nextPageCursor": ""}),
+        ]
+
+        result, truncated = client.get_executions_all(
+            symbol="BTCUSDT",
+            max_pages=2,
+            return_truncated=True,
+        )
+
+        assert result == [{"execId": "e1"}, {"execId": "e2"}]
+        assert truncated is False
+        assert mock_session.get_executions.call_count == 2
 
     def test_passes_time_range(self, client, mock_session):
         mock_session.get_executions.return_value = _ok_response(


### PR DESCRIPTION
## Summary
- `BybitRestClient.get_executions_all` gains an opt-in `return_truncated` flag that exposes whether pagination stopped at the safety cap while Bybit still advertised another page; existing callers continue to receive `list[dict]` unchanged.
- `GapReconciler.reconcile_executions` requests the flag, raises the per-cycle cap from 10 → 100 pages (`_PRIVATE_EXECUTION_RECONCILE_MAX_PAGES`), and refuses to persist anything when the REST window is truncated — logs an ERROR with symbol / account / max_pages / window and returns 0 so the gap stays open for operator follow-up.
- Documented the no-partial-backfill invariant in `RULES.md` by updating the existing "Private Reconciliation Pagination" note in place (not adding a parallel rule).

## Why
A private WS outage spanning more than `max_pages × page_size` executions would previously cause the reconciler to persist only the first slice and advance `last_execution_ts` past missing rows — replay and the live-vs-replay comparator then operate on corrupted ground truth with no warning. This is the same correctness bug raised in PR #86 (`app/cursor`), re-implemented here under our standard workflow with the three review gaps closed (RULES.md updated in place, `max_pages=2` boundary test, `caplog` ERROR assertion).

## Trade-off (also in `docs/features/0041_PLAN.md`)
Refuse instead of persist-and-warn. The refusal only guarantees that *this REST call* does not advance `last_execution_ts` via partial data — the live writer can still advance it independently, so a chronically truncating gap requires operator action, not self-healing. Documented under residual risk.

## Test plan
- [x] `uv run pytest packages/bybit_adapter/tests/test_rest_client.py::TestGetExecutionsAll apps/event_saver/tests/test_reconciler.py::TestReconcileExecutions -v` → 9 passed
- [x] `uv run pytest packages/bybit_adapter/tests apps/event_saver/tests -q` → 308 passed
- [ ] Manual: confirm the new ERROR log line appears once when truncation is forced in a dev environment
- [ ] Close PR #86 with a pointer to this PR after merge (do not delete the `cursor/critical-correctness-bugs-74d3` branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)