### PR TITLE
feat(0058): log USDT unrealized + realized PnL on position line

### DIFF
--- a/apps/gridbot/src/gridbot/runner.py
+++ b/apps/gridbot/src/gridbot/runner.py
@@ -836,6 +836,11 @@ class StrategyRunner:
         entry_price = float(position_data.get("avgPrice", 0) or position_data.get("entryPrice", 0))
         liq_price = float(position_data.get("liqPrice", 0) or 0)
         unrealized_pnl = float(position_data.get("unrealisedPnl", 0) or 0)
+        # cumRealisedPnl: lifetime cumulative realised PnL (does NOT reset per
+        # cycle; ~80x the UI value). curRealisedPnl: current-cycle realised PnL
+        # = the Bybit Web UI "Realized" column.
+        cum_realized_pnl = float(position_data.get("cumRealisedPnl", 0) or 0)
+        cur_realized_pnl = float(position_data.get("curRealisedPnl", 0) or 0)
 
         # Calculate margin
         size_d = Decimal(str(size))
@@ -851,6 +856,8 @@ class StrategyRunner:
             margin=margin,
             liquidation_price=Decimal(str(liq_price)),
             position_value=position_value,
+            cum_realized_pnl=Decimal(str(cum_realized_pnl)),
+            cur_realized_pnl=Decimal(str(cur_realized_pnl)),
         )
 
     def _execute_intents(

--- a/apps/gridbot/tests/test_runner.py
+++ b/apps/gridbot/tests/test_runner.py
@@ -884,6 +884,37 @@ class TestStrategyRunnerPositionUpdate:
             runner.get_amount_multiplier("short", "Unknown")
 
 
+class TestBuildPositionStateRealizedPnl:
+    """_build_position_state plumbs Bybit cum/curRealisedPnl into PositionState."""
+
+    def test_realised_pnls_parsed(self, runner):
+        pos = {"size": "1.0", "avgPrice": "50000",
+               "cumRealisedPnl": "123.45", "curRealisedPnl": "5.50"}
+        state = runner._build_position_state(pos, 10000.0, "long")
+        assert state.cum_realized_pnl == Decimal("123.45")
+        assert state.cur_realized_pnl == Decimal("5.50")
+
+    def test_realised_pnls_negative(self, runner):
+        pos = {"size": "1.0", "avgPrice": "50000",
+               "cumRealisedPnl": "-16.74", "curRealisedPnl": "-2.00"}
+        state = runner._build_position_state(pos, 10000.0, "short")
+        assert state.cum_realized_pnl == Decimal("-16.74")
+        assert state.cur_realized_pnl == Decimal("-2.00")
+
+    def test_realised_pnls_absent_default_zero(self, runner):
+        pos = {"size": "1.0", "avgPrice": "50000"}
+        state = runner._build_position_state(pos, 10000.0, "long")
+        assert state.cum_realized_pnl == Decimal("0")
+        assert state.cur_realized_pnl == Decimal("0")
+
+    def test_realised_pnls_empty_string_default_zero(self, runner):
+        pos = {"size": "1.0", "avgPrice": "50000",
+               "cumRealisedPnl": "", "curRealisedPnl": ""}
+        state = runner._build_position_state(pos, 10000.0, "long")
+        assert state.cum_realized_pnl == Decimal("0")
+        assert state.cur_realized_pnl == Decimal("0")
+
+
 class TestStrategyRunnerOrderUpdate:
     """Tests for order update events."""
     def test_on_order_update_fills_tracked(self, runner, mock_executor):

--- a/docs/features/0058_PLAN.md
+++ b/docs/features/0058_PLAN.md
@@ -1,0 +1,59 @@
+# Feature 0058 — USDT-denominated unrealized + realized PnL in the `gridcore.position` per-tick log line
+
+## Context
+
+The `gridcore.position` per-tick DEBUG log line (`packages/gridcore/src/gridcore/position.py:270-280`) currently records `margin` / `total_margin` as **dimensionless ratios** (positionValue / walletBalance) and `unrealized_pnl=X%` as a leverage-baked percentage return on margin. None of these convert cleanly to USDT — during 2026-05-28 multi-strat (LTC+SOL) monitoring, the `gridbot-health` monitor's conversion of these logged percentages was off by ~3 orders of magnitude vs the Bybit UI. Additionally, **realized PnL is not tracked anywhere in the gridbot path**, despite being the headline number for a long-running grid bot.
+
+This feature is a **purely additive log-line change**. It adds four USDT-denominated fields (`upnl_usdt`, `realized_usdt`, `cum_realized_usdt`, `pos_value_usdt`) sourced from existing/new `PositionState` `Decimal`s, plus two new realized-PnL fields on `PositionState` (`cur_realized_pnl`, `cum_realized_pnl`). There is **NO change** to the `unrealized_pnl_pct` computation, to any risk-mgmt adjustment threshold rule, or to existing log fields. The log line stays at DEBUG.
+
+**Realized-PnL semantics (corrected against feature 0056).** Bybit ships two realized fields and they are NOT interchangeable:
+- `curRealisedPnl` — realized PnL for the **current position cycle**; this is what the Bybit Web UI "Realized" column shows. → logged as `realized_usdt` (satisfies issue #135's "match Bybit UI per side" acceptance criterion).
+- `cumRealisedPnl` — **lifetime** cumulative realized PnL; does NOT reset per cycle (~80× the UI value). → logged as `cum_realized_usdt` (the all-time "is this strat profitable" number).
+
+## Verified facts (relied upon, do not re-derive)
+
+- `PositionState` dataclass at `position.py:32-47` already carries `unrealized_pnl: Decimal` (line 43) and `position_value: Decimal` (line 47); it **lacks** any realized-PnL fields. Callers use keyword arguments, so new defaulted fields are non-breaking. gridcore's `PositionState.*realized_pnl` is read only by the log line — the many other `realized_pnl` symbols in the repo (comparator/backtest) are a separate per-trade concept.
+- The target log line at `position.py:270-280` is DEBUG and **does** reach `/tmp/gridbot.log` (40k+ lines/day) because the bot runs with `--debug`: `main.py:199-202` sets the `gridcore` logger to DEBUG and the file handler is DEBUG-level (`main.py:61`). Keeping DEBUG is correct; the new fields will be parseable by the `gridbot-health` monitor.
+- `unrealized_pnl_pct` (logged as `unrealized_pnl=%.2f%%`) is computed separately in `calculate_amount_multiplier` (`position.py:214-219`, float arithmetic) and drives `_apply_long_position_rules` / `_apply_short_position_rules`. **Must NOT change.**
+- Bybit `unrealisedPnl` is already a signed USDT value (positive = profit) → logging `float(position.unrealized_pnl)` directly gives the correct sign.
+- Both `cumRealisedPnl` and `curRealisedPnl` are reliably present in Bybit `/v5/position/list` dicts and are already consumed together at `apps/recorder/src/recorder/recorder.py:521-530`, `apps/event_saver/src/event_saver/writers/position_writer.py:246-254`, `apps/pnl_checker/src/pnl_checker/fetcher.py:209-210`.
+- Field semantics are authoritatively documented in `docs/features/0056_PLAN.md`: `cumRealisedPnl` = lifetime (~80× UI), `curRealisedPnl` = current-cycle = Bybit UI "Realized". Note these in code comments.
+- The live `_build_position_state` (`apps/gridbot/src/gridbot/runner.py:825-854`) is the only live `PositionState` construction site: `unrealisedPnl` extraction at line 838, `PositionState(...)` call at lines 846-854. It returns `None` when `size == 0`, so realized won't be logged when flat (acceptable).
+- The backtest app has its OWN `_build_position_state` (`apps/backtest/src/backtest/runner.py:696-747`) that also constructs `PositionState` via keyword args. Adding defaulted `cum_realized_pnl` / `cur_realized_pnl` fields is non-breaking there; they keep the default `0` (backtest has no real Bybit realized values).
+
+## Files & changes
+
+### 1. `packages/gridcore/src/gridcore/position.py` — dataclass field + log line
+
+**1a. Add fields to `PositionState` (dataclass at lines 32-47).** Add `cum_realized_pnl: Decimal = Decimal('0')` and `cur_realized_pnl: Decimal = Decimal('0')` after the existing `position_value: Decimal = Decimal('0')` field. Include brief inline comments: `cum_realized_pnl` = Bybit `cumRealisedPnl` (lifetime, does NOT reset per cycle, ~80× UI); `cur_realized_pnl` = Bybit `curRealisedPnl` (current cycle = Web UI "Realized").
+
+**1b. Extend the DEBUG log statement (lines 270-280).** Add four USDT fields to the existing format string and args, sourced from existing/new `PositionState` `Decimal`s (no new exchange calls):
+- `upnl_usdt=%.4f` from `float(position.unrealized_pnl)`
+- `realized_usdt=%.4f` from `float(position.cur_realized_pnl)` (UI-matching)
+- `cum_realized_usdt=%.4f` from `float(position.cum_realized_pnl)` (lifetime)
+- `pos_value_usdt=%.2f` from `float(position.position_value)`
+
+Suggested placement: immediately after the existing `unrealized_pnl=...%` field. Keep level at DEBUG. Keep **all** existing fields (`margin`, `liq_ratio`, `unrealized_pnl=%`, `multiplier`, `position_ratio`, `total_margin`) unchanged in name, order, and formatting.
+
+### 2. `apps/gridbot/src/gridbot/runner.py` — populate realized fields in live construction
+
+In `_build_position_state` (lines 825-854): after the existing `unrealisedPnl` extraction (line 838), add `cum_realized_pnl = float(position_data.get("cumRealisedPnl", 0) or 0)` and `cur_realized_pnl = float(position_data.get("curRealisedPnl", 0) or 0)`. Pass both (`cum_realized_pnl=Decimal(str(cum_realized_pnl))`, `cur_realized_pnl=Decimal(str(cur_realized_pnl))`) into the `PositionState(...)` call (lines 846-854). The `key absent/empty → 0` semantics follow the same `(x, 0) or 0` idiom already used for `unrealisedPnl` and `liqPrice`. Add a brief code comment noting the cum (lifetime) vs cur (UI) semantics.
+
+### 3. Tests
+
+**3a. `packages/gridcore/tests/test_position.py` — caplog test.** Add a caplog-based test asserting that the per-tick log line emitted by `calculate_amount_multiplier` now contains the formatted `upnl_usdt=`, `realized_usdt=`, `cum_realized_usdt=`, and `pos_value_usdt=` values, that `realized_usdt` tracks `cur_realized_pnl` and `cum_realized_usdt` tracks `cum_realized_pnl` (distinct values so a swap is caught), and that a negative `unrealized_pnl` logs a negative `upnl_usdt`. Use `caplog.at_level(logging.DEBUG, logger="gridcore.position")`.
+
+**3b. `apps/gridbot/tests/test_runner.py` — parse test.** Add a test asserting `_build_position_state` parses `cumRealisedPnl`/`curRealisedPnl` into `PositionState.cum_realized_pnl`/`cur_realized_pnl` (positive and negative), and that both default to `Decimal('0')` when the keys are absent or empty-string. (Use a `size > 0` fixture so the method does not early-return `None`.)
+
+**3c. Regression.** Existing tests under `tests/unit/gridcore` and the backtest `test_build_position_state*` tests in `apps/backtest/tests/test_runner.py` must remain green (defaulted field is non-breaking; backtest keeps default `0`).
+
+## Field naming (confirmed by user)
+
+- `PositionState` fields: `cum_realized_pnl` (lifetime), `cur_realized_pnl` (current cycle / UI)
+- Log keys: `upnl_usdt` / `realized_usdt` (= cur, UI-matching) / `cum_realized_usdt` (= cum, lifetime) / `pos_value_usdt`
+
+## Out of scope (explicitly deferred — do NOT implement here)
+
+- The suspected `entry_price` vs Bybit `avgPrice` divergence (issue Notes) — separate future investigation, now enabled by having the USDT fields for direct comparison.
+- "Table 11: Net unrealised PnL per strat" addition to `.claude/skills/gridbot-health/analyze.py` — follow-on skill edit that will consume these fields.
+- Backtest log-line parity — backtest has no real Bybit realized values; leave its `cum_realized_pnl` / `cur_realized_pnl` defaults at `0`.

--- a/docs/features/0058_REVIEW.md
+++ b/docs/features/0058_REVIEW.md
@@ -1,0 +1,99 @@
+# Feature 0058 Code Review
+
+**Plan:** `docs/features/0058_PLAN.md`  
+**Scope:** `packages/gridcore/src/gridcore/position.py`, `apps/gridbot/src/gridbot/runner.py`, and their unit tests  
+**Review pass:** 2 (post-fix)
+
+---
+
+## Verdict
+
+**Approve.** The implementation matches the updated plan. Pass-1 semantic finding is resolved; no blocking or non-blocking defects remain.
+
+---
+
+## Resolved From Prior Review
+
+| Pass-1 ID | Resolution |
+|---|---|
+| P3 — `realized_usdt` mapped to `cumRealisedPnl` instead of UI “Realized” | Fixed — `realized_usdt` now logs `cur_realized_pnl` (`curRealisedPnl`); lifetime value is separate as `cum_realized_usdt` from `cum_realized_pnl`. Distinct test values (5.50 vs 123.45) catch a cur/cum swap. |
+
+---
+
+## Plan Implementation Check
+
+| Plan item | Status | Evidence |
+|---|---|---|
+| Add `cum_realized_pnl` and `cur_realized_pnl` to `PositionState` with 0056 semantics comments | Pass | `position.py:48-54` |
+| Extend DEBUG log with `upnl_usdt`, `realized_usdt` (cur), `cum_realized_usdt`, `pos_value_usdt` after `unrealized_pnl=%` | Pass | `position.py:278-288` |
+| `realized_usdt` sourced from `cur_realized_pnl`; `cum_realized_usdt` from `cum_realized_pnl` | Pass | `position.py:286-287` |
+| Keep existing log fields unchanged (name, order, formatting) | Pass | `margin`, `liq_ratio`, `unrealized_pnl=%`, `multiplier`, `position_ratio`, `total_margin` unchanged |
+| Do **not** change `unrealized_pnl_pct` computation or risk rules | Pass | pct logic at `position.py:224-226` untouched |
+| Parse `cumRealisedPnl` and `curRealisedPnl` in live `_build_position_state` with `(x, 0) or 0` idiom | Pass | `runner.py:842-843`, `859-860` |
+| Comment on cum (lifetime) vs cur (UI) semantics | Pass | `runner.py:839-841`, `position.py:48-53` |
+| caplog test: all four USDT fields; cur/cum distinct; negative upnl sign | Pass | `test_position.py:166-247` |
+| `_build_position_state` parse test: positive, negative, absent, empty string for both fields | Pass | `test_runner.py:887-915` |
+| Backtest keeps default `cum_realized_pnl` / `cur_realized_pnl` = 0 (non-breaking) | Pass | `backtest/runner.py:739-747` omits fields; defaults apply |
+| Out of scope items not implemented | Pass | No gridbot-health edits, no backtest log parity |
+
+---
+
+## Findings
+
+No blocking or non-blocking code review findings against the current working tree.
+
+### Notes (not defects)
+
+- **Explicit `None` values untested.** Runner tests cover absent keys and empty strings for both `cumRealisedPnl` and `curRealisedPnl`. An explicit `None` in the dict would also default to zero via the existing `(x, 0) or 0` idiom (same as `unrealisedPnl`). Optional one-liner test; not required for merge.
+- **`pos_value_usdt` uses computed notional.** Sourced from `calc_position_value(size, avgPrice)`, not Bybit’s `positionValue` REST field. Pre-existing behavior; plan defers `avgPrice` divergence investigation.
+- **Naming avoids comparator collision.** `PositionState.cum_realized_pnl` / `cur_realized_pnl` are distinct from the per-trade `realized_pnl` symbols in comparator/backtest, as noted in the plan.
+
+---
+
+## Code Quality Review
+
+### Correctness & data alignment
+
+- **camelCase:** Bybit keys `cumRealisedPnl` and `curRealisedPnl` read correctly; aligns with recorder/event-saver parsing at `recorder.py:521-530`.
+- **Semantic mapping:** `realized_usdt` → UI “Realized”; `cum_realized_usdt` → lifetime cumulative. Comments in dataclass, runner, and caplog test docstring are consistent with `0056_PLAN.md`.
+- **Sign preservation:** Negative `unrealisedPnl` and negative realized values tested.
+- **Flat positions:** `size == 0` → `_build_position_state` returns `None`; no per-tick log (acceptable per plan).
+
+### Over-engineering / style
+
+- Diff remains focused: 4 files, +150 lines, no new abstractions.
+- Test structure matches existing caplog and `_build_position_state` patterns.
+- No file-size or refactoring concerns.
+
+### Unit tests
+
+| Area | Assessment |
+|---|---|
+| Happy path | Covered — four USDT log fields; both realized fields parsed with distinct values |
+| Edge cases | Covered — absent keys, empty strings, negative signs |
+| cur/cum swap guard | Covered — `realized_usdt=5.5000` vs `cum_realized_usdt=123.4500` in caplog test |
+| Isolation | Good — no exchange I/O |
+| Regression | `251` tests in `test_position.py` + `test_runner.py` pass; backtest `build_position_state` tests pass |
+
+---
+
+## Commands Run
+
+```bash
+uv run pytest packages/gridcore/tests/test_position.py apps/gridbot/tests/test_runner.py -q
+```
+
+Result: `251 passed in 0.23s`
+
+```bash
+uv run pytest packages/gridcore/tests/ apps/backtest/tests/test_runner.py -q -k "build_position_state"
+```
+
+Result: `4 passed`
+
+```bash
+uv run ruff check packages/gridcore/src/gridcore/position.py apps/gridbot/src/gridbot/runner.py \
+  packages/gridcore/tests/test_position.py apps/gridbot/tests/test_runner.py
+```
+
+Result: `All checks passed!`

--- a/packages/gridcore/src/gridcore/position.py
+++ b/packages/gridcore/src/gridcore/position.py
@@ -45,6 +45,13 @@ class PositionState:
     liquidation_price: Decimal = Decimal('0')
     leverage: int = 1
     position_value: Decimal = Decimal('0')
+    # Bybit cumRealisedPnl: lifetime cumulative realised PnL; does NOT reset
+    # per cycle (~80x the Web UI "Realized" value).
+    cum_realized_pnl: Decimal = Decimal('0')
+    # Bybit curRealisedPnl: realised PnL for the current position cycle — what
+    # the Bybit Web UI "Realized" column shows. Retains the completed cycle
+    # total until the next opening fill resets it.
+    cur_realized_pnl: Decimal = Decimal('0')
 
 
 @dataclass
@@ -269,11 +276,16 @@ class Position:
         # Log position state (matches reference position.py:24-31)
         logger.debug(
             '%s margin=%.2f liq_ratio=%.2f unrealized_pnl=%.2f%% '
+            'upnl_usdt=%.4f realized_usdt=%.4f cum_realized_usdt=%.4f pos_value_usdt=%.2f '
             'multiplier=%s position_ratio=%.2f total_margin=%.2f',
             self.direction,
             float(position.margin),
             liq_ratio,
             unrealized_pnl_pct,
+            float(position.unrealized_pnl),
+            float(position.cur_realized_pnl),
+            float(position.cum_realized_pnl),
+            float(position.position_value),
             self.amount_multiplier,
             self.position_ratio,
             total_margin

--- a/packages/gridcore/tests/test_position.py
+++ b/packages/gridcore/tests/test_position.py
@@ -2,6 +2,7 @@
 Unit tests for Position module.
 """
 
+import logging
 from decimal import Decimal
 from gridcore.position import PositionState, PositionRiskManager, RiskConfig, Position
 
@@ -31,6 +32,22 @@ class TestPositionState:
         assert pos.direction == 'short'
         assert pos.size == Decimal('1.5')
         assert pos.leverage == 10
+
+    def test_position_state_realized_pnl_default(self):
+        """cum/cur realized_pnl default to Decimal('0')."""
+        pos = PositionState(direction=Position.DIRECTION_LONG)
+        assert pos.cum_realized_pnl == Decimal('0')
+        assert pos.cur_realized_pnl == Decimal('0')
+
+    def test_position_state_realized_pnl_value(self):
+        """cum/cur realized_pnl hold the supplied values."""
+        pos = PositionState(
+            direction=Position.DIRECTION_LONG,
+            cum_realized_pnl=Decimal('123.45'),
+            cur_realized_pnl=Decimal('5.50'),
+        )
+        assert pos.cum_realized_pnl == Decimal('123.45')
+        assert pos.cur_realized_pnl == Decimal('5.50')
 
 
 class TestPositionRiskManager:
@@ -145,6 +162,89 @@ class TestPositionRiskManager:
         # Should return multipliers dict
         assert 'Buy' in short_multipliers
         assert 'Sell' in short_multipliers
+
+    def test_log_line_includes_usdt_fields(self, caplog):
+        """Per-tick DEBUG log line carries upnl/realized/cum_realized/pos_value USDT fields.
+
+        realized_usdt mirrors curRealisedPnl (the UI 'Realized' value);
+        cum_realized_usdt mirrors cumRealisedPnl (lifetime).
+        """
+        risk_config = RiskConfig(
+            min_liq_ratio=0.8,
+            max_liq_ratio=1.2,
+            max_margin=5.0,
+            min_total_margin=1.0,
+        )
+        long_manager, _ = PositionRiskManager.create_linked_pair(risk_config)
+
+        position = PositionState(
+            direction=Position.DIRECTION_LONG,
+            size=Decimal('1.0'),
+            entry_price=Decimal('100000.0'),
+            unrealized_pnl=Decimal('6.37'),
+            cum_realized_pnl=Decimal('123.45'),
+            cur_realized_pnl=Decimal('5.50'),
+            margin=Decimal('2.0'),
+            liquidation_price=Decimal('50000.0'),
+            leverage=10,
+            position_value=Decimal('1500.0'),
+        )
+        opposite = PositionState(
+            direction=Position.DIRECTION_SHORT,
+            size=Decimal('1.0'),
+            entry_price=Decimal('100000.0'),
+            margin=Decimal('2.0'),
+            liquidation_price=Decimal('150000.0'),
+            leverage=10,
+        )
+
+        with caplog.at_level(logging.DEBUG, logger='gridcore.position'):
+            long_manager.calculate_amount_multiplier(
+                position, opposite, last_close=100000.0
+            )
+
+        assert 'upnl_usdt=6.3700' in caplog.text
+        assert 'realized_usdt=5.5000' in caplog.text
+        assert 'cum_realized_usdt=123.4500' in caplog.text
+        assert 'pos_value_usdt=1500.00' in caplog.text
+
+    def test_log_line_unrealized_sign_preserved(self, caplog):
+        """Negative Bybit unrealisedPnl is logged with its sign in upnl_usdt."""
+        risk_config = RiskConfig(
+            min_liq_ratio=0.8,
+            max_liq_ratio=1.2,
+            max_margin=5.0,
+            min_total_margin=1.0,
+        )
+        _, short_manager = PositionRiskManager.create_linked_pair(risk_config)
+
+        short_position = PositionState(
+            direction=Position.DIRECTION_SHORT,
+            size=Decimal('1.0'),
+            entry_price=Decimal('100000.0'),
+            unrealized_pnl=Decimal('-16.74'),
+            cum_realized_pnl=Decimal('0'),
+            cur_realized_pnl=Decimal('0'),
+            margin=Decimal('2.0'),
+            liquidation_price=Decimal('150000.0'),
+            leverage=10,
+            position_value=Decimal('1500.0'),
+        )
+        long_opposite = PositionState(
+            direction=Position.DIRECTION_LONG,
+            size=Decimal('1.0'),
+            entry_price=Decimal('100000.0'),
+            margin=Decimal('2.0'),
+            liquidation_price=Decimal('50000.0'),
+            leverage=10,
+        )
+
+        with caplog.at_level(logging.DEBUG, logger='gridcore.position'):
+            short_manager.calculate_amount_multiplier(
+                short_position, long_opposite, last_close=100000.0
+            )
+
+        assert 'upnl_usdt=-16.7400' in caplog.text
 
 
 class TestRiskConfig:


### PR DESCRIPTION
## Summary

Closes #135. Surfaces USDT-denominated P&L on the `gridcore.position` per-tick DEBUG log line so an external monitor (e.g. `gridbot-health`) can compute net USDT P&L per strat from the log alone — today the logged `margin`/`unrealized_pnl=%` are dimensionless/leveraged and don't convert cleanly to USDT.

New fields on the log line (after `unrealized_pnl=%`):
- `upnl_usdt` — Bybit `unrealisedPnl` (signed USDT)
- `realized_usdt` — Bybit **`curRealisedPnl`** = the Web UI "Realized" column (current cycle); satisfies #135's "match Bybit UI per side" criterion
- `cum_realized_usdt` — Bybit **`cumRealisedPnl`** = lifetime cumulative realized (~80× the UI value), the all-time "is this strat profitable" number
- `pos_value_usdt` — position notional in USDT

`PositionState` gains `cum_realized_pnl` and `cur_realized_pnl`, populated from the Bybit position dict in `_build_position_state`. **Purely additive** — no change to `unrealized_pnl_pct` or any risk-mgmt threshold.

### Note on the cum vs cur distinction
The issue text originally specified only `cumRealisedPnl`, but per `docs/features/0056_PLAN.md` that field is lifetime (~80× UI) and does **not** match the UI "Realized" column — `curRealisedPnl` does. Both are now logged under clearly-named keys.

## Test plan
- [x] gridcore: `PositionState` field defaults/values; caplog test asserts all four USDT keys with distinct cur/cum values (catches a swap) and negative-sign preservation
- [x] gridbot: `_build_position_state` parses `cumRealisedPnl`/`curRealisedPnl` (positive, negative, absent→0, empty→0)
- [x] `uv run pytest packages/gridcore/tests/ apps/gridbot/tests/test_runner.py apps/backtest/tests/test_runner.py` → 662 passed, 1 skipped
- [x] `uv run ruff check` on changed files → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)