### PR TITLE
docs(0061): plan + review for stale risk_limit_info test fix (#143)

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -2229,6 +2229,7 @@ Risk limit tiers determine maintenance margin (MM) and initial margin (IM) rates
 13. **rest_client `get_risk_limit()` structure**: Bybit API returns nested `{"list": [{"list": [tier, ...]}]}`. The parser unwraps the first symbol's inner list. Flat lists (missing inner `"list"` key) return empty `[]` and log an error — they are never passed through as-is.
 14. **_open_lock_file TOCTOU**: Uses `os.lstat()` (not `is_symlink()`) for pre-check and always validates path identity post-open via inode/device comparison, regardless of O_NOFOLLOW support.
 15. **Negative position_value**: `calc_initial_margin` logs a warning and returns zero for negative `position_value` (likely a data error).
+16. **In-process lock registry location**: `_IN_PROCESS_LOCKS` and `acquire_in_process_lock` / `release_in_process_lock` live in `cache_lock.py`, not `risk_limit_info.py`. Integration tests that assert ref-counts must import `backtest.cache_lock`; oversized-cache warnings log `CacheSizeExceededError` text (`"Cache file size"` … `"exceeds"`), not the legacy `"Cache file exceeds"` substring.
 
 ## Risk Limit Cache Format Evolution
 

--- a/docs/features/0061_PLAN.md
+++ b/docs/features/0061_PLAN.md
@@ -1,0 +1,126 @@
+# Feature 0061 — Fix stale failing tests in test_risk_limit_info.py (issue #143)
+
+## Brief
+
+Three pre-existing test failures in `apps/backtest/tests/test_risk_limit_info.py` surfaced during feature 0060 code review (documented in `docs/features/0060_REVIEW.md` lines 57 and 104). They are **unrelated to 0060** — that feature touched `runner.py`, `pnl.py`, `models.py`, and `test_runner.py` only, not `risk_limit_info`.
+
+Repro (expected before fix):
+
+```bash
+uv run pytest apps/backtest/tests/test_risk_limit_info.py -q
+# -> 3 failed, 91 passed
+```
+
+Failing tests:
+
+```
+FAILED apps/backtest/tests/test_risk_limit_info.py::TestRiskLimitProvider::test_load_from_cache_oversized_logs_size_error
+FAILED apps/backtest/tests/test_risk_limit_info.py::TestConcurrentCacheAccess::test_lock_registry_released_when_instances_deleted
+FAILED apps/backtest/tests/test_risk_limit_info.py::TestConcurrentCacheAccess::test_close_then_new_provider_keeps_lock_registry_consistent
+```
+
+These are **stale tests** — they reference internals and log strings from before a module split. Production code is correct; no runtime regression.
+
+## Root cause
+
+### Lock registry tests (2 failures)
+
+The in-process lock registry was moved out of `backtest.risk_limit_info` into `backtest.cache_lock` (see module docstring at `apps/backtest/src/backtest/risk_limit_info.py:6-9` and `apps/backtest/src/backtest/cache_lock.py:25-30`).
+
+- `_IN_PROCESS_LOCKS: dict[str, tuple[threading.Lock, int]]` now lives in `cache_lock.py`.
+- `RiskLimitProvider.__init__` (`risk_limit_info.py:223-225`) calls `acquire_in_process_lock(self.cache_path)` imported from `cache_lock`.
+- `RiskLimitProvider.close()` (`risk_limit_info.py:235-242`) invokes the `weakref.finalize` callback that calls `release_in_process_lock`.
+
+The two concurrent-access tests still imported `backtest.risk_limit_info as risk_limit_info_module` and asserted on `risk_limit_info_module._IN_PROCESS_LOCKS`, causing:
+
+```
+AttributeError: module 'backtest.risk_limit_info' has no attribute '_IN_PROCESS_LOCKS'
+```
+
+### Oversized cache log test (1 failure)
+
+Size validation was extracted into `apps/backtest/src/backtest/cache_validation.py`. The read path is:
+
+1. `RiskLimitProvider._load_cache_entry` (`risk_limit_info.py:315-348`) calls `validate_and_open_cache_file(self.cache_path, self.max_cache_size_bytes)`.
+2. `validate_and_open_cache_file` (`cache_validation.py:76-79`) raises `CacheSizeExceededError` with message:
+   `"Cache file size {fd_stat.st_size} exceeds {max_cache_size_bytes} byte limit"`.
+3. `_load_cache_entry` catches `CacheSizeExceededError` and logs `logger.warning(str(e))` (`risk_limit_info.py:338-339`).
+
+The test `test_load_from_cache_oversized_logs_size_error` (lines 164-175) wrote a file of `provider.max_cache_size_bytes + 1` bytes and asserted the log contained `"Cache file exceeds"`. That substring matched an older log format; the current message starts with `"Cache file size"`.
+
+## Design — test-only fix (no production changes)
+
+Production modules (`cache_lock.py`, `cache_validation.py`, `risk_limit_info.py`) require **no edits**. All work is in the test file (and optionally RULES.md note).
+
+### Step 1 — Fix lock-registry import targets
+
+In `apps/backtest/tests/test_risk_limit_info.py`, class `TestConcurrentCacheAccess`:
+
+**`test_lock_registry_released_when_instances_deleted`** (lines ~740-756):
+
+- Replace `import backtest.risk_limit_info as risk_limit_info_module` with `import backtest.cache_lock as cache_lock_module`.
+- Assert against `cache_lock_module._IN_PROCESS_LOCKS` instead of `risk_limit_info_module._IN_PROCESS_LOCKS`.
+- Keep `key = str(cache_path.resolve())` — this matches the registry key because `RiskLimitProvider` passes `self.cache_path` (already `.resolve()`'d in `__init__` at line 195) to `acquire_in_process_lock`, which uses `key = str(path)` (`cache_lock.py:35`).
+
+**`test_close_then_new_provider_keeps_lock_registry_consistent`** (lines ~758-783):
+
+- Same import and assertion renames.
+- Preserve behavioral checks: ref-count drops to 1 after `provider_a.close()`, closed provider raises on `save_to_cache`, new `provider_c` bumps ref-count back to 2, concurrent writes succeed.
+
+**Do not move these tests to `test_cache_lock.py` for this issue.** `apps/backtest/tests/test_cache_lock.py` already has unit-level registry tests (`TestInProcessLockRegistry`, lines 31-71) that call `acquire_in_process_lock` / `release_in_process_lock` directly. The two failing tests are **integration tests** verifying that `RiskLimitProvider` construction, `close()`, `weakref.finalize`, and GC correctly drive ref-counts through the provider lifecycle. Keeping them in `test_risk_limit_info.py` avoids duplicating provider setup while still targeting the relocated module symbol.
+
+### Step 2 — Fix oversized-cache log assertion
+
+In `test_load_from_cache_oversized_logs_size_error` (lines 164-175):
+
+- Keep setup: write `"x" * (provider.max_cache_size_bytes + 1)` to `cache_path`, call `provider.load_from_cache("BTCUSDT")`, assert `result is None`.
+- Replace the log assertion from an exact/old substring (`"Cache file exceeds"`) to match the current `CacheSizeExceededError` message logged by `_load_cache_entry`:
+
+  Assert **both** `"Cache file size"` and `"exceeds"` appear in at least one caplog record (same pattern already used by `test_save_rejects_oversized_cache` at lines 425 and `test_custom_max_cache_size_enforced` at line 622).
+
+This aligns with `cache_validation.py:77-79` without coupling to the exact numeric size in the message.
+
+### Step 3 — Verification
+
+Run the targeted failing tests:
+
+```bash
+uv run pytest apps/backtest/tests/test_risk_limit_info.py::TestRiskLimitProvider::test_load_from_cache_oversized_logs_size_error \
+  apps/backtest/tests/test_risk_limit_info.py::TestConcurrentCacheAccess::test_lock_registry_released_when_instances_deleted \
+  apps/backtest/tests/test_risk_limit_info.py::TestConcurrentCacheAccess::test_close_then_new_provider_keeps_lock_registry_consistent -q
+```
+
+Then the full file:
+
+```bash
+uv run pytest apps/backtest/tests/test_risk_limit_info.py -q
+# expect: 94 passed
+```
+
+Optionally confirm no regression in the dedicated lock module tests:
+
+```bash
+uv run pytest apps/backtest/tests/test_cache_lock.py -q
+```
+
+### Step 4 — RULES.md (optional, one line)
+
+If not already documented: note under the backtest cache section that `_IN_PROCESS_LOCKS` and lock acquire/release helpers live in `apps/backtest/src/backtest/cache_lock.py`; tests must not import them from `risk_limit_info`. (`RULES.md` already references `cache_lock.py` at lines 2194 and 2243 — add a pitfall only if missing after implementation.)
+
+## Files to change
+
+| File | Change |
+|------|--------|
+| `apps/backtest/tests/test_risk_limit_info.py` | Update 3 tests as above (only file that must change) |
+| `RULES.md` | Optional pitfall note about `_IN_PROCESS_LOCKS` location |
+
+## Files explicitly out of scope
+
+- `apps/backtest/src/backtest/risk_limit_info.py` — already imports from `cache_lock`; no bug
+- `apps/backtest/src/backtest/cache_lock.py` — registry implementation is correct
+- `apps/backtest/src/backtest/cache_validation.py` — size error message is intentional
+- Feature 0060 sources (`runner.py`, `pnl.py`, `models.py`, `test_runner.py`)
+
+## Reference implementation
+
+Commit `92b12b3` ("Fix stale risk limit info tests") on current `main` applies exactly the changes described in Steps 1–2. If that commit is present, issue #143 is resolved; this plan documents the fix for review/audit and for branches that still carry the stale assertions.

--- a/docs/features/0061_PLAN.md
+++ b/docs/features/0061_PLAN.md
@@ -123,4 +123,4 @@ If not already documented: note under the backtest cache section that `_IN_PROCE
 
 ## Reference implementation
 
-Commit `92b12b3` ("Fix stale risk limit info tests") on current `main` applies exactly the changes described in Steps 1–2. If that commit is present, issue #143 is resolved; this plan documents the fix for review/audit and for branches that still carry the stale assertions.
+The changes described in Steps 1–2 have already been applied to `apps/backtest/tests/test_risk_limit_info.py` on `main` (commit "Fix stale risk limit info tests"). Where that fix is present, issue #143 is resolved; this plan documents it for review/audit and for any branch that still carries the stale assertions.

--- a/docs/features/0061_REVIEW.md
+++ b/docs/features/0061_REVIEW.md
@@ -2,14 +2,14 @@
 
 **Plan:** `docs/features/0061_PLAN.md`  
 **Scope:** Fix three stale failures in `test_risk_limit_info.py` after `cache_lock` / `cache_validation` module split (issue #143)  
-**Implementation:** `92b12b3` on `main` (`Fix stale risk limit info tests`)  
+**Implementation:** applied to the test file on `main` (commit `Fix stale risk limit info tests`)  
 **Review pass:** 1
 
 ---
 
 ## Verdict
 
-**Approve.** The merged commit matches the plan’s test-only design: no production edits, correct import targets for `_IN_PROCESS_LOCKS`, and log assertions aligned with `CacheSizeExceededError`. All 94 tests in `test_risk_limit_info.py` and 13 in `test_cache_lock.py` pass. Optional `RULES.md` pitfall (plan Step 4) exists locally but is **not yet committed**; commit or drop before closing #143 documentation-only follow-ups.
+**Approve.** The merged commit matches the plan’s test-only design: no production edits, correct import targets for `_IN_PROCESS_LOCKS`, and log assertions aligned with `CacheSizeExceededError`. All 94 tests in `test_risk_limit_info.py` and 13 in `test_cache_lock.py` pass. The optional `RULES.md` pitfall (plan Step 4) is included in this PR.
 
 ---
 
@@ -24,20 +24,20 @@
 | **2** — Oversized load log assertion | Pass | `test_load_from_cache_oversized_logs_size_error` lines 172–175: `"Cache file size"` and `"exceeds"` in caplog |
 | **2** — Still assert `result is None` | Pass | Line 171 |
 | **3** — Verification | Pass | `uv run pytest apps/backtest/tests/test_risk_limit_info.py -q` → **94 passed**; `test_cache_lock.py` → **13 passed** |
-| **4** — RULES.md pitfall (optional) | Partial | Pitfall #16 present in working tree (`RULES.md:2232`) but **uncommitted** on `main` |
+| **4** — RULES.md pitfall (optional) | Pass | Pitfall #16 added in this PR (`RULES.md:2232`) |
 | **Out of scope** — No prod changes | Pass | Diff touches only `test_risk_limit_info.py` in `92b12b3` |
 
 ---
 
 ## Findings
 
-### N1 — Optional RULES.md not on `main` (Minor — housekeeping)
+### N1 — Optional RULES.md pitfall (Resolved in this PR)
 
-Plan Step 4 adds pitfall #16 under the backtest cache section. The text is correct and matches implementation, but it only exists as an unstaged local edit. Include it in the same PR/commit as `0061_PLAN.md` if you want docs and code fully aligned on `main`.
+Plan Step 4 adds pitfall #16 under the backtest cache section. The text is correct and matches implementation, and it is committed in this PR alongside `0061_PLAN.md`, so docs and the pitfall note land together.
 
-### N2 — Unrelated working-tree noise (Minor — pre-commit cleanup)
+### N2 — Unrelated working-tree change (context note — not part of this PR)
 
-`conf/gridbot_test.yaml` is modified (SOLUSDT `grid_step`) and is **not** part of 0061. Revert or split before any 0061-only commit.
+At review time the working tree also carried an unrelated `conf/gridbot_test.yaml` change (SOLUSDT `grid_step`). It is **not** part of feature 0061 and was deliberately excluded from this PR; it is mentioned here only so a future reader knows it was a separate concern, not an omission.
 
 ### N3 — Incidental diff in fix commit (Note — not a defect)
 
@@ -85,5 +85,5 @@ uv run pytest apps/backtest/tests/test_cache_lock.py -q
 
 ## Recommendation
 
-- **Merge status:** Fix is already on `main` via `92b12b3`; issue #143 is resolved for branches that include that commit.
-- **Follow-up (optional):** Commit `docs/features/0061_PLAN.md`, `RULES.md` pitfall #16, and revert unrelated `conf/gridbot_test.yaml` if preparing a docs-only housekeeping commit.
+- **Merge status:** the fix is already applied to the test file on `main`; issue #143 is resolved on branches that include it.
+- **Follow-up:** this PR commits `docs/features/0061_PLAN.md`, `docs/features/0061_REVIEW.md`, and `RULES.md` pitfall #16. The unrelated `conf/gridbot_test.yaml` change is intentionally not included.

--- a/docs/features/0061_REVIEW.md
+++ b/docs/features/0061_REVIEW.md
@@ -1,0 +1,89 @@
+# Feature 0061 Code Review
+
+**Plan:** `docs/features/0061_PLAN.md`  
+**Scope:** Fix three stale failures in `test_risk_limit_info.py` after `cache_lock` / `cache_validation` module split (issue #143)  
+**Implementation:** `92b12b3` on `main` (`Fix stale risk limit info tests`)  
+**Review pass:** 1
+
+---
+
+## Verdict
+
+**Approve.** The merged commit matches the plan’s test-only design: no production edits, correct import targets for `_IN_PROCESS_LOCKS`, and log assertions aligned with `CacheSizeExceededError`. All 94 tests in `test_risk_limit_info.py` and 13 in `test_cache_lock.py` pass. Optional `RULES.md` pitfall (plan Step 4) exists locally but is **not yet committed**; commit or drop before closing #143 documentation-only follow-ups.
+
+---
+
+## Plan Implementation Check
+
+| Step | Status | Evidence |
+|------|--------|----------|
+| **1** — Lock-registry tests import `cache_lock` | Pass | `test_risk_limit_info.py:742`, `760` — `import backtest.cache_lock as cache_lock_module` |
+| **1** — Assert on `cache_lock_module._IN_PROCESS_LOCKS` | Pass | Lines 749–756, 766–776 |
+| **1** — Registry key `str(cache_path.resolve())` | Pass | Matches `acquire_in_process_lock(self.cache_path)` where `cache_path` is already `.resolve()`'d (`risk_limit_info.py:195`, `cache_lock.py:35`) |
+| **1** — Keep integration tests in `test_risk_limit_info.py` | Pass | Not moved to `test_cache_lock.py`; unit registry tests remain in `test_cache_lock.py:31-71` |
+| **2** — Oversized load log assertion | Pass | `test_load_from_cache_oversized_logs_size_error` lines 172–175: `"Cache file size"` and `"exceeds"` in caplog |
+| **2** — Still assert `result is None` | Pass | Line 171 |
+| **3** — Verification | Pass | `uv run pytest apps/backtest/tests/test_risk_limit_info.py -q` → **94 passed**; `test_cache_lock.py` → **13 passed** |
+| **4** — RULES.md pitfall (optional) | Partial | Pitfall #16 present in working tree (`RULES.md:2232`) but **uncommitted** on `main` |
+| **Out of scope** — No prod changes | Pass | Diff touches only `test_risk_limit_info.py` in `92b12b3` |
+
+---
+
+## Findings
+
+### N1 — Optional RULES.md not on `main` (Minor — housekeeping)
+
+Plan Step 4 adds pitfall #16 under the backtest cache section. The text is correct and matches implementation, but it only exists as an unstaged local edit. Include it in the same PR/commit as `0061_PLAN.md` if you want docs and code fully aligned on `main`.
+
+### N2 — Unrelated working-tree noise (Minor — pre-commit cleanup)
+
+`conf/gridbot_test.yaml` is modified (SOLUSDT `grid_step`) and is **not** part of 0061. Revert or split before any 0061-only commit.
+
+### N3 — Incidental diff in fix commit (Note — not a defect)
+
+`92b12b3` also removes an unused `original_dump = json.dump` binding in `test_temp_file_cleaned_up_on_write_failure` (`~1222`). Harmless cleanup; not mentioned in the plan but improves the test file.
+
+No blocking or non-blocking test or production defects identified.
+
+### Notes (not defects)
+
+- **Log assertion style (load vs save).** Load path uses `"Cache file size"` + `"exceeds"`; save-path tests use `"exceeds"` + `"byte limit"` (`test_save_rejects_oversized_cache:425`, `test_custom_max_cache_size_enforced:622`). Both match the same `CacheSizeExceededError` string from `cache_validation.py:77-79`; the split is intentional per plan and avoids brittle numeric coupling.
+- **Registry integration vs unit tests.** `test_cache_lock.py` exercises acquire/release directly; the two fixed tests still validate `RiskLimitProvider` + `weakref.finalize` + `close()` lifecycle — appropriate layering, no duplication concern.
+- **GC sensitivity.** `test_lock_registry_released_when_instances_deleted` still depends on `gc.collect()` after `del provider_*` — pre-existing pattern; acceptable for integration coverage of finalizers.
+- **Data alignment.** No API shape or naming mismatches; failure mode was purely wrong module symbol and outdated log substring.
+- **Production correctness.** Confirmed: `_load_cache_entry` logs `str(CacheSizeExceededError)` (`risk_limit_info.py:338-339`); registry lives only in `cache_lock.py`.
+
+---
+
+## Unit Test Review
+
+| Area | Assessment |
+|------|------------|
+| Oversized cache on load | Covered — warning substrings + `None` return |
+| Lock ref-count with two providers | Covered — `test_lock_registry_released_when_instances_deleted` |
+| `close()` + new provider ref-count | Covered — `test_close_then_new_provider_keeps_lock_registry_consistent` (incl. closed-provider `RuntimeError`, concurrent writes) |
+| Happy paths / other edge cases | Unchanged — 91 other tests in file still pass |
+| Isolation | Good — `tmp_path`, no network; imports private registry only for integration assertions (same pattern as `test_cache_lock.py`) |
+| Naming / style | Matches existing `TestConcurrentCacheAccess` and caplog patterns |
+| Speed | Full file ~0.47s — no new heavy setup |
+
+No new tests required: this issue restores coverage of existing behavior after refactor, not new functionality.
+
+---
+
+## Commands Run
+
+```bash
+uv run pytest apps/backtest/tests/test_risk_limit_info.py -q
+# 94 passed in 0.47s
+
+uv run pytest apps/backtest/tests/test_cache_lock.py -q
+# 13 passed in 0.01s
+```
+
+---
+
+## Recommendation
+
+- **Merge status:** Fix is already on `main` via `92b12b3`; issue #143 is resolved for branches that include that commit.
+- **Follow-up (optional):** Commit `docs/features/0061_PLAN.md`, `RULES.md` pitfall #16, and revert unrelated `conf/gridbot_test.yaml` if preparing a docs-only housekeeping commit.


### PR DESCRIPTION
## Summary
- Adds audit/review docs for feature 0061 — the fix for three stale failing tests in `apps/backtest/tests/test_risk_limit_info.py` (issue #143) caused by the `cache_lock` / `cache_validation` module split.
- The fix itself is **already on `main`** via `92b12b3` (test-only). This PR is documentation + a RULES.md pitfall, not code.

## Contents
- `docs/features/0061_PLAN.md` — implementation plan (passed an adversarial plan-debate review, 0 findings).
- `docs/features/0061_REVIEW.md` — code review of `92b12b3`: verdict **Approve**, plan implemented exactly, 107 tests pass (94 risk_limit_info + 13 cache_lock).
- `RULES.md` pitfall #16 — records that `_IN_PROCESS_LOCKS` and `acquire_in_process_lock`/`release_in_process_lock` live in `cache_lock.py`, not `risk_limit_info.py`; oversized-cache warnings log the `CacheSizeExceededError` text (`"Cache file size" … "exceeds"`), not the legacy `"Cache file exceeds"`.

## Out of scope
- `conf/gridbot_test.yaml` (unrelated SOLUSDT grid_step change) deliberately excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)