### PR TITLE
fix(0048): remove per-tick drift detector, restore bbu2 grid semantics

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -219,6 +219,7 @@ make test-integration
 - `build_greed()` clears `self.greed = []` before building (prevents doubling on rebuilds)
 - `is_grid_correct()` accepts both BUY→WAIT→SELL and BUY→SELL patterns
 - **GridSideType enum**: `GridSideType.BUY`, `.SELL`, `.WAIT` — always use enum, never raw strings
+- **Feature 0048 (bbu2 parity)**: no per-tick grid walk on ticker events. Drift is handled by `update_grid` post-fill (`last_filled_price` keys WAIT via `_assign_sides`) and bounds-guard `build_grid` on the ticker path (`engine.py` out-of-bounds check). `_assign_sides(last_close, *, fill_price)` requires `fill_price` — no `last_close`-based WAIT path. `anchor_price` tracks build/restore center only; use `wait_center()` for live WAIT-band center.
 
 ### Engine Module (`engine.py`)
 

--- a/apps/gridbot/tests/test_runner.py
+++ b/apps/gridbot/tests/test_runner.py
@@ -4456,8 +4456,9 @@ class TestOnGridChangeExchangeTsPropagation:
             "short": [],
         })
 
-        # Second ticker at the same price — bounds OK, no recenter, but
-        # _check_and_place sees too many long orders and rebuilds.
+        # Second ticker at the same price — bounds OK, no grid mutation from
+        # the tick path itself, but _check_and_place sees too many long orders
+        # and rebuilds.
         ticker_ts = datetime(2026, 1, 1, 12, 1, 0, tzinfo=UTC)
         runner.on_ticker(self._ticker(50000.0, ticker_ts))
 

--- a/docs/features/0048_PLAN.md
+++ b/docs/features/0048_PLAN.md
@@ -1,0 +1,362 @@
+# Feature 0048 — Remove per-tick drift detector, restore bbu2 grid semantics (V3)
+
+> **Tracks** issues [#110](https://github.com/erzhan12/grid-bot-validation/issues/110)
+> (SAME ORDER prefix reuse — downstream symptom) and
+> [#111](https://github.com/erzhan12/grid-bot-validation/issues/111)
+> (Wait→Sell reassignment — direct root cause). Do **not** use `Closes`/`Fixes`
+> in PR titles or bodies — GitHub would auto-close at merge. **#111** closes in
+> Phase 6 only after the 7-day production pass gate (Phase 5). **#110** gets a
+> deploy comment in Phase 4; closure is operator discretion after observation.
+>
+> **Why this feature exists.**
+> Feature 0022 added `recenter_if_drifted` — a per-tick drift detector that
+> walks the grid toward `last_close` when price deviates more than one
+> `grid_step` from the current WAIT-band center. The method calls
+> `_assign_sides(last_close, fill_price=None)`, which marks WAIT only when
+> `last_close` is within `grid_step/4` of a level — a geometric proximity
+> test, not a semantic "was this level just filled?" test. As soon as price
+> drifts past that narrow window the WAIT marking is silently overwritten by
+> a fresh SELL or BUY based purely on price-vs-level position. The level
+> becomes actionable again; the engine emits a new `PlaceLimitIntent` with the
+> same deterministic `client_order_id` prefix; Bybit accepts it with a
+> different ms-suffix link_id (Feature 0030); both orders fill → SAME ORDER
+> detector (PR #100) flags `verdict=REAL_DUPLICATE`.
+>
+> Over 6 live mainnet days this produced **5 `REAL_DUPLICATE` events**.
+> 4 fired on 2026-05-20 alone. The grid_state_snapshots from Feature 0047
+> provide smoking-gun evidence — see section below.
+>
+> **Why V3 (full revert) over V1 (sticky WAIT patch) or V2 (semantic anchor +
+> threshold tuning).**
+>
+> - V1 (5-line sticky-WAIT guard in `_assign_sides`) stops the bleed but keeps
+>   Feature 0022's architectural divergence from bbu2 in place.
+> - V2 (re-center on `last_filled_price`, threshold `N × grid_step`) prevents
+>   overwriting a fill-based WAIT but requires ~200 LoC and production tuning
+>   of N.
+> - V3 (delete `recenter_if_drifted` and `_shift_grid`) reduces the codebase
+>   to bbu2's single-mode operation. bbu2's `greed.py` has no equivalent of
+>   `recenter_if_drifted` — drift is handled exclusively by `update_greed`
+>   post-fill (side reassignment keyed on `last_filled_price`) and the
+>   out-of-bounds rebuild in `update_greed:53-54`. Feature 0047's
+>   `grid_state_snapshots` makes the cold-restart "benefit" of 0022 fully
+>   redundant: the live grid is persisted to DB after every mutation and
+>   restored verbatim at replay seed time. The still-extant out-of-bounds
+>   rebuild path in `engine.py:167-195` handles the rare case where a
+>   restored grid's bounds no longer contain `last_close` on the first ticker.
+>   Net result: ~110–130 lines of src deleted (tests add more); one fewer
+>   moving part, full bbu2 parity.
+>
+> **Date:** 2026-05-20
+
+---
+
+## Smoking-Gun Evidence
+
+`grid_state_snapshots` from 2026-05-20, level 54.4 (strat `ltcusdt_test`):
+
+| snapshot id | exchange_ts | side at 54.4 | interpretation                            |
+|-------------|-------------|--------------|-------------------------------------------|
+| 8           | 12:54       | Sell         | initial state                             |
+| 9           | 12:55       | Wait         | fill landed — correct post-fill WAIT      |
+| 10          | 12:58       | Sell         | **left Wait after 3 min — root cause**    |
+| 17          | 14:22       | Sell         | —                                         |
+| 18          | 15:15       | Wait         | fill landed again                         |
+| 19          | 15:18       | Sell         | **left Wait again after 3 min**           |
+
+Pattern: Wait→Sell oscillation at fill levels 54.4 and 54.2. Each Sell
+transition re-exposes the level; each subsequent fill at the same price is
+a REAL_DUPLICATE. 39 `recenter_if_drifted` walks observed in 24 h on a
+sideway market (roughly 1 per 40 min); ~10% produced a REAL_DUPLICATE.
+Issues: #111 (direct root cause), #110 (downstream SAME ORDER prefix collision).
+
+---
+
+## bbu2 Parity Analysis
+
+| Concern | bbu2 (`greed.py`) | gridcore (post-0048) |
+|---|---|---|
+| Grid update after fill | `update_greed(last_filled_price, last_close)` line 48 | `update_grid(last_filled_price, last_close)` — identical logic |
+| Out-of-bounds rebuild | `update_greed:53-54` rebuilds when `last_close` outside bounds | `update_grid:265-267` rebuilds (same path) PLUS engine ticker-path rebuild at `engine.py:167-195` |
+| Per-tick drift walk | **does not exist** | **deleted by this feature** |
+| WAIT-band assignment | `__is_too_close(level, last_filled_price)` — fill-price keyed | `__is_too_close(level, fill_price)` — identical |
+| Grid rebalance | `__center_greed()` lines 68-94 | `__center_grid()` lines 374-416 — see comparison below |
+
+### `__center_grid` vs `__center_greed` comparison
+
+bbu2 (`greed.py:68-94`):
+```python
+def __center_greed(self):
+    buy_count = 0; sell_count = 0
+    highest_sell_price = 0
+    lowest_buy_price = self.greed[0]['price'] if self.greed else 0
+    step = self.greed_step / 100
+    for greed in self.greed:
+        if greed['side'] == self.BUY:
+            buy_count += 1
+        elif greed['side'] == self.SELL:
+            sell_count += 1
+            highest_sell_price = greed['price']
+    total_count = buy_count + sell_count
+    if total_count == 0: return
+    if (buy_count - sell_count) / total_count > 0.3:
+        self.greed.pop(0)
+        price = BybitApiUsdt.round_price(self.symbol, highest_sell_price*(1+step))
+        self.greed.append({'side': self.SELL, 'price': price})
+    elif (sell_count - buy_count) / total_count > 0.3:
+        self.greed.pop()
+        price = BybitApiUsdt.round_price(self.symbol, lowest_buy_price*(1-step))
+        self.greed.insert(0, {'side': self.BUY, 'price': price})
+```
+
+gridcore (`grid.py:374-416`): identical rebalance logic with one correct
+extension — `lowest_buy_price` is tracked per-iteration with a `< current`
+guard (bbu2 initialises it to `greed[0]['price']` which works only when the
+list is already sorted BUY-first; gridcore's per-iteration tracking is more
+robust and produces the same result for valid grids). The `rebalance_threshold`
+parameter (default 0.3) matches bbu2's hardcoded 0.3. The fall-back to
+`self.grid[0]['price']` when no BUY entries exist is a defensive addition not
+in bbu2; it is safe (the `total_count == 0` guard already handles the all-WAIT
+case).
+
+**Conclusion: `__center_grid` is already at parity with `__center_greed`. No
+porting work is required. There is no separate "port `__center_greed`" phase.**
+
+---
+
+## Files & Functions to Change
+
+### `packages/gridcore/src/gridcore/grid.py`
+
+| Symbol | Action | Lines (approx) |
+|---|---|---|
+| `RecenterResult` (NamedTuple) | **Delete** | 28–38 |
+| `recenter_if_drifted` | **Delete** | 325–372 |
+| `_shift_grid` | **Delete** | 308–323 |
+| `_assign_sides` | **Require `fill_price`** — `def _assign_sides(self, last_close: float, *, fill_price: float)` (no default). WAIT via `__is_too_close(level, fill_price)` only; delete `last_close` WAIT branch. Small scope beyond pure deletion, justified: closes the Wait→Sell primitive, matches bbu2 fill-keyed semantics, sole caller `update_grid` already passes `fill_price`. | 293–306 |
+| `restore_grid` | **Update** — remove the feature-0022 / post-recenter-walk comment at ~211. Keep `self._original_anchor_price = self.wait_center()`. | ~209-214 |
+| `anchor_price` property docstring | **Update** — remove recenter re-seed clause; state that anchor tracks build/restore center and is updated on `build_grid` / `__rebuild_grid` only (not on fills). | 567–581 |
+| `bounds` property docstring | **Update** — remove "(e.g. per-tick drift guard)" parenthetical. | ~221 |
+| `__is_too_close` | **Keep unchanged** | 418–433 |
+| `__center_grid` | **Keep unchanged** | 374–416 |
+| `update_grid` | **Keep unchanged** | 244–274 |
+
+### `packages/gridcore/src/gridcore/engine.py`
+
+| Symbol | Action | Lines (approx) |
+|---|---|---|
+| `recenter_if_drifted` call site | **Delete** lines 220–223: the `if not grid_just_built or fill_consumed_this_tick:` block and its body. | 220–223 |
+| Per-tick drift comment block | **Delete** lines 212–219 (feature 0022 rationale for recenter). | 212–219 |
+| `_log_drift` method | **Delete** — only called from recenter block and out-of-bounds metrics path. | 231–236 |
+| out-of-bounds rebuild block | **Keep** lines 167–195 — bbu2-parity safety net for restored grids. | 167–195 |
+| Out-of-bounds comments | **Update** lines 175–177 — remove references to "recenter's safety-cap path", "Grid drift" telemetry, and "per 0022 Step 3". | 175–177 |
+| out-of-bounds metrics sub-block | **Delete entire prelude** lines ~178–189 (`wait_center == 0` WARNING, deviation calc, `_log_drift`). Bounds check alone triggers rebuild. Retain only `logger.info('Restored grid out of range...')` + `build_grid`. | ~178–189 |
+| stale comment block | **Update** lines 355–360 in `_check_and_place` — see replacement text below. | 355–360 |
+| deferred-fill comment | **Update** ~198–201 — remove "before recenter" / drift-detection clauses; e.g. "Apply any deferred fill before checking and placing orders." | ~198–201 |
+| `fill_consumed_this_tick` variable | **Delete** declaration (~202) and assignment (~210). | ~202, ~210 |
+| `grid_just_built` variable | **Delete** declaration (~158) and assignments (~166, ~195). | ~158, ~166, ~195 |
+
+**`_check_and_place` replacement comment (lines 355–360):**
+```python
+# update_grid runs only on execution events (fills). On the tick path the grid
+# changes only via bounds-guard rebuild (build_grid) or deferred-fill
+# consumption (update_grid on _fill_pending).
+```
+
+### `packages/gridcore/tests/test_grid.py`
+
+| Test class / function | Action |
+|---|---|
+| `test_assign_sides_with_fill_price_preserves_legacy` (~942) | **Create** `TestAssignSides` and move test there before deleting `TestRecenterIfDrifted`. |
+| `test_assign_sides_post_walk` (~900) | **Delete** with `TestRecenterIfDrifted` (recenter-specific). |
+| `TestRecenterIfDrifted` (entire class, ~815–956) | **Delete** after moving the one keeper test out. |
+| `test_recenter_no_op_when_wait_center_is_zero` (~770, in `TestZeroDivisionGuards`) | **Delete** |
+| `test_recenter_no_op_when_grid_step_is_zero` (~788, in `TestZeroDivisionGuards`) | **Delete** |
+| `test_is_too_close_*` in `TestZeroDivisionGuards` | **Keep** |
+| **New** `TestUpdateGridSidewayOscillation` | **Add** — see Phase 2 (grid-level only; no fake "ticker" simulation) |
+
+### `packages/gridcore/tests/test_engine.py`
+
+| Test class / function | Action |
+|---|---|
+| **`TestRecenterIntegration`** (~1366–1732) | **Delete class** after moving keepers into `TestEngineNoRecenter` (see disposition + migration table). |
+| `TestAnchorPricePersistence.test_anchor_price_returns_original_center_after_fills` (~917–933) | **Stay in class** — **semantic rewrite** of inline comments: behavior unchanged (anchor at build center, fill level WAIT); reason is "`update_grid` runs only on fills", not "recenter below-threshold no-op". |
+
+#### `TestRecenterIntegration` disposition (~1366–1732)
+
+| Test | Action |
+|---|---|
+| `test_cold_start_drift_walks_grid` | **Delete** |
+| `test_mid_run_fast_move_recenters_in_one_tick` | **Delete** |
+| `test_idempotent_no_second_walk` | **Delete** |
+| `test_below_threshold_does_not_walk` | **Move** → `TestEngineNoRecenter`; rename/reword (ticker path does not mutate grid when price inside bounds). |
+| `test_below_threshold_does_not_migrate_wait_band` | **Move** → `TestEngineNoRecenter`; rename/reword (same — no side/price migration on tick-only drift). |
+| `test_cumulative_sub_step_drift_eventually_walks` | **Delete** (0022-only: in-bounds cumulative walk) |
+| `test_fill_before_first_ticker_is_consumed_once` | **Move** → `TestEngineNoRecenter` (deferred fill; strip recenter refs) |
+| `test_recenter_result_truthy_only_on_walk` | **Delete** |
+| `test_drift_measured_against_current_wait_band_after_fill` | **Delete** |
+| `test_fill_before_first_ticker_with_empty_grid` | **Move** → `TestEngineNoRecenter` |
+| `test_bounds_rebuild_handles_zero_wait_center` | **Move** → `TestEngineNoRecenter`; **update**: drop `wait_center is zero` assertion (WARNING removed with metrics prelude); keep `"Restored grid out of range"` + `anchor_price == last_close` |
+| `test_fresh_build_with_consumed_fill_runs_recenter` | **Delete** |
+| `test_stale_fill_does_not_cause_repeated_walks` | **Delete** |
+| `test_out_of_bounds_rebuild_emits_drift_log` | **Move** → `TestEngineNoRecenter`; **rename** `test_out_of_bounds_rebuild_logs_range_only`; assert `"Restored grid out of range"` only; **no** `"Grid drift"` |
+| `test_full_rebuild_fallback_via_engine` | **Delete** |
+| `TestRestoredGrid.test_drift_guard_does_not_fire_when_price_inside_grid` | **Update** comment — remove "feature-0022 recenter" wording (~1071) |
+
+#### Keeper migration summary
+
+| From | To | Notes |
+|---|---|---|
+| `TestRecenterIfDrifted` | **Create** `TestAssignSides` | move keeper test; copy `_make_grid` helper |
+| `TestRecenterIntegration` | **Create** `TestEngineNoRecenter` | move keepers; copy `_ticker`, `_restored_grid_around_100`, `_make_engine` |
+| `TestAnchorPricePersistence` | same class | `test_anchor_price_returns_original_center_after_fills` — comment rewrite only |
+
+### `RULES.md`
+
+- **Mostly additive**: no live `recenter_if_drifted` references today; pitfall ~339 already describes bounds-only restore. Add Grid Module 0048 note; tighten wording if needed.
+- Add under **Grid Module** (`grid.py`): per-tick drift detector removed in 0048; drift handled by `update_grid` post-fill and bounds-guard `build_grid` on ticker (`engine.py:167-195`).
+- Confirm **Grid State Persistence** pitfall ~339 stays accurate (bounds-only; no per-tick walk in-band).
+- Code docstrings in `grid.py` / `engine.py` still need 0022 cleanup (Phase 1).
+
+---
+
+## Recommended implementation order
+
+1. **Phase 1** — code deletion (`grid.py`, `engine.py`) + `_assign_sides` requires `fill_price`.
+2. **Create** `TestAssignSides` / `TestEngineNoRecenter` and move keeper tests, then delete recenter tests/classes.
+3. **Add** `TestUpdateGridSidewayOscillation`; add **`test_ticker_does_not_overwrite_post_fill_wait`** to the existing `TestEngineNoRecenter` (prioritize this test).
+4. **Fix** `test_bounds_rebuild_handles_zero_wait_center` (drop `wait_center is zero`; keep range log + anchor).
+5. **Rewrite** comments in `TestAnchorPricePersistence.test_anchor_price_returns_original_center_after_fills` (~917–933).
+6. Run **gridcore → replay → backtest** pytest.
+7. **RULES.md** + `0048_REVIEW.md`.
+
+---
+
+## Implementation Checklist
+
+### Phase 1 — Code deletion (`grid.py`, `engine.py`)
+
+- [ ] Delete `RecenterResult` NamedTuple (`grid.py:28-38`).
+- [ ] Delete `recenter_if_drifted` method (`grid.py:325-372`).
+- [ ] Delete `_shift_grid` method (`grid.py:308-323`).
+- [ ] **`_assign_sides`**: require `fill_price: float` (no optional default); WAIT always keyed on `fill_price`; remove `last_close`-as-WAIT-ref branch; update docstring.
+- [ ] Update `restore_grid` comment at ~line 211 — remove feature 0022 reference.
+- [ ] Update `anchor_price` property docstring — recenter re-seed removed; anchor updated on build/rebuild only.
+- [ ] Update `bounds` property docstring — remove "per-tick drift guard" parenthetical.
+- [ ] Delete recenter call block + per-tick drift comment block (`engine.py:212-223`).
+- [ ] Delete `fill_consumed_this_tick` and `grid_just_built` variables (all sites).
+- [ ] Delete `_log_drift` method (`engine.py:231-236`).
+- [ ] Simplify out-of-bounds block (`engine.py:167-195`): delete deviation-metrics prelude (~178-189); update comments ~175-177; keep `"Restored grid out of range"` INFO + `build_grid`.
+- [ ] Update `_check_and_place` comment (`engine.py:355-360`) — use replacement text in Files section.
+- [ ] Update deferred-fill comment (`engine.py:~198-201`).
+- [ ] Verify no remaining references: `grep -rn 'recenter_if_drifted\|RecenterResult\|_shift_grid\|fill_consumed_this_tick\|grid_just_built\|_log_drift' packages/ apps/`.
+
+### Phase 2 — Test rewrite
+
+- [ ] **Create** `TestAssignSides` (copy `_make_grid` from `TestRecenterIfDrifted`); **move** `test_assign_sides_with_fill_price_preserves_legacy`; add TypeError test for calls without `fill_price`.
+- [ ] Delete `TestRecenterIfDrifted` (includes `test_assign_sides_post_walk` and all recenter-only tests).
+- [ ] Delete `test_recenter_no_op_*` from `TestZeroDivisionGuards`.
+- [ ] **Create** `TestEngineNoRecenter` (copy `_ticker`, `_restored_grid_around_100`, `_make_engine` from `TestRecenterIntegration`); **move** keepers:
+  - `test_below_threshold_does_not_walk` → rename (ticker no-op, no grid mutation in-band)
+  - `test_below_threshold_does_not_migrate_wait_band` → rename (ticker no-op, sides unchanged)
+  - `test_fill_before_first_ticker_is_consumed_once` / `test_fill_before_first_ticker_with_empty_grid`
+  - `test_bounds_rebuild_handles_zero_wait_center` — drop `wait_center is zero` assert; keep range log + `anchor_price == last_close`
+  - `test_out_of_bounds_rebuild_emits_drift_log` → rename **`test_out_of_bounds_rebuild_logs_range_only`**
+- [ ] Delete remainder of `TestRecenterIntegration` per disposition table.
+- [ ] **Semantic rewrite** `TestAnchorPricePersistence.test_anchor_price_returns_original_center_after_fills` (~917–933).
+- [ ] Add `TestUpdateGridSidewayOscillation` to `test_grid.py`:
+  - `test_update_grid_marks_wait_at_fill_price` — `update_grid(fp, last_close)` marks level at `fp` WAIT; unrelated levels follow price-vs-level rules.
+  - `test_update_grid_restores_wait_after_second_fill` — fill at 54.4 (WAIT), price drifts to 54.6, second fill at 54.4 → 54.4 WAIT again via `update_grid`.
+  - `test_out_of_bounds_triggers_rebuild_not_oscillation` — build at 54.0; `update_grid(100.0, 100.0)` rebuilds around 100.0; no stale WAIT at 54.0.
+- [ ] **Add to** `TestEngineNoRecenter` (class created above):
+  - **`test_ticker_does_not_overwrite_post_fill_wait`** (key regression — must exercise the old failure mode):
+    1. Build grid; record `wait_center_before` if needed.
+    2. Execution fill at level **L** → `update_grid` marks L **WAIT**.
+    3. Compute post-fill `wait_center` via `grid.wait_center()`.
+    4. Send **one** ticker with `last_close` **in bounds** (`min_grid <= last_close <= max_grid`) and deviation from post-fill `wait_center` **strictly greater than one `grid_step`** (the regime that triggered `recenter_if_drifted` under 0022). Example: if fill pulled `wait_center` toward L, tick price on the far side of the band from `wait_center` by `> grid_step`%.
+    5. Assert: grid prices/sides unchanged vs pre-ticker snapshot (no walk, no `_assign_sides` from tick path); L still **WAIT**; **no** `PlaceLimitIntent` at price L.
+    6. Optionally repeat with a second in-band ticker in the same regime — still no mutation.
+    Do **not** use only sub-`grid_step` oscillation around L; that would not have triggered recenter and could pass before and after the fix.
+- [ ] Run gridcore: `uv run pytest packages/gridcore/tests/ --cov=gridcore --cov-fail-under=80 -v`
+- [ ] Run replay: `uv run pytest apps/replay/tests/ -v`
+- [ ] Run backtest: `uv run pytest apps/backtest/tests/ -v`
+
+### Phase 3 — Docs & RULES
+
+- [ ] Add `RULES.md` Grid Module 0048 note (recenter removal + bounds-guard ticker path); confirm pitfall ~339 (mostly additive).
+- [ ] Document `_assign_sides(..., fill_price=...)` as **fill-keyed only** (required kwarg; no `last_close`-based WAIT) — satisfies AC #7.
+- [ ] Leave `docs/features/0047_PLAN.md` recenter references as historical context.
+- [ ] Add `docs/features/0048_REVIEW.md` after implementation.
+
+### Phase 4 — Deploy + issue comments (not closure)
+
+- [ ] Deploy to live mainnet (`ltcusdt_test` strat).
+- [ ] Comment on **#111** (Wait→Sell): fix deployed (`recenter_if_drifted` removed, `_assign_sides` fill-keyed only); **leave open** until Phase 5 pass gate completes.
+- [ ] Comment on **#110** (SAME ORDER): `recenter_if_drifted` was the primary trigger; monitor 7-day window; SAME ORDER detector stays as defence-in-depth.
+
+### Phase 5 — Production observation (7-day pass gate)
+
+- [ ] Verify **0** `"Grid drift"` log lines (previously ~39/day; string only in gridcore/docs — no scripts/alerts to update). `"Restored grid out of range"` may still appear from bounds guard.
+- [ ] **7 calendar days**: 0 `verdict=REAL_DUPLICATE` on `ltcusdt_test` — required before closing #111.
+- [ ] Confirm Feature 0047 `grid_state_snapshots` still written (`_notify_change` unchanged).
+
+### Phase 6 — Issue closure (after Phase 5 pass gate)
+
+- [ ] **Close #111** only after AC #4 (7-day zero `REAL_DUPLICATE`) is satisfied.
+- [ ] Update **#110** comment with observation outcome (still open or closed per operator preference; detector retained either way).
+
+---
+
+## Risk Register
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Cold-restart without fill: grid not re-anchored until next fill | Low | 0047 DB snapshots restore grid verbatim. Bounds-guard `build_grid` if `last_close` outside restored range. |
+| In-bounds restored grid, price far from WAIT center, no fill yet | Low (bbu2-faithful) | **Main behavioral change vs 0022** — acceptable. 0047 snapshots preserve post-fill sides on live restart; the bug was tick-path mutation, not restore. Empty DB / no snapshot: empty grid → `build_grid(last_close)` on first ticker; out-of-range → bounds `build_grid` — same as today minus in-band walk. |
+| `anchor_price` diagnostics drift from live WAIT center | Low | Document: anchor = build/restore center only post-0048; use `wait_center()` for live band center. |
+| Sideway market: more `update_grid` + `__center_grid` vs 0022 walks | Negligible | Same O(n) per mutation. |
+| Replay/backtest divergence | Low | Run `apps/replay/tests` + `apps/backtest/tests` before deploy. |
+| Test coverage drop below 80% | Low | Replacement tests in `TestUpdateGridSidewayOscillation` + `TestEngineNoRecenter`. |
+| Accidental reintroduction of last-close WAIT marking | Low | `_assign_sides` requires `fill_price`; tick path has no side-assignment hook. |
+
+---
+
+## Pre-flight verification (confirmed 2026-05-20)
+
+These were open questions during plan review; grep results are already clean:
+
+| Check | Result |
+|---|---|
+| `_shift_grid` callers outside `recenter_if_drifted` | **None** — only `grid.py:368` inside deleted method |
+| `recenter_if_drifted` in `apps/` | **None** — only gridcore src/tests + docs |
+| `RecenterResult` imports outside `grid.py` | **None** |
+| Out-of-bounds metrics block | Sole consumer of `_log_drift`; safe to delete with method |
+
+---
+
+## Acceptance Criteria
+
+1. `grep -rn 'recenter_if_drifted\|RecenterResult\|_shift_grid\|fill_consumed_this_tick\|grid_just_built\|_log_drift' packages/ apps/` returns zero matches (same six symbols as Phase 1).
+2. `uv run pytest packages/gridcore/tests/ --cov=gridcore --cov-fail-under=80` passes.
+3. `uv run pytest apps/replay/tests/ -v` and `uv run pytest apps/backtest/tests/ -v` pass.
+4. Zero `verdict=REAL_DUPLICATE` for ≥ 7 calendar days on live `ltcusdt_test` after deploy (Phase 5 pass gate).
+5. **#111** closed only after AC #4; **#110** commented on deploy (Phase 4), outcome noted after gate (Phase 6).
+6. `RULES.md` has no `recenter_if_drifted` reference; bounds-only drift guard documented.
+7. `_assign_sides` requires `fill_price` — no `last_close`-based WAIT path remains.
+
+---
+
+## Estimated Effort
+
+- Code deletion + comment cleanup (Phase 1): 1–2 h
+- Test rewrite (Phase 2): 2–3 h
+- Docs + RULES (Phase 3): 30 min
+- Deploy + issue comments (Phase 4): part of release
+- Observation window (Phase 5): 7 calendar days (no engineering time)
+- Issue closure (Phase 6): after pass gate
+
+Total engineering: 1.5–2 days elapsed (+ 7 calendar days observation before #111 close).
+
+---
+
+*2026-05-20 — plan amended: Tracks issues header, regression test spec, phased issue closure, fill_price required, test-helper migration notes, line refs 167-195.*

--- a/docs/features/0048_REVIEW.md
+++ b/docs/features/0048_REVIEW.md
@@ -1,0 +1,87 @@
+# 0048 Code Review: Remove per-tick drift detector, restore bbu2 grid semantics
+
+**Reviewer:** automated review (2026-05-20)  
+**Plan:** `docs/features/0048_PLAN.md`  
+**Scope:** `grid.py`, `engine.py`, `test_grid.py`, `test_engine.py`, `RULES.md`
+
+---
+
+## Findings
+
+No blocking or non-blocking code review findings remain.
+
+The prior test-quality finding in `TestUpdateGridSidewayOscillation` is resolved. `test_update_grid_remarks_wait_on_repeat_fill_at_same_price` now re-queries the live grid by `fill_price` after the second `update_grid`, and its name/docstring describe repeat-fill behavior accurately.
+
+---
+
+## Plan Implementation
+
+The implementation matches the feature plan:
+
+| Plan item | Status | Notes |
+|-----------|--------|-------|
+| Delete `RecenterResult`, `recenter_if_drifted`, `_shift_grid` | Done | Removed from `packages/gridcore/src/gridcore/grid.py` |
+| `_assign_sides(..., *, fill_price: float)` required | Done | No default; sole source caller is `update_grid` |
+| Remove tick-path recenter block | Done | `grid_just_built`, `fill_consumed_this_tick`, and `_log_drift` removed from `engine.py` |
+| Keep bounds-guard rebuild | Done | Ticker path still rebuilds when restored/stale grid is out of range |
+| Simplify out-of-bounds telemetry | Done | Only `"Restored grid out of range"` remains; `"Grid drift"` source telemetry removed |
+| Migrate/delete recenter tests | Done | `TestRecenterIfDrifted` and `TestRecenterIntegration` removed/replaced |
+| Add no-recenter regression coverage | Done | `TestEngineNoRecenter.test_ticker_does_not_overwrite_post_fill_wait` covers the production failure mode |
+| Update `RULES.md` | Done | Grid module note documents 0048 semantics |
+
+Root cause coverage is sound: the tick path no longer calls `_assign_sides`, and `_assign_sides` can no longer use `last_close` as its WAIT reference. A post-fill WAIT level cannot be overwritten by in-band price drift unless another fill-driven `update_grid` occurs.
+
+---
+
+## Other Risks And Notes
+
+- `update_grid` still uses exclusive bounds (`__min_grid < last_close < __max_grid`, grid.py:250) while ticker rebuild uses inclusive bounds (`min_p <= last_close <= max_p`, engine.py:171). At an exact boundary price, `update_grid` rebuilds but the tick path does not. Pre-existing, not introduced by 0048; worth a follow-up to unify.
+- `_assign_sides` leaves a level unchanged when `last_close == level['price']` and the level is not close to `fill_price`. This is pre-existing bbu2-style behavior.
+- Some names remain legacy wording (`test_drift_guard_*`, `test_bounds_rebuild_handles_zero_wait_center`), but the assertions now match bounds-only behavior.
+
+### Second-pass parallel review (2026-05-20)
+
+A five-category parallel pass (code quality, security, performance, testing, documentation) found one additional minor item:
+
+- **Suggestion** — `apps/gridbot/tests/test_runner.py:4459` carries a stale inline comment `"Second ticker at the same price — bounds OK, no recenter, but"`. The test logic still passes under 0048 (it asserts ticker-timestamp propagation), but the "no recenter" phrasing predates the feature; reword to `"bounds OK, no grid mutation, but"` next time the file is touched.
+
+No new Critical or Warning items. Security, performance, and test coverage are confirmed clean: `_assign_sides` is keyword-only `fill_price` with one caller (`update_grid`), the tick path has no `_assign_sides` invocation, and `test_ticker_does_not_overwrite_post_fill_wait` (test_engine.py:1506) actually exercises the in-bounds, deviation-greater-than-`grid_step` regime that triggered the production REAL_DUPLICATE under feature 0022.
+
+---
+
+## Verification
+
+Commands run:
+
+```bash
+uv run pytest -q packages/gridcore/tests/test_grid.py packages/gridcore/tests/test_engine.py
+# 119 passed in 0.05s
+
+uv run pytest -q packages/gridcore/tests/ --cov=gridcore --cov-fail-under=80
+# 391 passed, 1 skipped; total coverage 93.70%
+
+uv run pytest -q apps/replay/tests/
+# 92 passed in 0.56s
+
+uv run pytest -q apps/backtest/tests/
+# 426 passed, 3 failed
+```
+
+Backtest failures appear unrelated to 0048:
+
+- `apps/backtest/tests/test_risk_limit_info.py::TestRiskLimitProvider::test_load_from_cache_oversized_logs_size_error` expects `"Cache file exceeds"` but implementation logs `"Cache file size 10000001 exceeds 10000000 byte limit"`.
+- `apps/backtest/tests/test_risk_limit_info.py::TestConcurrentCacheAccess::test_lock_registry_released_when_instances_deleted` fails because `backtest.risk_limit_info` has no `_IN_PROCESS_LOCKS`.
+- `apps/backtest/tests/test_risk_limit_info.py::TestConcurrentCacheAccess::test_close_then_new_provider_keeps_lock_registry_consistent` fails for the same missing `_IN_PROCESS_LOCKS` symbol.
+
+Removed-symbol search:
+
+```bash
+rg -n "recenter_if_drifted|RecenterResult|_shift_grid|fill_consumed_this_tick|grid_just_built|_log_drift" packages apps
+# no matches
+```
+
+---
+
+## Verdict
+
+Approve from code review. The implementation and updated tests are consistent with the 0048 plan; remaining Phase 4-6 work is operational deploy/observation, not a code-review blocker.

--- a/packages/gridcore/src/gridcore/engine.py
+++ b/packages/gridcore/src/gridcore/engine.py
@@ -155,7 +155,6 @@ class GridEngine:
         self.last_close = float(event.last_price)
 
         # Build grid if empty (a restored grid skips this branch)
-        grid_just_built = False
         if len(self.grid.grid) == 0:
             build_price = self._anchor_price if self._anchor_price else self.last_close
             if self._anchor_price:
@@ -163,43 +162,23 @@ class GridEngine:
             else:
                 logger.info('%s: Building grid from market price %s', self.symbol, build_price)
             self.grid.build_grid(build_price)
-            grid_just_built = True
         else:
-            # Drift guard: if restored (or stale) grid is far from the current
-            # price, rebuild around last_close. Mirrors update_grid's bounds
-            # check (grid.py:157) but applies on the tick path so a restored
-            # grid does not need a fill event to re-anchor. Single-pass bounds
-            # to keep the per-tick cost low.
+            # Bounds guard: if restored (or stale) grid no longer contains
+            # last_close, rebuild around market price. Mirrors update_grid's
+            # bounds check but applies on the tick path so a restored grid
+            # does not need a fill event to re-anchor.
             min_p, max_p = self.grid.bounds
             if not (min_p <= self.last_close <= max_p):
-                # Emit the same Grid-drift INFO line that recenter's safety-cap
-                # path uses, so out-of-bounds rebuilds are observable through
-                # the same telemetry hook (per 0022 Step 3).
-                wait_center = self.grid.wait_center()
-                if wait_center == 0:
-                    logger.warning(
-                        '%s: wait_center is zero, cannot calculate drift metrics',
-                        self.symbol,
-                    )
-                    deviation_pct = 0.0
-                    n_steps = 0
-                else:
-                    deviation_pct = abs(self.last_close - wait_center) / wait_center * 100
-                    n_steps = int(deviation_pct / self.grid.grid_step) if self.grid.grid_step > 0 else 0
-                self._log_drift(deviation_pct, n_steps, self.last_close)
                 logger.info(
                     '%s: Restored grid out of range (last_close=%s, range=[%s, %s]), rebuilding',
                     self.symbol, self.last_close, min_p, max_p,
                 )
                 self.grid.build_grid(self.last_close)
-                grid_just_built = True
 
         # Consume any deferred fill (one that arrived before last_close was set).
-        # Apply it before recenter so __center_grid and post-fill WAIT marking
-        # both get a chance to run before drift detection sees the grid state.
-        # Runs even on the same tick as build_grid so a fill that arrived first
-        # is applied to the freshly-built grid, not deferred to the next ticker.
-        fill_consumed_this_tick = False
+        # Apply any deferred fill before checking and placing orders. Runs even
+        # on the same tick as build_grid so a fill that arrived first is applied
+        # to the freshly-built grid, not deferred to the next ticker.
         if (
             self._fill_pending
             and self.last_filled_price is not None
@@ -207,33 +186,12 @@ class GridEngine:
         ):
             self.grid.update_grid(self.last_filled_price, self.last_close)
             self._fill_pending = False
-            fill_consumed_this_tick = True
-
-        # Per-tick drift detector (feature 0022). Independent of last_filled_price,
-        # so it fires on cold start and after WS reconnect even before the first
-        # fill. Skipped on a plain fresh-build tick — the freshly built grid
-        # reflects an explicit anchor or market-price choice that recenter would
-        # otherwise immediately overwrite. BUT: if a pending fill was consumed
-        # this tick, the consumed fill may have shifted the WAIT band far enough
-        # that drift now legitimately exceeds one grid_step; allow recenter in
-        # that case so order placement isn't done against a stale grid.
-        if not grid_just_built or fill_consumed_this_tick:
-            walked, deviation_pct, n_steps = self.grid.recenter_if_drifted(self.last_close)
-            if walked:
-                self._log_drift(deviation_pct, n_steps, self.last_close)
 
         # Check and place orders for both directions
         intents.extend(self._check_and_place('long', limit_orders.get('long', [])))
         intents.extend(self._check_and_place('short', limit_orders.get('short', [])))
 
         return intents
-
-    def _log_drift(self, deviation_pct: float, n_steps: int, last_close: float) -> None:
-        """Log grid drift recentering event."""
-        logger.info(
-            '%s: Grid drift %.2f%% (N=%d steps) — recentering at %s',
-            self.symbol, deviation_pct, n_steps, last_close,
-        )
 
     def _handle_execution_event(self, event: ExecutionEvent) -> list[PlaceLimitIntent | CancelIntent]:
         """
@@ -352,12 +310,9 @@ class GridEngine:
             intents.extend(self._cancel_all_limits(limits, 'rebuild'))
             return intents
 
-        # NOTE: Pre-0022 this path also called update_grid(last_filled_price,
-        # last_close) every tick. After 0022 added recenter_if_drifted on the
-        # tick path, that call would re-mark WAIT around a stale last_filled_price
-        # and undo recenter's side assignment, causing repeated walks on identical
-        # ticks. update_grid is now driven only by _handle_execution_event (where
-        # fills actually happen); recenter handles per-tick side assignment.
+        # update_grid runs only on execution events (fills). On the tick path the
+        # grid changes only via bounds-guard rebuild (build_grid) or deferred-fill
+        # consumption (update_grid on _fill_pending).
 
         # Place grid orders
         intents.extend(self._place_grid_orders(limits, direction))

--- a/packages/gridcore/src/gridcore/grid.py
+++ b/packages/gridcore/src/gridcore/grid.py
@@ -13,7 +13,7 @@ import logging
 from datetime import datetime
 from decimal import Decimal
 from enum import StrEnum
-from typing import Callable, NamedTuple, Optional
+from typing import Callable, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -23,19 +23,6 @@ class GridSideType(StrEnum):
     BUY = 'Buy'
     SELL = 'Sell'
     WAIT = 'Wait'
-
-
-class RecenterResult(NamedTuple):
-    """Outcome of a recenter_if_drifted() call.
-
-    Truthy when (and only when) the grid was actually mutated. Tuple-compatible
-    so callers can also destructure as `walked, dev, n = grid.recenter_if_drifted(...)`."""
-    walked: bool
-    deviation_pct: float
-    n_steps: int
-
-    def __bool__(self) -> bool:
-        return self.walked
 
 
 class Grid:
@@ -208,9 +195,7 @@ class Grid:
             return False
 
         # Derive _original_anchor_price from the WAIT center so anchor_price
-        # property continues to reflect a meaningful "center" value. Uses
-        # wait_center() to keep the post-restore anchor consistent with the
-        # post-recenter-walk anchor (feature 0022, Step 5.5).
+        # property continues to reflect a meaningful "center" value.
         self._original_anchor_price = self.wait_center()
 
         return True
@@ -219,7 +204,7 @@ class Grid:
     def bounds(self) -> tuple[float, float]:
         """(min_price, max_price) computed in one pass. Raises ValueError if
         the grid is empty. Prefer this over min_grid + max_grid in hot paths
-        (e.g. per-tick drift guard) — saves one full iteration over the grid."""
+        — saves one full iteration over the grid."""
         if not self.grid:
             raise ValueError("Cannot get bounds from empty grid")
         lo = hi = self.grid[0]['price']
@@ -290,86 +275,18 @@ class Grid:
             return (self.grid[n // 2 - 1]['price'] + self.grid[n // 2]['price']) / 2
         return self.grid[n // 2]['price']
 
-    def _assign_sides(self, last_close: float, *, fill_price: Optional[float] = None) -> None:
+    def _assign_sides(self, last_close: float, *, fill_price: float) -> None:
         """Assign side (BUY/SELL/WAIT) to every level relative to last_close.
 
-        WAIT marking uses __is_too_close against fill_price when given (post-fill
-        path used by update_grid), or against last_close otherwise (drift-recenter
-        path used by recenter_if_drifted)."""
-        too_close_ref = fill_price if fill_price is not None else last_close
+        WAIT marking uses __is_too_close against fill_price only (bbu2 parity).
+        Called exclusively from update_grid on fill events."""
         for level in self.grid:
-            if self.__is_too_close(level['price'], too_close_ref):
+            if self.__is_too_close(level['price'], fill_price):
                 level['side'] = GridSideType.WAIT
             elif last_close < level['price']:
                 level['side'] = GridSideType.SELL
             elif last_close > level['price']:
                 level['side'] = GridSideType.BUY
-
-    def _shift_grid(self, n_steps: int, direction: str) -> None:
-        """Walk the grid by n_steps levels. Side placeholder is not meaningful;
-        the caller must follow up with _assign_sides()."""
-        step = self.grid_step / 100
-        if direction == 'up':
-            for _ in range(n_steps):
-                self.grid.pop(0)
-                new_top = self._round_price(self.grid[-1]['price'] * (1 + step))
-                self.grid.append({'side': GridSideType.SELL, 'price': new_top})
-        elif direction == 'down':
-            for _ in range(n_steps):
-                self.grid.pop()
-                new_bot = self._round_price(self.grid[0]['price'] * (1 - step))
-                self.grid.insert(0, {'side': GridSideType.BUY, 'price': new_bot})
-        else:
-            raise ValueError(f"direction must be 'up' or 'down', got {direction!r}")
-
-    def recenter_if_drifted(self, last_close: float) -> RecenterResult:
-        """Per-tick drift detector: walk the grid by N steps toward last_close
-        when it has moved more than one grid_step from the current WAIT-band
-        center. Falls back to a full rebuild when N >= grid_count // 2.
-
-        Independent of last_filled_price, so it fires on cold restart and after
-        WS reconnect even before the first fill of the session.
-
-        Below-threshold ticks are TRUE no-ops: no side reassignment, no anchor
-        update. This preserves the plan's Step 2 contract and prevents the
-        WAIT band from silently migrating when last_close drifts within one
-        grid_step per tick — a sequence of sub-step ticks must still trigger
-        a walk once cumulative drift from the current WAIT center exceeds the
-        threshold.
-
-        Drift is measured against the current `wait_center()` per plan Q1
-        (the detector self-adjusts as the grid walks or as `update_grid()`
-        expands the WAIT band after a fill).
-
-        Returns a RecenterResult that is truthy only when the grid was mutated."""
-        if not self.grid:
-            return RecenterResult(False, 0.0, 0)
-
-        wait_center = self.wait_center()
-        if wait_center == 0:
-            logger.warning('wait_center is zero, cannot calculate drift')
-            return RecenterResult(False, 0.0, 0)
-        deviation_pct = abs(last_close - wait_center) / wait_center * 100
-        if deviation_pct <= self.grid_step:
-            return RecenterResult(False, deviation_pct, 0)
-
-        if self.grid_step == 0:
-            logger.warning('grid_step is zero, cannot compute n_steps')
-            return RecenterResult(False, deviation_pct, 0)
-        n_steps = int(deviation_pct / self.grid_step)
-
-        if n_steps >= self.grid_count // 2:
-            # Walk would push the entire grid past one side — rebuild instead.
-            self.__rebuild_grid(last_close)
-            # __rebuild_grid -> build_grid already fires _notify_change.
-            return RecenterResult(True, deviation_pct, n_steps)
-
-        direction = 'up' if last_close > wait_center else 'down'
-        self._shift_grid(n_steps, direction)
-        self._assign_sides(last_close)
-        self._original_anchor_price = self.wait_center()
-        self._notify_change()
-        return RecenterResult(True, deviation_pct, n_steps)
 
     def __center_grid(self) -> None:
         """
@@ -569,11 +486,10 @@ class Grid:
         """
         Get anchor price (WAIT zone center price).
 
-        Tracks the build-time center until a drift walk updates it: a fill via
-        `update_grid` does NOT mutate the anchor (post-fill WAIT marks are not
-        reflected here), but `recenter_if_drifted` DOES re-seed it to the new
-        WAIT-band center after an incremental walk (feature 0022, Step 5.5).
-        On `restore_grid`, the anchor is derived from the restored WAIT center.
+        Tracks the build/restore center. Updated on `build_grid` and
+        `__rebuild_grid` only — not on fills (`update_grid` does not mutate
+        the anchor). On `restore_grid`, the anchor is derived from the restored
+        WAIT center. Use `wait_center()` for the live WAIT-band center.
 
         Returns:
             Current anchor price, or None if grid was never built

--- a/packages/gridcore/src/gridcore/grid.py
+++ b/packages/gridcore/src/gridcore/grid.py
@@ -278,8 +278,22 @@ class Grid:
     def _assign_sides(self, last_close: float, *, fill_price: float) -> None:
         """Assign side (BUY/SELL/WAIT) to every level relative to last_close.
 
-        WAIT marking uses __is_too_close against fill_price only (bbu2 parity).
-        Called exclusively from update_grid on fill events."""
+        For each level:
+        - WAIT if __is_too_close(level['price'], fill_price) — i.e. the level
+          is within grid_step/4 of the most recent fill. This is bbu2 parity:
+          WAIT marks the just-filled level so the engine does not immediately
+          re-expose it. The reference is the FILL price, not last_close — that
+          is the change introduced by feature 0048 (see RULES.md Grid Module
+          0048 note).
+        - SELL if last_close < level['price'] (level is above market)
+        - BUY  if last_close > level['price'] (level is below market)
+        - unchanged if last_close == level['price'] and not WAIT (rare; pre-
+          existing bbu2 behavior).
+
+        fill_price is a required keyword-only argument; there is no
+        last_close-based WAIT path. Sole caller: update_grid, which runs only
+        on execution events.
+        """
         for level in self.grid:
             if self.__is_too_close(level['price'], fill_price):
                 level['side'] = GridSideType.WAIT

--- a/packages/gridcore/tests/test_engine.py
+++ b/packages/gridcore/tests/test_engine.py
@@ -914,9 +914,8 @@ class TestAnchorPricePersistence:
         }
         engine.on_event(ticker_after_fill, existing_limits)
 
-        # Verify anchor_price still returns original center (100k), not filled price (99800).
-        # The drift between last_close (99850) and original anchor (100000) is below
-        # one grid_step, so recenter does not walk and anchor stays put.
+        # Verify anchor_price still returns original build center (100k), not fill price.
+        # update_grid runs only on fills; the tick path does not mutate anchor_price.
         anchor_after_fill = engine.get_anchor_price()
         assert anchor_after_fill == 100000.0, \
             f"Expected anchor_price to remain 100000.0 after fill, got {anchor_after_fill}"
@@ -925,12 +924,7 @@ class TestAnchorPricePersistence:
         filled_level = next(g for g in engine.grid.grid if g['price'] == 99800.0)
         assert filled_level['side'] == GridSideType.WAIT, \
             f"Filled level should be WAIT, got {filled_level['side']}"
-        # Note: pre-0022 the per-tick update_grid call in _check_and_place would
-        # have reassigned the original center 100000.0 from WAIT to SELL on the
-        # ticker after the fill. Post-0022 below-threshold ticks are true no-ops
-        # (Step 2), so 100000.0 retains its build-time WAIT status until a walk
-        # rewrites the grid. This is by design — drift is measured against the
-        # persisted anchor, and side reassignment only happens on walks.
+        # Tick path does not reassign sides — build-time WAIT at 100000.0 is unchanged.
 
 
 class TestRestoredGrid:
@@ -1067,8 +1061,7 @@ class TestRestoredGrid:
             strat_id='btcusdt_test',
             restored_grid=restored,
         )
-        # Price within grid_step of WAIT center → neither bounds-based drift
-        # guard NOR feature-0022 recenter fires.
+        # Price inside restored bounds → neither bounds-guard rebuild nor side migration.
         engine.on_event(self._ticker(100.1), {'long': [], 'short': []})
 
         prices = [g['price'] for g in engine.grid.grid]
@@ -1363,8 +1356,8 @@ class TestReduceOnlyMap:
             )
 
 
-class TestRecenterIntegration:
-    """Engine-level tests for feature 0022 (per-tick grid drift detector)."""
+class TestEngineNoRecenter:
+    """Engine-level tests after feature 0048 (per-tick recenter removed)."""
 
     def _ticker(self, price: float) -> TickerEvent:
         return TickerEvent(
@@ -1408,101 +1401,32 @@ class TestRecenterIntegration:
             kwargs['restored_grid'] = self._restored_grid_around_100()
         return GridEngine(**kwargs)
 
-    def test_cold_start_drift_walks_grid(self, caplog):
-        """Restored grid centered at 100, ticker at 103.5 (within bounds, dev=3.5% > 1*step).
-        Expected n_steps = 3."""
+    def test_ticker_in_band_does_not_mutate_grid(self, caplog):
+        """In-band ticker with drift > grid_step does not walk or reassign sides."""
         engine = self._make_engine()
         with caplog.at_level('INFO'):
             engine.on_event(self._ticker(103.5), {'long': [], 'short': []})
-
-        # Grid walked: bottom three BUYs dropped, three SELLs added on top.
-        prices = [g['price'] for g in engine.grid.grid]
-        assert 95.0 not in prices
-        assert 96.0 not in prices
-        assert 97.0 not in prices
-        # Length preserved
-        assert len(prices) == 11
-        # New top is roughly 105 * (1.01)^3 ≈ 108.18 (after rounding)
-        assert prices[-1] > 105.0
-
-        drift_logs = [r.message for r in caplog.records if 'Grid drift' in r.message]
-        assert len(drift_logs) == 1
-        assert 'N=3' in drift_logs[0]
-        assert 'BTCUSDT' in drift_logs[0]
-
-    def test_mid_run_fast_move_recenters_in_one_tick(self, caplog):
-        """3 * grid_step jump triggers an N=3 walk in a single tick."""
-        engine = self._make_engine()
-        # Warm up with an in-band ticker first (no drift)
-        engine.on_event(self._ticker(100.2), {'long': [], 'short': []})
-        caplog.clear()
-        # Now jump 3% above WAIT center
-        with caplog.at_level('INFO'):
-            engine.on_event(self._ticker(103.2), {'long': [], 'short': []})
-
-        drift_logs = [r.message for r in caplog.records if 'Grid drift' in r.message]
-        assert len(drift_logs) == 1
-        assert 'N=3' in drift_logs[0]
-
-    def test_idempotent_no_second_walk(self, caplog):
-        """Two ticker events with the same last_close → only one walk."""
-        engine = self._make_engine()
-        with caplog.at_level('INFO'):
-            engine.on_event(self._ticker(103.5), {'long': [], 'short': []})
-            engine.on_event(self._ticker(103.5), {'long': [], 'short': []})
-        drift_logs = [r.message for r in caplog.records if 'Grid drift' in r.message]
-        assert len(drift_logs) == 1
-
-    def test_below_threshold_does_not_walk(self, caplog):
-        """Deviation = 0.5 * grid_step → no recenter, no log line."""
-        engine = self._make_engine()
-        with caplog.at_level('INFO'):
-            engine.on_event(self._ticker(100.5), {'long': [], 'short': []})
         drift_logs = [r.message for r in caplog.records if 'Grid drift' in r.message]
         assert drift_logs == []
-        # Grid prices unchanged
         prices = [g['price'] for g in engine.grid.grid]
         assert prices == [g['price'] for g in self._restored_grid_around_100()]
 
-    def test_below_threshold_does_not_migrate_wait_band(self):
-        """Sub-step drift must NOT migrate the WAIT band — that would let
-        cumulative drift hide indefinitely. Below-threshold ticks are true
-        no-ops: prices AND sides unchanged."""
+    def test_ticker_in_band_does_not_migrate_wait_band(self):
+        """Sub-step and supra-step in-band drift must not migrate sides on tick path."""
         engine = self._make_engine()
         original_grid = self._restored_grid_around_100()
-        # Drift 0.9% (< 1.0 grid_step) — should be no-op
         engine.on_event(self._ticker(100.9), {'long': [], 'short': []})
 
         for actual, expected in zip(engine.grid.grid, original_grid):
             assert actual['price'] == expected['price']
-            # Side must match restored (no migration of WAIT mark)
             assert str(actual['side']) == expected['side'], (
                 f"side at {actual['price']} migrated: "
                 f"expected {expected['side']}, got {actual['side']}"
             )
 
-    def test_cumulative_sub_step_drift_eventually_walks(self, caplog):
-        """A sequence of below-threshold ticks must eventually trigger a walk
-        once cumulative drift from the persisted anchor exceeds grid_step."""
-        engine = self._make_engine()
-        with caplog.at_level('INFO'):
-            for price in [100.5, 100.9, 100.99]:
-                engine.on_event(self._ticker(price), {'long': [], 'short': []})
-            drift_logs = [r.message for r in caplog.records if 'Grid drift' in r.message]
-            assert drift_logs == [], "no walk expected yet (all sub-step)"
-            # Now cross the threshold against fixed anchor=100
-            engine.on_event(self._ticker(101.5), {'long': [], 'short': []})
-
-        drift_logs = [r.message for r in caplog.records if 'Grid drift' in r.message]
-        assert len(drift_logs) == 1, f"expected exactly one walk, got {drift_logs}"
-
     def test_fill_before_first_ticker_is_consumed_once(self):
-        """ExecutionEvent that arrives before any TickerEvent (last_close=None)
-        must be applied on the first ticker. Pre-0022 the per-tick update_grid
-        in _check_and_place would always re-apply it; post-0022 we use a
-        _fill_pending flag for one-shot consumption."""
+        """ExecutionEvent before any TickerEvent is applied on the first ticker."""
         engine = self._make_engine()
-        # Fill arrives before any ticker — last_close is still None.
         fill_event = ExecutionEvent(
             event_type=EventType.EXECUTION,
             symbol='BTCUSDT',
@@ -1515,69 +1439,13 @@ class TestRecenterIntegration:
         engine.on_event(fill_event)
         assert engine._fill_pending is True
 
-        # First ticker — must consume the pending fill exactly once.
         engine.on_event(self._ticker(100.0), {'long': [], 'short': []})
         assert engine._fill_pending is False
-        # Filled level (99) is WAIT; level 100 is still the anchor (WAIT from build).
         filled_level = next(g for g in engine.grid.grid if g['price'] == 99.0)
         assert filled_level['side'] == GridSideType.WAIT
 
-    def test_recenter_result_truthy_only_on_walk(self):
-        """RecenterResult must be falsy on no-op so callers using
-        `if grid.recenter_if_drifted(...):` see only real walks."""
-        engine = self._make_engine()
-        result_no_walk = engine.grid.recenter_if_drifted(100.5)
-        assert bool(result_no_walk) is False
-        result_walk = engine.grid.recenter_if_drifted(103.5)
-        assert bool(result_walk) is True
-
-    def test_drift_measured_against_current_wait_band_after_fill(self, caplog):
-        """Plan Q1: drift reference is the CURRENT WAIT band, not the original
-        anchor. After a fill expands the WAIT band, recenter must measure
-        against the new wait_center so a tick that crosses one grid_step from
-        the new center triggers a walk even when it would not have crossed
-        from the original anchor."""
-        config = GridConfig(grid_count=10, grid_step=1.0)
-        engine = GridEngine(
-            symbol='BTCUSDT',
-            tick_size=Decimal('0.01'),
-            config=config,
-            strat_id='btcusdt_test',
-        )
-        # Build at 100.0; original anchor and wait_center both = 100.0.
-        engine.on_event(self._ticker(100.0), {'long': [], 'short': []})
-        assert engine.grid.anchor_price == 100.0
-
-        # Fill at 99.0 (last_close still 100.0 at fill time). update_grid
-        # marks 99.0 as WAIT and the equality keeps 100.0 as WAIT, so the
-        # WAIT band becomes [99.0, 100.0] and wait_center becomes 99.5.
-        fill = ExecutionEvent(
-            event_type=EventType.EXECUTION,
-            symbol='BTCUSDT',
-            exchange_ts=datetime.now(UTC),
-            local_ts=datetime.now(UTC),
-            price=Decimal('99.0'),
-            qty=Decimal('0.01'),
-            side='Buy',
-        )
-        engine.on_event(fill)
-
-        # last_close = 100.6:
-        #   - drift from anchor=100.0: 0.6% → would NOT walk if anchor was the reference
-        #   - drift from wait_center=99.5: ≈1.106% > 1% → MUST walk per plan
-        with caplog.at_level('INFO'):
-            engine.on_event(self._ticker(100.6), {'long': [], 'short': []})
-
-        drift_logs = [r.message for r in caplog.records if 'Grid drift' in r.message]
-        assert len(drift_logs) == 1, (
-            f"expected one walk (drift > 1*step from current WAIT center 99.5), "
-            f"got {drift_logs}"
-        )
-
     def test_fill_before_first_ticker_with_empty_grid(self):
-        """P2: pending fill must be consumed on the first ticker that builds
-        the grid (empty-engine path). Pre-fix the consume gate was skipped on
-        grid_just_built=True ticks, leaving the fill stranded for one cycle."""
+        """Pending fill is consumed on the first ticker that builds the grid."""
         config = GridConfig(grid_count=10, grid_step=1.0)
         engine = GridEngine(
             symbol='BTCUSDT',
@@ -1585,7 +1453,6 @@ class TestRecenterIntegration:
             config=config,
             strat_id='btcusdt_test',
         )
-        # No restored_grid, no anchor — engine starts truly empty.
         assert len(engine.grid.grid) == 0
 
         fill = ExecutionEvent(
@@ -1600,20 +1467,14 @@ class TestRecenterIntegration:
         engine.on_event(fill)
         assert engine._fill_pending is True
 
-        # First ticker builds the grid AND consumes the pending fill.
         engine.on_event(self._ticker(100.0), {'long': [], 'short': []})
         assert engine._fill_pending is False, "pending fill must be consumed on first build tick"
         filled_level = next(g for g in engine.grid.grid if g['price'] == 99.0)
         assert filled_level['side'] == GridSideType.WAIT
 
     def test_bounds_rebuild_handles_zero_wait_center(self, caplog):
-        """Defensive: if the bounds-guard rebuild path encounters wait_center==0
-        (degenerate restored grid), it must emit a WARNING and the consolidated
-        drift INFO line with deterministic zeros — and proceed to rebuild."""
+        """Out-of-bounds ticker rebuilds around last_close even with degenerate grid."""
         config = GridConfig(grid_count=10, grid_step=1.0)
-        # Build a symmetric ±X grid where wait_center() returns 0. This needs to
-        # both (a) make wait_center == 0 and (b) trigger the bounds-guard so
-        # last_close is OUTSIDE [min_grid, max_grid] (last_close > 1.0 here).
         engine = GridEngine(
             symbol='BTCUSDT',
             tick_size=Decimal('0.01'),
@@ -1625,108 +1486,71 @@ class TestRecenterIntegration:
             {'side': GridSideType.WAIT, 'price': 1.0},
         ]
 
-        with caplog.at_level('WARNING'):
+        with caplog.at_level('INFO'):
             engine.on_event(self._ticker(100.0), {'long': [], 'short': []})
 
-        assert any('wait_center is zero' in r.message for r in caplog.records)
-        # Rebuild still happens — anchor lands at last_close.
+        assert any('Restored grid out of range' in r.message for r in caplog.records)
         assert engine.grid.anchor_price == 100.0
 
-    def test_fresh_build_with_consumed_fill_runs_recenter(self, caplog):
-        """If a pending fill consumed on the same tick as build_grid shifts
-        the WAIT band far enough from last_close to exceed one grid_step,
-        recenter must run before order placement instead of being skipped
-        by the grid_just_built guard."""
-        config = GridConfig(grid_count=10, grid_step=1.0)
+    def test_out_of_bounds_rebuild_logs_range_only(self, caplog):
+        """Bounds-guard rebuild logs range message only (no Grid drift telemetry)."""
+        engine = self._make_engine()
+        with caplog.at_level('INFO'):
+            engine.on_event(self._ticker(200.0), {'long': [], 'short': []})
+
+        msgs = [r.message for r in caplog.records]
+        assert not any('Grid drift' in m for m in msgs)
+        assert any('Restored grid out of range' in m for m in msgs)
+        assert engine.grid.anchor_price == 200.0
+
+    def test_ticker_does_not_overwrite_post_fill_wait(self):
+        """Key regression: post-fill WAIT must survive in-band tick with >grid_step drift."""
+        config = GridConfig(grid_count=20, grid_step=1.0)
         engine = GridEngine(
             symbol='BTCUSDT',
             tick_size=Decimal('0.01'),
             config=config,
             strat_id='btcusdt_test',
         )
+        engine.on_event(self._ticker(100.0), {'long': [], 'short': []})
 
-        # Fill at 98.01 — this is a grid level 2 steps below the build anchor
-        # (100 * 0.99^2 = 98.01). After build at 100 and post-fill update_grid,
-        # WAIT band becomes [98.01, 100.0] → wait_center=99.005. Deviation
-        # |100 - 99.005| / 99.005 ≈ 1.005% > 1*grid_step → walk should fire.
+        fill_price = next(g['price'] for g in engine.grid.grid if abs(g['price'] - 99.0) < 0.01)
         fill = ExecutionEvent(
             event_type=EventType.EXECUTION,
             symbol='BTCUSDT',
             exchange_ts=datetime.now(UTC),
             local_ts=datetime.now(UTC),
-            price=Decimal('98.01'),
+            price=Decimal(str(fill_price)),
             qty=Decimal('0.01'),
             side='Buy',
         )
         engine.on_event(fill)
-        assert engine._fill_pending is True
+        filled_level = next(g for g in engine.grid.grid if g['price'] == fill_price)
+        assert filled_level['side'] == GridSideType.WAIT
 
-        with caplog.at_level('INFO'):
-            engine.on_event(self._ticker(100.0), {'long': [], 'short': []})
+        snapshot = [(g['price'], g['side']) for g in engine.grid.grid]
+        wait_center = engine.grid.wait_center()
+        min_p, max_p = engine.grid.bounds
+        # In bounds but > grid_step from post-fill wait_center (0022 would have walked).
+        tick_price = min(max_p - 0.01, wait_center * (1 + 0.02))
+        assert min_p <= tick_price <= max_p
+        assert abs(tick_price - wait_center) / wait_center * 100 > engine.grid.grid_step
 
-        drift_logs = [r.message for r in caplog.records if 'Grid drift' in r.message]
-        assert len(drift_logs) == 1, (
-            "fresh-build tick that consumed a pending fill must still run recenter "
-            "when the post-fill WAIT center diverges from last_close beyond one step; "
-            f"got {drift_logs}"
-        )
+        intents = engine.on_event(self._ticker(tick_price), {'long': [], 'short': []})
+        assert [(g['price'], g['side']) for g in engine.grid.grid] == snapshot
+        assert filled_level['side'] == GridSideType.WAIT
+        place_at_fill = [
+            i for i in intents
+            if isinstance(i, PlaceLimitIntent) and float(i.price) == fill_price
+        ]
+        assert place_at_fill == []
 
-    def test_stale_fill_does_not_cause_repeated_walks(self, caplog):
-        """P1 regression: a stale last_filled_price + existing limits used to
-        cause _check_and_place's update_grid to overwrite recenter's WAIT
-        assignment, so two identical ticks each triggered a fresh walk.
-        After fix, a stale fill must not re-trigger the walk on the second
-        identical ticker."""
-        engine = self._make_engine()
-        # Stale fill from a prior session — last_filled_price set, no fresh fill.
-        engine.last_filled_price = 99.0
-        existing_limits = {
-            'long': [{'orderId': '1', 'price': '99.0', 'side': 'Buy'}],
-            'short': [],
-        }
-        with caplog.at_level('INFO'):
-            engine.on_event(self._ticker(103.5), existing_limits)
-            grid_after_first = [g['price'] for g in engine.grid.grid]
-            engine.on_event(self._ticker(103.5), existing_limits)
-            grid_after_second = [g['price'] for g in engine.grid.grid]
-
-        drift_logs = [r.message for r in caplog.records if 'Grid drift' in r.message]
-        assert len(drift_logs) == 1, f"expected 1 drift log, got {len(drift_logs)}: {drift_logs}"
-        assert grid_after_first == grid_after_second, "second identical ticker must not mutate grid"
-
-    def test_out_of_bounds_rebuild_emits_drift_log(self, caplog):
-        """P3: when the bounds-guard rebuilds at last_close because price is
-        outside the restored grid, the planned 'Grid drift ... N=...' INFO line
-        is emitted alongside the existing 'Restored grid out of range' line."""
-        engine = self._make_engine()
-        # 200 is far outside the restored grid [95..105].
-        with caplog.at_level('INFO'):
-            engine.on_event(self._ticker(200.0), {'long': [], 'short': []})
-
-        msgs = [r.message for r in caplog.records]
-        assert any('Grid drift' in m and 'N=' in m for m in msgs)
-        assert any('Restored grid out of range' in m for m in msgs)
-        assert engine.grid.anchor_price == 200.0
-
-    def test_full_rebuild_fallback_via_engine(self, caplog):
-        """deviation that yields n_steps >= grid_count // 2 → full rebuild via fallback.
-        With grid_count=10, threshold = 5. A 6% deviation (last_close=106 inside bounds
-        of [95..105]? No — 106 is outside max, would trigger engine's own out-of-bounds
-        rebuild. Use a wider grid for this case."""
-        # Use grid_count=10 still but pick last_close close to upper bound but inside.
-        engine = self._make_engine()
-        # last_close = 104.99 → deviation ≈ 4.99% → n_steps = 4 → walk path (NOT fallback).
-        # Need n_steps >= 5 while staying in [95, 105]. With 1% step and centre=100,
-        # max in-bounds last_close ≈ 105 → max deviation ≈ 5%. n_steps = int(5/1) = 5,
-        # which equals grid_count // 2 = 5 → fallback triggers.
-        # Use last_close = 105.0 exactly (still inside bounds inclusive).
-        with caplog.at_level('INFO'):
-            engine.on_event(self._ticker(105.0), {'long': [], 'short': []})
-
-        drift_logs = [r.message for r in caplog.records if 'Grid drift' in r.message]
-        assert len(drift_logs) == 1
-        # Grid is fully rebuilt around 105.0 — anchor must equal 105.0.
-        assert engine.grid.anchor_price == 105.0
-        # Original prices like 95.0, 96.0 should not survive the rebuild.
-        prices = [g['price'] for g in engine.grid.grid]
-        assert 95.0 not in prices
+        # Second identical in-band ticker — still no mutation.
+        intents2 = engine.on_event(self._ticker(tick_price), {'long': [], 'short': []})
+        assert [(g['price'], g['side']) for g in engine.grid.grid] == snapshot
+        assert filled_level['side'] == GridSideType.WAIT
+        place_at_fill2 = [
+            i for i in intents2
+            if isinstance(i, PlaceLimitIntent) and float(i.price) == fill_price
+        ]
+        assert place_at_fill2 == []

--- a/packages/gridcore/tests/test_grid.py
+++ b/packages/gridcore/tests/test_grid.py
@@ -846,9 +846,9 @@ class TestUpdateGridSidewayOscillation:
 
         drift_close = fill_price * 1.004
         grid.update_grid(fill_price, drift_close)
-        filled_after = next(g for g in grid.grid if g['price'] == fill_price)
-        assert filled_after is filled
-        assert filled_after['side'] == GridSideType.WAIT
+        refilled_level = next(g for g in grid.grid if g['price'] == fill_price)
+        assert refilled_level is filled
+        assert refilled_level['side'] == GridSideType.WAIT
 
     def test_out_of_bounds_triggers_rebuild_not_oscillation(self):
         grid = self._make_grid(anchor=54.0, grid_step=0.2)

--- a/packages/gridcore/tests/test_grid.py
+++ b/packages/gridcore/tests/test_grid.py
@@ -767,38 +767,6 @@ class TestZeroDivisionGuards:
     make these unreachable in production, but the guards are exercised here
     to lock in the contract."""
 
-    def test_recenter_no_op_when_wait_center_is_zero(self, caplog):
-        """If the WAIT band is symmetric around zero (e.g. [-1, 1]), wait_center
-        returns 0. recenter_if_drifted must early-return rather than divide."""
-        grid = Grid(tick_size=Decimal('0.01'), grid_count=10, grid_step=1.0)
-        # Bypass build_grid validation by setting grid directly.
-        grid.grid = [
-            {'side': GridSideType.WAIT, 'price': -1.0},
-            {'side': GridSideType.WAIT, 'price': 1.0},
-        ]
-        assert grid.wait_center() == 0.0
-
-        with caplog.at_level('WARNING'):
-            result = grid.recenter_if_drifted(5.0)
-
-        assert bool(result) is False
-        assert result.n_steps == 0
-        assert any('wait_center is zero' in r.message for r in caplog.records)
-
-    def test_recenter_no_op_when_grid_step_is_zero(self, caplog):
-        """grid_step == 0 would crash int(deviation_pct / 0). Guard returns
-        a no-op RecenterResult."""
-        grid = Grid(tick_size=Decimal('0.01'), grid_count=10, grid_step=1.0)
-        grid.build_grid(100.0)
-        grid.grid_step = 0  # break GridConfig invariant for the test
-
-        with caplog.at_level('WARNING'):
-            result = grid.recenter_if_drifted(105.0)
-
-        assert bool(result) is False
-        assert result.n_steps == 0
-        assert any('grid_step is zero' in r.message for r in caplog.records)
-
     def test_is_too_close_returns_false_on_zero_price(self):
         """__is_too_close divides by price1 — guard short-circuits on zero."""
         grid = Grid(tick_size=Decimal('0.01'), grid_count=10, grid_step=1.0)
@@ -812,132 +780,13 @@ class TestZeroDivisionGuards:
         assert grid._Grid__is_too_close(100.0, 100.0) is False
 
 
-class TestRecenterIfDrifted:
-    """Tests for Grid.recenter_if_drifted (feature 0022)."""
+class TestAssignSides:
+    """Tests for Grid._assign_sides (fill-keyed WAIT marking, feature 0048)."""
 
     def _make_grid(self, anchor=100.0, grid_count=20, grid_step=1.0):
         grid = Grid(tick_size=Decimal('0.01'), grid_count=grid_count, grid_step=grid_step)
         grid.build_grid(anchor)
         return grid
-
-    def test_no_action_when_grid_empty(self):
-        grid = Grid(tick_size=Decimal('0.01'), grid_count=10, grid_step=1.0)
-        walked, dev, n = grid.recenter_if_drifted(100.0)
-        assert walked is False
-        assert n == 0
-
-    def test_no_action_when_deviation_below_grid_step(self):
-        grid = self._make_grid(anchor=100.0, grid_step=1.0)
-        # 0.5% deviation < 1.0% grid_step
-        walked, dev, n = grid.recenter_if_drifted(100.5)
-        assert walked is False
-        assert n == 0
-        assert dev < 1.0
-
-    def test_no_action_at_exact_grid_step(self):
-        grid = self._make_grid(anchor=100.0, grid_step=1.0)
-        # exactly at threshold; trigger uses '>', not '>='
-        walked, dev, n = grid.recenter_if_drifted(101.0)
-        assert walked is False
-        assert n == 0
-
-    def test_walks_n_steps_up_when_price_above_band(self):
-        grid = self._make_grid(anchor=100.0, grid_count=20, grid_step=1.0)
-        original_min = grid.grid[0]['price']
-        original_max = grid.grid[-1]['price']
-        original_len = len(grid.grid)
-        # 3.5% deviation → n_steps = 3
-        walked, dev, n = grid.recenter_if_drifted(103.5)
-        assert walked is True
-        assert n == 3
-        assert len(grid.grid) == original_len  # length preserved
-        assert grid.grid[0]['price'] > original_min  # bottom raised
-        assert grid.grid[-1]['price'] > original_max  # top raised
-
-    def test_walks_n_steps_down_when_price_below_band(self):
-        grid = self._make_grid(anchor=100.0, grid_count=20, grid_step=1.0)
-        original_min = grid.grid[0]['price']
-        original_max = grid.grid[-1]['price']
-        original_len = len(grid.grid)
-        # -2.5% deviation → n_steps = 2 (deviation_pct ≈ 2.439, floor = 2)
-        walked, dev, n = grid.recenter_if_drifted(97.5)
-        assert walked is True
-        assert n == 2
-        assert len(grid.grid) == original_len
-        assert grid.grid[0]['price'] < original_min
-        assert grid.grid[-1]['price'] < original_max
-
-    def test_round_trip_outside_walked_region(self):
-        """Walk-up by N: levels at indices [0..len-N-1] post-walk == levels at [N..len-1] pre-walk."""
-        grid = self._make_grid(anchor=100.0, grid_count=20, grid_step=1.0)
-        pre_prices = [g['price'] for g in grid.grid]
-        walked, _, n = grid.recenter_if_drifted(103.5)
-        assert walked is True
-        post_prices = [g['price'] for g in grid.grid]
-        assert post_prices[: len(pre_prices) - n] == pre_prices[n:]
-
-    def test_full_rebuild_fallback_when_n_steps_exceeds_half(self):
-        grid = self._make_grid(anchor=100.0, grid_count=20, grid_step=1.0)
-        original_prices = {g['price'] for g in grid.grid}
-        # 15% deviation → n_steps = 15 > grid_count // 2 = 10 → fallback
-        walked, dev, n = grid.recenter_if_drifted(115.0)
-        assert walked is True
-        assert n >= grid.grid_count // 2
-        # Grid is rebuilt around 115.0; very few (if any) shared prices with original
-        new_prices = {g['price'] for g in grid.grid}
-        # Rebuilt grid is centered far from original — bulk of prices differ.
-        overlap = original_prices & new_prices
-        assert len(overlap) <= 1
-
-    def test_anchor_updated_to_wait_center_after_walk(self):
-        grid = self._make_grid(anchor=100.0, grid_count=20, grid_step=1.0)
-        walked, _, _ = grid.recenter_if_drifted(103.5)
-        assert walked is True
-        # _original_anchor_price should now equal new wait_center (close to 103.5)
-        assert grid._original_anchor_price == grid.wait_center()
-        assert abs(grid._original_anchor_price - 103.5) < 1.0
-
-    def test_assign_sides_post_walk(self):
-        grid = self._make_grid(anchor=100.0, grid_count=20, grid_step=1.0)
-        walked, _, _ = grid.recenter_if_drifted(103.5)
-        assert walked is True
-        last_close = 103.5
-        for level in grid.grid:
-            diff_pct = abs(level['price'] - last_close) / level['price'] * 100
-            if diff_pct < grid.grid_step / 4:
-                assert level['side'] == GridSideType.WAIT
-            elif level['price'] > last_close:
-                assert level['side'] == GridSideType.SELL
-            elif level['price'] < last_close:
-                assert level['side'] == GridSideType.BUY
-
-    def test_notify_change_called_on_walk(self):
-        calls = []
-        grid = Grid(
-            tick_size=Decimal('0.01'),
-            grid_count=20,
-            grid_step=1.0,
-            on_change=lambda g, ts: calls.append(len(g)),
-        )
-        grid.build_grid(100.0)
-        calls_after_build = len(calls)
-        walked, _, _ = grid.recenter_if_drifted(103.5)
-        assert walked is True
-        assert len(calls) == calls_after_build + 1
-
-    def test_notify_change_not_called_when_no_action(self):
-        calls = []
-        grid = Grid(
-            tick_size=Decimal('0.01'),
-            grid_count=20,
-            grid_step=1.0,
-            on_change=lambda g, ts: calls.append(len(g)),
-        )
-        grid.build_grid(100.0)
-        calls_after_build = len(calls)
-        walked, _, _ = grid.recenter_if_drifted(100.2)
-        assert walked is False
-        assert len(calls) == calls_after_build  # no extra notify
 
     def test_assign_sides_with_fill_price_preserves_legacy(self):
         """_assign_sides(last_close, fill_price=fp) preserves update_grid semantics:
@@ -953,3 +802,57 @@ class TestRecenterIfDrifted:
         # fill_price as reference, not last_close. (If it were last_close, this
         # level would also be WAIT.)
         assert grid.grid[12]['side'] != GridSideType.WAIT
+
+    def test_assign_sides_requires_fill_price(self):
+        """fill_price is a required keyword-only argument (no last_close WAIT path)."""
+        grid = self._make_grid(anchor=100.0, grid_count=20, grid_step=1.0)
+        with pytest.raises(TypeError):
+            grid._assign_sides(100.0)
+
+
+class TestUpdateGridSidewayOscillation:
+    """Grid-level regression tests for post-fill WAIT stability (feature 0048)."""
+
+    def _make_grid(self, anchor=54.0, grid_count=20, grid_step=0.2):
+        grid = Grid(tick_size=Decimal('0.01'), grid_count=grid_count, grid_step=grid_step)
+        grid.build_grid(anchor)
+        return grid
+
+    def test_update_grid_marks_wait_at_fill_price(self):
+        grid = self._make_grid(anchor=54.0, grid_step=0.2)
+        fill_idx = len(grid.grid) // 2 + 2
+        fp = grid.grid[fill_idx]['price']
+        last_close = grid.grid[-3]['price']
+        grid.update_grid(fp, last_close)
+        filled = next(g for g in grid.grid if g['price'] == fp)
+        assert filled['side'] == GridSideType.WAIT
+        # Unrelated levels follow price-vs-level rules
+        for level in grid.grid:
+            if level['price'] == fp:
+                continue
+            if last_close < level['price']:
+                assert level['side'] == GridSideType.SELL
+            elif last_close > level['price']:
+                assert level['side'] == GridSideType.BUY
+
+    def test_update_grid_remarks_wait_on_repeat_fill_at_same_price(self):
+        """Second update_grid at the same fill_price re-marks that level WAIT."""
+        grid = self._make_grid(anchor=54.0, grid_step=0.2)
+        fill_idx = len(grid.grid) // 2 + 2
+        fill_price = grid.grid[fill_idx]['price']
+        grid.update_grid(fill_price, fill_price)
+        filled = next(g for g in grid.grid if g['price'] == fill_price)
+        assert filled['side'] == GridSideType.WAIT
+
+        drift_close = fill_price * 1.004
+        grid.update_grid(fill_price, drift_close)
+        filled_after = next(g for g in grid.grid if g['price'] == fill_price)
+        assert filled_after is filled
+        assert filled_after['side'] == GridSideType.WAIT
+
+    def test_out_of_bounds_triggers_rebuild_not_oscillation(self):
+        grid = self._make_grid(anchor=54.0, grid_step=0.2)
+        grid.update_grid(100.0, 100.0)
+        assert grid.anchor_price == 100.0
+        stale_wait = next((g for g in grid.grid if g['price'] == 54.0), None)
+        assert stale_wait is None or stale_wait['side'] != GridSideType.WAIT


### PR DESCRIPTION
## Summary

- Removes Feature 0022's `recenter_if_drifted` per-tick drift detector; drift now handled by `update_grid` post-fill (bbu2 parity) plus bounds-guard `build_grid` on the tick path.
- `_assign_sides` now requires `fill_price` keyword-only — no `last_close`-based WAIT path remains; closes the WAIT→SELL primitive that caused #111.
- Net ~110 LoC removed from src, recenter test classes replaced with `TestEngineNoRecenter` + `TestUpdateGridSidewayOscillation`; new regression `test_ticker_does_not_overwrite_post_fill_wait` exercises the in-bounds, deviation-greater-than-`grid_step` regime that triggered the production REAL_DUPLICATE under 0022.

Tracks #110 (SAME ORDER prefix reuse — downstream symptom) and #111 (Wait→Sell reassignment — direct root cause). Issues remain open until the Phase 5 7-day production pass gate.

Plan: `docs/features/0048_PLAN.md` · Review: `docs/features/0048_REVIEW.md`

## Test plan

- [x] `uv run pytest -q packages/gridcore/tests/test_grid.py packages/gridcore/tests/test_engine.py` — 119 passed
- [x] `uv run pytest -q packages/gridcore/tests/ --cov=gridcore --cov-fail-under=80` — 391 passed, coverage 93.70%
- [x] `uv run pytest -q apps/replay/tests/` — 92 passed
- [x] `uv run pytest -q apps/backtest/tests/` — 426 passed, 3 pre-existing failures unrelated to 0048 (risk_limit_info cache wording and `_IN_PROCESS_LOCKS`)
- [x] Removed-symbol grep clean: no `recenter_if_drifted | RecenterResult | _shift_grid | fill_consumed_this_tick | grid_just_built | _log_drift`
- [ ] Live deploy to mainnet `ltcusdt_test`; observe 7 days for zero `verdict=REAL_DUPLICATE` (Phase 5 pass gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)