### PR TITLE
feat(0057): add SOLUSDT as second strategy (multi-strat)

### DIFF
--- a/apps/recorder/conf/recorder_ltcusdt.yaml
+++ b/apps/recorder/conf/recorder_ltcusdt.yaml
@@ -17,6 +17,7 @@
 
 symbols:
   - "LTCUSDT"
+  - "SOLUSDT"
 
 # Store in project-root data/ directory
 database_url: "sqlite:///data/recorder_ltcusdt_phase4.db"

--- a/conf/gridbot_test.yaml
+++ b/conf/gridbot_test.yaml
@@ -18,6 +18,18 @@ strategies:
     increase_same_position_on_low_margin: true
     shadow_mode: false  # start with shadow mode to avoid real orders
 
+  - strat_id: solusdt_test
+    account: mainnet_live
+    symbol: SOLUSDT
+    tick_size: "0.01"
+    grid_count: 30
+    grid_step: 1.0
+    amount: "x0.0005"
+    max_margin: 3.0
+    min_total_margin: 2.5
+    increase_same_position_on_low_margin: true
+    shadow_mode: false
+
 database_url: "${DATABASE_URL}"
 
 auth_cooldown_minutes: 30


### PR DESCRIPTION
## Summary

- Add `solusdt_test` strategy alongside existing `ltcusdt_test` on shared `mainnet_live` account, exercising the multi-strat code path for the first time in production.
- Distinct parameters from LTC (`grid_count=30`, `grid_step=1.0`, `amount=x0.0005`, `max_margin=3.0`, `min_total_margin=2.5`) so per-strat differentiation is visible in logs and Bybit UI.
- Add `SOLUSDT` to the recorder symbols list so both pairs are captured for replay.

## Pre-merge audit findings

Before flipping the switch we audited the multi-strat code paths (orchestrator, runner, GridStateWriter, WS client, PositionFetcher, orderLinkId, SAME_ORDER dedup, low_margin boost, risk-mgmt rule, bootstrap fingerprint). For the LTC + SOL scenario (distinct symbols on shared account) the audit found **no blockers**:

- `client_order_id = sha256(symbol_side_price_direction)[:16]` already includes `symbol` → distinct strats produce distinct ids → no orderLinkId collision risk.
- `_same_order_dedup_cache` is an instance attribute on `StrategyRunner`; execution events are routed per-`_symbol_to_runners` → no cross-strat contamination.
- GridStateWriter writes scoped by `(run_id, account_id, strat_id)` → no overwrites.
- Bootstrap grid_state_snapshots loop iterates per strat (PR #109).
- WS client subscribes to both symbols on one connection (`['LTCUSDT', 'SOLUSDT']`).

The one remaining item — low_margin boost (Feature 0040) interaction with cross-margin shared wallet — is documented as operational concern, not a blocker (defense fires per-strat using local position margin, not wallet-level).

## Live validation (15+ hours)

| Check | Result |
|-------|--------|
| Both strats initialized, separate `run_id` | ✅ |
| WS multi-symbol subscription | ✅ |
| Bybit instrument verified: SOLUSDT tick_size=0.010 | ✅ |
| First SOL fill (22:14:18.921) → contra placed in 27ms | ✅ |
| SAME_ORDER events across both strats | 0 |
| 110072 orderLinkId errors | 0 |
| GridStateWriter insert errors | 0 |
| Bootstrap anomaly cross-check | 0 |
| Risk-mgmt grow-losing-side fires per-strat correctly | ✅ (5 LTC + 41 SOL in a window, mult=2.0 observed per side) |
| WS storm recoveries (1× disc+recon, 3× transient blip) | ✅ self-recovered |
| Realized cross-strat contamination | NONE detected |

## Follow-up monitoring upgrades (already in main via `.claude/skills/gridbot-health/`)

- Table 9: per-strat × per-direction defense breakdown (low_margin + risk_mgmt + moderate + high + EMERGENCY) with `mult=2.0` cross-check
- Table 10: per-strat order book snapshot (latest `Order sync` count per strat)
- Bootstrap anomaly (0049) cross-check row
- 0048 drift detector removal invariant table
- `liq_distance` semantics correction (`|liq_ratio - 1|` not raw ratio)

## Known follow-up (not blocking)

Issue #135: `gridcore.position` log line lacks USDT-denominated unrealised + realized PnL. The `margin` field is a ratio (`positionValue / walletBalance`), not USDT. External monitor can't reconcile with Bybit UI today. Will be addressed in a separate branch.

## Test plan

- [x] Live for 15h on `mainnet_live` with real funds
- [x] All safety nets verified via `gridbot-health` skill hourly cron
- [x] No errors caused by SOL addition itself; only sporadic network blips (all transient)
- [ ] Continue monitoring; if bugs surface post-merge → file new issue + branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)