### PR TITLE
feat(0047): persist grid_state snapshots to DB

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -340,6 +340,25 @@ If the saved `grid_step` or `grid_count` differs from the current strategy confi
 - **`anchor_price` parameter on `GridEngine` is retained for backtest compatibility**, separate from `restored_grid`. Backtest pins grid origin via `anchor_price`; live runner uses `restored_grid` for full-state restore. They serve different use cases.
 - **Known limitation**: an in-flight writer thread that has already popped a payload from `_pending_payload` and is waiting on `_io_lock` cannot be cancelled by a concurrent `delete()`. The writer will eventually re-persist the entry after the delete. Acceptable for current usage (delete is for "strat removed from config" — no concurrent saves expected); not currently fixed.
 
+### Grid State DB snapshots — feature 0047
+
+Live writes the same `grid.grid` payload to **two parallel sinks** from `_on_grid_change`:
+
+1. **Legacy file** — `GridStateStore` (see section above). Timestamp-agnostic, latest-wins-per-strat coalesced into one `db/grid_anchor.json`. Owns live-restart parity.
+2. **DB table** — `grid_state_snapshots` (column set: `run_id, account_id, strat_id, symbol, exchange_ts, local_ts, grid_json, grid_step, grid_count, raw_fingerprint`). Owns Phase 4 replay seeding. Written by `apps/gridbot/src/gridbot/writers/grid_state_writer.py:GridStateWriter` — sync API + `queue.Queue` + single worker thread; **NOT asyncio** (gridbot's main loop is sync; the event_saver writers live in a different process).
+
+Both backends are independent guards in `runner._on_grid_change(grid, exchange_ts)` — file fires whenever `state_store` is configured; DB fires only when `grid_state_writer` is set AND `exchange_ts is not None`. The `on_change` callback signature is `(grid, exchange_ts)`; constructor-time `restore_grid` produces `exchange_ts=None` and DB drops the write (file is unaffected because it doesn't time-index).
+
+**Replay loader priority** (`apps/replay/src/replay/engine.py:_load_seed`): DB row at-or-before `seed.at_ts` → file path if `seed.grid_state_path is not None` → fresh blank-build. `Grid.restore_grid` consumes both DB and file payloads identically (same `list[{side, price}]` shape).
+
+**Pitfalls**
+
+- **`on_change` arity is silently swallowed** at `grid.py:78` — every callsite passing `on_change=` must use `(grid, exchange_ts)`. The grep gate `grep -rE 'on_change|on_grid_change' packages/ apps/ --include='*.py'` should show no single-arg lambdas.
+- **`account_id` MUST match the `uuid5(NAMESPACE, "account:<name>")` formula** at `orchestrator.py:1156-1162`. Any deviation breaks the FK link to `runs.account_id` and replay returns no row. `Orchestrator._account_id_for()` is the single source of truth.
+- **Partial unique index `uq_grid_state_snapshots_fingerprint_at_ts`** is scoped to `(run_id, account_id, strat_id, exchange_ts, raw_fingerprint) WHERE raw_fingerprint IS NOT NULL`. The repository's `insert()` must pass both `index_elements=[...]` AND `index_where=GridStateSnapshot.raw_fingerprint.is_not(None)` to ON CONFLICT DO NOTHING, otherwise the partial constraint won't bind.
+- **`id DESC` tie-break depends on FIFO insertion** for same-`(run, account, strat, exchange_ts)` enqueues. The writer's single global queue preserves this; do NOT introduce per-strat queues or batch reordering without preserving per-(strat, ts) order, or `update_grid` out-of-bounds rebuilds will replay the intermediate (post-rebuild) state instead of the final (post-side-assignment) state.
+- **Bootstrap window**: writer is constructed in `Orchestrator.__init__` but `_run_ids` is populated later in `start()` via `_create_run_records`. Writer's `run_id_provider` returns `None` during this window; writes are dropped with a one-time INFO. WS connect happens AFTER `_create_run_records`, and reconciliation does not mutate the grid, so the first real `_on_grid_change` always fires with `_run_ids` populated.
+
 ## Logging Configuration
 
 Gridcore uses Python's standard library `logging` module. Loggers are named after their modules (`gridcore.grid`, `gridcore.engine`, `gridcore.position`).

--- a/apps/gridbot/src/gridbot/orchestrator.py
+++ b/apps/gridbot/src/gridbot/orchestrator.py
@@ -36,6 +36,7 @@ from gridbot.reconciler import Reconciler
 from gridbot.retry_queue import RetryQueue
 from gridbot.position_fetcher import PositionFetcher, _POSITION_TICK_BASE
 from gridbot.auth_cooldown_manager import AuthCooldownManager
+from gridbot.writers import GridStateWriter
 
 _HEALTH_CHECK_INTERVAL = 10  # seconds
 _WS_HEALTH_CHECK_INTERVAL = 10.0  # seconds — bbu2 ENSURE_SOCKET_INTERVAL parity
@@ -118,6 +119,25 @@ class Orchestrator:
 
         # Run tracking
         self._run_ids: dict[str, UUID] = {}  # strat_id -> run_id
+
+        # 0047: parallel DB grid-state writer. Constructed only when a DB
+        # is configured — standalone / no-DB runs (where _create_run_records
+        # early-returns) get a None writer. Background thread starts in
+        # start() (after _create_run_records populates _run_ids). The
+        # run_id_provider closure reads _run_ids lazily at write time;
+        # bootstrap-window writes (before _create_run_records) return None
+        # and are dropped by the writer with an INFO log.
+        if self._db is not None:
+            self._grid_state_writer: Optional[GridStateWriter] = GridStateWriter(
+                db=self._db,
+                run_id_provider=lambda strat_id: (
+                    str(self._run_ids[strat_id])
+                    if strat_id in self._run_ids
+                    else None
+                ),
+            )
+        else:
+            self._grid_state_writer = None
 
         # Event routing maps
         self._symbol_to_runners: dict[str, list[StrategyRunner]] = {}  # symbol -> runners
@@ -265,6 +285,28 @@ class Orchestrator:
 
         # Create database Run records (populates _run_ids)
         self._create_run_records()
+
+        # 0047: ensure the new ``grid_state_snapshots`` table exists on
+        # pre-0047 production DBs. ``Base.metadata.create_all`` is
+        # idempotent — only missing tables get created — and this project
+        # provisions schema this way (no Alembic). Without this, deploys
+        # would need an out-of-band ``python -m grid_db.init_db`` step or
+        # the loader's ``has_table`` fallback would suppress every write.
+        if self._db is not None:
+            try:
+                self._db.create_tables()
+            except Exception as e:
+                logger.warning(
+                    "Schema provisioning failed (continuing without DB grid-state writer): %s",
+                    e,
+                )
+
+        # 0047: start the DB grid-state writer's worker thread now that
+        # _run_ids is populated; bootstrap-window writes (between runner
+        # construction and this point) were dropped by the writer's
+        # provider-returns-None guard.
+        if self._grid_state_writer is not None:
+            self._grid_state_writer.start()
 
         # Connect WebSocket streams (pybit internal threads start here)
         for account_name in self._public_ws:
@@ -577,6 +619,14 @@ class Orchestrator:
         # SIGTERM. 10s matches typical fsync upper bounds on healthy disks.
         self._state_store.flush(timeout=10.0)
 
+        # 0047: drain the parallel DB writer before exit so the last
+        # post-fill snapshot(s) sitting in its queue don't get killed
+        # along with the daemon thread. Guarded for standalone / no-DB
+        # mode where the writer was never constructed.
+        if self._grid_state_writer is not None:
+            self._grid_state_writer.flush(timeout=10.0)
+            self._grid_state_writer.stop()
+
         # Update Run records
         self._update_run_records_stopped()
 
@@ -634,6 +684,16 @@ class Orchestrator:
 
         logger.info(f"Initialized account: {name}")
 
+    # 0047: shared UUID5 namespace for deterministic account/user/run/strategy
+    # IDs. Must match _create_run_records exactly or grid-state-writer FK
+    # validation against runs.account_id will fail.
+    _UUID_NAMESPACE = UUID("12345678-1234-5678-1234-567812345678")
+
+    @classmethod
+    def _account_id_for(cls, account_name: str) -> str:
+        """UUID5 derivation matching _create_run_records (orchestrator.py:1156-1162)."""
+        return str(uuid5(cls._UUID_NAMESPACE, f"account:{account_name}"))
+
     def _init_strategy(self, strategy_config: StrategyConfig) -> None:
         """Initialize a strategy runner."""
         strat_id = strategy_config.strat_id
@@ -670,8 +730,10 @@ class Orchestrator:
         runner = StrategyRunner(
             strategy_config=strategy_config,
             executor=executor,
+            account_id=self._account_id_for(account_name),
             instrument_info=instrument_info,
             state_store=self._state_store,
+            grid_state_writer=self._grid_state_writer,
             on_intent_failed=lambda intent, error: retry_queue.add(intent, error),
             on_retry_cancel_for_prefix=lambda prefix: retry_queue.cancel_for_prefix(prefix),
             on_unknown_order=self._request_immediate_order_sync,

--- a/apps/gridbot/src/gridbot/runner.py
+++ b/apps/gridbot/src/gridbot/runner.py
@@ -14,7 +14,10 @@ from collections import deque
 from dataclasses import dataclass, field, replace
 from datetime import datetime, UTC, timedelta
 from decimal import Decimal
-from typing import Optional, Callable
+from typing import Optional, Callable, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from gridbot.writers.grid_state_writer import GridStateWriter
 
 from gridcore import (
     GridEngine,
@@ -149,12 +152,21 @@ class StrategyRunner:
         runner.on_execution(execution_event)
     """
 
+    # Sentinel default for ``account_id``: avoids forcing every existing
+    # test/fixture (~40 sites) to pass a real UUID while still letting the
+    # constructor reject the dummy if a DB writer is actually wired —
+    # otherwise snapshots would silently land under the zero UUID and be
+    # invisible to replay's real account scope (feature 0047).
+    _ACCOUNT_ID_DEFAULT = "00000000-0000-0000-0000-000000000000"
+
     def __init__(
         self,
         strategy_config: StrategyConfig,
         executor: IntentExecutor,
+        account_id: str = _ACCOUNT_ID_DEFAULT,
         instrument_info: Optional[InstrumentInfo] = None,
         state_store: Optional[GridStateStore] = None,
+        grid_state_writer: Optional["GridStateWriter"] = None,
         on_intent_failed: Optional[Callable[[PlaceLimitIntent | CancelIntent, str], None]] = None,
         on_unknown_order: Optional[Callable[[str], None]] = None,
         notifier: Optional[Notifier] = None,
@@ -165,8 +177,15 @@ class StrategyRunner:
         Args:
             strategy_config: Strategy configuration.
             executor: Intent executor for API calls.
+            account_id: UUID5-derived account identifier; matches the value
+                ``orchestrator.py:1156-1162`` computes from the account name.
+                Used by the DB grid-state writer (feature 0047) so snapshots
+                FK-match ``runs.account_id``.
             instrument_info: Instrument info for qty rounding (None uses no rounding).
             state_store: Optional grid state store for persistence.
+            grid_state_writer: Optional DB writer for ``grid_state_snapshots``
+                (feature 0047). When provided, ``_on_grid_change`` writes a
+                second snapshot path in parallel with ``state_store``.
             on_intent_failed: Callback when intent execution fails (for retry queue).
             on_unknown_order: Callback when WS reports a New order we don't track
                 (for fast-tracking the next order-sync sweep).
@@ -174,9 +193,27 @@ class StrategyRunner:
             on_retry_cancel_for_prefix: Optional callback to cancel queued
                 placement retries after reconcile proves the order was accepted.
         """
+        # 0047: if a DB writer is wired, account_id MUST be explicitly set —
+        # the dummy default would FK-mismatch with replay's account scope
+        # (and `runs.account_id` does not catch this because the writer's
+        # FK is to `runs.run_id`). Orchestrator passes the real UUID5; any
+        # other caller wiring the writer must do the same.
+        if (
+            grid_state_writer is not None
+            and account_id == self._ACCOUNT_ID_DEFAULT
+        ):
+            raise ValueError(
+                "StrategyRunner.account_id must be set explicitly when "
+                "grid_state_writer is provided; got the placeholder default. "
+                "Orchestrator derives it via Orchestrator._account_id_for("
+                "account_name) (uuid5(NAMESPACE, 'account:<name>'))."
+            )
+
         self._config = strategy_config
         self._executor = executor
+        self._account_id = account_id
         self._state_store = state_store
+        self._grid_state_writer = grid_state_writer
         self._on_intent_failed = on_intent_failed
         self._on_unknown_order = on_unknown_order
         self._notifier = notifier
@@ -369,20 +406,38 @@ class StrategyRunner:
             )
             return None
 
-    def _on_grid_change(self, grid: list[dict]) -> None:
+    def _on_grid_change(self, grid: list[dict], exchange_ts: Optional[datetime]) -> None:
         """Persist grid mutations triggered from inside Grid.build_grid /
         Grid.update_grid. Skips writes for the just-built single-WAIT case
-        and for empty grids (a restored grid that failed validation)."""
-        if self._state_store is None:
-            return
+        and for empty grids (a restored grid that failed validation).
+
+        Backends are independent guards (0047): file path is timestamp-agnostic
+        and runs whenever ``_state_store`` is configured; DB path requires
+        ``_grid_state_writer`` AND a non-None ``exchange_ts`` (constructor-time
+        restore_grid carries no triggering event and would falsify
+        ``at_or_before`` lookups).
+        """
         if len(grid) <= 1:
             return
-        self._state_store.save(
-            strat_id=self._config.strat_id,
-            grid=grid,
-            grid_step=self._config.grid_step,
-            grid_count=self._config.grid_count,
-        )
+
+        if self._state_store is not None:
+            self._state_store.save(
+                strat_id=self._config.strat_id,
+                grid=grid,
+                grid_step=self._config.grid_step,
+                grid_count=self._config.grid_count,
+            )
+
+        if self._grid_state_writer is not None and exchange_ts is not None:
+            self._grid_state_writer.write(
+                strat_id=self._config.strat_id,
+                grid=grid,
+                grid_step=self._config.grid_step,
+                grid_count=self._config.grid_count,
+                account_id=self._account_id,
+                symbol=self._config.symbol,
+                exchange_ts=exchange_ts,
+            )
 
     def get_limit_orders(self) -> dict[str, list[dict]]:
         """Get current limit orders in format expected by GridEngine.

--- a/apps/gridbot/src/gridbot/writers/__init__.py
+++ b/apps/gridbot/src/gridbot/writers/__init__.py
@@ -1,0 +1,11 @@
+"""Gridbot writers — sync, threading-based DB writers.
+
+Distinct from ``apps/event_saver/.../writers`` which are asyncio-based and
+live in the recorder process. Gridbot's main loop is synchronous (uses
+``time.sleep``), so writers here mirror ``gridcore.persistence.GridStateStore``'s
+sync API + background ``threading.Thread`` pattern.
+"""
+
+from gridbot.writers.grid_state_writer import GridStateWriter
+
+__all__ = ["GridStateWriter"]

--- a/apps/gridbot/src/gridbot/writers/grid_state_writer.py
+++ b/apps/gridbot/src/gridbot/writers/grid_state_writer.py
@@ -1,0 +1,257 @@
+"""DB writer for verbatim grid-state snapshots (feature 0047).
+
+Mirrors ``gridcore.persistence.GridStateStore``'s sync-API + background-thread
+pattern. **Not** asyncio — gridbot's main loop is synchronous.
+
+Concurrency model:
+* One global FIFO ``queue.Queue`` per writer instance, drained by a single
+  worker thread; INSERTs land in dequeue order so the loader's
+  ``ORDER BY exchange_ts DESC, id DESC`` tie-break picks the FINAL notify
+  of a multi-notify outer mutation (e.g. ``update_grid`` out-of-bounds path).
+* In-memory tuple dedupe is a separate gate run BEFORE enqueue: if the new
+  ``grid_fingerprint(...)`` tuple equals the last-enqueued tuple for the
+  same ``(run_id, account_id, strat_id)``, the write is dropped pre-queue.
+  Latest-wins-per-strat semantic — same as the file writer.
+* If ``run_id_provider(strat_id)`` returns ``None`` (orchestrator hasn't
+  populated ``_run_ids`` yet), or ``exchange_ts`` is ``None`` (no triggering
+  event in scope), the snapshot is dropped with an INFO log.
+"""
+
+import logging
+import queue
+import threading
+from datetime import datetime, UTC
+from decimal import Decimal
+from typing import Callable, Optional
+
+from grid_db import DatabaseFactory
+from grid_db.models import GridStateSnapshot
+from grid_db.repositories import GridStateSnapshotRepository
+from gridcore.persistence import grid_fingerprint, grid_fingerprint_hash
+
+
+logger = logging.getLogger(__name__)
+
+
+# Sentinel pushed onto the queue by ``stop()`` to wake the worker for a
+# clean exit.
+_STOP_SENTINEL = object()
+
+
+class GridStateWriter:
+    """Persists ``grid.grid`` mutations to ``grid_state_snapshots``.
+
+    Lifecycle:
+        writer = GridStateWriter(db, run_id_provider=lambda sid: run_ids.get(sid))
+        writer.start()              # launches worker thread
+
+        # In _on_grid_change:
+        writer.write(strat_id, grid, grid_step, grid_count,
+                     account_id, symbol, exchange_ts)
+
+        writer.flush(timeout=10.0)   # drain queue
+        writer.stop()                # signal worker, join thread
+    """
+
+    def __init__(
+        self,
+        db: DatabaseFactory,
+        run_id_provider: Callable[[str], Optional[str]],
+        max_queue_size: int = 0,
+    ):
+        """Initialize writer.
+
+        Args:
+            db: DatabaseFactory for session management.
+            run_id_provider: Callable that maps ``strat_id`` to a ``run_id``
+                or ``None`` if the orchestrator hasn't populated it yet
+                (bootstrap window before ``_create_run_records``). Late-bound
+                resolution decouples writer construction from run-record
+                creation; see plan 0047 v18 Phase 2B.
+            max_queue_size: Upper bound on pending snapshots. 0 = unbounded
+                (default — grid mutations are rare relative to ticker rate).
+        """
+        self._db = db
+        self._run_id_provider = run_id_provider
+        self._queue: queue.Queue = queue.Queue(maxsize=max_queue_size)
+        # Per-scope last-enqueued fingerprint tuple; guards pre-enqueue
+        # dedupe so identical successive mutations don't bloat the queue.
+        self._last_fingerprint: dict[tuple[str, str, str], tuple] = {}
+        # Lock guards _last_fingerprint only — the queue itself is
+        # thread-safe.
+        self._dedupe_lock = threading.Lock()
+        self._worker: Optional[threading.Thread] = None
+        self._running = False
+        # One-time log gate for the "run_id not yet set" bootstrap window.
+        self._warned_missing_run_id: set[str] = set()
+
+        # Stats
+        self._total_written = 0
+        self._total_dropped_no_run_id = 0
+        self._total_dropped_no_ts = 0
+        self._total_dedup_skipped = 0
+        self._total_errors = 0
+
+    def write(
+        self,
+        strat_id: str,
+        grid: list[dict],
+        grid_step: float,
+        grid_count: int,
+        account_id: str,
+        symbol: str,
+        exchange_ts: Optional[datetime],
+    ) -> None:
+        """Enqueue a snapshot (drops on missing run_id, missing ts, or dedupe).
+
+        Note: no ``run_id`` parameter at the call site — the writer resolves
+        it via ``run_id_provider`` at enqueue time so the runner does not
+        need to know about run lifecycle.
+        """
+        if exchange_ts is None:
+            self._total_dropped_no_ts += 1
+            return
+
+        run_id = self._run_id_provider(strat_id)
+        if run_id is None:
+            self._total_dropped_no_run_id += 1
+            if strat_id not in self._warned_missing_run_id:
+                self._warned_missing_run_id.add(strat_id)
+                logger.info(
+                    "%s: skipped DB snapshot — run_id not yet set", strat_id,
+                )
+            return
+
+        scope = (run_id, account_id, strat_id)
+        fp_tuple = grid_fingerprint(grid, grid_step, grid_count)
+        with self._dedupe_lock:
+            if self._last_fingerprint.get(scope) == fp_tuple:
+                self._total_dedup_skipped += 1
+                return
+            self._last_fingerprint[scope] = fp_tuple
+
+        fp_hash = grid_fingerprint_hash(grid, grid_step, grid_count)
+        local_ts = datetime.now(UTC)
+        snapshot = GridStateSnapshot(
+            run_id=run_id,
+            account_id=account_id,
+            strat_id=strat_id,
+            symbol=symbol,
+            exchange_ts=exchange_ts,
+            local_ts=local_ts,
+            # Defensive copy: callers may mutate ``grid`` in place between
+            # enqueue and worker drain.
+            grid_json=[dict(level) for level in grid],
+            grid_step=Decimal(str(grid_step)),
+            grid_count=grid_count,
+            raw_fingerprint=fp_hash,
+        )
+        # Pair scope + fingerprint with the snapshot so the worker can roll
+        # back the dedupe key on insert failure without clobbering a newer
+        # enqueued payload that arrived in the meantime (mirrors
+        # GridStateStore._writer_loop semantics).
+        self._queue.put((snapshot, scope, fp_tuple))
+
+    def start(self) -> None:
+        """Launch the worker thread."""
+        if self._running:
+            return
+        self._running = True
+        self._worker = threading.Thread(
+            target=self._worker_loop,
+            name="GridStateWriter",
+            daemon=True,
+        )
+        self._worker.start()
+        logger.info("GridStateWriter worker started")
+
+    def flush(self, timeout: float = 10.0) -> None:
+        """Block until all queued snapshots have been processed.
+
+        Uses ``queue.join`` semantics (worker calls ``task_done`` after each
+        insert). On timeout the remaining snapshots stay queued — caller may
+        retry by calling ``flush`` again.
+        """
+        deadline_event = threading.Event()
+
+        def _wait() -> None:
+            self._queue.join()
+            deadline_event.set()
+
+        waiter = threading.Thread(target=_wait, daemon=True)
+        waiter.start()
+        if not deadline_event.wait(timeout=timeout):
+            logger.warning(
+                "GridStateWriter.flush timed out after %.1fs with ~%d items pending",
+                timeout, self._queue.qsize(),
+            )
+
+    def stop(self) -> None:
+        """Signal worker to drain and exit, then join."""
+        if not self._running:
+            return
+        self._running = False
+        self._queue.put(_STOP_SENTINEL)
+        if self._worker is not None:
+            self._worker.join(timeout=10.0)
+        logger.info(
+            "GridStateWriter stopped. written=%d dedup_skipped=%d "
+            "dropped_no_run_id=%d dropped_no_ts=%d errors=%d",
+            self._total_written, self._total_dedup_skipped,
+            self._total_dropped_no_run_id, self._total_dropped_no_ts,
+            self._total_errors,
+        )
+
+    def _worker_loop(self) -> None:
+        """Drain the queue, one snapshot per session-and-commit.
+
+        Per-snapshot commits trade throughput for safety: a poison snapshot
+        cannot block subsequent ones from landing, and ``orchestrator.stop()``
+        flush is bounded by the number of inflight items.
+        """
+        while True:
+            item = self._queue.get()
+            try:
+                if item is _STOP_SENTINEL:
+                    return
+                snapshot, scope, fp_tuple = item
+                self._insert_one(snapshot, scope, fp_tuple)
+            finally:
+                self._queue.task_done()
+
+    def _insert_one(
+        self,
+        snapshot: GridStateSnapshot,
+        scope: tuple[str, str, str],
+        fp_tuple: tuple,
+    ) -> None:
+        try:
+            with self._db.get_session() as session:
+                repo = GridStateSnapshotRepository(session)
+                inserted = repo.insert(snapshot)
+                if inserted:
+                    self._total_written += 1
+                else:
+                    # Partial-index conflict — silent no-op is correct
+                    # (race-double-insert protection).
+                    self._total_dedup_skipped += 1
+        except Exception as e:
+            self._total_errors += 1
+            logger.error("GridStateWriter insert failed: %s", e, exc_info=True)
+            # Roll back the in-memory dedupe key so a retry with the same
+            # state can still reach the DB. Race-safe: only pop if a newer
+            # enqueue has not already replaced the value — otherwise we'd
+            # clobber the in-flight newer payload's gate.
+            with self._dedupe_lock:
+                if self._last_fingerprint.get(scope) == fp_tuple:
+                    self._last_fingerprint.pop(scope, None)
+
+    def get_stats(self) -> dict:
+        return {
+            "total_written": self._total_written,
+            "total_dedup_skipped": self._total_dedup_skipped,
+            "total_dropped_no_run_id": self._total_dropped_no_run_id,
+            "total_dropped_no_ts": self._total_dropped_no_ts,
+            "total_errors": self._total_errors,
+            "queue_size": self._queue.qsize(),
+        }

--- a/apps/gridbot/tests/test_grid_state_writer.py
+++ b/apps/gridbot/tests/test_grid_state_writer.py
@@ -1,0 +1,348 @@
+"""Tests for ``GridStateWriter`` (feature 0047).
+
+Real SQLite session — the partial unique index and FIFO id ordering are
+both dialect-level behaviours that mocked sessions cannot exercise.
+"""
+
+from datetime import datetime, UTC
+from decimal import Decimal
+
+import pytest
+
+from grid_db.database import DatabaseFactory
+from grid_db.models import (
+    BybitAccount,
+    GridStateSnapshot,
+    Run,
+    Strategy,
+    User,
+)
+from grid_db.repositories import GridStateSnapshotRepository
+from grid_db.settings import DatabaseSettings
+from gridbot.writers.grid_state_writer import GridStateWriter
+from gridcore.persistence import grid_fingerprint_hash
+
+
+@pytest.fixture
+def db() -> DatabaseFactory:
+    """Fresh in-memory SQLite DB with seeded parent rows for each test."""
+    settings = DatabaseSettings(db_type="sqlite", db_name=":memory:")
+    db = DatabaseFactory(settings)
+    db.create_tables()
+    with db.get_session() as sess:
+        sess.add_all([
+            User(user_id="u1", username="u1"),
+            BybitAccount(
+                account_id="acc1", user_id="u1",
+                account_name="n", environment="mainnet",
+            ),
+            Strategy(
+                strategy_id="s1", account_id="acc1",
+                strategy_type="GridStrategy", symbol="LTCUSDT",
+                config_json={},
+            ),
+            Run(
+                run_id="run1", user_id="u1", account_id="acc1",
+                strategy_id="s1", run_type="live",
+            ),
+        ])
+    return db
+
+
+@pytest.fixture
+def grid() -> list[dict]:
+    return [
+        {"side": "Buy", "price": 100.0},
+        {"side": "Wait", "price": 101.0},
+        {"side": "Sell", "price": 102.0},
+    ]
+
+
+def _make_writer(db, run_ids: dict[str, str]) -> GridStateWriter:
+    writer = GridStateWriter(db, run_id_provider=lambda sid: run_ids.get(sid))
+    writer.start()
+    return writer
+
+
+def _rows(db) -> list[dict]:
+    """Return snapshots as plain dicts so attributes survive session close."""
+    with db.get_session() as sess:
+        rows = (
+            sess.query(GridStateSnapshot)
+            .order_by(GridStateSnapshot.id)
+            .all()
+        )
+        return [
+            {
+                "id": r.id,
+                "run_id": r.run_id,
+                "account_id": r.account_id,
+                "strat_id": r.strat_id,
+                "symbol": r.symbol,
+                "exchange_ts": r.exchange_ts,
+                "local_ts": r.local_ts,
+                "grid_json": r.grid_json,
+                "grid_step": r.grid_step,
+                "grid_count": r.grid_count,
+                "raw_fingerprint": r.raw_fingerprint,
+            }
+            for r in rows
+        ]
+
+
+class TestGridStateWriter:
+    def test_happy_path_insert(self, db, grid):
+        writer = _make_writer(db, {"strat1": "run1"})
+        writer.write(
+            strat_id="strat1", grid=grid, grid_step=0.5, grid_count=3,
+            account_id="acc1", symbol="LTCUSDT",
+            exchange_ts=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        writer.flush(timeout=5.0)
+        writer.stop()
+
+        rows = _rows(db)
+        assert len(rows) == 1
+        assert rows[0]["run_id"] == "run1"
+        assert rows[0]["account_id"] == "acc1"
+        assert rows[0]["strat_id"] == "strat1"
+        assert rows[0]["symbol"] == "LTCUSDT"
+        assert rows[0]["grid_step"] == Decimal("0.5")
+        assert rows[0]["grid_count"] == 3
+        assert rows[0]["raw_fingerprint"] == grid_fingerprint_hash(grid, 0.5, 3)
+        assert len(rows[0]["grid_json"]) == 3
+
+    def test_drop_when_run_id_provider_returns_none(self, db, grid, caplog):
+        # No mapping → provider returns None → snapshot dropped with INFO.
+        writer = _make_writer(db, {})
+        with caplog.at_level("INFO"):
+            writer.write(
+                strat_id="strat1", grid=grid, grid_step=0.5, grid_count=3,
+                account_id="acc1", symbol="LTCUSDT",
+                exchange_ts=datetime(2026, 1, 1, tzinfo=UTC),
+            )
+        writer.flush(timeout=5.0)
+        writer.stop()
+
+        assert _rows(db) == []
+        assert writer.get_stats()["total_dropped_no_run_id"] == 1
+        assert any(
+            "run_id not yet set" in rec.message for rec in caplog.records
+        )
+
+    def test_drop_when_exchange_ts_none(self, db, grid):
+        writer = _make_writer(db, {"strat1": "run1"})
+        writer.write(
+            strat_id="strat1", grid=grid, grid_step=0.5, grid_count=3,
+            account_id="acc1", symbol="LTCUSDT",
+            exchange_ts=None,
+        )
+        writer.flush(timeout=5.0)
+        writer.stop()
+
+        assert _rows(db) == []
+        assert writer.get_stats()["total_dropped_no_ts"] == 1
+
+    def test_in_memory_dedup_skips_identical_successive_writes(self, db, grid):
+        writer = _make_writer(db, {"strat1": "run1"})
+        ts = datetime(2026, 1, 1, tzinfo=UTC)
+        for _ in range(3):
+            writer.write(
+                strat_id="strat1", grid=grid, grid_step=0.5, grid_count=3,
+                account_id="acc1", symbol="LTCUSDT", exchange_ts=ts,
+            )
+        writer.flush(timeout=5.0)
+        writer.stop()
+
+        rows = _rows(db)
+        assert len(rows) == 1
+        # Two of the three writes hit the in-memory dedupe gate before enqueue.
+        assert writer.get_stats()["total_dedup_skipped"] >= 2
+
+    def test_partial_index_conflict_do_nothing(self, db, grid):
+        """Race-double-insert simulation: bypass dedupe by using two writers.
+
+        The partial unique index ``uq_grid_state_snapshots_fingerprint_at_ts``
+        must no-op the second insert (rowcount=0), not raise. NULL fingerprint
+        rows are NOT blocked by the constraint (sub-assert).
+        """
+        # Manually insert two identical rows via the repository to bypass
+        # the writer's pre-enqueue dedupe gate.
+        snap = GridStateSnapshot(
+            run_id="run1", account_id="acc1", strat_id="strat1",
+            symbol="LTCUSDT",
+            exchange_ts=datetime(2026, 1, 1, tzinfo=UTC),
+            local_ts=datetime(2026, 1, 1, tzinfo=UTC),
+            grid_json=grid, grid_step=Decimal("0.5"), grid_count=3,
+            raw_fingerprint=grid_fingerprint_hash(grid, 0.5, 3),
+        )
+        with db.get_session() as sess:
+            repo = GridStateSnapshotRepository(sess)
+            assert repo.insert(snap) == 1
+            # Reuse another instance with identical fields — partial unique
+            # blocks via ON CONFLICT DO NOTHING.
+            snap_dup = GridStateSnapshot(
+                run_id=snap.run_id, account_id=snap.account_id,
+                strat_id=snap.strat_id, symbol=snap.symbol,
+                exchange_ts=snap.exchange_ts, local_ts=snap.local_ts,
+                grid_json=snap.grid_json, grid_step=snap.grid_step,
+                grid_count=snap.grid_count,
+                raw_fingerprint=snap.raw_fingerprint,
+            )
+            assert repo.insert(snap_dup) == 0
+            # NULL fingerprint rows fall outside the partial unique scope.
+            snap_null1 = GridStateSnapshot(
+                run_id=snap.run_id, account_id=snap.account_id,
+                strat_id=snap.strat_id, symbol=snap.symbol,
+                exchange_ts=snap.exchange_ts, local_ts=snap.local_ts,
+                grid_json=snap.grid_json, grid_step=snap.grid_step,
+                grid_count=snap.grid_count,
+                raw_fingerprint=None,
+            )
+            snap_null2 = GridStateSnapshot(
+                run_id=snap.run_id, account_id=snap.account_id,
+                strat_id=snap.strat_id, symbol=snap.symbol,
+                exchange_ts=snap.exchange_ts, local_ts=snap.local_ts,
+                grid_json=snap.grid_json, grid_step=snap.grid_step,
+                grid_count=snap.grid_count,
+                raw_fingerprint=None,
+            )
+            assert repo.insert(snap_null1) == 1
+            assert repo.insert(snap_null2) == 1
+
+        rows = _rows(db)
+        assert len(rows) == 3  # 1 hashed + 2 nulls
+
+    def test_flush_and_stop_drain_queue(self, db, grid):
+        writer = _make_writer(db, {"strat1": "run1"})
+        for i in range(5):
+            grid_variant = [{"side": "Buy", "price": 100.0 + i}, *grid[1:]]
+            writer.write(
+                strat_id="strat1", grid=grid_variant,
+                grid_step=0.5, grid_count=3,
+                account_id="acc1", symbol="LTCUSDT",
+                exchange_ts=datetime(2026, 1, 1, 0, i, tzinfo=UTC),
+            )
+        writer.flush(timeout=5.0)
+        writer.stop()
+        assert len(_rows(db)) == 5
+
+    def test_writer_preserves_fifo_for_same_strat_same_ts(self, db):
+        """Two snapshots with identical (run,account,strat,exchange_ts) but
+        different ``grid_json`` payloads must INSERT in enqueue order.
+
+        Critical for the loader's ``ORDER BY exchange_ts DESC, id DESC``
+        tie-break to pick the FINAL notify of a multi-notify outer mutation
+        (e.g. ``update_grid`` out-of-bounds path emits post-rebuild then
+        post-side-assignment).
+        """
+        writer = _make_writer(db, {"strat1": "run1"})
+        ts = datetime(2026, 1, 1, tzinfo=UTC)
+        # Different grids → different fingerprints → both bypass the
+        # in-memory dedupe gate.
+        intermediate = [
+            {"side": "Buy", "price": 100.0}, {"side": "Wait", "price": 101.0},
+            {"side": "Sell", "price": 102.0},
+        ]
+        final = [
+            {"side": "Buy", "price": 100.0}, {"side": "Buy", "price": 101.0},
+            {"side": "Wait", "price": 102.0}, {"side": "Sell", "price": 103.0},
+        ]
+        writer.write(
+            strat_id="strat1", grid=intermediate, grid_step=0.5, grid_count=3,
+            account_id="acc1", symbol="LTCUSDT", exchange_ts=ts,
+        )
+        writer.write(
+            strat_id="strat1", grid=final, grid_step=0.5, grid_count=4,
+            account_id="acc1", symbol="LTCUSDT", exchange_ts=ts,
+        )
+        writer.flush(timeout=5.0)
+        writer.stop()
+
+        rows = _rows(db)
+        assert len(rows) == 2
+        # First row inserted (smaller id) is the intermediate payload.
+        assert rows[0]["grid_count"] == 3
+        # Larger id is the final post-side-assignment payload — what the
+        # loader's id DESC tie-break must pick.
+        assert rows[1]["grid_count"] == 4
+        assert rows[0]["id"] < rows[1]["id"]
+
+    def test_dedupe_rolled_back_after_insert_failure(self, db, grid):
+        """0047 P1: a transient DB failure on the first write must NOT
+        block the same state from being re-enqueued and persisted.
+
+        Without rollback, ``_last_fingerprint`` keeps the failed payload's
+        tuple and the next identical mutation hits the dedupe gate — but
+        no DB row exists, so replay has no seed.
+        """
+        writer = _make_writer(db, {"strat1": "run1"})
+
+        # Force the FIRST insert to fail by patching the repository class
+        # on the module the worker imports it from. We restore before the
+        # second write so the retry can land.
+        from gridbot.writers import grid_state_writer as gsw
+
+        original_repo = gsw.GridStateSnapshotRepository
+        call_count = {"n": 0}
+
+        class FlakyRepo(original_repo):
+            def insert(self, snapshot):
+                call_count["n"] += 1
+                if call_count["n"] == 1:
+                    raise RuntimeError("simulated transient DB failure")
+                return super().insert(snapshot)
+
+        ts = datetime(2026, 1, 1, tzinfo=UTC)
+        gsw.GridStateSnapshotRepository = FlakyRepo
+        try:
+            writer.write(
+                strat_id="strat1", grid=grid, grid_step=0.5, grid_count=3,
+                account_id="acc1", symbol="LTCUSDT", exchange_ts=ts,
+            )
+            writer.flush(timeout=5.0)
+            assert writer.get_stats()["total_errors"] == 1
+            # Second write of the SAME state must NOT be dedup'd — rollback
+            # cleared the in-memory gate.
+            writer.write(
+                strat_id="strat1", grid=grid, grid_step=0.5, grid_count=3,
+                account_id="acc1", symbol="LTCUSDT", exchange_ts=ts,
+            )
+            writer.flush(timeout=5.0)
+        finally:
+            gsw.GridStateSnapshotRepository = original_repo
+            writer.stop()
+
+        rows = _rows(db)
+        assert len(rows) == 1
+        assert rows[0]["raw_fingerprint"] == grid_fingerprint_hash(grid, 0.5, 3)
+
+    def test_get_at_or_before_picks_largest_id_on_tie(self, db):
+        """End-to-end: writer enqueues two same-ts payloads; loader's
+        ``get_at_or_before`` returns the row with the larger ``id``."""
+        writer = _make_writer(db, {"strat1": "run1"})
+        ts = datetime(2026, 1, 1, tzinfo=UTC)
+        intermediate = [
+            {"side": "Buy", "price": 100.0}, {"side": "Wait", "price": 101.0},
+        ]
+        final = [
+            {"side": "Buy", "price": 100.0}, {"side": "Sell", "price": 101.0},
+        ]
+        writer.write(
+            strat_id="strat1", grid=intermediate, grid_step=0.5, grid_count=2,
+            account_id="acc1", symbol="LTCUSDT", exchange_ts=ts,
+        )
+        writer.write(
+            strat_id="strat1", grid=final, grid_step=0.5, grid_count=2,
+            account_id="acc1", symbol="LTCUSDT", exchange_ts=ts,
+        )
+        writer.flush(timeout=5.0)
+        writer.stop()
+
+        with db.get_session() as sess:
+            repo = GridStateSnapshotRepository(sess)
+            picked = repo.get_at_or_before(
+                "run1", "acc1", "strat1", datetime(2026, 1, 2, tzinfo=UTC),
+            )
+            assert picked is not None
+            assert picked.grid_json == final

--- a/apps/gridbot/tests/test_orchestrator.py
+++ b/apps/gridbot/tests/test_orchestrator.py
@@ -1755,6 +1755,179 @@ class TestOrchestratorDbRecords:
         assert orchestrator._run_ids == {}
 
 
+class TestOrchestratorGridStateWriterWiring:
+    """Feature 0047 — regression coverage for the parallel DB grid-state writer.
+
+    The writer is constructed in ``Orchestrator.__init__`` conditional on
+    ``db is not None``, threaded into every ``StrategyRunner`` via
+    ``_init_strategy``, started in ``start()`` AFTER ``_create_run_records``,
+    and flushed + stopped in ``stop()``. These tests assert each link
+    individually so a regression in any one of them is caught before
+    feature 0047 silently produces zero snapshots.
+    """
+
+    def test_no_writer_constructed_when_db_is_none(self, gridbot_config):
+        orchestrator = Orchestrator(gridbot_config, db=None)
+        assert orchestrator._grid_state_writer is None
+
+    def test_writer_constructed_when_db_present(self, gridbot_config):
+        from grid_db import DatabaseFactory, DatabaseSettings
+        from gridbot.writers import GridStateWriter
+
+        db = DatabaseFactory(DatabaseSettings(db_name=":memory:"))
+        db.create_tables()
+
+        orchestrator = Orchestrator(gridbot_config, db=db)
+        assert isinstance(orchestrator._grid_state_writer, GridStateWriter)
+
+    @patch("gridbot.orchestrator.BybitRestClient")
+    @patch("gridbot.orchestrator.PublicWebSocketClient")
+    @patch("gridbot.orchestrator.PrivateWebSocketClient")
+    def test_writer_threaded_into_runner_with_correct_account_id(
+        self, mock_private_ws, mock_public_ws, mock_rest_client,
+        gridbot_config, account_config, strategy_config,
+    ):
+        """``_init_strategy`` passes the shared writer + uuid5 account_id
+        into every ``StrategyRunner`` so ``_on_grid_change`` can fire the
+        DB write path."""
+        from uuid import UUID, uuid5
+        from grid_db import DatabaseFactory, DatabaseSettings
+
+        db = DatabaseFactory(DatabaseSettings(db_name=":memory:"))
+        db.create_tables()
+
+        orchestrator = Orchestrator(gridbot_config, db=db)
+        orchestrator._init_account(account_config)
+        orchestrator._init_strategy(strategy_config)
+
+        runner = orchestrator._runners["btcusdt_test"]
+        # Same instance — one writer shared by every runner.
+        assert runner._grid_state_writer is orchestrator._grid_state_writer
+        # account_id must match the orchestrator's UUID5 formula or
+        # snapshots FK-mismatch replay's account scope.
+        namespace = UUID("12345678-1234-5678-1234-567812345678")
+        expected = str(uuid5(namespace, f"account:{account_config.name}"))
+        assert runner._account_id == expected
+
+    @patch("gridbot.orchestrator.BybitRestClient")
+    @patch("gridbot.orchestrator.PublicWebSocketClient")
+    @patch("gridbot.orchestrator.PrivateWebSocketClient")
+    def test_start_starts_writer_after_run_records_populated(
+        self, mock_private_ws, mock_public_ws, mock_rest_client,
+        gridbot_config, account_config, strategy_config,
+    ):
+        """``start()`` invokes ``writer.start()`` only AFTER
+        ``_create_run_records`` has populated ``_run_ids`` — otherwise
+        the writer's ``run_id_provider`` would drop all early enqueues.
+        """
+        from grid_db import DatabaseFactory, DatabaseSettings
+
+        db = DatabaseFactory(DatabaseSettings(db_name=":memory:"))
+        db.create_tables()
+
+        orchestrator = Orchestrator(gridbot_config, db=db)
+        # Replace the writer with a MagicMock so we can observe start().
+        writer_mock = MagicMock()
+        orchestrator._grid_state_writer = writer_mock
+
+        # Capture the state of _run_ids at the moment start() is called.
+        run_ids_when_started: dict = {}
+
+        def _capture_state():
+            run_ids_when_started.update(dict(orchestrator._run_ids))
+
+        writer_mock.start.side_effect = _capture_state
+
+        # Patch out networked pieces so start() completes without I/O.
+        with patch.object(orchestrator, "_connect_websockets"), \
+             patch.object(orchestrator, "_position_fetcher") as fetcher:
+            fetcher.fetch_and_update = MagicMock()
+            orchestrator.start()
+
+        writer_mock.start.assert_called_once()
+        # _run_ids must already be populated when writer.start() fires.
+        assert "btcusdt_test" in run_ids_when_started
+
+    @patch("gridbot.orchestrator.BybitRestClient")
+    @patch("gridbot.orchestrator.PublicWebSocketClient")
+    @patch("gridbot.orchestrator.PrivateWebSocketClient")
+    def test_stop_flushes_and_stops_writer(
+        self, mock_private_ws, mock_public_ws, mock_rest_client,
+        gridbot_config, account_config, strategy_config,
+    ):
+        """``stop()`` calls ``writer.flush(timeout=10.0)`` then
+        ``writer.stop()`` so the last post-fill snapshots in the queue
+        are persisted before the process exits.
+        """
+        from grid_db import DatabaseFactory, DatabaseSettings
+
+        db = DatabaseFactory(DatabaseSettings(db_name=":memory:"))
+        db.create_tables()
+
+        orchestrator = Orchestrator(gridbot_config, db=db)
+        writer_mock = MagicMock()
+        orchestrator._grid_state_writer = writer_mock
+
+        with patch.object(orchestrator, "_connect_websockets"), \
+             patch.object(orchestrator, "_position_fetcher") as fetcher:
+            fetcher.fetch_and_update = MagicMock()
+            orchestrator.start()
+            orchestrator.stop()
+
+        writer_mock.flush.assert_called_once_with(timeout=10.0)
+        writer_mock.stop.assert_called_once()
+
+    def test_stop_does_not_crash_without_writer(self, gridbot_config):
+        """Standalone / no-DB orchestrator stop() must not NPE on the
+        ``self._grid_state_writer is None`` branch."""
+        orchestrator = Orchestrator(gridbot_config, db=None)
+        # Mark started so stop() takes the real path.
+        orchestrator._started = True
+        # No WS to disconnect — empty dicts already cover that.
+        orchestrator.stop()  # Must not raise.
+
+    @patch("gridbot.orchestrator.BybitRestClient")
+    @patch("gridbot.orchestrator.PublicWebSocketClient")
+    @patch("gridbot.orchestrator.PrivateWebSocketClient")
+    def test_start_provisions_grid_state_snapshots_table_on_pre_0047_db(
+        self, mock_private_ws, mock_public_ws, mock_rest_client,
+        gridbot_config, account_config, strategy_config,
+    ):
+        """0047: deploying 0047 onto a pre-0047 production DB must
+        auto-create the missing ``grid_state_snapshots`` table at
+        ``start()``. ``Base.metadata.create_all`` is idempotent so
+        existing tables are untouched.
+        """
+        from sqlalchemy import inspect as sa_inspect
+        from grid_db import DatabaseFactory, DatabaseSettings
+        from grid_db.models import Base, GridStateSnapshot
+
+        # Provision the schema MINUS grid_state_snapshots to simulate a
+        # pre-0047 DB.
+        db = DatabaseFactory(DatabaseSettings(db_name=":memory:"))
+        Base.metadata.create_all(
+            db.engine,
+            tables=[
+                t for t in Base.metadata.sorted_tables
+                if t.name != GridStateSnapshot.__tablename__
+            ],
+        )
+        assert not sa_inspect(db.engine).has_table(
+            GridStateSnapshot.__tablename__
+        )
+
+        orchestrator = Orchestrator(gridbot_config, db=db)
+        with patch.object(orchestrator, "_connect_websockets"), \
+             patch.object(orchestrator, "_position_fetcher") as fetcher:
+            fetcher.fetch_and_update = MagicMock()
+            orchestrator.start()
+
+        # Table now present — writer can land snapshots.
+        assert sa_inspect(db.engine).has_table(
+            GridStateSnapshot.__tablename__
+        )
+
+
 class TestOrchestratorRetryDispatcher:
     """Tests for retry queue intent dispatch routing."""
 

--- a/apps/gridbot/tests/test_runner.py
+++ b/apps/gridbot/tests/test_runner.py
@@ -4153,10 +4153,348 @@ class TestStateStoreWiring:
         runner = StrategyRunner(
             strategy_config=strategy_config, executor=mock_executor, state_store=store,
         )
-        runner._on_grid_change([])
-        runner._on_grid_change([{"side": "Wait", "price": 100.0}])
+        runner._on_grid_change([], None)
+        runner._on_grid_change([{"side": "Wait", "price": 100.0}], None)
         store.save.assert_not_called()
 
     def test_on_grid_change_no_store_is_noop(self, strategy_config, mock_executor):
         runner = StrategyRunner(strategy_config=strategy_config, executor=mock_executor)
-        runner._on_grid_change([{"side": "Wait", "price": 100.0}] * 5)
+        runner._on_grid_change([{"side": "Wait", "price": 100.0}] * 5, None)
+
+    def test_account_id_required_when_grid_state_writer_wired(
+        self, strategy_config, mock_executor,
+    ):
+        """0047: dummy account_id default must NOT be silently accepted
+        when a DB writer is wired — would FK-mismatch replay's account
+        scope and snapshots become invisible.
+        """
+        writer = Mock()
+        with pytest.raises(ValueError, match="account_id must be set"):
+            StrategyRunner(
+                strategy_config=strategy_config,
+                executor=mock_executor,
+                # account_id omitted on purpose — dummy default kicks in.
+                grid_state_writer=writer,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Feature 0047 — exchange_ts propagation through _on_grid_change.
+#
+# These tests assert each mutation path enumerated in plan v18 carries the
+# correct triggering-event timestamp into ``GridStateWriter.write``. Wrong
+# timestamps would persist cleanly (no test fails) but break replay's
+# ``at_or_before(seed.at_ts)`` lookup — the same silent-failure class the
+# plan calls out for the ``grid.py:78`` arity swallow.
+# ---------------------------------------------------------------------------
+
+
+class TestOnGridChangeDbWriter:
+    """0047: ``_on_grid_change`` writer-side behaviour (independent of engine paths)."""
+
+    _ACCOUNT_ID = "00000000-0000-0000-0000-000000000001"
+
+    def _runner(self, strategy_config, mock_executor, *, writer=None, store=None):
+        return StrategyRunner(
+            strategy_config=strategy_config,
+            executor=mock_executor,
+            account_id=self._ACCOUNT_ID,
+            state_store=store,
+            grid_state_writer=writer,
+        )
+
+    def test_writes_to_db_when_writer_configured(self, strategy_config, mock_executor):
+        store = Mock()
+        store.load.return_value = None
+        writer = Mock()
+        runner = self._runner(strategy_config, mock_executor, writer=writer, store=store)
+
+        ts = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        grid = [
+            {"side": "Buy", "price": 99.0},
+            {"side": "Wait", "price": 100.0},
+            {"side": "Sell", "price": 101.0},
+        ]
+        runner._on_grid_change(grid, ts)
+
+        writer.write.assert_called_once()
+        call = writer.write.call_args
+        assert call.kwargs["strat_id"] == strategy_config.strat_id
+        assert call.kwargs["grid"] is grid
+        assert call.kwargs["grid_step"] == strategy_config.grid_step
+        assert call.kwargs["grid_count"] == strategy_config.grid_count
+        assert call.kwargs["account_id"] == self._ACCOUNT_ID
+        assert call.kwargs["symbol"] == strategy_config.symbol
+        assert call.kwargs["exchange_ts"] == ts
+        # File path also fired in parallel (independent backend guards).
+        store.save.assert_called_once()
+
+    def test_skips_db_write_when_writer_not_configured(self, strategy_config, mock_executor):
+        store = Mock()
+        store.load.return_value = None
+        runner = self._runner(strategy_config, mock_executor, store=store)
+        runner._on_grid_change(
+            [{"side": "Buy", "price": 99.0}, {"side": "Sell", "price": 101.0}],
+            datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        # No grid_state_writer attribute means no DB write path — file path still fires.
+        store.save.assert_called_once()
+
+    def test_db_write_fires_when_state_store_is_none(self, strategy_config, mock_executor):
+        """v12 guard split: backends are independent. DB write fires even
+        when the legacy file backend is disabled (the v11 plan would have
+        skipped this case via the early ``state_store is None`` return)."""
+        writer = Mock()
+        runner = self._runner(strategy_config, mock_executor, writer=writer, store=None)
+        ts = datetime(2026, 1, 1, tzinfo=UTC)
+        runner._on_grid_change(
+            [{"side": "Buy", "price": 99.0}, {"side": "Sell", "price": 101.0}],
+            ts,
+        )
+        writer.write.assert_called_once()
+        assert writer.write.call_args.kwargs["exchange_ts"] == ts
+
+    def test_skips_db_when_exchange_ts_none(self, strategy_config, mock_executor):
+        """Constructor-time restore_grid (or any other code path without a
+        triggering event) carries ``exchange_ts=None``; the DB write must
+        be skipped — non-null column would FK-write garbage and break
+        ``at_or_before`` lookups. File writer is unaffected."""
+        store = Mock()
+        store.load.return_value = None
+        writer = Mock()
+        runner = self._runner(strategy_config, mock_executor, writer=writer, store=store)
+        runner._on_grid_change(
+            [{"side": "Buy", "price": 99.0}, {"side": "Sell", "price": 101.0}],
+            None,
+        )
+        writer.write.assert_not_called()
+        store.save.assert_called_once()
+
+
+class TestOnGridChangeExchangeTsPropagation:
+    """0047: engine-path coverage that the triggering event's exchange_ts
+    is the value that lands at ``GridStateWriter.write``.
+
+    Each test drives one of the engine mutation paths enumerated in plan
+    v18 (restored-grid OOB rebuild, deferred-fill consumption, etc.) and
+    inspects the captured ``exchange_ts`` on a Mock writer.
+    """
+
+    _ACCOUNT_ID = "00000000-0000-0000-0000-000000000001"
+
+    def _runner(
+        self,
+        strategy_config,
+        mock_executor,
+        *,
+        writer,
+        restored_grid=None,
+    ) -> StrategyRunner:
+        store = Mock()
+        store.load.return_value = (
+            {
+                "grid": restored_grid,
+                "grid_step": strategy_config.grid_step,
+                "grid_count": strategy_config.grid_count,
+            }
+            if restored_grid is not None
+            else None
+        )
+        return StrategyRunner(
+            strategy_config=strategy_config,
+            executor=mock_executor,
+            account_id=self._ACCOUNT_ID,
+            state_store=store,
+            grid_state_writer=writer,
+        )
+
+    @staticmethod
+    def _ticker(price: float, ts: datetime) -> TickerEvent:
+        return TickerEvent(
+            event_type=EventType.TICKER,
+            symbol="BTCUSDT",
+            exchange_ts=ts,
+            local_ts=ts,
+            last_price=Decimal(str(price)),
+            mark_price=Decimal(str(price)),
+            bid1_price=Decimal(str(price - 0.5)),
+            ask1_price=Decimal(str(price + 0.5)),
+            funding_rate=Decimal("0.0001"),
+        )
+
+    @staticmethod
+    def _execution(price: float, ts: datetime, side: str = "Buy") -> ExecutionEvent:
+        return ExecutionEvent(
+            event_type=EventType.EXECUTION,
+            symbol="BTCUSDT",
+            exchange_ts=ts,
+            local_ts=ts,
+            exec_id=f"exec-{ts.isoformat()}",
+            order_id=f"order-{ts.isoformat()}",
+            order_link_id="abcdef0123456789-1715170800000",
+            side=side,
+            price=Decimal(str(price)),
+            qty=Decimal("0.001"),
+        )
+
+    def test_first_ticker_build_carries_ticker_ts(
+        self, strategy_config, mock_executor,
+    ):
+        """The very first ticker triggers ``build_grid`` (engine.py:151);
+        the snapshot must carry the ticker's ``exchange_ts``."""
+        writer = Mock()
+        runner = self._runner(strategy_config, mock_executor, writer=writer)
+        runner._wallet_balance = Decimal("10000")
+        ticker_ts = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        runner.on_ticker(self._ticker(50000.0, ticker_ts))
+
+        writer.write.assert_called_once()
+        assert writer.write.call_args.kwargs["exchange_ts"] == ticker_ts
+
+    def test_restored_grid_oob_rebuild_carries_ticker_ts(
+        self, strategy_config, mock_executor,
+    ):
+        """``engine.py:160-181``: first ticker is outside the restored
+        grid's bounds → engine rebuilds around ``last_close``. The
+        snapshot from this mutation must carry the ticker's ts (not the
+        save's wall-clock)."""
+        # Restored grid pinned far below the incoming ticker. The grid
+        # must be valid for ``is_grid_correct`` to accept restoration:
+        # strict-ascending prices, Buy levels < Sell levels.
+        restored_grid = [
+            {"side": "Buy", "price": float(p)}
+            for p in range(100, 100 + strategy_config.grid_count // 2)
+        ] + [{"side": "Wait", "price": float(100 + strategy_config.grid_count // 2)}] + [
+            {"side": "Sell", "price": float(p)}
+            for p in range(
+                100 + strategy_config.grid_count // 2 + 1,
+                100 + strategy_config.grid_count + 1,
+            )
+        ]
+        writer = Mock()
+        runner = self._runner(
+            strategy_config, mock_executor, writer=writer,
+            restored_grid=restored_grid,
+        )
+        runner._wallet_balance = Decimal("10000")
+        # Ticker at 50000 is far above the restored grid (100..150) →
+        # bounds check triggers a rebuild.
+        ticker_ts = datetime(2026, 1, 1, 13, 0, 0, tzinfo=UTC)
+        runner.on_ticker(self._ticker(50000.0, ticker_ts))
+
+        # At least one snapshot must carry the ticker's exchange_ts.
+        assert writer.write.called
+        observed = [c.kwargs["exchange_ts"] for c in writer.write.call_args_list]
+        assert ticker_ts in observed
+        # No wall-clock substitute.
+        assert all(ts == ticker_ts for ts in observed)
+
+    def test_deferred_fill_consumption_uses_ticker_ts(
+        self, strategy_config, mock_executor,
+    ):
+        """``engine.py:194``: execution arrives BEFORE first ticker
+        (``_fill_pending`` set, no grid yet). When ticker arrives, the
+        deferred fill is consumed and ``update_grid`` mutates the grid.
+        The snapshot must carry the **ticker's** ts (the moment live
+        actually mutates), not the earlier execution's.
+        """
+        writer = Mock()
+        runner = self._runner(strategy_config, mock_executor, writer=writer)
+        runner._wallet_balance = Decimal("10000")
+        exec_ts = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        ticker_ts = datetime(2026, 1, 1, 12, 0, 5, tzinfo=UTC)
+
+        # Execution first — engine has no last_close so just sets _fill_pending.
+        runner.on_execution(self._execution(50000.0, exec_ts))
+        assert writer.write.call_count == 0  # no grid mutation yet
+
+        # Ticker — builds grid AND consumes deferred fill.
+        runner.on_ticker(self._ticker(50000.0, ticker_ts))
+        assert writer.write.called
+        observed = [c.kwargs["exchange_ts"] for c in writer.write.call_args_list]
+        # The deferred-fill consumption snapshot must carry the ticker's ts.
+        assert ticker_ts in observed
+        # The earlier execution's ts MUST NOT appear — live mutated at
+        # ticker time, not execution time.
+        assert exec_ts not in observed
+
+    def test_check_and_place_rebuild_carries_ticker_ts(
+        self, strategy_config, mock_executor,
+    ):
+        """``engine.py:331``: when ``_check_and_place`` sees more limits
+        than the grid can fit (``len(limits) > len(grid) + 10``), it
+        rebuilds the grid via ``build_grid(self.last_close)``. The
+        snapshot must carry the **ticker's** ``exchange_ts`` — the
+        rebuild fires inside ``_handle_ticker_event`` whose try/finally
+        already pinned ``_current_exchange_ts`` to the ticker's ts.
+        """
+        writer = Mock()
+        runner = self._runner(strategy_config, mock_executor, writer=writer)
+        runner._wallet_balance = Decimal("10000")
+
+        # First ticker — builds the grid (grid_count=50 → 51 levels).
+        first_ts = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        runner.on_ticker(self._ticker(50000.0, first_ts))
+        writer.reset_mock()
+
+        # Stub get_limit_orders so the second ticker sees > 61 long
+        # orders, which triggers the too-many-orders rebuild branch
+        # (engine.py:347-349). Order shapes are intentionally minimal —
+        # the rebuild check just measures len().
+        runner.get_limit_orders = Mock(return_value={
+            "long": [
+                {
+                    "orderId": f"o{i}",
+                    "orderLinkId": f"link-{i}",
+                    "price": "50000.0",
+                    "qty": "0.001",
+                    "side": "Buy",
+                    "reduceOnly": False,
+                }
+                for i in range(70)
+            ],
+            "short": [],
+        })
+
+        # Second ticker at the same price — bounds OK, no recenter, but
+        # _check_and_place sees too many long orders and rebuilds.
+        ticker_ts = datetime(2026, 1, 1, 12, 1, 0, tzinfo=UTC)
+        runner.on_ticker(self._ticker(50000.0, ticker_ts))
+
+        assert writer.write.called
+        observed = [c.kwargs["exchange_ts"] for c in writer.write.call_args_list]
+        # Every snapshot from this mutation carries the ticker's ts.
+        assert all(ts == ticker_ts for ts in observed)
+        # Earlier ticker ts must NOT bleed in via stale state.
+        assert first_ts not in observed
+
+    def test_update_grid_out_of_bounds_rebuild_carries_execution_ts(
+        self, strategy_config, mock_executor,
+    ):
+        """``engine.py:241``: first ticker sets ``last_close``; then an
+        execution at an OOB price triggers ``update_grid`` rebuild →
+        ``_notify_change`` fires twice (post-rebuild intermediate +
+        post-side-assignment final). Both snapshots must carry the
+        execution's ``exchange_ts``.
+        """
+        writer = Mock()
+        runner = self._runner(strategy_config, mock_executor, writer=writer)
+        runner._wallet_balance = Decimal("10000")
+        ticker_ts = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        exec_ts = datetime(2026, 1, 1, 12, 5, 0, tzinfo=UTC)
+
+        # First ticker — builds grid centered around 50000 with step 0.2%.
+        runner.on_ticker(self._ticker(50000.0, ticker_ts))
+        writer.reset_mock()
+
+        # Execution far above the grid → update_grid OOB branch fires;
+        # _notify_change is called from build_grid (intermediate) and
+        # again after _assign_sides (final).
+        runner.on_execution(self._execution(70000.0, exec_ts, side="Buy"))
+
+        assert writer.write.called
+        observed = [c.kwargs["exchange_ts"] for c in writer.write.call_args_list]
+        # Every snapshot from this mutation carries the execution's ts.
+        assert all(ts == exec_ts for ts in observed)
+        # Ticker ts must NOT bleed in via stale _current_exchange_ts.
+        assert ticker_ts not in observed

--- a/apps/replay/src/replay/config.py
+++ b/apps/replay/src/replay/config.py
@@ -124,9 +124,14 @@ class SeedConfig(BaseModel):
         default=None,
         description="Strategy identifier used as GridStateStore key. Required when enabled.",
     )
-    grid_state_path: str = Field(
-        default="db/grid_anchor.json",
-        description="Path to grid-state JSON file shared with live (legacy filename retained from feature 0021).",
+    grid_state_path: Optional[str] = Field(
+        default=None,
+        description=(
+            "Path to legacy grid-state JSON file (feature 0021). With 0047 "
+            "the engine prefers ``grid_state_snapshots`` in DB and only "
+            "falls back to this file when a path is set AND no DB snapshot "
+            "covers ``at_ts``. None disables the file fallback entirely."
+        ),
     )
     wallet_coin: str = Field(
         default="USDT",

--- a/apps/replay/src/replay/engine.py
+++ b/apps/replay/src/replay/engine.py
@@ -63,6 +63,7 @@ from replay.snapshot_loader import (
     WalletSeed,
     load_active_orders,
     load_grid_state,
+    load_grid_state_from_snapshots,
     load_position_snapshots,
     load_wallet_seed_full,
 )
@@ -644,16 +645,35 @@ class ReplayEngine:
                 "seed.enabled=True but at_ts/account_id/strat_id are unset"
             )
 
-        # Grid state lives outside the DB; load before opening a session.
-        grid_seed = load_grid_state(
-            GridStateStore(file_path=seed.grid_state_path),
-            seed.strat_id,
-            expected_step=config.strategy.grid_step,
-            expected_count=config.strategy.grid_count,
-        )
-
+        # 0047: try the DB grid-state snapshot first, fall back to the file
+        # path, then to a blank build. DB lookup needs a session, so open it
+        # FIRST and run all loaders inside.
         with self._db.get_session() as db_session:
             self._seed_pre_check(db_session, run_id, seed.at_ts)
+
+            grid_seed = load_grid_state_from_snapshots(
+                db_session,
+                run_id,
+                seed.account_id,
+                seed.strat_id,
+                seed.at_ts,
+                expected_step=config.strategy.grid_step,
+                expected_count=config.strategy.grid_count,
+            )
+            grid_source = "db"
+            if grid_seed is None and seed.grid_state_path is not None:
+                grid_seed = load_grid_state(
+                    GridStateStore(file_path=seed.grid_state_path),
+                    seed.strat_id,
+                    expected_step=config.strategy.grid_step,
+                    expected_count=config.strategy.grid_count,
+                )
+                grid_source = "file" if grid_seed is not None else "fresh"
+            elif grid_seed is None:
+                grid_source = "fresh"
+            logger.info(
+                "%s: grid seed source=%s", seed.strat_id, grid_source,
+            )
 
             long_seed, short_seed = load_position_snapshots(
                 db_session,

--- a/apps/replay/src/replay/snapshot_loader.py
+++ b/apps/replay/src/replay/snapshot_loader.py
@@ -42,9 +42,12 @@ from datetime import datetime
 from decimal import Decimal
 from typing import Optional
 
+from sqlalchemy import inspect as sa_inspect
 from sqlalchemy.orm import Session
 
 from grid_db import (
+    GridStateSnapshot,
+    GridStateSnapshotRepository,
     OrderRepository,
     PositionSnapshotRepository,
     WalletSnapshotRepository,
@@ -262,6 +265,74 @@ def load_grid_state(
         grid=entry["grid"],
         grid_step=saved_step,
         grid_count=saved_count,
+    )
+
+
+def load_grid_state_from_snapshots(
+    db_session: Session,
+    run_id: str,
+    account_id: str,
+    strat_id: str,
+    at_ts: datetime,
+    expected_step: float,
+    expected_count: int,
+) -> Optional[GridStateSeed]:
+    """Load grid state from the ``grid_state_snapshots`` DB table (0047).
+
+    Mirrors ``load_grid_state`` (file path) but pulls the row written by
+    gridbot's ``GridStateWriter`` at the latest ``exchange_ts`` ≤ ``at_ts``.
+    Returns ``None`` on no-row-found or on step/count mismatch (engine
+    falls back to file path, then to a fresh blank-build).
+
+    ``grid_step`` comparison uses ``Decimal(str(...))`` normalisation so a
+    binary-imprecise float (e.g. ``0.1`` literal vs ``Decimal('0.10000000')``
+    from ``Numeric(20, 8)``) doesn't false-reject.
+
+    Pre-0047 recorder DBs do not have the ``grid_state_snapshots`` table.
+    The project provisions schema via ``Base.metadata.create_all`` rather
+    than Alembic, so an old DB literally does not contain this table.
+    Return ``None`` (with INFO) when the table is missing so the engine's
+    file fallback at ``engine.py:_load_seed`` runs.
+    """
+    # Use ``session.connection()`` (NOT ``get_bind()``) so the inspector
+    # shares the session's open transaction. ``inspect(engine).has_table``
+    # would acquire a fresh connection from the pool — on SQLite
+    # ``:memory:`` + StaticPool this issues a ROLLBACK that wipes the
+    # session's uncommitted writes.
+    if not sa_inspect(db_session.connection()).has_table(
+        GridStateSnapshot.__tablename__,
+    ):
+        logger.info(
+            "%s: grid_state_snapshots table not present (pre-0047 DB); "
+            "falling back to file path / fresh build",
+            strat_id,
+        )
+        return None
+    row = GridStateSnapshotRepository(db_session).get_at_or_before(
+        run_id, account_id, strat_id, at_ts,
+    )
+    if row is None:
+        logger.info(
+            "%s: no grid snapshot at-or-before %s", strat_id, at_ts,
+        )
+        return None
+    if int(row.grid_count) != int(expected_count):
+        logger.info(
+            "%s: saved grid_count=%d differs from replay config %d; falling back",
+            strat_id, row.grid_count, expected_count,
+        )
+        return None
+    if Decimal(str(row.grid_step)) != Decimal(str(expected_step)):
+        logger.info(
+            "%s: saved grid_step=%s differs from replay config %s; falling back",
+            strat_id, row.grid_step, expected_step,
+        )
+        return None
+    return GridStateSeed(
+        strat_id=strat_id,
+        grid=row.grid_json,
+        grid_step=float(row.grid_step),
+        grid_count=int(row.grid_count),
     )
 
 
@@ -538,6 +609,7 @@ __all__ = [
     "SeedConfigMismatchError",
     "SeedDataQualityError",
     "load_grid_state",
+    "load_grid_state_from_snapshots",
     "load_position_snapshots",
     "load_wallet_seed_full",
     "load_wallet_snapshot",

--- a/apps/replay/tests/test_engine_seed.py
+++ b/apps/replay/tests/test_engine_seed.py
@@ -18,6 +18,7 @@ import pytest
 
 from grid_db import (
     BybitAccount,
+    GridStateSnapshot,
     Order,
     OrderRepository,
     PositionSnapshot,
@@ -28,8 +29,9 @@ from grid_db import (
     WalletSnapshot,
     WalletSnapshotRepository,
 )
+from grid_db.repositories import GridStateSnapshotRepository
 
-from gridcore.persistence import GridStateStore
+from gridcore.persistence import GridStateStore, grid_fingerprint_hash
 
 from replay.config import ReplayConfig, ReplayStrategyConfig, SeedConfig
 from replay.engine import ReplayEngine
@@ -350,6 +352,98 @@ class TestReplayEngineSeedingPipeline:
         assert short_seed is not None
         assert grid_seed is not None
         assert order_seeds is not None
+
+    def test_load_seed_prefers_db_over_file(
+        self, seeded_db, replay_config, snapshot_ts, mock_instrument,
+    ):
+        """0047: when a DB snapshot covers ``at_ts``, engine returns it
+        — the file grid (different payload) is ignored."""
+        db_grid = [
+            {"side": "Buy", "price": 90000.0},
+            {"side": "Buy", "price": 90200.0},
+            {"side": "Sell", "price": 90600.0},
+            {"side": "Sell", "price": 90800.0},
+        ]
+        with seeded_db.get_session() as session:
+            GridStateSnapshotRepository(session).insert(
+                GridStateSnapshot(
+                    run_id="seed-run", account_id="acc-1", strat_id=STRAT_ID,
+                    symbol=SYMBOL,
+                    exchange_ts=snapshot_ts, local_ts=snapshot_ts,
+                    grid_json=db_grid, grid_step=Decimal("0.2"), grid_count=4,
+                    raw_fingerprint=grid_fingerprint_hash(db_grid, 0.2, 4),
+                )
+            )
+
+        engine = ReplayEngine(config=replay_config, db=seeded_db)
+        run_id, *_ = engine._resolve_run(replay_config)
+        _, _, _, grid_seed, _ = engine._load_seed(replay_config, run_id)
+        assert grid_seed is not None
+        assert grid_seed.grid == db_grid
+
+    def test_load_seed_falls_back_to_file_when_no_db_snapshot(
+        self, seeded_db, replay_config, mock_instrument,
+    ):
+        """0047: no DB row at-or-before at_ts → file path wins."""
+        engine = ReplayEngine(config=replay_config, db=seeded_db)
+        run_id, *_ = engine._resolve_run(replay_config)
+        _, _, _, grid_seed, _ = engine._load_seed(replay_config, run_id)
+        assert grid_seed is not None
+        # File fixture has 4 levels starting at 99600.0 (see grid_state_path).
+        assert grid_seed.grid[0]["price"] == 99600.0
+
+    def test_load_seed_falls_back_to_file_when_table_missing(
+        self, seeded_db, replay_config, mock_instrument,
+    ):
+        """0047 P1: pre-0047 DB (no ``grid_state_snapshots`` table) must
+        still drop into the file path so old recorder datasets stay
+        usable. Without this, SQLAlchemy raises ``no such table`` and the
+        plan's "old datasets stay on file mode" out-of-scope clause breaks.
+        """
+        GridStateSnapshot.__table__.drop(seeded_db.engine)
+        try:
+            engine = ReplayEngine(config=replay_config, db=seeded_db)
+            run_id, *_ = engine._resolve_run(replay_config)
+            _, _, _, grid_seed, _ = engine._load_seed(replay_config, run_id)
+        finally:
+            GridStateSnapshot.__table__.create(seeded_db.engine)
+
+        assert grid_seed is not None
+        # File fixture has 4 levels starting at 99600.0.
+        assert grid_seed.grid[0]["price"] == 99600.0
+
+    def test_load_seed_falls_back_to_fresh_when_no_db_and_no_file(
+        self, seeded_db, seed_ts, mock_instrument,
+    ):
+        """0047: no DB row AND grid_state_path is None → grid_seed is None."""
+        seed_config = SeedConfig(
+            enabled=True,
+            at_ts=seed_ts,
+            account_id="acc-1",
+            strat_id=STRAT_ID,
+            grid_state_path=None,
+            wallet_coin="USDT",
+        )
+        replay_config = ReplayConfig(
+            database_url="sqlite:///:memory:",
+            run_id="seed-run",
+            symbol=SYMBOL,
+            start_ts=seed_ts,
+            end_ts=seed_ts + timedelta(hours=1),
+            strategy=ReplayStrategyConfig(
+                tick_size=Decimal("0.1"),
+                grid_count=4,
+                grid_step=0.2,
+                enable_risk_multipliers=True,
+            ),
+            initial_balance=Decimal("10000"),
+            enable_funding=False,
+            seed=seed_config,
+        )
+        engine = ReplayEngine(config=replay_config, db=seeded_db)
+        run_id, *_ = engine._resolve_run(replay_config)
+        _, _, _, grid_seed, _ = engine._load_seed(replay_config, run_id)
+        assert grid_seed is None
 
 
 # ---------------------------------------------------------------------------

--- a/apps/replay/tests/test_snapshot_loader.py
+++ b/apps/replay/tests/test_snapshot_loader.py
@@ -10,6 +10,7 @@ import pytest
 
 from grid_db import (
     BybitAccount,
+    GridStateSnapshot,
     Order,
     OrderRepository,
     PositionSnapshot,
@@ -20,8 +21,9 @@ from grid_db import (
     WalletSnapshot,
     WalletSnapshotRepository,
 )
+from grid_db.repositories import GridStateSnapshotRepository
 
-from gridcore.persistence import GridStateStore
+from gridcore.persistence import GridStateStore, grid_fingerprint_hash
 
 from replay.snapshot_loader import (
     ActiveOrderSeed,
@@ -32,6 +34,7 @@ from replay.snapshot_loader import (
     WalletSeed,
     load_active_orders,
     load_grid_state,
+    load_grid_state_from_snapshots,
     load_position_snapshots,
     load_wallet_seed_full,
     load_wallet_snapshot,
@@ -205,6 +208,368 @@ class TestLoadGridState:
 
         seed = load_grid_state(store, "strat-C", expected_step=0.2, expected_count=99)
         assert seed is None
+
+
+# ---------------------------------------------------------------------------
+# load_grid_state_from_snapshots (feature 0047)
+# ---------------------------------------------------------------------------
+
+
+def _make_grid_row(
+    sample_run,
+    sample_account,
+    *,
+    strat_id: str = "strat-A",
+    grid: list[dict] | None = None,
+    grid_step: float = 0.2,
+    grid_count: int = 3,
+    exchange_ts: datetime | None = None,
+    raw_fingerprint: str | None = None,
+) -> GridStateSnapshot:
+    grid = grid or [
+        {"side": "Buy", "price": 100.0},
+        {"side": "Wait", "price": 101.0},
+        {"side": "Sell", "price": 102.0},
+    ]
+    ts = exchange_ts or datetime(2026, 5, 7, 10, 0, 0, tzinfo=timezone.utc)
+    if raw_fingerprint is None:
+        raw_fingerprint = grid_fingerprint_hash(grid, grid_step, grid_count)
+    return GridStateSnapshot(
+        run_id=sample_run.run_id,
+        account_id=str(sample_account.account_id),
+        strat_id=strat_id,
+        symbol="BTCUSDT",
+        exchange_ts=ts,
+        local_ts=ts,
+        grid_json=grid,
+        grid_step=Decimal(str(grid_step)),
+        grid_count=grid_count,
+        raw_fingerprint=raw_fingerprint,
+    )
+
+
+class TestLoadGridStateFromSnapshots:
+    """Loader-level coverage for the 0047 DB grid-state path."""
+
+    def test_happy_path_returns_seed(
+        self, session, sample_account, sample_run, base_ts
+    ):
+        repo = GridStateSnapshotRepository(session)
+        repo.insert(_make_grid_row(sample_run, sample_account, exchange_ts=base_ts))
+        session.flush()
+
+        seed = load_grid_state_from_snapshots(
+            session,
+            run_id=sample_run.run_id,
+            account_id=str(sample_account.account_id),
+            strat_id="strat-A",
+            at_ts=base_ts + timedelta(minutes=1),
+            expected_step=0.2,
+            expected_count=3,
+        )
+        assert seed is not None
+        assert seed.strat_id == "strat-A"
+        assert seed.grid_step == 0.2
+        assert seed.grid_count == 3
+        assert seed.grid[0]["side"] == "Buy"
+
+    def test_no_snapshot_returns_none(
+        self, session, sample_account, sample_run, base_ts, caplog
+    ):
+        with caplog.at_level(logging.INFO):
+            seed = load_grid_state_from_snapshots(
+                session,
+                run_id=sample_run.run_id,
+                account_id=str(sample_account.account_id),
+                strat_id="missing",
+                at_ts=base_ts,
+                expected_step=0.2,
+                expected_count=3,
+            )
+        assert seed is None
+        assert any(
+            "no grid snapshot at-or-before" in rec.message for rec in caplog.records
+        )
+
+    def test_same_exchange_ts_picks_latest_by_id(
+        self, session, sample_account, sample_run, base_ts
+    ):
+        """Two snapshots at the same exchange_ts (multi-notify simulation) →
+        loader returns the row inserted second (larger id)."""
+        repo = GridStateSnapshotRepository(session)
+        intermediate = [
+            {"side": "Buy", "price": 100.0},
+            {"side": "Wait", "price": 101.0},
+        ]
+        final = [
+            {"side": "Buy", "price": 100.0},
+            {"side": "Sell", "price": 101.0},
+        ]
+        repo.insert(
+            _make_grid_row(
+                sample_run, sample_account, grid=intermediate, grid_count=2,
+                exchange_ts=base_ts,
+            )
+        )
+        repo.insert(
+            _make_grid_row(
+                sample_run, sample_account, grid=final, grid_count=2,
+                exchange_ts=base_ts,
+            )
+        )
+        session.flush()
+
+        seed = load_grid_state_from_snapshots(
+            session,
+            run_id=sample_run.run_id,
+            account_id=str(sample_account.account_id),
+            strat_id="strat-A",
+            at_ts=base_ts + timedelta(minutes=1),
+            expected_step=0.2,
+            expected_count=2,
+        )
+        assert seed is not None
+        assert seed.grid == final
+
+    def test_picks_latest_at_or_before(
+        self, session, sample_account, sample_run, base_ts
+    ):
+        repo = GridStateSnapshotRepository(session)
+        repo.insert(_make_grid_row(sample_run, sample_account, exchange_ts=base_ts))
+        repo.insert(
+            _make_grid_row(
+                sample_run, sample_account,
+                grid=[
+                    {"side": "Buy", "price": 200.0},
+                    {"side": "Wait", "price": 201.0},
+                    {"side": "Sell", "price": 202.0},
+                ],
+                exchange_ts=base_ts + timedelta(minutes=10),
+            )
+        )
+        session.flush()
+
+        seed = load_grid_state_from_snapshots(
+            session,
+            run_id=sample_run.run_id,
+            account_id=str(sample_account.account_id),
+            strat_id="strat-A",
+            at_ts=base_ts + timedelta(minutes=5),
+            expected_step=0.2,
+            expected_count=3,
+        )
+        assert seed is not None
+        # First row (base_ts) wins — later row (+10m) is past the at_ts upper bound.
+        assert seed.grid[0]["price"] == 100.0
+
+    def test_cross_run_isolation(
+        self, session, sample_user, sample_account, sample_strategy, sample_run,
+        base_ts,
+    ):
+        """Snapshot present for another run only → loader returns None."""
+        other_run = Run(
+            user_id=sample_user.user_id,
+            account_id=sample_account.account_id,
+            strategy_id=sample_strategy.strategy_id,
+            run_type="recording",
+            status="running",
+            start_ts=base_ts,
+        )
+        session.add(other_run)
+        session.flush()
+        repo = GridStateSnapshotRepository(session)
+        repo.insert(_make_grid_row(other_run, sample_account, exchange_ts=base_ts))
+        session.flush()
+
+        seed = load_grid_state_from_snapshots(
+            session,
+            run_id=sample_run.run_id,
+            account_id=str(sample_account.account_id),
+            strat_id="strat-A",
+            at_ts=base_ts + timedelta(minutes=1),
+            expected_step=0.2,
+            expected_count=3,
+        )
+        assert seed is None
+
+    def test_cross_strat_isolation(
+        self, session, sample_account, sample_run, base_ts
+    ):
+        repo = GridStateSnapshotRepository(session)
+        repo.insert(
+            _make_grid_row(
+                sample_run, sample_account, strat_id="other-strat",
+                exchange_ts=base_ts,
+            )
+        )
+        session.flush()
+        seed = load_grid_state_from_snapshots(
+            session,
+            run_id=sample_run.run_id,
+            account_id=str(sample_account.account_id),
+            strat_id="strat-A",
+            at_ts=base_ts + timedelta(minutes=1),
+            expected_step=0.2,
+            expected_count=3,
+        )
+        assert seed is None
+
+    def test_step_count_mismatch_returns_none(
+        self, session, sample_account, sample_run, base_ts, caplog
+    ):
+        repo = GridStateSnapshotRepository(session)
+        repo.insert(_make_grid_row(sample_run, sample_account, exchange_ts=base_ts))
+        session.flush()
+        with caplog.at_level(logging.INFO):
+            seed = load_grid_state_from_snapshots(
+                session,
+                run_id=sample_run.run_id,
+                account_id=str(sample_account.account_id),
+                strat_id="strat-A",
+                at_ts=base_ts + timedelta(minutes=1),
+                expected_step=0.2,
+                expected_count=99,  # Mismatch.
+            )
+        assert seed is None
+        assert any("grid_count" in rec.message for rec in caplog.records)
+
+    def test_pre_0047_db_missing_table_returns_none(
+        self, db, sample_account, sample_run, base_ts, caplog
+    ):
+        """0047 P1: replay against a pre-0047 recorder DB (no
+        ``grid_state_snapshots`` table) must return ``None`` with INFO so
+        the engine falls back to ``seed.grid_state_path``. Without this,
+        SQLAlchemy raises ``no such table`` and the file fallback never
+        runs — breaking the plan's "old datasets stay on file mode"
+        out-of-scope clause.
+        """
+        # The other sample_* fixtures already used ``db`` to create all
+        # tables; drop the 0047 table to simulate the pre-0047 schema.
+        GridStateSnapshot.__table__.drop(db.engine)
+        try:
+            with db.get_session() as sess:
+                with caplog.at_level(logging.INFO):
+                    seed = load_grid_state_from_snapshots(
+                        sess,
+                        run_id=sample_run.run_id,
+                        account_id=str(sample_account.account_id),
+                        strat_id="strat-A",
+                        at_ts=base_ts,
+                        expected_step=0.2,
+                        expected_count=3,
+                    )
+            assert seed is None
+            assert any(
+                "table not present" in rec.message for rec in caplog.records
+            )
+        finally:
+            # Restore the table so other tests in the session aren't affected.
+            GridStateSnapshot.__table__.create(db.engine)
+
+    def test_step_value_mismatch_returns_none(
+        self, session, sample_account, sample_run, base_ts, caplog
+    ):
+        """Step branch is exercised independently of the count branch:
+        stored step != expected step → None + INFO. Count is left equal
+        on purpose so count branch is not what catches the mismatch.
+        """
+        repo = GridStateSnapshotRepository(session)
+        repo.insert(
+            _make_grid_row(
+                sample_run, sample_account,
+                grid_step=0.2, grid_count=3, exchange_ts=base_ts,
+            )
+        )
+        session.flush()
+        with caplog.at_level(logging.INFO):
+            seed = load_grid_state_from_snapshots(
+                session,
+                run_id=sample_run.run_id,
+                account_id=str(sample_account.account_id),
+                strat_id="strat-A",
+                at_ts=base_ts + timedelta(minutes=1),
+                expected_step=0.5,  # Mismatch — distinct decimal value.
+                expected_count=3,
+            )
+        assert seed is None
+        assert any("grid_step" in rec.message for rec in caplog.records)
+
+    def test_loader_output_round_trips_through_restore_grid(
+        self, session, sample_account, sample_run, base_ts
+    ):
+        """The loader's payload must drop straight into
+        ``Grid.restore_grid`` (live's restart API) without massaging.
+        Locks the invariant: anything ``GridStateWriter`` writes must be
+        consumable by the same code that consumes the legacy JSON file.
+        """
+        from decimal import Decimal
+        from gridcore.grid import Grid
+
+        # Use a Grid-valid layout (strict-ascending prices, Buy → Wait →
+        # Sell). ``is_grid_correct`` rejects anything else.
+        canonical_grid = [
+            {"side": "Buy", "price": 99.0},
+            {"side": "Buy", "price": 99.5},
+            {"side": "Wait", "price": 100.0},
+            {"side": "Sell", "price": 100.5},
+            {"side": "Sell", "price": 101.0},
+        ]
+        repo = GridStateSnapshotRepository(session)
+        repo.insert(
+            _make_grid_row(
+                sample_run, sample_account,
+                grid=canonical_grid, grid_step=0.5, grid_count=5,
+                exchange_ts=base_ts,
+            )
+        )
+        session.flush()
+        seed = load_grid_state_from_snapshots(
+            session,
+            run_id=sample_run.run_id,
+            account_id=str(sample_account.account_id),
+            strat_id="strat-A",
+            at_ts=base_ts + timedelta(minutes=1),
+            expected_step=0.5,
+            expected_count=5,
+        )
+        assert seed is not None
+
+        # Same restore_grid call live performs on cold start.
+        grid_obj = Grid(
+            tick_size=Decimal("0.1"),
+            grid_count=seed.grid_count,
+            grid_step=seed.grid_step,
+        )
+        assert grid_obj.restore_grid(seed.grid) is True
+        assert grid_obj.grid == canonical_grid
+
+    def test_step_binary_imprecise_match_accepted(
+        self, session, sample_account, sample_run, base_ts
+    ):
+        """``expected_step=0.1`` (float) must accept ``Decimal('0.10000000')`` row.
+
+        Naive ``Decimal == float`` would reject because Python's ``0.1``
+        literal is ``0.1000000000000000055511...``.
+        """
+        repo = GridStateSnapshotRepository(session)
+        repo.insert(
+            _make_grid_row(
+                sample_run, sample_account,
+                grid_step=0.1,
+                exchange_ts=base_ts,
+            )
+        )
+        session.flush()
+        seed = load_grid_state_from_snapshots(
+            session,
+            run_id=sample_run.run_id,
+            account_id=str(sample_account.account_id),
+            strat_id="strat-A",
+            at_ts=base_ts + timedelta(minutes=1),
+            expected_step=0.1,
+            expected_count=3,
+        )
+        assert seed is not None
 
 
 # ---------------------------------------------------------------------------

--- a/docs/features/0029_RUNBOOK.md
+++ b/docs/features/0029_RUNBOOK.md
@@ -292,11 +292,26 @@ Verify nothing's left running:
 ps aux | grep -E "gridbot|recorder" | grep -v grep   # expect: empty
 ```
 
-Snapshot the final live grid state so replay reads the same file:
+**Grid-state snapshot — branch by run vintage**:
 
-```bash
-cp db/grid_anchor.json db/grid_anchor.phase4.json
-```
+* **Runs recorded with feature 0047 or later** (the live gridbot is
+  writing to the ``grid_state_snapshots`` DB table — check with
+  ``sqlite3 data/recorder_ltcusdt_phase4.db 'SELECT COUNT(*) FROM
+  grid_state_snapshots WHERE run_id = "<RUN_ID>"';`` — expect > 0):
+  **skip the ``cp`` step**. Replay reads the DB row at-or-before
+  ``seed.at_ts``. Leave ``seed.grid_state_path`` unset (or remove the
+  line entirely) in your Step 8 YAML.
+
+* **Pre-0047 runs** (no ``grid_state_snapshots`` table, or zero rows
+  for the run): snapshot the live grid state file so replay reads it:
+
+  ```bash
+  cp db/grid_anchor.json db/grid_anchor.phase4.json
+  ```
+
+  and set ``seed.grid_state_path: "db/grid_anchor.phase4.json"`` in
+  your Step 8 YAML. The 2026-05-18 18 h dataset and any prior run
+  uses this path.
 
 ## Step 8 — Replay config
 

--- a/docs/features/0047_PLAN.md
+++ b/docs/features/0047_PLAN.md
@@ -1,0 +1,1169 @@
+# Feature 0047 — Persist grid_state snapshots to DB (v18)
+
+> Tracks issue [#101](https://github.com/erzhan12/grid-bot-validation/issues/101).
+> Renumbered from 0046 on main (0046 is the SAME ORDER throttle —
+> commits `b41287b`, `91c3b43`).
+>
+> **Scope pivot at v11**: v1–v10 attempted to *reconstruct* the grid
+> from the `orders` table. Ten review rounds surfaced fundamental
+> geometric limits — `(1-s) ≠ 1/(1+s)` ratio asymmetry across the
+> WAIT center, `recenter_if_drifted` migrating WAIT off-grid, etc.
+> v11 abandons reconstruction and instead **persists `grid.grid`
+> directly to DB**, mirroring the existing JSON file path. Replay
+> then loads the latest snapshot at-or-before `seed.at_ts` verbatim
+> — byte-identical to live, no geometry, no drift.
+>
+> **v12 fixes** four wiring issues in v11:
+> 1. Snapshots carry `exchange_ts` from the triggering event (not
+>    wall-clock), so `at_or_before(seed.at_ts)` queries are valid
+>    against the same time scale as the other seed dimensions.
+> 2. Writer accepts a `run_id_provider` callable to handle the
+>    orchestrator lifecycle gap (runner is constructed before
+>    `_create_run_records` populates `_run_ids`).
+> 3. `_on_grid_change` split into independent backend guards so
+>    DB writes don't depend on `state_store` being configured.
+> 4. `grid_step` comparison normalised via `Decimal(str(...))` to
+>    avoid float-vs-Decimal false rejects.
+>
+> **v18 fixes** one real lifecycle contradiction and a handful of
+> stale-wording / typo issues left by v17:
+> 1. **Lifecycle contradiction**: v17 said "instantiate
+>    `GridStateWriter` in `start()` AFTER `_create_run_records()`"
+>    AND "pass the writer into `StrategyRunner` constructor".
+>    Runners are created in `_init_strategy` BEFORE
+>    `_create_run_records()` runs (`orchestrator.py:242-244 → 267`),
+>    so the writer can't be both post-run-records-init and a
+>    constructor-time runner dependency. The whole point of the
+>    `run_id_provider` callable from v15 is to make this lazy —
+>    v18 drops the "AFTER `_create_run_records()`" constraint and
+>    moves writer construction into `Orchestrator.__init__`
+>    (same lifecycle as `GridStateStore`). Provider returns `None`
+>    until `_create_run_records()` populates `_run_ids`; writes
+>    in that window are dropped (already covered by writer test
+>    #2).
+> 2. **Test path typo**: writer moved to gridbot in v17 but tests
+>    still pointed at `apps/event_saver/tests/...`. Corrected to
+>    `apps/gridbot/tests/test_grid_state_writer.py`.
+> 3. **`grid_fingerprint_hash` canonicalised**: three different
+>    specs in v17 (checklist, persistence section, writer section)
+>    diverged on `default=str`. v18 fixes one canonical form
+>    everywhere: `sha256(json.dumps(grid_fingerprint(...),
+>    separators=(",", ":"), sort_keys=False,
+>    default=str).encode()).hexdigest()`.
+> 4. **Loader signature aligned**: v17 spec'd
+>    `load_grid_state_from_snapshots(... run, ...)`, but existing
+>    loaders in `snapshot_loader.py:268+` take `run_id: str`.
+>    Aligned to `run_id: str`.
+> 5. **Stale "Why this approach" wording**: "trivial sibling of
+>    `WalletWriter` / `OrderWriter`" reworded — writer is sync +
+>    threading, not asyncio.
+> 6. **Phase 2D duplication**: checklist Phase 2D (runbook + RULES)
+>    collided with the body's "Recorder integration (Phase 2D —
+>    optional)" section. The latter renamed to "Recorder
+>    integration (out of scope — future work)" so phase labels
+>    are unambiguous.
+> 7. **Phase 2A writer model clarified**: v17 mixed
+>    `GridStateStore`'s "per-strat pending slot" wording with
+>    `WalletWriter`'s "batch_size / flush_interval / FIFO queue"
+>    wording. v18 reconciles: **one global FIFO queue + batch
+>    insert in dequeue order**; in-memory tuple dedupe is a
+>    separate gate run BEFORE enqueue.
+> 8. **Bootstrap window note**: `_create_run_records` runs before
+>    WS connect (~`orchestrator.py:269`); reconciliation does not
+>    mutate the grid, so the first snapshots fire after `_run_ids`
+>    is already populated. Window is known-safe; documented as a
+>    one-line note.
+>
+> **v17 fixes** thirteen implementation gaps that would have surfaced
+> during coding, organised by severity:
+>
+> Critical / High:
+> 1. **Writer must live in gridbot, not event_saver, and use
+>    threading not asyncio.** event_saver writers
+>    (`apps/event_saver/.../wallet_writer.py`) are async with
+>    `asyncio.Lock` / `await write()` / `start_auto_flush()` as an
+>    asyncio task; they run inside the recorder process. gridbot is
+>    sync and already persists grid state via `GridStateStore` with
+>    a `threading.Thread` background writer (`persistence.py:184`).
+>    Copying the event_saver template into gridbot would mismatch
+>    the process's concurrency model. v17 relocates the writer to
+>    `apps/gridbot/src/gridbot/writers/grid_state_writer.py` and
+>    mirrors `GridStateStore.save`'s sync-API + background-thread
+>    pattern.
+> 2. **`raw_fingerprint` serialisation defined.**
+>    `GridStateStore._fingerprint` (`persistence.py:72-80`) returns
+>    a tuple — incompatible with the `String(64)` column. v17 adds
+>    a public helper `grid_fingerprint_hash(grid, grid_step,
+>    grid_count) -> str` returning a SHA-256 hex digest, and uses
+>    it in both writer and tests.
+> 3. **`orchestrator.stop()` flushes the new writer.** v16 specced
+>    `start()` / `stop()` for the writer but did not wire its
+>    `flush()` into orchestrator shutdown alongside
+>    `state_store.flush(timeout=10.0)` (`orchestrator.py:571-578`).
+>    Without it, the last post-fill snapshots are lost on
+>    shutdown — the same class of bug the file path already
+>    handles.
+> 4. **`account_id` derivation fixed to `uuid5`.**
+>    `orchestrator.py:1162` computes `account_id =
+>    str(uuid5(namespace, f"account:{account_config.name}"))` with
+>    `namespace = UUID("12345678-1234-5678-1234-567812345678")`
+>    (line 1156). v15 just said "resolve from strat→account
+>    mapping" — too loose. v17 makes the exact formula explicit so
+>    writer's `account_id` matches the FK target used by replay.
+>
+> Medium:
+> 5. **`_load_seed` refactor.** `engine.py:647-653` loads the file
+>    grid OUTSIDE the DB session; DB-mode loader needs the session.
+>    v17 specifies opening the session FIRST, trying DB loader
+>    inside, falling back to file (still inside the session block
+>    or after exit — either works).
+> 6. **Missing mutation path: restored-grid out-of-bounds rebuild
+>    on first ticker (`engine.py:160-181`).** The
+>    `current_event_ts` set at handler top already covers it, but
+>    enumerate it for completeness and add a test.
+> 7. **In-memory dedupe trade-off documented.** Dedupe scope is
+>    `(run_id, account_id, strat_id)` without `exchange_ts`; a
+>    grid returning to a prior state later in the run is dropped
+>    by the in-memory check (the DB unique already allows it via
+>    the v15 ts scoping). Same latest-wins-per-strat semantic as
+>    the file writer; document as deliberate.
+> 8. **Lockstep audit extended to gridcore tests.**
+>    `packages/gridcore/tests/test_grid.py` and
+>    `packages/gridcore/tests/test_engine.py` have `on_change=
+>    lambda g: ...` callbacks; the silent-swallow at `grid.py:78`
+>    will hide arity mismatches at runtime — these MUST be
+>    updated in the same PR.
+> 9. **Partial-index migration + real-SQLite test.** Alembic
+>    migration must use `postgresql_where=...` (and equivalent for
+>    SQLite via raw SQL or `sqlite_where=` if supported). The
+>    `test_partial_index_conflict_do_nothing` test must run
+>    against a real SQLite backend, not a mocked session, because
+>    the repository currently has no other partial-ON-CONFLICT
+>    user to lean on for confidence.
+>
+> Low / Nits:
+> 10. **Orchestrator line-ref corrected** — writers aren't created
+>     near `orchestrator.py:113-124`; that block declares dict
+>     attributes only. Actual writer instantiation happens during
+>     `start()` and is part of this feature.
+>     **[superseded by v18]** — v18 moves writer instantiation
+>     into `Orchestrator.__init__` (same lifecycle slot as
+>     `GridStateStore`), not `start()`. The thread is what
+>     starts in `start()`. See v18 entry #1 above.
+> 11. **Implementation Checklist** added near the top of the plan
+>     so implementer doesn't read through 16 revisions of history
+>     to find what to do.
+> 12. **`_fingerprint` promoted to public helper.** Writer
+>     importing a private static method of `GridStateStore` is
+>     fragile; v17 introduces `grid_fingerprint(...)` (tuple form)
+>     and `grid_fingerprint_hash(...)` (hex digest) as public
+>     names in `gridcore/persistence.py`, with the old `_fingerprint`
+>     becoming a thin internal wrapper.
+> 13. **Acceptance criteria sharpened** — names the dataset
+>     reference (a new recording started after this feature ships)
+>     and the rollback path (revert the orchestrator wiring so
+>     file mode remains authoritative; the DB table can stay).
+>
+> **v16 fixes** two implementation-detail gaps left by v15:
+> 1. v15 spec'd a partial unique index `WHERE raw_fingerprint IS
+>    NOT NULL` and said the writer does `on_conflict_do_nothing`
+>    against it, but did NOT specify that the
+>    `on_conflict_do_nothing` call needs an `index_where=` clause
+>    matching the partial index predicate. Without it the
+>    PostgreSQL / SQLite INSERT won't bind to the partial unique
+>    constraint and the writer will either error or silently
+>    bypass dedup. v16 makes the `index_where` parameter explicit
+>    in both dialect branches of the repository method.
+> 2. `id DESC` tie-break depends on FIFO insertion order within a
+>    single `(run_id, account_id, strat_id, exchange_ts)` scope.
+>    v15 only mentioned "multi-strat ordering" in the writer
+>    tests, which is the cross-strat case; same-strat
+>    same-exchange_ts FIFO was not contracted. v16 makes FIFO an
+>    explicit writer requirement and adds a test.
+>
+> **v15 fixes** three issues left by v14:
+> 1. v14 kept a unique constraint on `(run_id, account_id, strat_id,
+>    raw_fingerprint)`. Combined with `on_conflict_do_nothing`, this
+>    could silently drop the **final** post-side-assignment snapshot
+>    of an `update_grid` out-of-bounds path if its fingerprint
+>    happened to equal an earlier snapshot in the same run. Replay
+>    would then read the intermediate (post-rebuild, pre-assign)
+>    snapshot at the same `exchange_ts` — the wrong state. v15
+>    narrows the unique constraint to include `exchange_ts` so the
+>    race-double-insert protection stays but cross-time
+>    fingerprint reuse is allowed.
+> 2. v14 wrote `account_id=self._account_id` in the runner
+>    pseudocode, but `StrategyRunner.__init__` (`runner.py:152-162`)
+>    has no `account_id` parameter today. v15 makes the wiring
+>    change explicit: add `account_id: str` to the constructor,
+>    have the orchestrator resolve it from the strategy config
+>    (the strategy → account mapping the orchestrator already
+>    uses for routing) and pass at construction time.
+> 3. v14 spec'd `id BigInteger PK` without the SQLite variant.
+>    Other tables in `shared/db/src/grid_db/models.py` (lines 226,
+>    250, 276, 318, 367) use `BigInteger().with_variant(Integer,
+>    "sqlite")` so autoincrement works on SQLite test backends —
+>    which the `id DESC` tie-break logic depends on. v15 aligns.
+>
+> **v14 fixes** three issues left by v13:
+> 1. v13 spec'd `Grid._notify_change` to reset
+>    `_current_exchange_ts` to `None` after firing. But
+>    `update_grid` fires `_notify_change` twice on the out-of-bounds
+>    path (`grid.py:155` from `build_grid` + `grid.py:264` final),
+>    so the second call would see `None` and the DB writer would
+>    drop the final snapshot — exactly the state we want. v14
+>    moves ts cleanup into the engine handler's `finally` block so
+>    multiple inner notifies in one outer mutation call all share
+>    the same ts. `get_at_or_before` is tightened with
+>    `ORDER BY exchange_ts DESC, id DESC` so the latest insert
+>    (the final notify) wins.
+> 2. Added a test for the `update_grid` out-of-bounds rebuild
+>    path inside `_handle_execution_event` — distinct from the
+>    v13-covered `_check_and_place` ticker-side rebuild and
+>    deferred-fill paths.
+> 3. v13 said "file/DB writer drops persistence when `exchange_ts`
+>    is `None`", but the file writer is timestamp-independent and
+>    must keep saving regardless — it preserves live restart
+>    parity. Reworded to "DB writer skips; file writer unaffected".
+>
+> **v13 fixes** four issues left by v12:
+> 1. v11 claimed "Nothing in gridcore changes" but v12 in fact
+>    changes the `on_change` callback arity. `grid.py:78` swallows
+>    exceptions, so an arity mismatch would silently break
+>    persistence. v13 removes the "no gridcore changes" claim,
+>    documents lockstep migration with the exact call-site list,
+>    and forbids gradual rollout.
+> 2. `_check_and_place` rebuild path (`engine.py:331`) also mutates
+>    the grid via `build_grid(self.last_close)`. v12 did not
+>    explicitly cover it. v13 routes timestamp via an engine-level
+>    `current_event_ts` attribute set at the top of each event
+>    handler so every nested mutation (including this rebuild and
+>    the deferred-fill consumption) inherits the right ts
+>    automatically.
+> 3. Deferred-fill consumption (`engine.py:194`) happens inside
+>    `_handle_ticker_event`; the snapshot timestamp must be the
+>    ticker's `exchange_ts` (when live actually mutates), not the
+>    earlier execution's. v13 specifies this and adds a test.
+> 4. The "## Algorithm" pseudocode at the file end contradicted
+>    the loader text on `Decimal` normalisation. v13 deletes the
+>    redundant pseudocode block.
+
+## Implementation Checklist (v18 — read this first)
+
+Phase 1 (sequential, blocking):
+- [ ] `GridStateSnapshot` model in
+  `shared/db/src/grid_db/models.py` with
+  `BigInteger().with_variant(Integer, "sqlite")` PK, partial
+  unique on
+  `(run_id, account_id, strat_id, exchange_ts, raw_fingerprint)`
+  WHERE `raw_fingerprint IS NOT NULL`.
+- [ ] Alembic migration with `postgresql_where=...` for the
+  partial unique index and equivalent raw SQL for SQLite.
+- [ ] `GridStateSnapshotRepository.insert(...)` with dialect
+  branch + `index_where=GridStateSnapshot.raw_fingerprint.is_not(None)`
+  on the `on_conflict_do_nothing(...)` call.
+- [ ] `GridStateSnapshotRepository.get_at_or_before(run_id,
+  account_id, strat_id, at_ts)` returning the row by
+  `ORDER BY exchange_ts DESC, id DESC LIMIT 1`.
+
+Phase 1.5 (sequential, breaking):
+- [ ] Promote `GridStateStore._fingerprint` →
+  `gridcore.persistence.grid_fingerprint(grid, grid_step,
+  grid_count) -> tuple` (public) and add
+  `grid_fingerprint_hash(...) -> str` returning
+  `hashlib.sha256(json.dumps(grid_fingerprint(...),
+  separators=(",", ":"), sort_keys=False,
+  default=str).encode()).hexdigest()` (64-char hex; column type
+  matches; `default=str` for safe `Decimal` / `float`
+  serialisation). **Use this exact form in all three places**
+  (checklist, persistence section, writer section); v17's spec
+  diverged across them.
+- [ ] Change `Grid` `on_change` callback contract to
+  `Callable[[list[dict], Optional[datetime]], None]`.
+- [ ] Engine sets `self.grid._current_exchange_ts` at the top of
+  each handler in a `try`, clears in `finally`; `_notify_change`
+  reads only.
+- [ ] Lockstep audit: update every `on_change=` callsite in
+  `apps/gridbot/`, `apps/replay/`, `packages/gridcore/tests/`
+  (specifically `test_grid.py` and `test_engine.py` lambdas).
+
+Phase 2A (parallel after 1.5):
+- [ ] `apps/gridbot/src/gridbot/writers/grid_state_writer.py` with
+  a **single global FIFO queue + worker thread** (not
+  `GridStateStore`'s per-strat pending slot, not event_saver's
+  asyncio model). In-memory tuple dedupe is a separate gate
+  run BEFORE enqueue.
+- [ ] FIFO contract preserved for same-`(strat, exchange_ts)`
+  enqueues.
+- [ ] Writer tests (FIFO, partial-index conflict, dedupe, drops
+  on missing run_id / exchange_ts).
+
+Phase 2B (parallel after 1.5):
+- [ ] `StrategyRunner.__init__` gets `account_id: str` parameter.
+- [ ] Orchestrator resolves
+  `account_id = str(uuid5(namespace, f"account:{strategy_config.account}"))`
+  with the same `namespace = UUID("12345678-1234-5678-1234-567812345678")`
+  used at `orchestrator.py:1156`, and passes at construction.
+- [ ] `_on_grid_change(grid, exchange_ts)` split into independent
+  file/DB guards (each backend independent; DB skips on
+  `exchange_ts is None`; file unaffected).
+- [ ] Orchestrator instantiates `GridStateWriter` in
+  `__init__` (same lifecycle slot as `GridStateStore`) **only
+  when `self._db is not None`** (orchestrator runs without DB in
+  standalone / test mode where `_create_run_records()` early-
+  returns; in that mode `self._grid_state_writer = None`).
+  Passes `run_id_provider=lambda strat_id:
+  self._run_ids.get(strat_id)` (resolves lazily — returns `None`
+  until `_create_run_records()` populates `_run_ids` during
+  `start()`). Writer's background thread is started/stopped in
+  `start()` / `stop()` (guarded by
+  `if self._grid_state_writer is not None`), but its
+  construction does NOT depend on `_create_run_records()` having
+  run. Pass into `StrategyRunner.__init__` from
+  `_init_strategy`; runner stores it as `Optional[GridStateWriter]`
+  and the `_on_grid_change` DB-write branch is already guarded
+  by `if self._grid_state_writer is not None`.
+- [ ] **`orchestrator.stop()`** calls
+  `self._grid_state_writer.flush(timeout=10.0)` next to the
+  existing `self._state_store.flush(...)` at
+  `orchestrator.py:571-578`, **guarded by
+  `if self._grid_state_writer is not None`** so standalone /
+  no-DB runs don't NPE.
+
+Phase 2C (parallel after Phase 1):
+- [ ] `load_grid_state_from_snapshots(...)` in
+  `apps/replay/src/replay/snapshot_loader.py` with
+  `Decimal(str(...))` normalised fingerprint check.
+- [ ] `_load_seed` refactored in `apps/replay/src/replay/engine.py`:
+  open DB session first, try DB loader, fall back to file
+  (currently file loads OUTSIDE the session at line 647-653 —
+  move inside).
+- [ ] `SeedConfig.grid_state_path` relaxed to `Optional[str] = None`.
+
+Phase 2D (parallel docs):
+- [ ] `docs/features/0029_RUNBOOK.md` Step 7 — drop the
+  `cp db/grid_anchor.json` step for runs produced after this
+  feature ships.
+- [ ] `RULES.md` updates (see corresponding section below).
+
+Verification:
+- [ ] Pre-merge grep gate (defends against the silent
+  arity-mismatch failure mode at `grid.py:78`):
+  `grep -rE 'on_change|on_grid_change' packages/ apps/
+  --include='*.py'`. Every match must use the new
+  `(grid, exchange_ts)` callback signature; no single-arg
+  callbacks may remain. Cheap; run before pushing the PR for
+  review.
+- [ ] Start a fresh recording AFTER all phases ship; let it
+  collect ≥ 1 h with multiple fills.
+- [ ] Run Phase 4 replay against that new recording; match rate
+  must be ≥ 95 % (issue #101 acceptance target).
+- [ ] If match rate is < 95 %: do NOT roll back the schema.
+  Revert only the orchestrator wiring so `_on_grid_change` no
+  longer calls the writer; the file path stays authoritative
+  for live and replay falls through to file mode.
+
+## Context
+
+Phase 4 replay currently loads grid state from a **manual snapshot**
+of live's `db/grid_anchor.json` (per `docs/features/0029_RUNBOOK.md`
+Step 7). The file's mtime on disk is whenever live last wrote it, not
+`seed.at_ts` — so the operator's `cp` step is racy with live writes.
+
+On the 2026-05-18 18 h dataset (94 execs, `run_id=f9854727-…`) replay
+against both the stale `grid_anchor.phase4.json` and the live
+`grid_anchor.json` gave a 2.1 % trade-level match rate. Neither file
+reflected the grid at `seed.at_ts`.
+
+## Insight from how live already solves it
+
+Live persists grid state through a simple flow:
+
+* `GridEngine.__init__(on_grid_change=...)`
+  (`packages/gridcore/src/gridcore/engine.py:63-65`) accepts a callback
+  fired after every `Grid.build_grid` / `Grid.update_grid` /
+  `Grid._shift_grid` mutation that touches `self.grid`.
+* `Grid` invokes that callback via `_notify_change`
+  (`grid.py:264`, `grid.py:361`).
+* The live runner wires it to
+  `GridBotRunner._on_grid_change` (`apps/gridbot/src/gridbot/runner.py:372-385`).
+* That handler calls
+  `GridStateStore.save(strat_id, grid, grid_step, grid_count)`
+  (`packages/gridcore/src/gridcore/persistence.py:137`) which writes
+  the **full `grid.grid` list** (every level's `{side, price}`) to
+  `db/grid_anchor.json`.
+* On restart, `GridStateStore.load` + `Grid.restore_grid`
+  (`grid.py:166-198`) restore the grid **verbatim** via
+  `is_grid_correct` validation. No reconstruction — the saved blob is
+  authoritative.
+
+The 0029 file-mode loader for replay already mirrors this:
+`load_grid_state` in `apps/replay/src/replay/snapshot_loader.py:212` reads
+the same JSON file. The problem is purely the manual `cp` step, not
+the underlying data shape.
+
+### Why we need an `exchange_ts` plumbing change
+
+The existing `on_change(grid)` callback signature does not carry the
+triggering event's `exchange_ts` — `Grid` calls `_notify_change`
+without it. For the JSON file path this is fine because the
+loader doesn't time-index. For DB snapshots we need
+`at_or_before(seed.at_ts)` matching, and `seed.at_ts` is
+**exchange-time** (it's compared against
+`PositionSnapshot.exchange_ts`, `Order.exchange_ts`, etc. in the
+0029 pre-check). Writing `exchange_ts = datetime.now(UTC)` would
+mismatch the time scale under WS lag, clock skew, and event
+batching, and could silently pick the wrong snapshot at seed time.
+v12 threads the triggering event's `exchange_ts` through the
+callback so the writer stores it correctly.
+
+## Proposal
+
+Add a **second write path** on the same `on_grid_change` callback that
+persists each grid mutation to a new DB table
+`grid_state_snapshots`. Replay reads the latest snapshot at-or-before
+`seed.at_ts` and feeds the saved `grid` list straight into the same
+`Grid.restore_grid` API the live runner uses on restart. The file
+path stays as a legacy fallback for runs recorded before this
+feature.
+
+`gridcore` requires **one breaking change**: the `on_change` callback
+gains a second parameter for the triggering event's `exchange_ts`
+(see "gridcore signature change" and "gridcore lockstep migration"
+sections below). The `GridStateStore` API itself stays intact — only
+the callback contract widens. We add a parallel writer at the runner
+layer.
+
+## Files & functions to change
+
+### Schema (data layer — Phase 1)
+
+* `shared/db/src/grid_db/models.py` — **new** `GridStateSnapshot`
+  table:
+  ```
+  grid_state_snapshots(
+      id           BigInteger().with_variant(Integer, "sqlite"),
+                   primary_key=True, autoincrement=True,
+      run_id       String(36) FK runs.run_id ON DELETE CASCADE,
+      account_id   String(36),
+      strat_id     String(50),
+      symbol       String(20),
+      exchange_ts  DateTime(tz=True),
+      local_ts     DateTime(tz=True),
+      grid_json    JSON,                  -- the saved grid list verbatim
+      grid_step    Numeric(20, 8),
+      grid_count   Integer,
+      raw_fingerprint  String(64) NULL    -- same fingerprint
+                                          --   GridStateStore.save uses
+                                          --   for dedupe
+  )
+  with indexes:
+      ix_grid_state_snapshots_lookup
+          ON (run_id, account_id, strat_id, exchange_ts DESC, id DESC)
+      uq_grid_state_snapshots_fingerprint_at_ts
+          ON (run_id, account_id, strat_id, exchange_ts, raw_fingerprint)
+          WHERE raw_fingerprint IS NOT NULL
+  ```
+  PK column uses the `BigInteger().with_variant(Integer, "sqlite")`
+  pattern that the rest of the schema follows so autoincrement is
+  guaranteed on SQLite test backends — the `id DESC` tie-break logic
+  in `get_at_or_before` depends on it.
+  The unique constraint is **scoped to `exchange_ts`**, not global
+  across the run: race-double-insert at the same instant is still
+  blocked, but the same grid state recurring later in the run is
+  allowed through. This prevents `on_conflict_do_nothing` from
+  silently dropping a final post-side-assignment snapshot whose
+  fingerprint happens to match an earlier one in the run — which
+  would otherwise leave only the intermediate post-rebuild row
+  at the same `exchange_ts` and break the `id DESC` tie-break.
+  `grid_json` stores the `list[{'side': str, 'price': float}]` as-is —
+  same shape `GridStateStore.save` writes today. The fingerprint
+  column is optional but useful so the writer can short-circuit
+  identical successive snapshots (mirrors `GridStateStore`'s in-memory
+  dedupe at `persistence.py:157-163`).
+
+* `shared/db/src/grid_db/migrations/versions/NNNN_grid_state_snapshots.py`
+  — Alembic migration for the new table. The partial unique
+  index requires dialect-aware DDL:
+  * PostgreSQL: `op.create_index(..., postgresql_where=
+    sa.text("raw_fingerprint IS NOT NULL"))`.
+  * SQLite: `op.create_index(..., sqlite_where=
+    sa.text("raw_fingerprint IS NOT NULL"))` if SQLAlchemy
+    supports the kwarg in the project's pinned version; otherwise
+    fall back to raw SQL inside `op.execute(
+    "CREATE UNIQUE INDEX uq_grid_state_snapshots_fingerprint_at_ts
+     ON grid_state_snapshots(run_id, account_id, strat_id,
+     exchange_ts, raw_fingerprint) WHERE raw_fingerprint IS NOT NULL;")`.
+  Verify both paths produce the same constraint behaviour via the
+  `test_partial_index_conflict_do_nothing` repository test
+  (Phase 2A) running on the project's SQLite test fixtures.
+
+* `shared/db/src/grid_db/repositories.py` — **new**
+  `GridStateSnapshotRepository(BaseRepository[GridStateSnapshot])`:
+  * `insert(snapshot: GridStateSnapshot) -> None` — single-row
+    insert with dialect-specific `on_conflict_do_nothing` against
+    the **partial** unique index
+    `uq_grid_state_snapshots_fingerprint_at_ts`.
+    `on_conflict_do_nothing(...)` must pass both
+    `index_elements=["run_id", "account_id", "strat_id",
+    "exchange_ts", "raw_fingerprint"]` AND
+    `index_where=GridStateSnapshot.raw_fingerprint.is_not(None)`
+    — the latter matches the partial index predicate. Without it
+    PostgreSQL won't bind the conflict target to the partial
+    constraint and SQLite (≥3.24 with partial-index ON CONFLICT
+    support) behaves the same way. Branch on
+    `self.session.get_bind().dialect.name` and call
+    `postgresql_insert(...).on_conflict_do_nothing(...)` or
+    `sqlite_insert(...).on_conflict_do_nothing(...)` — same dialect
+    branching pattern `TickerSnapshotRepository.bulk_insert`
+    uses (`repositories.py:591-599`), with the added
+    `index_where` argument here because the constraint is partial.
+  * `get_at_or_before(run_id, account_id, strat_id, at_ts) ->
+    Optional[GridStateSnapshot]` — `WHERE run_id = ? AND account_id =
+    ? AND strat_id = ? AND exchange_ts <= at_ts ORDER BY exchange_ts
+    DESC, id DESC LIMIT 1`. Run-scoped (no cross-window leakage
+    possible). The `id DESC` secondary sort matters because a single
+    outer mutation call (e.g. `update_grid` on the out-of-bounds
+    path) can produce two snapshots with the same `exchange_ts`
+    (post-rebuild intermediate + post-side-assignment final); the
+    auto-increment id breaks the tie in insertion order, so replay
+    reads the final notify, not the intermediate.
+
+### gridcore signature change (Phase 1.5 — small, sequential, breaking)
+
+This is a **breaking change** to `gridcore`'s `on_change` callback
+contract — the call goes from one argument to two. `grid.py:78`
+catches `Exception` from the callback and only logs it, so an arity
+mismatch in production code would **silently disable persistence**
+without raising. The change MUST be applied in a single PR across all
+call sites; gradual rollout is forbidden.
+
+* `packages/gridcore/src/gridcore/persistence.py` — **public
+  fingerprint helpers**:
+  * Rename `GridStateStore._fingerprint(grid, grid_step,
+    grid_count) -> tuple` to module-level
+    `grid_fingerprint(grid, grid_step, grid_count) -> tuple`
+    (signature and body unchanged). Keep a thin
+    `GridStateStore._fingerprint = staticmethod(grid_fingerprint)`
+    alias for backward compatibility with any external callers.
+  * Add `grid_fingerprint_hash(grid, grid_step, grid_count) -> str`
+    returning
+    `hashlib.sha256(json.dumps(grid_fingerprint(grid, grid_step,
+    grid_count), separators=(",", ":"), sort_keys=False,
+    default=str).encode()).hexdigest()`. 64-char hex matching the
+    `raw_fingerprint VARCHAR(64)` column. `default=str` handles
+    `Decimal` / `float` mixed numeric types safely.
+  * Writer imports the public names; tests reuse them so the
+    fingerprint serialisation is single-sourced.
+
+* `packages/gridcore/src/gridcore/grid.py`:
+  * `Grid.__init__(... on_change=Optional[Callable[[list[dict],
+    Optional[datetime]], None]])` — new signature.
+  * Engine sets the triggering event's ts on a private
+    `Grid._current_exchange_ts: Optional[datetime] = None` slot
+    at the top of each event handler, and clears it in a
+    `finally` block at the bottom of the handler — **never inside
+    `_notify_change`**. Reason: `update_grid` on the out-of-bounds
+    path fires `_notify_change` twice (once from the internal
+    `__rebuild_grid` → `build_grid` chain at `grid.py:155`, then a
+    final one at `grid.py:264` after `_assign_sides` + `__center_grid`).
+    If `_notify_change` reset the slot after the first call, the
+    second call would see `None` and the DB writer would skip the
+    final state — exactly what we need to persist. Sharing one ts
+    across all inner notifies is the correct behaviour; the JSON
+    file writer already accepts the same (it just overwrites the
+    file on each call).
+  * `Grid._notify_change(self)` (signature unchanged) reads
+    `self._current_exchange_ts` and forwards it to the callback
+    without clearing it. The engine handler owns the ts lifecycle.
+  * Multiple snapshots inserted with the same `exchange_ts` are
+    distinguished at query time by id. The repository's
+    `get_at_or_before` adds `ORDER BY exchange_ts DESC, id DESC`
+    so replay reads the final notify (largest id at that ts).
+* `packages/gridcore/src/gridcore/engine.py`:
+  * Add `self.current_event_ts: Optional[datetime] = None` to
+    engine state. Top of `_handle_ticker_event` (line 125): set
+    `self.current_event_ts = event.exchange_ts` alongside
+    `self.last_close = float(event.last_price)`. Top of
+    `_handle_execution_event`: same with `event.exchange_ts`.
+    Restored to `None` on handler exit (defensive — wrapped in
+    try / finally).
+  * Before invoking any Grid mutation method, set
+    `self.grid._current_exchange_ts = self.current_event_ts`. This
+    covers four mutation paths:
+    1. `build_grid` on first ticker (`engine.py:180`).
+    1a. `build_grid` rebuild of **restored grid** when first
+        ticker is out of restored-grid bounds (`engine.py:160-181`,
+        immediately after `restore_grid` succeeded). Same handler
+        as path 1, so `current_event_ts` is already set; needs
+        its own test for confidence.
+    2. `update_grid` from deferred-fill consumption inside
+       `_handle_ticker_event` (`engine.py:194`) — ts is the
+       **ticker's** exchange_ts, not the earlier execution's,
+       because that's when live actually mutates.
+    3. `update_grid` from `_handle_execution_event` direct fill
+       handling (`engine.py:241`).
+    4. `build_grid` rebuild inside `_check_and_place` when there
+       are too many orders (`engine.py:331`). This path is called
+       from a ticker handler, so `self.current_event_ts` is
+       already set to the ticker's ts when it fires.
+    5. `recenter_if_drifted` inside `_handle_ticker_event`
+       (`engine.py:207`).
+  * Pre-existing call sites with no triggering event (e.g.
+    constructor-time `restore_grid`) leave
+    `self.grid._current_exchange_ts = None`. **DB writer drops the
+    snapshot** when `exchange_ts is None` — query-time ordering
+    requires a non-NULL ts and there is no triggering event to
+    timestamp against. **The file writer is unaffected** by ts and
+    keeps saving on every mutation; this preserves the existing
+    live-restart parity contract (`GridStateStore.save` has no ts
+    concept).
+
+### gridcore lockstep migration (call-site audit)
+
+Every site that currently passes an `on_change` callback or registers
+a Grid with one MUST be updated in the same PR. Audit list (verified
+by `grep on_change packages/ apps/` at planning time; the
+implementer re-verifies before coding):
+
+1. `apps/gridbot/src/gridbot/runner.py:206` — `on_grid_change=
+   self._on_grid_change` (engine constructor argument).
+2. `apps/gridbot/src/gridbot/runner.py:372` — the
+   `_on_grid_change(self, grid)` method definition itself; signature
+   becomes `_on_grid_change(self, grid, exchange_ts)`.
+3. `packages/gridcore/tests/test_grid.py` — every `on_change=
+   lambda g: ...` callable. `grid.py:78` catches `TypeError` and
+   only logs, so an arity mismatch passes the test silently while
+   the callback is never actually invoked.
+4. `packages/gridcore/tests/test_engine.py` — same audit; the
+   plan author's spot-check found
+   `test_on_grid_change_callback_fires_on_build` near line 1086
+   as one example. Implementer re-greps the file before coding.
+5. `apps/gridbot/tests/test_runner.py` — any unit test that mocks
+   `_on_grid_change` or asserts on its call args. **Also: every
+   `StrategyRunner(...)` construction must add the new required
+   `account_id: str` positional argument** (Phase 2B wiring
+   change). Spot-check by `grep -n 'StrategyRunner(' apps/gridbot/tests/`
+   before coding — expect ~40 construction sites needing
+   mechanical update. Tests that don't drive the orchestrator
+   can pass a fixed UUID literal (e.g. `"00000000-0000-0000-0000-000000000001"`);
+   they're testing runner internals, not account routing.
+6. `apps/replay/src/replay/engine.py` and tests — replay's GridEngine
+   construction sites; replay typically passes `on_grid_change=None`
+   (no persistence in replay), so these are safe but verify.
+
+Forbidden alternatives I considered and rejected:
+
+* **`inspect.signature` defensive adapter** (auto-detect arity, call
+  with one or two args): would hide future regressions where someone
+  forgets to update a callback signature; the silent-swallow at
+  `grid.py:78` already makes this class of bug invisible. We want
+  loud type errors during implementation, not silent skip.
+* **New separate callback `on_change_with_ts`** alongside `on_change`:
+  leaves a stale single-arg path that future code might still wire
+  up to a stale persistence layer. Single contract beats two.
+
+### Writer (Phase 2A — can run in parallel with Phase 2B)
+
+* `apps/gridbot/src/gridbot/writers/grid_state_writer.py` —
+  **new** module (note: in gridbot, NOT event_saver; event_saver
+  writers are asyncio-based and live in the recorder process).
+  Sync-API + background-thread, **NOT** asyncio. **Do NOT copy
+  `wallet_writer.py`'s asyncio template** — gridbot's main loop
+  is sync.
+
+  **Concurrency model** (single canonical statement; v17 mixed
+  two different patterns):
+  * **One global FIFO queue per writer instance**, drained by a
+    single worker thread; INSERTs land in dequeue order.
+    `WalletWriter`'s overall shape (queue + auto-flush thread +
+    `start()` / `stop()` / `flush()` lifecycle methods) is the
+    structural reference — but the queue itself is a plain
+    `collections.deque` or `queue.Queue` protected by a
+    `threading.Lock`, not an `asyncio.Queue`.
+  * **In-memory tuple dedupe** is a **separate gate** that runs
+    BEFORE enqueue: if the new `grid_fingerprint(...)` tuple
+    equals the last-enqueued tuple for the same
+    `(run_id, account_id, strat_id)`, the write is dropped
+    pre-queue. Same latest-wins-per-strat semantic as
+    `GridStateStore.save` (`persistence.py:157-163`). NOT the
+    same as `GridStateStore`'s "per-strat pending slot"
+    (which is a single-slot debouncer between save calls and
+    file writes); the DB writer uses FIFO across all strats so
+    that same-ts double-notify within one mutation preserves
+    insertion order on the way to the DB.
+  * **FIFO contract** for the queue: snapshots enqueued for
+    the same `(run_id, account_id, strat_id, exchange_ts)` MUST
+    INSERT in enqueue order. This is what makes the loader's
+    `ORDER BY exchange_ts DESC, id DESC` tie-break correctly
+    pick the FINAL notify of a multi-notify outer mutation
+    (`update_grid` out-of-bounds path emits two snapshots at the
+    same ts: post-rebuild intermediate, then post-side-assignment
+    final). Do NOT introduce per-strat queues or batch
+    reordering; if a future change adds them, it must
+    preserve per-(strat, ts) order or break the loader contract.
+  * `class GridStateWriter` with `batch_size`, `flush_interval`,
+    auto-flush thread, `start()` / `stop()` / `flush()`.
+  * Constructor: `GridStateWriter(db, run_id_provider, batch_size,
+    flush_interval)` where
+    `run_id_provider: Callable[[str], Optional[UUID]]` is a late-bound
+    resolver (looks up the orchestrator's `_run_ids` by `strat_id`).
+    Decouples writer construction from run-record creation, which
+    happens inside `Orchestrator.start()` at line 267 — long after
+    the runner is built at line 670.
+  * `write(strat_id, grid, grid_step, grid_count, account_id, symbol,
+    exchange_ts)` — note **no `run_id` parameter** at the call site;
+    the writer resolves it via `run_id_provider(strat_id)` at
+    enqueue time. If the provider returns `None` (early bootstrap
+    window) the writer drops the snapshot with a one-time INFO log
+    `"%s: skipped DB snapshot — run_id not yet set"`.
+  * If `exchange_ts is None` (constructor-time restore, or any
+    other code path without a triggering event) the writer also
+    drops the snapshot — the DB column is non-nullable and a
+    wall-clock substitute would break `at_or_before` queries.
+  * Imports the new public helpers from `gridcore/persistence.py`:
+    `grid_fingerprint(grid, grid_step, grid_count) -> tuple` (the
+    raw tuple form, identical to the existing
+    `GridStateStore._fingerprint` body — that method is renamed
+    public and the private alias is kept as a thin shim for
+    backward compatibility) and `grid_fingerprint_hash(grid,
+    grid_step, grid_count) -> str`. The latter is the **single
+    canonical form** specified in the persistence section above:
+    `hashlib.sha256(json.dumps(grid_fingerprint(...),
+    separators=(",", ":"), sort_keys=False,
+    default=str).encode()).hexdigest()` — 64-char hex matching
+    `raw_fingerprint VARCHAR(64)`. Use the HASH form for the DB
+    column and the unique index; use the TUPLE form for
+    in-memory dedupe (cheaper, no JSON serialisation).
+  * In-memory dedupe scope: `(run_id, account_id, strat_id)` →
+    last_enqueued_tuple. Skip enqueue if the new tuple equals the
+    last for the same scope. **Deliberate trade-off**: a grid
+    returning to a previously-seen state later in the run is NOT
+    re-enqueued — same latest-wins-per-strat semantic as the file
+    writer (`GridStateStore.save` at `persistence.py:137-163`
+    short-circuits on fingerprint match). Replay only needs one
+    snapshot per distinct grid state to reconstruct correctly; the
+    timeline-of-when-state-recurred information is not part of the
+    `seed_at_ts` contract.
+  * `local_ts = datetime.now(UTC)` for telemetry only; not used in
+    seed lookups.
+
+* `apps/gridbot/tests/test_grid_state_writer.py` — **new** unit
+  tests:
+  1. Happy-path insert with both `run_id_provider` returning a UUID
+     and `exchange_ts` non-`None`.
+  2. `run_id_provider` returns `None` → snapshot dropped with INFO.
+  3. `exchange_ts is None` → snapshot dropped.
+  4. Same fingerprint enqueued twice → second is dedup'd.
+  5. On-conflict-do-nothing on the unique fingerprint index when
+     two writers race.
+  6. Flush / stop / multi-strat ordering (cross-strat
+     interleaving doesn't matter for correctness, just smoke-test).
+  7. `test_writer_preserves_fifo_for_same_strat_same_ts` — enqueue
+     two snapshots with identical `(run_id, account_id, strat_id,
+     exchange_ts)` but different `grid_json` payloads (mirrors the
+     two-notify case from `update_grid` out-of-bounds). Flush.
+     Query the table ordered by `id ASC`; assert the **first**
+     row's `grid_json` matches the **first** enqueued payload and
+     the **second** row's matches the second. Critical for the
+     loader's `id DESC` final-notify tie-break.
+  8. `test_partial_index_conflict_do_nothing` — write the same
+     `(run_id, account_id, strat_id, exchange_ts, raw_fingerprint)`
+     twice (race-double-insert simulation). Second insert must
+     no-op via the partial unique constraint, not raise. Verifies
+     the `index_where` argument is wired correctly — without it
+     the constraint would not match and the second insert would
+     either raise or duplicate. **Must run against a real SQLite
+     backend** (the existing test-fixture in-memory session), NOT
+     a mocked session: the repository today has no other
+     partial-ON-CONFLICT user, so mocked behaviour cannot be
+     trusted to match dialect-level partial-index semantics.
+     Sub-assert: an INSERT with `raw_fingerprint = NULL` is NOT
+     blocked by the constraint — the `WHERE raw_fingerprint IS NOT
+     NULL` predicate keeps NULL rows outside the unique scope.
+
+### Runner wiring (Phase 2B)
+
+* `apps/gridbot/src/gridbot/runner.py:372-385` `_on_grid_change`:
+  Change signature to
+  `_on_grid_change(self, grid: list[dict], exchange_ts:
+  Optional[datetime])` and refactor the body to **independent
+  backend guards** (not an early-return tower — DB writes must
+  fire even when `state_store` is `None`):
+
+  ```
+  if len(grid) <= 1:
+      return                          # common guard, same as today
+
+  if self._state_store is not None:
+      self._state_store.save(
+          strat_id=..., grid=grid,
+          grid_step=..., grid_count=...,
+      )                               # unchanged file path
+
+  if self._grid_state_writer is not None and exchange_ts is not None:
+      self._grid_state_writer.write(
+          strat_id=self._config.strat_id,
+          grid=grid,
+          grid_step=self._config.grid_step,
+          grid_count=self._config.grid_count,
+          account_id=self._account_id,
+          symbol=self._config.symbol,
+          exchange_ts=exchange_ts,
+      )                               # new DB path
+  ```
+
+  The writer call omits `run_id` — the writer resolves it
+  internally via the `run_id_provider`. **`self._account_id` is not
+  currently a runner attribute** (`runner.py:152-162` constructor
+  has no `account_id` parameter); v15 adds it as a required
+  wiring change:
+
+  * `StrategyRunner.__init__` gets a new `account_id: str`
+    parameter (positional, alongside the existing
+    `strategy_config`). Stored as `self._account_id` for the
+    writer call site.
+  * `Orchestrator._init_strategy` (at `orchestrator.py:637`, where `StrategyRunner(...)`
+    is instantiated near `orchestrator.py:670`) resolves
+    `account_id` from the strategy → account mapping the
+    orchestrator already maintains for routing (the same mapping
+    `_account_to_runners` at `orchestrator.py:124` is built from)
+    and computes the UUID via the **exact same formula** used at
+    `orchestrator.py:1156-1162`:
+    ```
+    namespace = UUID("12345678-1234-5678-1234-567812345678")
+    account_id = str(uuid5(namespace, f"account:{strategy_config.account}"))
+    ```
+    Any deviation (different namespace, different prefix, raw
+    account name) breaks the FK match with `runs.account_id` and
+    replay's `get_at_or_before(... account_id ...)` lookup returns
+    nothing.
+
+  All other places that today construct a `StrategyRunner` (tests,
+  fixtures) need updating in the same PR; this is a small but
+  fan-out wiring change similar to the `on_change` lockstep
+  migration in the gridcore section.
+
+* `apps/gridbot/src/gridbot/orchestrator.py`:
+  * Instantiate `GridStateWriter` in `Orchestrator.__init__`,
+    same lifecycle slot the existing `GridStateStore` occupies
+    (`orchestrator.py:103` `self._state_store = GridStateStore(...)`).
+    **Conditional on `self._db is not None`** — orchestrator runs
+    without DB in standalone / test mode (`_create_run_records`
+    early-returns when `db is None`); in that path
+    `self._grid_state_writer = None`. Otherwise
+    `self._grid_state_writer = GridStateWriter(...)` here means
+    the writer exists by the time `_init_strategy()` is called
+    from `start()` (`orchestrator.py:242-244`), which happens
+    BEFORE `_create_run_records()` at line 267. Pass into
+    each `StrategyRunner` constructor inside `_init_strategy`
+    (runner stores it as `Optional[GridStateWriter]`).
+    The writer's background thread is started in `start()`
+    inside `if self._grid_state_writer is not None:` (after
+    `_create_run_records()` is fine — but the writer object
+    itself must exist earlier so it can be threaded through the
+    runner constructor).
+  * Pass `run_id_provider=lambda strat_id: self._run_ids.get(strat_id)`
+    so the writer reads from `_run_ids` **lazily at write time**.
+    Bootstrap window: `_create_run_records()` runs before WS
+    connect (`orchestrator.py:267` then ~269); reconciliation
+    does not mutate the grid, so the first grid mutation (and
+    thus the first writer call) happens on the first ticker
+    AFTER `_run_ids` is populated. Window is known-safe.
+    Provider returning `None` is still defensively handled by
+    the writer (drops with INFO; see writer test #2) for any
+    other edge cases.
+  * Start/stop the writer in the orchestrator lifecycle, **all
+    calls guarded by `if self._grid_state_writer is not None`**
+    so standalone / no-DB runs don't NPE. **Stop semantics
+    require an explicit flush**: `orchestrator.stop()` already
+    calls `self._state_store.flush(timeout=10.0)` at
+    `orchestrator.py:571-578`. Add a parallel guarded call:
+    ```
+    if self._grid_state_writer is not None:
+        self._grid_state_writer.flush(timeout=10.0)
+    ```
+    immediately after the file-flush line. Without this, the
+    last post-fill snapshot(s) sitting in the writer's queue are
+    lost on shutdown — the same class of bug that the file path
+    already guards against with `state_store.flush(...)`.
+  * Pass the writer into `StrategyRunner` constructor as an
+    optional dependency (alongside `state_store`).
+
+### Replay loader (Phase 2C — depends on Phase 1)
+
+* `apps/replay/src/replay/snapshot_loader.py`:
+  * **New** `load_grid_state_from_snapshots(db_session, run_id,
+    account_id, strat_id, at_ts, expected_step, expected_count) ->
+    Optional[GridStateSeed]`. Note: `run_id: str`, matching the
+    signature pattern of existing loaders in the same file
+    (`load_position_snapshots`, `load_wallet_seed_full`,
+    `load_active_orders` at `snapshot_loader.py:268-460`). The
+    engine's `_load_seed` already has `run_id: str` in scope —
+    don't materialise a `Run` ORM object for this one loader.
+    1. `row = GridStateSnapshotRepository(db_session).get_at_or_before(
+       run_id, account_id, strat_id, at_ts)`.
+    2. `None` → INFO `"%s: no grid snapshot at-or-before %s"` +
+       return `None`.
+    3. Fingerprint check with **normalised comparison** —
+       `grid_count` (Integer) compared directly; `grid_step`
+       (Decimal from SQLAlchemy `Numeric(20,8)` vs float from
+       config) normalised via the codebase's standard
+       `Decimal(str(x))` pattern. On mismatch: emit INFO
+       (mirroring the file loader's `load_grid_state`
+       step-mismatch path at `snapshot_loader.py:252-258`) and
+       return `None`:
+       ```
+       if int(row.grid_count) != int(expected_count):
+           logger.info(
+               "%s: saved grid_count=%d differs from replay "
+               "config %d; falling back",
+               strat_id, row.grid_count, expected_count,
+           )
+           return None
+       if Decimal(str(row.grid_step)) != Decimal(str(expected_step)):
+           logger.info(
+               "%s: saved grid_step=%s differs from replay "
+               "config %s; falling back",
+               strat_id, row.grid_step, expected_step,
+           )
+           return None
+       ```
+       Direct `Decimal == float` comparison would falsely reject
+       valid snapshots for any binary-imprecise step
+       (e.g. `expected_step=0.1` stored as `Decimal('0.10000000')`
+       — `Decimal('0.10000000') == 0.1` is `False` because the
+       Python `0.1` literal is
+       `0.1000000000000000055511...`). Memory obs 777 (2026-05-12):
+       codebase already uses `Decimal(str(...))` consistently.
+       The two INFO logs are what
+       `test_step_count_mismatch_returns_none` and
+       `test_step_binary_imprecise_match_accepted` assert on.
+    4. Return `GridStateSeed(strat_id=strat_id, grid=row.grid_json,
+       grid_step=float(row.grid_step), grid_count=int(row.grid_count))`.
+       `grid` field is the list of dicts as-stored — no type
+       coercion needed; `Grid.restore_grid` already accepts the
+       JSON-roundtripped shape.
+  * Keep existing `load_grid_state` (file loader) unchanged.
+
+* `apps/replay/src/replay/engine.py:600+` `_load_seed` — order
+  refactor required: today the file grid is loaded BEFORE the DB
+  session opens (`engine.py:647-653`). DB-mode loader needs the
+  session. Restructure as:
+  1. Open the DB session FIRST (move
+     `with self._db.get_session() as db_session:` above the
+     grid-load block).
+  2. Inside the session, try
+     `load_grid_state_from_snapshots(db_session, run_id,
+     account_id, strat_id=seed.strat_id, at_ts=seed.at_ts,
+     expected_step=..., expected_count=...)`.
+  3. If it returns `None` AND `seed.grid_state_path is not None`,
+     fall back to `load_grid_state(GridStateStore(file_path=
+     seed.grid_state_path), ...)` (still inside the session block
+     is fine; the file loader doesn't use the session).
+  4. On both `None` → fresh blank-build on first ticker (current
+     behaviour).
+  5. INFO log at the end: `"grid seed source=db|file|fresh"`.
+
+* `apps/replay/src/replay/config.py:127` `SeedConfig.grid_state_path`
+  — relax to `Optional[str] = None`. File mode marked legacy in the
+  field docstring.
+
+### Tests
+
+* `apps/replay/tests/test_snapshot_loader.py` — **new** class
+  `TestLoadGridStateFromSnapshots`:
+  1. `test_happy_path_returns_seed` — fixture inserts a snapshot;
+     loader returns the seed verbatim.
+  2. `test_no_snapshot_returns_none` — empty table for this scope →
+     `None`, INFO logged.
+  3a. `test_same_exchange_ts_picks_latest_by_id` — insert two
+      snapshots with **identical** `exchange_ts` (simulating the
+      `update_grid` out-of-bounds path's two notifies) but different
+      `grid_json` payloads. Loader must return the row with the
+      larger `id` (the final notify), driven by the
+      `ORDER BY exchange_ts DESC, id DESC` clause.
+  3. `test_picks_latest_at_or_before` — multiple snapshots inserted
+     at different `exchange_ts`; loader picks the one ≤ `at_ts`
+     closest to it, not the latest overall.
+  4. `test_cross_run_isolation` — snapshot exists for a different
+     `run_id` only → `None` (no cross-run leakage).
+  5. `test_cross_strat_isolation` — same `run_id` but different
+     `strat_id` → `None`.
+  6. `test_step_count_mismatch_returns_none` — snapshot exists but
+     `grid_step` / `grid_count` differ from `expected_*` → `None`,
+     INFO logged.
+  6a. `test_step_binary_imprecise_match_accepted` — snapshot
+      stored with `grid_step=Decimal('0.10000000')`, loader called
+      with `expected_step=0.1` (float). Must accept (after
+      `Decimal(str(...))` normalisation), not reject.
+  7. `test_grid_passes_restore_grid` — sanity check that the loader's
+     output round-trips through `Grid.restore_grid` cleanly (since the
+     stored payload is what live's restore path was designed for).
+
+* `apps/replay/tests/test_engine_seed.py`:
+  * `test_load_seed_prefers_db_over_file` — both DB and file present
+    with different grids → engine ends with DB grid.
+  * `test_load_seed_falls_back_to_file` — no DB snapshot, file
+    present → engine uses file.
+  * `test_load_seed_falls_back_to_fresh` — neither present → blank
+    build.
+
+* `apps/gridbot/tests/test_runner.py` — extend existing
+  `_on_grid_change` tests:
+  * `test_on_grid_change_writes_to_db_when_writer_configured` — mock
+    writer, assert `write(...)` called with the same payload as the
+    file save plus the threaded `exchange_ts`.
+  * `test_on_grid_change_skips_db_write_when_writer_not_configured`
+    — backward compatibility for tests / standalone runs.
+  * `test_on_grid_change_db_write_fires_when_state_store_is_none`
+    — covers the v12 guard split: writer fires even when the
+    legacy file backend is disabled (the v11 plan would have
+    skipped this case via the early `state_store is None` return).
+  * `test_on_grid_change_skips_db_when_exchange_ts_none` — early
+    bootstrap (constructor-time restore_grid) has no triggering
+    event; writer is not called.
+  * `test_restored_grid_oob_rebuild_carries_ticker_ts` — fixture:
+    construct engine with a `restored_grid` whose bounds are
+    far from the first ticker price; first ticker triggers the
+    out-of-bounds rebuild at `engine.py:160-181` (rebuild around
+    `last_close`). Snapshot from this mutation must carry the
+    ticker's `exchange_ts`. Distinct from the other rebuild paths
+    because it's the first-ticker post-restore branch.
+  * `test_check_and_place_rebuild_carries_ticker_ts` — drive engine
+    through `_check_and_place` rebuild path (too many orders → grid
+    rebuild at `engine.py:331`) inside a ticker handler. Snapshot
+    captured by the mock writer must carry the ticker's
+    `exchange_ts`, not `None` and not a wall-clock value.
+  * `test_deferred_fill_consumption_uses_ticker_ts` — fixture:
+    execution arrives BEFORE first ticker (`_fill_pending` set,
+    no grid mutation yet). Then ticker arrives, deferred fill
+    consumed at `engine.py:194`, grid mutates, snapshot fires. The
+    snapshot's `exchange_ts` must equal the **ticker's**
+    exchange_ts, not the execution's earlier ts — because that is
+    the moment live actually mutates the grid.
+  * `test_update_grid_out_of_bounds_rebuild_carries_execution_ts`
+    — fixture: first ticker establishes `last_close` inside grid
+    bounds (no mutation needed). Then an execution arrives at a
+    price that, combined with the ticker, would put the grid out
+    of bounds when `update_grid` runs at `engine.py:241`. The
+    out-of-bounds branch (`grid.py:255`) fires `__rebuild_grid →
+    build_grid → _notify_change` (intermediate), then continues to
+    `_assign_sides + __center_grid + _notify_change` (final). Both
+    snapshots must carry the **execution's** exchange_ts (the
+    `current_event_ts` set at the top of `_handle_execution_event`).
+    The final snapshot — picked by `ORDER BY exchange_ts DESC, id
+    DESC` — must reflect the post-side-assignment grid (Wait band
+    around fill_price, not just the bare rebuild).
+
+### Recorder integration (out of scope — future work, not a phase)
+
+The natural source for `grid_state_snapshots` is live gridbot itself
+(Phase 2B writes them). Recorder runs in a separate process and does
+not have the in-memory grid. **Out of scope for this feature**:
+making the recorder reconstruct snapshots for runs it has already
+captured but where gridbot wasn't writing to DB. Those runs continue
+to use file mode (or remain unreplayable from DB; document in the
+runbook).
+
+### Runbook & docs
+
+* `docs/features/0029_RUNBOOK.md` Step 7 — drop the
+  `cp db/grid_anchor.json db/grid_anchor.phase4.json` line for runs
+  produced after this feature ships. Document that the snapshot is
+  now in the DB automatically.
+
+* `RULES.md`:
+  * Bullet: "Grid state is persisted via two parallel writers from
+    `_on_grid_change`: the legacy JSON file (`GridStateStore`) and
+    the new `grid_state_snapshots` table. Replay prefers the DB
+    table; the file is a fallback."
+  * Bullet: "Replay loads grid state verbatim via `restore_grid`,
+    just like live's startup path. No geometric reconstruction
+    happens. If `grid_state_snapshots` has no row at-or-before
+    `seed.at_ts`, the loader returns `None` and the engine falls
+    through to file / fresh."
+
+## Algorithm
+
+There is no algorithm. The DB snapshot is a verbatim copy of
+`grid.grid` produced by the same on_change path that already populates
+the JSON file. The loader is a single indexed `SELECT` followed by a
+`Decimal(str(...))`-normalised fingerprint check, then return the
+seed. See the "Replay loader" section above for the exact
+normalisation rules — no separate pseudocode block here, to avoid the
+v12 bug where a brief restatement reintroduced the float-vs-Decimal
+issue the detailed text had just fixed.
+
+## Why this approach is correct
+
+* **Source of truth alignment.** Replay reads exactly what live wrote.
+  The same `grid.grid` list that lived in memory at `seed.at_ts` (or
+  the closest preceding mutation tick) becomes the seed for replay.
+  Live and replay use the same `Grid.restore_grid` API to consume it.
+* **No reconstruction.** All the geometric problems that consumed
+  v1–v10 — `(1-s) ≠ 1/(1+s)` asymmetry, `recenter_if_drifted`
+  off-grid WAIT, hedge-mode duplication, placement-skip count drift —
+  are non-issues because we aren't deriving anything. We persist what
+  live observed and read it back.
+* **Backward compatible.** Existing recordings without DB snapshots
+  fall through to file mode unchanged. The file write stays in
+  `_on_grid_change` for live-restart parity.
+* **Run-scoped.** The new table carries `run_id` so cross-window
+  leakage is impossible. The 0029 pre-check already validates seed
+  bounds against `run.start_ts`; the snapshot fits the same model.
+* **Reuses live's existing persistence shape.** `GridStateWriter`
+  mirrors `GridStateStore`'s sync-API + background-thread pattern
+  (`packages/gridcore/src/gridcore/persistence.py:137-200`) and
+  shares the same lifecycle slot in `Orchestrator.__init__`. It
+  is **structurally similar** to the event_saver writers
+  (`WalletWriter` / `OrderWriter` / `PositionWriter`) but
+  intentionally NOT asyncio-based — gridbot's main loop is sync
+  and those event_saver writers live in a different process
+  (the recorder). No new infrastructure category; new code
+  only.
+
+## Out of scope
+
+* Reconstructing grid state from `orders` / `private_executions` /
+  `ticker_snapshots` — abandoned. The orders table is a downstream
+  view of grid mutations, and after `recenter_if_drifted` the
+  geometric inversion is lossy.
+* Reformatting `grid_json` from `list[dict]` to a more compact
+  binary — keep parity with `GridStateStore`'s JSON shape so
+  `restore_grid` consumes both paths identically.
+* Removing `GridStateStore` or the JSON file — live still uses them
+  for its own restart path. Out of scope to migrate live's own
+  persistence; this feature only adds a parallel DB path for replay.
+* Back-filling snapshots for the 2026-05-18 18 h dataset — that run
+  was captured before this feature. It stays on file mode. New runs
+  recorded after this ships will use DB mode automatically.
+
+## Phasing
+
+Phase 1 (sequential): schema + Alembic migration + repository.
+Phase 2 (parallel after Phase 1 lands):
+* 2A — `GridStateWriter` and its tests.
+* 2B — runner / orchestrator wiring.
+* 2C — replay loader + engine wiring + replay tests.
+* 2D — runbook + RULES updates.
+
+**Acceptance** (issue #101 target ≥ 95 % match):
+
+* **Dataset**: a new recording started AFTER all Phase 1 + Phase 2
+  changes are deployed to live. Must run for ≥ 1 h with at least
+  10 fills to exercise multiple grid mutations. The 2026-05-18
+  18 h dataset (`run_id=f9854727-…`) was captured before this
+  feature ships and stays on file mode — do not use it for
+  acceptance.
+* **Verification step**: follow
+  `docs/features/0029_RUNBOOK.md` (updated by Phase 2D) end to
+  end on the new recording. Phase 4 replay match rate ≥ 95 % is
+  the pass bar; record the actual rate in the PR description.
+* **Rollback policy on miss**: do NOT revert the schema or
+  migrations. Revert ONLY the orchestrator wiring change (`Phase 2B`)
+  so `_on_grid_change` no longer calls `GridStateWriter.write`.
+  The DB table stays empty for new runs; replay's loader falls
+  through to file mode automatically (the file path is unchanged
+  by this feature). Leaves the door open for fixing the loader
+  in a follow-up without re-migrating.

--- a/docs/features/0047_REVIEW.md
+++ b/docs/features/0047_REVIEW.md
@@ -1,0 +1,151 @@
+# Feature 0047 — Code Review: Persist `grid_state` snapshots to DB
+
+**Reviewer:** Cursor (against `docs/features/0047_PLAN.md` v18)  
+**Revision:** 2 (post-fix re-review)  
+**Scope:** Working tree — gridbot, gridcore, shared/db, replay  
+**Tests run:** 44 targeted 0047 tests passed (`TestOnGridChangeDbWriter`, `TestOnGridChangeExchangeTsPropagation`, `test_grid_state_writer`, `TestLoadGridStateFromSnapshots`, `test_engine_seed` 0047 cases, `TestOrchestratorGridStateWriterWiring` including new provisioning test).
+
+---
+
+## Summary
+
+The follow-up work addresses the main gaps from **revision 1**. Runner-level `exchange_ts` propagation is now covered for the highest-risk engine paths; loader tests include `restore_grid` round-trip and independent `grid_step` mismatch; the runbook branches by run vintage; and `Orchestrator.start()` calls `create_tables()` so pre-0047 production DBs get `grid_state_snapshots` without a separate migration step.
+
+**Verdict:** Implementation and test coverage are **strong**. Remaining items are minor (one optional plan test path, stale docstring, acceptance run). **Ready to merge** from a code-review perspective; feature closure still depends on live acceptance (≥1 h recording + Phase 4 replay ≥95%).
+
+---
+
+## Changes since revision 1
+
+| Revision 1 finding | Status |
+|--------------------|--------|
+| Missing runner `exchange_ts` / DB-guard tests | ✅ Fixed — `TestOnGridChangeDbWriter` (4 tests) + `TestOnGridChangeExchangeTsPropagation` (4 engine-path tests) |
+| No `restore_grid` loader test | ✅ Fixed — `test_loader_output_round_trips_through_restore_grid` |
+| No dedicated `grid_step` mismatch test | ✅ Fixed — `test_step_value_mismatch_returns_none` |
+| Runbook still mandatory `cp` for all runs | ✅ Fixed — branched “0047+ vs pre-0047” in `0029_RUNBOOK.md` Step 7 |
+| Schema rollout / no Alembic | ✅ Mitigated — `orchestrator.start()` calls `db.create_tables()` after `_create_run_records`; test `test_start_provisions_grid_state_snapshots_table_on_pre_0047_db` |
+| Pre-merge grep gate not evidenced | ✅ Verified — no single-arg `on_change` / `on_grid_change` lambdas remain |
+
+---
+
+## 1. Plan implementation checklist
+
+| Item | Status | Notes |
+|------|--------|-------|
+| `GridStateSnapshot` model + partial unique index | ✅ | Unchanged from rev 1 |
+| Alembic migration | ⚠️ Intentional deviation | Project uses `create_all`; **now also invoked from `Orchestrator.start()`** (`orchestrator.py:289-302`) |
+| `GridStateSnapshotRepository` | ✅ | |
+| `grid_fingerprint` / `grid_fingerprint_hash` | ✅ | |
+| `on_change(grid, exchange_ts)` + engine lifecycle | ✅ | |
+| Lockstep call sites | ✅ | Grep: no single-arg callbacks |
+| `GridStateWriter` | ✅ | |
+| Runner + orchestrator wiring | ✅ | + `create_tables` on start |
+| Replay loader + `_load_seed` | ✅ | |
+| `RULES.md` | ✅ | |
+| `0029_RUNBOOK.md` | ✅ | Vintage branching documented |
+| Runner / engine `exchange_ts` tests | ✅ Mostly | See §3.1 for one optional gap |
+| Loader `restore_grid` + step mismatch tests | ✅ | |
+| Pre-merge grep gate | ✅ | Run locally; clean |
+| Acceptance (new recording, ≥95% replay) | ⏳ | Still operator-owned |
+
+---
+
+## 2. Correctness (unchanged strengths)
+
+- **Data shape:** `grid_json` as `list[{side, price}]`; defensive copy in writer; `Decimal(str(grid_step))` on write.
+- **Scoping:** `run_id` / `account_id` / `strat_id` filters; UUID5 `account_id` matches `_create_run_records`.
+- **Ordering:** FIFO same-`exchange_ts` inserts; `ORDER BY exchange_ts DESC, id DESC`; partial index + `index_where`.
+- **Fallbacks:** Missing table → file path; DB preferred over file in `_load_seed`.
+- **Lifecycle:** Writer in `__init__` when `db is not None`; thread after `_create_run_records` + schema provision; `flush` + `stop` on shutdown.
+- **Silent-failure guard:** Independent file/DB backends; `account_id` required when writer wired.
+
+---
+
+## 3. Remaining issues
+
+### 3.1 Low — `test_check_and_place_rebuild_carries_ticker_ts` not added
+
+Plan listed a runner test for the `_check_and_place` rebuild path (`engine.py:331` — too many orders → `build_grid`). **Not present** in `test_runner.py`. Other ticker-scoped paths are covered (`test_first_ticker_build_carries_ticker_ts`, restored OOB rebuild, deferred fill). Risk is **low** because that path runs inside `_handle_ticker_event`, which already sets `_current_exchange_ts` in try/finally — same mechanism as the covered paths. Add only if you want exhaustive plan checklist closure.
+
+### 3.2 Low — documented dedupe trade-off (unchanged)
+
+In-memory dedupe on `(run_id, account_id, strat_id)` without `exchange_ts` can skip re-persisting an identical grid geometry later in the run. Deliberate per plan; replay may see an older row if state recurs. No change needed unless product wants full timeline fidelity.
+
+### 3.3 Nit — stale `models.py` module docstring
+
+Header still says “Supports 10 tables” and omits `grid_state_snapshots`. Cosmetic only.
+
+### 3.4 Out of scope for code review — acceptance
+
+Issue #101 bar: new recording ≥1 h, Phase 4 replay ≥95%. Rollback policy (revert orchestrator wiring only) unchanged.
+
+---
+
+## 4. New test coverage (revision 2)
+
+### `TestOnGridChangeDbWriter` (`test_runner.py`)
+
+| Test | Plan mapping |
+|------|----------------|
+| `test_writes_to_db_when_writer_configured` | `test_on_grid_change_writes_to_db_when_writer_configured` |
+| `test_skips_db_write_when_writer_not_configured` | ✓ |
+| `test_db_write_fires_when_state_store_is_none` | v12 independent guards |
+| `test_skips_db_when_exchange_ts_none` | ✓ |
+
+### `TestOnGridChangeExchangeTsPropagation` (`test_runner.py`)
+
+| Test | Plan mapping |
+|------|----------------|
+| `test_first_ticker_build_carries_ticker_ts` | Initial `build_grid` path |
+| `test_restored_grid_oob_rebuild_carries_ticker_ts` | `engine.py:160-181` |
+| `test_deferred_fill_consumption_uses_ticker_ts` | `engine.py:194` — asserts exec ts **not** used |
+| `test_update_grid_out_of_bounds_rebuild_carries_execution_ts` | Execution OOB double-notify |
+
+Tests drive real `StrategyRunner.on_ticker` / `on_execution` with `Mock` writer — good integration depth without brittle engine internals.
+
+### Replay loader (`test_snapshot_loader.py`)
+
+- `test_step_value_mismatch_returns_none` — `grid_step` branch isolated from count.
+- `test_loader_output_round_trips_through_restore_grid` — `Grid.restore_grid` on loader output.
+
+### Orchestrator (`test_orchestrator.py`)
+
+- `test_start_provisions_grid_state_snapshots_table_on_pre_0047_db` — simulates DB without table; `start()` creates it.
+
+All **44** targeted tests passed in re-review run.
+
+---
+
+## 5. Data alignment / regressions
+
+No new alignment issues found. Re-checked:
+
+- Callback arity lockstep across `apps/` and `packages/`.
+- `exchange_ts` on writer mock matches event timestamps in propagation tests.
+- Loader `Decimal(str(...))` still covered by `test_step_binary_imprecise_match_accepted`.
+
+---
+
+## 6. Over-engineering / style
+
+No new concerns. `create_tables()` in `start()` is a small, idempotent addition appropriate for this repo’s schema model.
+
+---
+
+## 7. Verdict (revision 2)
+
+| Category | Revision 1 | Revision 2 |
+|----------|------------|------------|
+| Plan fidelity | Good | **Very good** |
+| Test completeness vs plan | Fair | **Good** (one optional path omitted) |
+| Production safety | Good | **Very good** (schema provision on start) |
+| Ready to merge (code) | Yes, with follow-up tests | **Yes** |
+| Ready to close feature | No | **No** — acceptance run still required |
+
+### Pre-merge / post-merge checklist
+
+1. ~~Add runner `exchange_ts` tests~~ — done.
+2. ~~Runbook vintage branching~~ — done.
+3. ~~Schema provision on deploy~~ — `create_tables()` in `start()` + test.
+4. **Operator:** fresh recording ≥1 h post-deploy; Phase 4 replay ≥95%; record rate in PR.
+5. **Optional:** `test_check_and_place_rebuild_carries_ticker_ts`; fix `models.py` table count in docstring.

--- a/packages/gridcore/src/gridcore/engine.py
+++ b/packages/gridcore/src/gridcore/engine.py
@@ -9,6 +9,7 @@ Extracted from bbu2-master/strat.py Strat50 class with the following transformat
 """
 
 import logging
+from datetime import datetime
 from decimal import Decimal
 from typing import Callable, Optional
 
@@ -45,7 +46,7 @@ class GridEngine:
     def __init__(self, symbol: str, tick_size: Decimal, config: GridConfig,
                  strat_id: str, anchor_price: Optional[float] = None,
                  restored_grid: Optional[list[dict]] = None,
-                 on_grid_change: Optional[Callable[[list[dict]], None]] = None):
+                 on_grid_change: Optional[Callable[[list[dict], Optional[datetime]], None]] = None):
         """
         Initialize grid trading engine.
 
@@ -60,9 +61,11 @@ class GridEngine:
                          on construction. Used by the live runner to resume after restart.
                          If validation fails the engine falls back to a fresh build on
                          the first ticker.
-            on_grid_change: Optional callback invoked with the current grid after every
-                         build_grid / update_grid mutation. Used by the live runner to
-                         persist grid state.
+            on_grid_change: Optional callback invoked with ``(grid, exchange_ts)``
+                         after every build_grid / update_grid mutation. ``exchange_ts``
+                         is the triggering event's exchange time (or ``None`` for
+                         non-event mutations, e.g. constructor-time restore_grid).
+                         Used by the live runner to persist grid state.
         """
         self.symbol = symbol
         self.config = config
@@ -135,6 +138,17 @@ class GridEngine:
         Returns:
             List of intents for order placement/cancellation
         """
+        # 0047: propagate the triggering event's exchange_ts to any nested
+        # grid mutation. Cleared in `finally` so subsequent constructor-time
+        # or out-of-handler `_notify_change` calls see None (DB writer
+        # skips; file writer is ts-independent).
+        self.grid._current_exchange_ts = event.exchange_ts
+        try:
+            return self._handle_ticker_event_body(event, limit_orders)
+        finally:
+            self.grid._current_exchange_ts = None
+
+    def _handle_ticker_event_body(self, event: TickerEvent, limit_orders: dict[str, list[dict]]) -> list[PlaceLimitIntent | CancelIntent]:
         intents: list[PlaceLimitIntent | CancelIntent] = []
 
         # Update last close price
@@ -233,18 +247,24 @@ class GridEngine:
         Returns:
             List of intents (typically empty, grid update is internal)
         """
-        # Update last filled price
-        self.last_filled_price = float(event.price)
+        # 0047: see _handle_ticker_event for the rationale on
+        # _current_exchange_ts lifecycle.
+        self.grid._current_exchange_ts = event.exchange_ts
+        try:
+            # Update last filled price
+            self.last_filled_price = float(event.price)
 
-        # Update grid based on fill
-        if self.last_close is not None:
-            self.grid.update_grid(self.last_filled_price, self.last_close)
-        else:
-            # Defer: no last_close yet, so update_grid would early-return.
-            # Consume on first ticker event.
-            self._fill_pending = True
+            # Update grid based on fill
+            if self.last_close is not None:
+                self.grid.update_grid(self.last_filled_price, self.last_close)
+            else:
+                # Defer: no last_close yet, so update_grid would early-return.
+                # Consume on first ticker event.
+                self._fill_pending = True
 
-        return []
+            return []
+        finally:
+            self.grid._current_exchange_ts = None
 
     def _handle_order_update_event(self, event: OrderUpdateEvent) -> list[PlaceLimitIntent | CancelIntent]:
         """

--- a/packages/gridcore/src/gridcore/grid.py
+++ b/packages/gridcore/src/gridcore/grid.py
@@ -10,6 +10,7 @@ Extracted from bbu2-master/greed.py with the following key transformations:
 """
 
 import logging
+from datetime import datetime
 from decimal import Decimal
 from enum import StrEnum
 from typing import Callable, NamedTuple, Optional
@@ -47,7 +48,7 @@ class Grid:
     """
 
     def __init__(self, tick_size: Decimal, grid_count: int = 50, grid_step: float = 0.2, rebalance_threshold: float = 0.3,
-                 on_change: Optional[Callable[[list[dict]], None]] = None):
+                 on_change: Optional[Callable[[list[dict], Optional[datetime]], None]] = None):
         """
         Initialize Grid calculator.
 
@@ -57,8 +58,13 @@ class Grid:
             grid_step: Step size in percentage (default 0.2 = 0.2% between levels)
             rebalance_threshold: Threshold for rebalancing grid when imbalanced (default 0.3 = 30%)
             on_change: Optional callback fired after build_grid/update_grid mutates self.grid.
-                Used by callers (e.g. live runner) to persist grid state. Grid stays pure —
-                the callback is just a function reference, no I/O knowledge here.
+                Signature is ``(grid, exchange_ts)`` — ``exchange_ts`` is the
+                triggering event's timestamp (set by the engine handler in a
+                try/finally on ``self._current_exchange_ts``) or ``None`` if
+                no triggering event is in scope (e.g. constructor-time
+                ``restore_grid``). Callbacks must accept both args; arity
+                mismatches are silenced by ``_notify_change`` and would
+                disable persistence silently (feature 0047).
         """
         self.grid: list[dict] = []
         self.tick_size = tick_size
@@ -67,6 +73,10 @@ class Grid:
         self.REBALANCE_THRESHOLD = rebalance_threshold
         self._original_anchor_price: Optional[float] = None
         self._on_change = on_change
+        # 0047: engine sets this in a try/finally at the top of each event
+        # handler so multiple inner notifies share the same ts; cleared on
+        # handler exit. Read-only here — never reset by _notify_change.
+        self._current_exchange_ts: Optional[datetime] = None
 
     def _notify_change(self) -> None:
         """Invoke on_change callback. Errors are logged but never propagate —
@@ -74,7 +84,7 @@ class Grid:
         if self._on_change is None:
             return
         try:
-            self._on_change(self.grid)
+            self._on_change(self.grid, self._current_exchange_ts)
         except Exception as e:
             logger.error("Grid on_change callback failed: %s", e, exc_info=True)
 

--- a/packages/gridcore/src/gridcore/persistence.py
+++ b/packages/gridcore/src/gridcore/persistence.py
@@ -19,6 +19,7 @@ runs a synchronous main loop (time.sleep), so asyncio.create_task would
 always fall through to the sync path and block the loop on fsync.
 """
 
+import hashlib
 import json
 import logging
 import os
@@ -26,6 +27,37 @@ import threading
 from typing import Optional
 
 logger = logging.getLogger(__name__)
+
+
+def grid_fingerprint(grid: list[dict], grid_step: float, grid_count: int) -> tuple:
+    """Cheap structural identity of a grid payload.
+
+    Comparable, hashable, and ~50x cheaper than deepcopy + dict equality.
+    Public form of the helper used by both ``GridStateStore`` (file path)
+    and ``GridStateWriter`` (DB path) so dedupe is single-sourced.
+    """
+    return (
+        tuple((g['side'], g['price']) for g in grid),
+        grid_step,
+        grid_count,
+    )
+
+
+def grid_fingerprint_hash(grid: list[dict], grid_step: float, grid_count: int) -> str:
+    """SHA-256 hex digest of the canonical grid fingerprint.
+
+    64-char hex matches the ``raw_fingerprint VARCHAR(64)`` column on
+    ``grid_state_snapshots``. ``default=str`` lets ``json.dumps`` serialise
+    ``Decimal`` / ``float`` mixed numerics safely.
+    """
+    return hashlib.sha256(
+        json.dumps(
+            grid_fingerprint(grid, grid_step, grid_count),
+            separators=(",", ":"),
+            sort_keys=False,
+            default=str,
+        ).encode()
+    ).hexdigest()
 
 
 class GridStateStore:
@@ -69,15 +101,9 @@ class GridStateStore:
         if strat_id == "":
             raise ValueError("strat_id must be a non-empty string")
 
-    @staticmethod
-    def _fingerprint(grid: list[dict], grid_step: float, grid_count: int) -> tuple:
-        """Cheap structural identity of a payload — comparable, hashable,
-        and ~50x cheaper than deepcopy + dict equality."""
-        return (
-            tuple((g['side'], g['price']) for g in grid),
-            grid_step,
-            grid_count,
-        )
+    # Thin alias for backward compatibility — public form lives at module
+    # scope as ``grid_fingerprint`` (0047).
+    _fingerprint = staticmethod(grid_fingerprint)
 
     def _read_all_data(self) -> dict:
         """Read the full JSON file, returning {} on any error or if the root

--- a/packages/gridcore/tests/test_engine.py
+++ b/packages/gridcore/tests/test_engine.py
@@ -1083,7 +1083,7 @@ class TestRestoredGrid:
             tick_size=Decimal('0.1'),
             config=config,
             strat_id='btcusdt_test',
-            on_grid_change=lambda g: captured.append(len(g)),
+            on_grid_change=lambda g, ts: captured.append(len(g)),
         )
         engine.on_event(self._ticker(100.0), {'long': [], 'short': []})
         assert captured == [11]

--- a/packages/gridcore/tests/test_grid.py
+++ b/packages/gridcore/tests/test_grid.py
@@ -574,7 +574,7 @@ class TestGridOnChangeCallback:
     def test_callback_fires_after_build_grid(self):
         calls = []
         grid = Grid(tick_size=Decimal('0.1'), grid_count=10, grid_step=0.2,
-                    on_change=lambda g: calls.append(list(g)))
+                    on_change=lambda g, ts: calls.append(list(g)))
         grid.build_grid(100.0)
         assert len(calls) == 1
         assert len(calls[0]) == 11  # 5 buy + 1 wait + 5 sell
@@ -582,7 +582,7 @@ class TestGridOnChangeCallback:
     def test_callback_fires_after_update_grid(self):
         calls = []
         grid = Grid(tick_size=Decimal('0.1'), grid_count=10, grid_step=0.2,
-                    on_change=lambda g: calls.append(list(g)))
+                    on_change=lambda g, ts: calls.append(list(g)))
         grid.build_grid(100.0)
         calls.clear()
         grid.update_grid(last_filled_price=100.2, last_close=100.0)
@@ -593,7 +593,7 @@ class TestGridOnChangeCallback:
         what was already on disk)."""
         calls = []
         grid = Grid(tick_size=Decimal('0.1'), grid_count=10, grid_step=0.2,
-                    on_change=lambda g: calls.append(list(g)))
+                    on_change=lambda g, ts: calls.append(list(g)))
         serialized = [
             {'side': 'Buy', 'price': 99.0},
             {'side': 'Buy', 'price': 99.5},
@@ -607,7 +607,7 @@ class TestGridOnChangeCallback:
     def test_callback_errors_do_not_break_grid(self):
         """Callback failures are logged but never propagate — persistence
         failures must not crash strategy logic."""
-        def raise_callback(g):
+        def raise_callback(g, ts):
             raise RuntimeError("boom")
 
         grid = Grid(tick_size=Decimal('0.1'), grid_count=10, grid_step=0.2,
@@ -917,7 +917,7 @@ class TestRecenterIfDrifted:
             tick_size=Decimal('0.01'),
             grid_count=20,
             grid_step=1.0,
-            on_change=lambda g: calls.append(len(g)),
+            on_change=lambda g, ts: calls.append(len(g)),
         )
         grid.build_grid(100.0)
         calls_after_build = len(calls)
@@ -931,7 +931,7 @@ class TestRecenterIfDrifted:
             tick_size=Decimal('0.01'),
             grid_count=20,
             grid_step=1.0,
-            on_change=lambda g: calls.append(len(g)),
+            on_change=lambda g, ts: calls.append(len(g)),
         )
         grid.build_grid(100.0)
         calls_after_build = len(calls)

--- a/shared/db/src/grid_db/__init__.py
+++ b/shared/db/src/grid_db/__init__.py
@@ -19,6 +19,7 @@ from grid_db.models import (
     Order,
     PositionSnapshot,
     WalletSnapshot,
+    GridStateSnapshot,
 )
 from grid_db.enums import RunType
 from grid_db.utils import redact_db_url
@@ -35,6 +36,7 @@ from grid_db.repositories import (
     OrderRepository,
     PositionSnapshotRepository,
     WalletSnapshotRepository,
+    GridStateSnapshotRepository,
 )
 
 __all__ = [
@@ -58,6 +60,7 @@ __all__ = [
     "Order",
     "PositionSnapshot",
     "WalletSnapshot",
+    "GridStateSnapshot",
     # Repositories
     "BaseRepository",
     "UserRepository",
@@ -71,6 +74,7 @@ __all__ = [
     "OrderRepository",
     "PositionSnapshotRepository",
     "WalletSnapshotRepository",
+    "GridStateSnapshotRepository",
     # Utils
     "redact_db_url",
 ]

--- a/shared/db/src/grid_db/models.py
+++ b/shared/db/src/grid_db/models.py
@@ -1,9 +1,9 @@
 """SQLAlchemy ORM models for multi-tenant grid bot database.
 
-Supports 10 tables:
+Supports 12 tables:
 - Core entities: users, bybit_accounts, api_credentials, strategies, runs
 - Data tables: ticker_snapshots, public_trades, private_executions, orders,
-  position_snapshots, wallet_snapshots
+  position_snapshots, wallet_snapshots, grid_state_snapshots
 """
 
 from datetime import datetime, UTC
@@ -24,6 +24,7 @@ from sqlalchemy import (
     JSON,
     BigInteger,
     Integer,
+    text,
 )
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
@@ -407,6 +408,58 @@ class PositionSnapshot(Base):
         CheckConstraint(
             "source IN ('live', 'backtest')",
             name="ck_position_snapshots_source",
+        ),
+    )
+
+
+class GridStateSnapshot(Base):
+    """Verbatim grid-state snapshots written by gridbot's on_grid_change path.
+
+    Replay's seed loader reads the latest at-or-before ``seed.at_ts`` row and
+    feeds ``grid_json`` into ``Grid.restore_grid``, byte-identical to live's
+    restart path. The partial unique index blocks race-double-inserts at the
+    same instant while allowing the same grid state to recur later in the
+    run.
+    """
+
+    __tablename__ = "grid_state_snapshots"
+
+    id: Mapped[int] = mapped_column(
+        BigInteger().with_variant(Integer, "sqlite"),
+        primary_key=True,
+        autoincrement=True,
+    )
+    run_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("runs.run_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    account_id: Mapped[str] = mapped_column(String(36), nullable=False)
+    strat_id: Mapped[str] = mapped_column(String(50), nullable=False)
+    symbol: Mapped[str] = mapped_column(String(20), nullable=False)
+    exchange_ts: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    local_ts: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    grid_json: Mapped[list[dict[str, Any]]] = mapped_column(JSON, nullable=False)
+    grid_step: Mapped[Decimal] = mapped_column(Numeric(20, 8), nullable=False)
+    grid_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    raw_fingerprint: Mapped[Optional[str]] = mapped_column(String(64))
+
+    __table_args__ = (
+        Index(
+            "ix_grid_state_snapshots_lookup",
+            "run_id", "account_id", "strat_id", "exchange_ts", "id",
+        ),
+        # Partial unique index: blocks race-double-inserts at the same
+        # (run, account, strat, ts, fingerprint) while allowing repeats
+        # across different exchange_ts values. Migration creates the
+        # partial WHERE predicate; declaring it here lets ON CONFLICT DO
+        # NOTHING bind via index_where=raw_fingerprint.is_not(None).
+        Index(
+            "uq_grid_state_snapshots_fingerprint_at_ts",
+            "run_id", "account_id", "strat_id", "exchange_ts", "raw_fingerprint",
+            unique=True,
+            sqlite_where=text("raw_fingerprint IS NOT NULL"),
+            postgresql_where=text("raw_fingerprint IS NOT NULL"),
         ),
     )
 

--- a/shared/db/src/grid_db/repositories.py
+++ b/shared/db/src/grid_db/repositories.py
@@ -23,6 +23,7 @@ from grid_db.models import (
     Order,
     PositionSnapshot,
     WalletSnapshot,
+    GridStateSnapshot,
 )
 
 
@@ -1181,5 +1182,96 @@ class WalletSnapshotRepository(BaseRepository[WalletSnapshot]):
                 WalletSnapshot.exchange_ts <= at_ts,
             )
             .order_by(WalletSnapshot.exchange_ts.desc())
+            .first()
+        )
+
+
+class GridStateSnapshotRepository(BaseRepository[GridStateSnapshot]):
+    """Repository for GridStateSnapshot operations (feature 0047).
+
+    Insert path is single-row with ``ON CONFLICT DO NOTHING`` against the
+    partial unique index ``uq_grid_state_snapshots_fingerprint_at_ts`` (only
+    rows with non-NULL ``raw_fingerprint`` participate). The replay loader
+    reads back via ``get_at_or_before`` which orders by
+    ``exchange_ts DESC, id DESC`` — the latter breaks ties for
+    multi-notify outer mutations (e.g. ``update_grid`` out-of-bounds path
+    emits post-rebuild then post-side-assignment at the same ts; the
+    largest id wins, which by writer FIFO contract is the final snapshot).
+    """
+
+    def __init__(self, session: Session):
+        super().__init__(session, GridStateSnapshot)
+
+    def insert(self, snapshot: GridStateSnapshot) -> int:
+        """Insert a single snapshot, no-op on partial-index conflict.
+
+        Returns rowcount (0 if dedup'd by the partial unique constraint).
+        """
+        snapshot_data = {
+            "run_id": snapshot.run_id,
+            "account_id": snapshot.account_id,
+            "strat_id": snapshot.strat_id,
+            "symbol": snapshot.symbol,
+            "exchange_ts": snapshot.exchange_ts,
+            "local_ts": snapshot.local_ts,
+            "grid_json": snapshot.grid_json,
+            "grid_step": snapshot.grid_step,
+            "grid_count": snapshot.grid_count,
+            "raw_fingerprint": snapshot.raw_fingerprint,
+        }
+
+        # index_where MUST match the partial-index WHERE predicate or
+        # PostgreSQL won't bind the conflict target to the partial constraint
+        # (and SQLite >=3.24 partial-index ON CONFLICT behaves the same way).
+        index_elements = [
+            "run_id", "account_id", "strat_id", "exchange_ts", "raw_fingerprint",
+        ]
+        index_where = GridStateSnapshot.raw_fingerprint.is_not(None)
+
+        db_dialect = self.session.get_bind().dialect.name
+        if db_dialect == "postgresql":
+            stmt = postgresql_insert(GridStateSnapshot).values(**snapshot_data)
+            stmt = stmt.on_conflict_do_nothing(
+                index_elements=index_elements,
+                index_where=index_where,
+            )
+        elif db_dialect == "sqlite":
+            stmt = sqlite_insert(GridStateSnapshot).values(**snapshot_data)
+            stmt = stmt.on_conflict_do_nothing(
+                index_elements=index_elements,
+                index_where=index_where,
+            )
+        else:
+            stmt = insert(GridStateSnapshot).values(**snapshot_data)
+
+        result = self.session.execute(stmt)
+        self.session.flush()
+        return result.rowcount if result.rowcount else 0
+
+    def get_at_or_before(
+        self,
+        run_id: str,
+        account_id: str,
+        strat_id: str,
+        at_ts: datetime,
+    ) -> Optional[GridStateSnapshot]:
+        """Latest grid snapshot for the scope at-or-before ``at_ts``.
+
+        ``ORDER BY exchange_ts DESC, id DESC`` — the secondary ``id`` sort
+        picks the final notify of a multi-notify outer mutation when both
+        snapshots share the same ``exchange_ts``.
+        """
+        return (
+            self.session.query(GridStateSnapshot)
+            .filter(
+                GridStateSnapshot.run_id == run_id,
+                GridStateSnapshot.account_id == account_id,
+                GridStateSnapshot.strat_id == strat_id,
+                GridStateSnapshot.exchange_ts <= at_ts,
+            )
+            .order_by(
+                GridStateSnapshot.exchange_ts.desc(),
+                GridStateSnapshot.id.desc(),
+            )
             .first()
         )


### PR DESCRIPTION
## Summary

- Replace replay's racy manual `cp db/grid_anchor.json` with a DB-backed grid-state seed loader: live gridbot writes every grid mutation to a new `grid_state_snapshots` table; replay reads the latest row at-or-before `seed.at_ts` and feeds it straight into `Grid.restore_grid` — byte-identical to live's restart path.
- Widens `Grid.on_change` to `(grid, exchange_ts)`; engine handlers pin `_current_exchange_ts` in a try/finally so multi-notify outer mutations (e.g. `update_grid` OOB rebuild) share the triggering event's ts. Backwards-compat shim left on `GridStateStore._fingerprint`.
- Wires `GridStateWriter` (sync API, single FIFO queue, worker thread) into `Orchestrator.__init__`; threads it into every `StrategyRunner`; starts the worker after `_create_run_records()` populates `_run_ids`; flushes + stops it on shutdown. `Orchestrator.start()` also calls `db.create_tables()` (idempotent) so pre-0047 production DBs auto-provision the new table.
- Closes #101 (acceptance still requires ≥1 h post-deploy recording with ≥95 % Phase 4 match — operator step).

## Highlights

- **Partial unique index** on `(run_id, account_id, strat_id, exchange_ts, raw_fingerprint) WHERE raw_fingerprint IS NOT NULL`, with `index_where` matching the predicate so `ON CONFLICT DO NOTHING` actually binds.
- **`account_id` derived via `uuid5(NAMESPACE, "account:<name>")`** to FK-match `runs.account_id`. `StrategyRunner` raises if `grid_state_writer` is wired without an explicit non-default `account_id`.
- **Dedupe rollback** on insert failure (race-safe — only pops the in-memory fingerprint when no newer enqueue has replaced it). Mirrors `GridStateStore._writer_loop` semantics so transient DB errors don't permanently mask the latest grid state.
- **FIFO same-strat-same-ts contract** so the loader's `ORDER BY exchange_ts DESC, id DESC` tie-break picks the final notify of a multi-notify outer mutation.
- **Pre-0047 fallback** — loader uses `inspect(session.connection()).has_table(...)` (NOT `inspect(engine).has_table(...)` — the latter rolls back the test transaction on SQLite `:memory:` + StaticPool) so old recorder DBs without the new table fall through to the file path.
- **RUNBOOK Step 7** now branches by run vintage (0047+ skips the `cp`; pre-0047 keeps it).

## Test plan

- [x] `uv run pytest --ignore=apps/backtest/tests/test_risk_limit_info.py -q` — 2099 passed, 3 skipped (3 pre-existing failures in `test_risk_limit_info.py` unrelated to 0047).
- [x] Grep gate: no single-arg `on_change` / `on_grid_change` lambdas in `packages/` or `apps/`.
- [x] New tests (+25): `TestGridStateWriter` (9), `TestOnGridChangeDbWriter` (4), `TestOnGridChangeExchangeTsPropagation` (5), `TestLoadGridStateFromSnapshots` (11), `TestOrchestratorGridStateWriterWiring` (7), plus replay engine_seed coverage for DB > file > fresh + pre-0047 fallback.
- [ ] **Operator:** start a fresh recording AFTER deploy, collect ≥ 1 h with ≥ 10 fills, run Phase 4 replay per the updated `docs/features/0029_RUNBOOK.md`, record the match rate. Rollback on miss: revert the orchestrator wiring change only (schema stays).

🤖 Generated with [Claude Code](https://claude.com/claude-code)