### PR TITLE
Fix risk tier monitor fetch failure handling

### DIFF
--- a/.github/workflows/risk-tier-monitor.yml
+++ b/.github/workflows/risk-tier-monitor.yml
@@ -70,3 +70,11 @@ jobs:
               labels: ['risk-tiers', 'automated'],
               assignees: ['erzhan12'],
             });
+
+      - name: Warn on tier fetch failure
+        if: steps.drift-check.outputs.exit_code == '2'
+        run: |
+          echo "::warning::Tier fetch failed — IP block / transient. Not creating issue."
+          echo "### Tier fetch failed" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Tier fetch failed — IP block / transient. Not creating issue." >> "$GITHUB_STEP_SUMMARY"

--- a/apps/backtest/tests/test_check_tier_drift.py
+++ b/apps/backtest/tests/test_check_tier_drift.py
@@ -6,7 +6,6 @@ from unittest.mock import patch, MagicMock
 import pytest
 
 # Import the functions under test directly from the script module.
-import importlib
 import sys
 from pathlib import Path
 
@@ -15,7 +14,7 @@ _scripts_dir = str(Path(__file__).resolve().parent.parent.parent.parent / "scrip
 if _scripts_dir not in sys.path:
     sys.path.insert(0, _scripts_dir)
 
-from check_tier_drift import compare_tiers, _rate_drift_pct, _fetch_live_tiers, main
+from check_tier_drift import compare_tiers, _rate_drift_pct, _fetch_live_tiers, main  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -192,10 +191,7 @@ class TestMain:
 
     def test_drift_returns_one(self, capsys):
         """main() returns 1 when drift is detected."""
-        from gridcore.pnl import MM_TIERS
-
         # Create modified tiers with large drift
-        first_symbol = next(iter(MM_TIERS))
         modified = [
             (Decimal("999999"), Decimal("0.99"), Decimal("0"), Decimal("0.99")),
         ]
@@ -209,16 +205,40 @@ class TestMain:
         captured = capsys.readouterr()
         assert "Drift detected" in captured.out
 
-    def test_api_failure_reports_error(self, capsys):
-        """main() includes API failures in drift report."""
+    def test_fetch_failure_returns_two(self, capsys):
+        """main() returns 2 when fetch failures occur without real drift."""
         with patch("check_tier_drift._fetch_live_tiers") as mock_fetch:
             mock_fetch.side_effect = ConnectionError("timeout")
             with patch("sys.argv", ["check_tier_drift.py"]):
                 result = main()
 
+        assert result == 2
+        captured = capsys.readouterr()
+        assert "WARNING: Failed to fetch live tiers" in captured.out
+        assert "failed to fetch live tiers" in captured.out
+
+    def test_drift_with_fetch_failure_returns_one(self, capsys):
+        """main() returns 1 when any real drift is found, even with fetch failures."""
+        from gridcore.pnl import MM_TIERS
+
+        first_symbol = next(iter(MM_TIERS))
+        modified = [
+            (Decimal("999999"), Decimal("0.99"), Decimal("0"), Decimal("0.99")),
+        ]
+
+        def fetch(symbol):
+            if symbol == first_symbol:
+                return modified
+            raise ConnectionError("timeout")
+
+        with patch("check_tier_drift._fetch_live_tiers", side_effect=fetch):
+            with patch("sys.argv", ["check_tier_drift.py", "--threshold", "0.05"]):
+                result = main()
+
         assert result == 1
         captured = capsys.readouterr()
-        assert "failed to fetch live tiers" in captured.out
+        assert "WARNING: Failed to fetch live tiers" in captured.out
+        assert "Drift detected" in captured.out
 
     def test_custom_threshold_respected(self, capsys):
         """Custom --threshold value is passed through to compare_tiers."""

--- a/scripts/check_tier_drift.py
+++ b/scripts/check_tier_drift.py
@@ -18,7 +18,6 @@ from decimal import Decimal
 
 from gridcore.pnl import (
     MM_TIERS,
-    MM_TIERS_DEFAULT,
     MMTiers,
     parse_risk_limit_tiers,
 )
@@ -56,7 +55,6 @@ def compare_tiers(
 ) -> list[str]:
     """Compare hardcoded vs live tiers and return a list of drift messages."""
     drifts: list[str] = []
-    max_len = max(len(hardcoded), len(live))
 
     if len(hardcoded) != len(live):
         drifts.append(
@@ -115,22 +113,32 @@ def main() -> int:
     args = parser.parse_args()
 
     all_drifts: list[str] = []
+    fetch_failures: list[str] = []
 
     for symbol, hardcoded in MM_TIERS.items():
         print(f"Checking {symbol}...")
         try:
             live = _fetch_live_tiers(symbol)
         except Exception as e:
-            all_drifts.append(f"{symbol}: failed to fetch live tiers — {e}")
+            fetch_failures.append(f"{symbol}: failed to fetch live tiers — {e}")
             continue
         drifts = compare_tiers(symbol, hardcoded, live, args.threshold)
         all_drifts.extend(drifts)
+
+    if fetch_failures:
+        print("\nWARNING: Failed to fetch live tiers:")
+        for failure in fetch_failures:
+            print(f"  - {failure}")
 
     if all_drifts:
         print("\nDrift detected:")
         for d in all_drifts:
             print(f"  - {d}")
         return 1
+
+    if fetch_failures:
+        print("\nNo drift detected, but one or more live tier fetches failed.")
+        return 2
 
     print("\nNo drift detected. Hardcoded tiers match live API data.")
     return 0


### PR DESCRIPTION
## Summary

Fix the weekly risk tier monitor so transient Bybit fetch failures do not get reported as tier drift.

## What changed

- Split live tier fetch failures from real drift results in `scripts/check_tier_drift.py`.
- Return exit code `2` when fetch failures occur without real drift.
- Keep exit code `1` reserved for actual drift, including mixed drift plus fetch-failure cases.
- Add a GitHub Actions warning and step summary for exit code `2` without creating an issue.
- Add focused tests for clean, drift, fetch-failure-only, and mixed outcomes.

## Root cause

Bybit can block GitHub Actions runner IPs, causing public API fetches to fail. The monitor previously grouped those fetch failures with drift findings, so the workflow opened false-positive issues.

## Validation

- `uv run pytest -q apps/backtest/tests/test_check_tier_drift.py`
- `uv run ruff check scripts/check_tier_drift.py apps/backtest/tests/test_check_tier_drift.py`