### PR TITLE
Feature 0063: gridbot-health durable cross-restart state (#145)

### DIFF
--- a/docs/features/0063_PLAN.md
+++ b/docs/features/0063_PLAN.md
@@ -1,0 +1,358 @@
+# Feature 0063 — gridbot-health: durable cross-restart monitoring state (issue #145)
+
+## Brief
+
+The `gridbot-health` analyzer (`.claude/skills/gridbot-health/analyze.py`) is windowed and loses per-run context except **all-time peaks**, which today persist in `/tmp/gridbot-health-peaks.json` (`PEAKS_PATH`, line 24) and reset on laptop reboot. For multi-strat `mainnet_live` validation (LTC + SOL), operators need durable evidence of **which safety branches ever fired**, **which rare code paths were exercised**, and an **append-only activity / realized-PnL trend** across runs.
+
+Introduce a **single durable file** at `.claude/skills/gridbot-health/health_state.json` (gitignored via `.claude/`), merge all four ledger sections each run, replace `/tmp` peaks with the `peaks` subsection, add Tables 12–14, extend `--json`, and honor `--no-state` (merge for display, skip disk write). Scope is **only** `analyze.py` + `SKILL.md`; no gridbot/runtime changes.
+
+**Persistence contract:** `peaks` uses extremum merge (re-applying the same window cannot worsen records). `defense_coverage`, `event_coverage`, and `activity` are **additive** under normal **monotonic, near-non-overlapping** windows via the `/tmp` cursor (cron path). Re-processing the same log slice (fixed `--since`, cursor rewind, ad-hoc replay) must not advance durable ledgers — use `--no-state` for display-only replays of a fixed window.
+
+**Known 1-line boundary over-count:** the `/tmp` cursor stores `lines[-1].ts` (`analyze.py:1548`) and `load_window` keeps `ts >= cutoff` (strict `<` at line 112), so the single boundary line reappears at the *start* of the next window. Its contribution to additive ledgers is counted in both runs: `defense_coverage` / `event_coverage` `count` over-increments by **at most one event per boundary**; `first_seen` / `last_seen` are idempotent (min/max); `activity` is unaffected (the boundary line shifts `window_start` so the next sample's bounds differ, no duplicate sample). The replay-guard fingerprint does **not** suppress this — the two windows have different `(window_start, window_end)`. Accept as a known ≤1-event/run skew, **or** advance the cursor to just past `lines[-1].ts` (e.g. `+1µs`) so consecutive windows are strictly disjoint.
+
+**Window fingerprint (replay guard):** After each successful merge, persist root `last_applied_window: {window_start, window_end}` at **microsecond precision** (`%Y-%m-%d %H:%M:%S.%f` via `_fp_key`, see **Timestamp format** below) — matching the `/tmp` cursor precision (`analyze.py:1548`/`87`). This is **deliberately finer** than the display `_ts_key` (`%S`) used for activity-sample `window_start`/`window_end`: the documented over-count analysis (Brief) reasons about cursor behavior at `.%f` granularity, so the guard must compare at the same granularity. Truncating the fingerprint to whole seconds would let two genuinely distinct windows whose boundary lines fall within the same wall-clock second (plausible under burst logging or sub-hourly invocation) collide and wrongly **SKIP** a legitimate additive merge — a silent under-count of Tables 12–14, the opposite of the analyzed over-count. Before merging `defense_coverage`, `event_coverage`, or `activity`, if incoming `(window_start, window_end)` `_fp_key` pair equals `last_applied_window`, **skip** those three merges entirely (Tables 12–14 unchanged for that slice). `merge_peaks_section` still runs (extremum-safe). Operational rule: only the default cursor-advanced path persists Tables 12–14; fingerprint covers the failure mode where `save_health_state` succeeds but the `/tmp` cursor write fails (next run re-reads the same slice — Table 14 no longer duplicates alone; Tables 12–13 are protected too). If **`save_health_state` itself fails**, nothing is persisted (including `last_applied_window`); the cursor is not advanced (see **Atomic persistence order**). A retry on the same log slice may double-count additive ledgers — see Testing / verification.
+
+**Atomic persistence order:** In `main()`, when persisting: `save_health_state(merged)` first, then write cursor **only if** state save succeeded. Never advance the cursor without a successful state write. Empty window: no disk writes, no metadata bump, no cursor write. `save_health_state` **must signal failure** (raise / return `False`) so the cursor gate is real — it must **not** swallow `OSError` the way `save_peaks` (lines 287–291) does; see Phase 1.4.
+
+Also track **`max_position_ratio`** in peaks (issue comment): mirror existing `min_position_ratio` with `max` merge op and a second Table 8 row.
+
+**Out of scope:** restart/incident narrative history, config-change ledger, per-tick metric duplication.
+
+---
+
+## Files to change
+
+| File | Role |
+|------|------|
+| `.claude/skills/gridbot-health/analyze.py` | State I/O, merge helpers, window extractors, Table 8 extension, Tables 12–14, `main()` / `to_json()`, `parse_args()` `--no-state` help text |
+| `.claude/skills/gridbot-health/SKILL.md` | Document `health_state.json`, four sections, Tables 12–14; remove "Resets if /tmp is wiped" for Table 8 |
+| `.claude/skills/gridbot-health/test_analyze.py` | **New (gitignored local-only test aid, not committed)** — pytest unit tests for the pure merge/IO helpers (Phase 8); lives in the gitignored `.claude/` tree like `analyze.py`/`SKILL.md` themselves; run via `uv run pytest .claude/skills/gridbot-health/test_analyze.py` |
+
+No new runtime dependencies (stdlib `json` + `os`/`pathlib` + `re`, all already imported). The config-first symbol→strat_id map (Phase 5.1) does **not** add PyYAML — it reuses the dependency-free regex scan of `CONFIG_PATH` already established by `_read_config_thresholds` (`analyze.py:32–`).
+
+---
+
+## Constants and paths
+
+- Add `SKILL_DIR = Path(__file__).resolve().parent` and `HEALTH_STATE_PATH = SKILL_DIR / "health_state.json"`.
+- Keep `PEAKS_PATH` only for **one-time import** (`/tmp/gridbot-health-peaks.json`); remove as the active write target.
+- `CURSOR_PATH` (`/tmp/gridbot-health-cursor`, line 23) unchanged — window cursor stays in `/tmp` by design.
+
+**Timestamp format (single canonical form for durable state):** All timestamps written into `health_state.json` — root metadata (`tracking_started`, `last_updated`, `last_window_end`), `last_applied_window`, activity sample `window_start` / `window_end`, defense/event `first_seen` / `last_seen`, and peak entry `ts` fields — use `line.ts.strftime("%Y-%m-%d %H:%M:%S")` (same as `find_window_extremes` line 225 and existing `merge_peaks` `now_iso` at line 1530). Do **not** use `datetime.isoformat()` for any persisted or fingerprint-compared field (mixed formats break string equality on the replay guard). Helper: `_ts_key(ts: datetime) -> str` returning that `%S`-granularity strftime, used for **display/ledger** fields — activity samples' `window_start`/`window_end`, defense/event `first_seen`/`last_seen`, event timestamps. **Separate helper `_fp_key(ts: datetime) -> str` returning `ts.strftime("%Y-%m-%d %H:%M:%S.%f")` (microsecond precision, matching the cursor) is used only for the replay-guard fingerprint** — `last_applied_window.{window_start,window_end}` and the incoming `window_fingerprint` pair (Phase 6). Fingerprint precision must match the cursor (`analyze.py:1548`) so distinct sub-second-apart windows do not collide and silently skip an additive merge. `to_json()` may keep `isoformat()` on its top-level `"window"` object for backward compatibility — that output is display/API only and is not compared to `last_applied_window`.
+
+Default empty state shape (when file is **missing** — first run / reboot import; a **corrupt** file is handled separately, see Phase 1.1 fail-closed):
+
+- `schema_version: 1` — only a **missing** `schema_version` triggers legacy normalization (1.1, the `/tmp` peaks-only file). A future bump (`>= 2`) needs an explicit migration step; out of scope for v1, but `load_health_state` should leave a comment marking where that branch goes so it isn't forgotten.
+- `tracking_started`, `last_updated`, `last_window_end` (ISO-ish strings matching existing `"%Y-%m-%d %H:%M:%S"` style used in `merge_peaks` line 266)
+- `last_applied_window: {window_start, window_end}` — null when no additive merge applied yet; set when defense/event/activity merges run for a window
+- `peaks: {}`
+- `defense_coverage: {}`
+- `event_coverage: {}` — pre-seed **exactly these keys**, each `{count: 0, first_seen: null, last_seen: null}` (+ `autoclear_ok: null` only on `same_order_ws_glitch`): `same_order_ws_glitch`, `same_order_real_dup`, `same_order_unknown`, `same_order_crosscheck_failed`, `oob_rebuild`, `bootstrap_anomaly`, `error_network`, `error_pybit_ws`, `error_clock_drift`, `error_grid_state_writer`, `error_other`, `ws_disconnect`, `restart`. **Do not** seed `error_same_order` or `error_qty_zero` — `_categorize_error` (`analyze.py:296–319`) emits only `network` / `pybit_ws` / `clock_drift` / `grid_state_writer` / `other`. Most `same_order` incidents are covered by the three 0031 verdict keys, **with one carve-out**: the REST cross-check FAILURE path at `runner.py:1595–1598` logs `{strat_id}: SAME ORDER REST cross-check failed (diagnostic only, ignoring): {e}` at **ERROR** level with **no `verdict=` token**, so `verdict_events` / `verdict_breakdown` never capture it (they key off `verdict=(WS_GLITCH_SUSPECTED|REAL_DUPLICATE|UNKNOWN)`). `_categorize_error` returns `same_order` for it (msg contains "SAME ORDER"). This genuine failure path (REST cross-check raised, soft-block left latched, cache left UNKNOWN) would otherwise be recorded in **no** durable key — hence the dedicated `same_order_crosscheck_failed` key (Phase 4.1 carves it out of the blanket same_order skip). This is the closed key set — there is no external issue schema to consult.
+- `activity: {max_samples: 720, samples: []}`
+
+---
+
+## Phase 1 — Unified health state I/O (replaces peaks-only persistence)
+
+### 1.1 `load_health_state() -> dict`
+
+Returns the state dict. Because `health_state.json` is now the **sole durable record** across reboots, distinguish two read failures and fail **closed** on corruption:
+
+- **File MISSING** (`not HEALTH_STATE_PATH.exists()`): could be a legitimate first run / reboot import **or** the deferred tail of a prior corruption. Before returning the default-with-save-allowed, check the quarantine latch `SKILL_DIR / "health_state.json.corrupt"`:
+  - **(a) `.corrupt` EXISTS while main file is missing** — a prior run quarantined a corrupt file (moved it to `.corrupt`) and the operator has **not** yet repaired/removed it. This is the persistent latch: **FAIL CLOSED**. Return the default flagged `state["_load_corrupt"] = True` (reuse the same private marker so `main()` already skips both `save_health_state` and the cursor write — Phase 1.4 / Algorithms step 8), and print a **distinct** stderr warning: `WARNING: health_state.json missing but health_state.json.corrupt present — refusing to re-initialize and erase history; inspect/restore or delete the .corrupt file to resume durable tracking.` Without this latch the corrupt-gate would protect only the run that quarantined the file: the *next* cron tick sees the main file gone (it was moved), takes the first-run path, writes a fresh **empty** state and advances the cursor — permanently erasing Tables 8/12/13/14, the exact failure the gate prevents, merely deferred one tick.
+  - **(b) `.corrupt` does NOT exist while main file is missing** — genuine first run / reboot import. Return the default empty state (above). Saving is allowed this run.
+  - **Latch clearing:** the latch clears when the operator removes/renames `health_state.json.corrupt` **or** restores a valid `health_state.json`. If **both** a valid main file and `.corrupt` exist, the **PRESENT-file path wins** and loads normally — `.corrupt` only gates the MISSING case (it is not consulted when the main file parses).
+- **File PRESENT but `json.loads` raises, OR top-level parsed value is not a `dict`**: this is **corruption** (disk error, manual edit, partial write from a pre-atomic version). Do **not** silently fall back to the empty default — that would let the next `save_health_state` overwrite the corrupt-but-recoverable file and erase all accumulated ledgers (Tables 8/12/13/14). Instead:
+  - Print a clear stderr warning (e.g. `WARNING: health_state.json unparseable — preserving as health_state.json.corrupt, skipping save this run`).
+  - Move the bad file to a sibling `health_state.json.corrupt` in `SKILL_DIR` via `os.replace(HEALTH_STATE_PATH, SKILL_DIR / "health_state.json.corrupt")` (overwrite any existing `.corrupt` — single-slot, latest corruption wins; `os.replace` is atomic and clobbers).
+  - Return the default empty state **flagged as corrupt** so the caller can fail closed: set `state["_load_corrupt"] = True` (a private, non-persisted marker; strip it before any save). `main()` checks this flag (Phase 1.4 / Algorithms step 8) and **skips both** `save_health_state` and the cursor write for this run — never advance durable state on top of a corruption event.
+- Normalize (only on a successfully-parsed dict): if top-level keys look like legacy peaks-only file (`min_liq_distance` at root without `schema_version`), wrap into `peaks` subsection (defensive; primary migration is `/tmp` import).
+
+### 1.2 `import_legacy_peaks(state: dict) -> dict`
+
+- If `PEAKS_PATH.exists()` and `state["peaks"]` is empty (no keys other than optional metadata):
+  - `json.loads` legacy file; move peak keys (`min_liq_distance`, `max_abs_pnl_pct`, `min_position_ratio`, `max_position_ratio`, `min_total_margin`, `max_multiplier`) into `state["peaks"]`.
+  - Copy `tracking_started` from legacy top-level if present.
+  - `state.pop("min_liq_ratio", None)` handled later in peak merge (existing line 277 behavior).
+
+### 1.3 Peak merge (refactor `merge_peaks` → `merge_peaks_section`)
+
+- Operate on `state["peaks"]` + `find_window_extremes()` output (`analyze()` line 790 → `window_peaks`).
+- `op_for` map (lines 267–272) extended with `"max_position_ratio": "max"`.
+- Preserve side label on `min_liq_distance` wins (window dict already includes `"side"` at lines 236–238).
+- Root metadata: set `tracking_started` on first merge (line 265–266 logic); always update `last_updated` and `last_window_end` to current run’s window end (from `lines[-1].ts` in `main()`).
+
+### 1.4 `save_health_state(state)` / `load_health_state` wiring in `main()`
+
+Replace block at lines 1526–1534:
+
+```text
+stored = load_health_state()
+stored = import_legacy_peaks(stored)
+merged = merge_health_state(stored, contributions, now_iso, window_end_iso)
+a["merged_peaks"] = merged["peaks"] wrapped with tracking_started for Table 8 footer
+a["health_state"] = merged
+if not args.no_state and lines and not stored.get("_load_corrupt"):
+    save_health_state(merged)   # strip "_load_corrupt" before dumping
+```
+
+**Corrupt-load gate:** when `load_health_state` returned a state flagged `_load_corrupt` (Phase 1.1), `main()` skips **both** `save_health_state` and the cursor write for this run (fail closed — do not advance durable state on top of corruption), prints the warning, and proceeds to render tables for display only. The `_load_corrupt` marker is private and must be stripped (e.g. `merged.pop("_load_corrupt", None)`) before any `json.dumps`.
+
+- Delete `save_peaks` / direct `PEAKS_PATH` writes.
+- Table 8 continues to read `a.get("merged_peaks")` (lines 1219–1262) but peaks dict is the `peaks` subsection plus `tracking_started` copied from root for the `_tracking since …_` footer (line 1260–1262).
+
+**`save_health_state(state)` requirements (differs from `save_peaks`):**
+
+- **Propagate failure.** Do **not** copy `save_peaks`'s silent `except OSError: pass` (lines 287–291). Either let `OSError` raise, or return a `bool`. The "write cursor only on successful save" guarantee (Atomic persistence order) is a no-op unless the caller can detect a failed save. In `main()`: on raise / `False`, **skip the cursor write** and print a stderr warning (mirror the existing cursor-failure warning at lines 1549–1551).
+- **Atomic write.** `health_state.json` is now the **sole durable record across reboots**. Write to a temp file in the **same directory** (`SKILL_DIR`) and `os.replace()` it into place, so a crash mid-`json.dumps`/write cannot truncate the live file. A truncated/corrupt file makes `load_health_state` (1.1) fall back to the empty default → silent loss of all accumulated ledgers (Tables 8/12/13/14 reset to zero). The legacy `/tmp` peaks file tolerated this because it was disposable; the durable file does not.
+
+### 1.5 `max_position_ratio` in `find_window_extremes` (lines 210–249)
+
+- In the `_PR_RE.findall` loop (lines 243–244), add `upd("max_position_ratio", float(v), ts_str, "max")` alongside existing `min_position_ratio` min op.
+
+### 1.6 Table 8 render (lines 1234–1248)
+
+- Insert row after min position_ratio:
+  - Label: `max position_ratio (deepest long-heavy imbalance)`
+  - Key: `max_position_ratio`
+
+---
+
+## Phase 2 — `_classify_defense` refactor (Table 9 byte-identical)
+
+Extract lines 549–560 from `_analyze_defenses_per_strat` into:
+
+```text
+def _classify_defense(raw_type: str) -> str | None:
+```
+
+- Same branching: `EMERGENCY` / `high` / `moderate` / `low_margin` / `risk_mgmt` (`increasing` + `ratio=`) / else `None`.
+- `_analyze_defenses_per_strat` (lines 520–563): call `_classify_defense(m.group(2).strip())`; if `None`, `continue`; else increment bucket — **no other logic changes** so Table 9 markdown (lines 1272–1327) stays identical for a given window.
+
+---
+
+## Phase 3 — Defense coverage ledger (`defense_coverage`)
+
+### 3.1 Window extraction: `_collect_defense_events(lines)`
+
+- Reuse `_walk_strat_attributed(lines, is_adjust)` (lines 418–457) where `is_adjust` matches `_analyze_defenses_per_strat` (lines 540–543).
+- Yield `(strat_id, direction, defense_type, ts_iso)` with `ts_iso = l.ts.strftime("%Y-%m-%d %H:%M:%S")` from the **adjustment line** (not window end).
+- Defense types: `low_margin`, `risk_mgmt`, `moderate`, `high`, `EMERGENCY`.
+
+### 3.2 Window boost map
+
+- Reuse `boost_per_strat` from `analyze()` (line 644, `_analyze_boost_per_strat` lines 460–489): `{strat: {long|short: bool}}` for same-side mult > 1.0 in window.
+
+### 3.3 `merge_defense_coverage(stored, events, boost_per_strat, window_fingerprint) -> dict`
+
+- Nested structure: `stored[strat][side][defense_type] -> {count, first_seen, last_seen, boost_confirmed?}`.
+- Per `(strat, side)` latched flags live under **`stored[strat][side]["_meta"]`** (not a defense_type key):
+
+```json
+"defense_coverage": {
+  "LTC": {
+    "long": {
+      "_meta": {
+        "defense_low_or_risk_ever": false,
+        "boost_ever_seen": false
+      },
+      "low_margin": { "count": 0, "first_seen": null, "last_seen": null, "boost_confirmed": false }
+    }
+  }
+}
+```
+
+- For each event: increment `count`; `first_seen = min(ts)`; `last_seen = max(ts)` (string compare OK if fixed format).
+- **Latched all-time `boost_confirmed`** (low_margin / risk_mgmt only): update `_meta.defense_low_or_risk_ever` after any window with a `low_margin` or `risk_mgmt` event for that pair; update `_meta.boost_ever_seen` after any window where `boost_per_strat[strat][side]` is true (including windows with no adjustment line). Set per-row `boost_confirmed` true when **both** `_meta` flags are true — they need not occur in the same window. Once true, stays true. Table 12 render skips `_meta` keys.
+- If `window_fingerprint` matches `stored["last_applied_window"]` at orchestration time, caller skips this merge (see Phase 6).
+
+### 3.4 Table 12 — render after Table 11 (before `f0040_fail` / итог, ~line 1414)
+
+- Title: `### Table 12: Liquidation defense coverage (all-time)`
+- Columns: Strat | Side | defense_type | count | first_seen | last_seen | boost_confirmed (✅/➖, only for low_margin/risk_mgmt)
+- One row per (strat, side, type) present in merged state; placeholder row when `defense_coverage` empty: `(no defense events yet)`.
+- Sort: strat, side, fixed column order low_margin → risk_mgmt → moderate → high → EMERGENCY.
+- **Label `boost_confirmed` as "ever", not causation.** It latches from the two all-time `_meta` flags, which need not co-occur in the same window (Phase 3.3) — unlike Table 9, which correlates trigger + mult-shift within one window. Header tooltip / footnote must read "defense ever fired AND mult ever >1.0 for this pair" so an operator does not read it as "this defense caused this boost".
+
+---
+
+## Phase 4 — Rare-event coverage ledger (`event_coverage`)
+
+### 4.1 Window snapshot builder `_build_event_coverage_window(a, lines) -> dict[str, list[datetime]]`
+
+Map analyze outputs + targeted line scans to schema keys; collect **event timestamps** (not just counts) for `first_seen` / `last_seen`:
+
+| Key | Source |
+|-----|--------|
+| `same_order_ws_glitch` | Reuse `a["verdict_events"]` from `analyze()` (lines 737–743): **one timestamp per 60s burst**, not per matching log line. `autoclear_ok` per burst: any `soft-block auto-cleared` within 60s (lines 744–749) |
+| `same_order_real_dup` | Reuse `verdict_breakdown` clustering (lines 751–768): emit **one timestamp per logical REAL_DUPLICATE** (first line of each 60s same-kind cluster) |
+| `same_order_unknown` | Same 60s clustering as `verdict_breakdown` for `UNKNOWN` |
+| `oob_rebuild` | `"Restored grid out of range"` (same as `_analyze_0048` line 344) |
+| `bootstrap_anomaly` | `"Bootstrap grid snapshot anomaly"` (`_analyze_0047` line 588) |
+| `same_order_crosscheck_failed` | ERROR lines where `_categorize_error == "same_order"` **and** message contains `cross-check failed` (`runner.py:1595–1598`, no `verdict=` token — not captured by verdict keys). See ERROR algorithm below |
+| `error_network`, `error_pybit_ws`, `error_clock_drift`, `error_grid_state_writer`, `error_other` | See ERROR algorithm below (no `error_same_order` key) |
+| `ws_disconnect` | `"Detected disconnection"` (line 619) |
+| `restart` | `"Loaded configuration"` (line 594) |
+
+**ERROR lines (deterministic, no double-count with verdict keys):** For each ERROR-level line in `lines`, `cat = _categorize_error(message)`. If `cat == "same_order"`, do **not** blanket-skip: check whether the message contains `cross-check failed` (equivalently `cross-check` + `failed`) — if so, append `line.ts` to `same_order_crosscheck_failed` (this is the `runner.py:1595–1598` failure path that carries no `verdict=` token and is therefore captured by **no** 0031 verdict key); otherwise **skip** (the success-path same_order incidents are already covered by `same_order_ws_glitch` / `same_order_real_dup` / `same_order_unknown`, which parse `verdict=`). For all other `cat`: map `network`→`error_network`, `pybit_ws`→`error_pybit_ws`, `clock_drift`→`error_clock_drift`, `grid_state_writer`→`error_grid_state_writer`, `other`→`error_other`; append `line.ts` to that key’s timestamp list.
+
+Per key merge: `count += len(timestamps)`; update first/last seen. For `same_order_ws_glitch`, merge `autoclear_ok`: false if any burst lacked clear; true if all bursts cleared when count > 0; null when count 0.
+
+### 4.2 `merge_event_coverage(stored, window_events, window_autoclear_ok) -> dict`
+
+- Additive counter merge on fixed key set (initialize missing keys); under normal cursor-advanced windows only.
+- **Implementation note:** the replay-guard fingerprint check is hoisted to the orchestrator (`merge_health_state` only calls this when `not replay` — Phase 6), so the third parameter is **not** the fingerprint but `window_autoclear_ok` (the per-window all-cleared verdict the autoclear latch in Phase 4.1 needs). The replay skip still happens — just one level up.
+- The caller (`merge_health_state`) skips this merge entirely when the incoming `window_fingerprint` matches `stored["last_applied_window"]` (see Phase 6 / Brief fingerprint).
+
+### 4.3 Table 13 — render after Table 12
+
+- Columns: Event | count | first_seen | last_seen | ever seen (✅ if count>0 else ➖) | Notes (e.g. autoclear ✅/❌ for ws_glitch)
+- Human-readable event labels matching schema keys; include a `same_order_crosscheck_failed` row labelled e.g. `SAME ORDER REST cross-check failed (soft-block latched, cache UNKNOWN)` so this otherwise-invisible failure path is operator-visible.
+- Placeholder when all counts zero.
+
+---
+
+## Phase 5 — Activity / realized trend (`activity`)
+
+### 5.1 `_analyze_activity_per_strat(lines) -> dict[str, dict]`
+
+- Count per `strat_id` in window:
+  - **fills**: `gridbot.runner` / `gridbot.orchestrator` lines matching `_STRAT_PREFIX_RE` and `"Order filled"` in message (pattern from `runner.py`: `{strat_id}: Order filled:`).
+  - **placements**: lines on logger `gridbot.executor` matching a **new** regex `_PLACE_SYM_RE` — the **repo-owned, version-stable** placement log emitted at `executor.py:196`: `Placed {Buy|Sell} order: {SYMBOL} qty=… price=… order_id=… link_id=…`. This line fires only on **successful** placement and carries the **symbol**. It is prefix-less (no `{strat_id}:`), so attribute by symbol (below); do **not** require a strat prefix.
+    - **Do NOT use the `Placing Limit (Buy|Sell) order: {SYMBOL}` line for Table 14.** That line is emitted by the **vendored** `bybit_adapter.rest_client` (it has no producer anywhere in the repo source tree — it exists only in the live log) and is an *attempt*, not a confirmed placement. Tables 2/3 still parse `Placing Limit` via `_PLACE_SIDE_RE` (see their isolation rationale — leave them untouched); Table 14's activity ledger uses the repo-owned `Placed` line instead, so its count is version-stable and counts successes.
+  - **Placement attribution (by symbol — exact, not temporal):** add a **new** regex `_PLACE_SYM_RE = re.compile(r"Placed (Buy|Sell) order:\s+(\S+)")` (group 1 = side, group 2 = `SYMBOL` e.g. `LTCUSDT`), matched against `gridbot.executor` lines. **Do not mutate `_PLACE_SIDE_RE`** — it is shared by the Fill→Contra path (`analyze.py:677`) and the Table 2 / Table 3 `Placing Limit` counts; it must stay exactly as-is.
+  - **Build the `symbol → strat_id` map config-FIRST, log-derived fallback** — a placement-only or sparse window (placements present but no `{strat_id}:` markers, no fills, no `pnl_per_strat` keys) yields an **empty** window-seen set, so a log-only map would bucket valid LTCUSDT/SOLUSDT placements as `"unknown"` even though `conf/gridbot_test.yaml` has the exact mapping. Therefore:
+    1. **Config map (primary):** add helper `_config_symbol_map() -> dict[str, str]` that reads `CONFIG_PATH` (the existing constant at `analyze.py:27–29`, `conf/gridbot_test.yaml`) and builds `{ entry["symbol"].upper(): entry["strat_id"] }` from the `strategies:` list (e.g. `LTCUSDT → ltcusdt_test`, `SOLUSDT → solusdt_test`). These fields need **no** env-var substitution (only `api_key`/`api_secret`/`database_url` use `${…}`), so plain parsing of the `strategies:` block suffices. **No new dependency:** PyYAML is **not** an analyzer dependency — mirror the existing dependency-free pattern in `_read_config_thresholds` (`analyze.py:32–`), which already regex-scans this same YAML for the 0040 knobs. Reuse that file read; extract `strat_id` + `symbol` pairs with a small regex over the `strategies:` block (each strategy item has a `strat_id:` and a `symbol:` line). On unreadable/missing file or parse failure: warn once to stderr, return `{}`, and rely entirely on the fallback (do not crash).
+    2. **Log-derived fallback (secondary):** for any `SYMBOL` **not** present in the config map, fall back to window-seen strat_ids — collect the set from `_STRAT_PREFIX_RE` markers on `gridbot.runner` / `gridbot.orchestrator` lines (union with `fills` and `pnl_per_strat` keys), then map the `SYMBOL` to the strat_id whose name **starts with** `SYMBOL.lower()`. Each strat trades a distinct symbol, so this is exact and order-independent.
+    3. If neither config nor window-seen strat_id matches the symbol, bucket as `"unknown"`.
+    - Config-path resolution: use the existing module-level `CONFIG_PATH` constant (already an absolute path to `conf/gridbot_test.yaml`); no new constant needed. State in **Files to change** that no new runtime dependency is introduced (dependency-free YAML scan, same as `_read_config_thresholds`).
+  - **Why not temporal / "last strat marker" attribution:** placements fire from `_execute_intents` inside `on_ticker` (`runner.py:514`), `on_execution` (592), and `on_order_update` (640). The `{strat_id}:` prefix is emitted by `on_position_update`'s `Position update -` marker (`runner.py:739`) and `Order filled` (582) — **not** by the happy-path ticker handler; the orchestrator logs a strat prefix only on *errors* (`orchestrator.py:404` / `489`). So a ticker-triggered placement has no preceding same-strat marker, and under interleaved LTC+SOL the most recent prefixed line frequently belongs to the *other* strat → silent misattribution. A 90 s look-back window makes a wrong-strat hit *more* likely, not less. Symbol-based mapping sidesteps this entirely — which matters precisely because multi-strat is this feature's motivation.
+- Union strat keys from fills, placements, and `pnl_per_strat`.
+- **Reconciliation caveat (placements):** Table 14's per-strat `placements` count **successful** placements from the repo-owned `Placed …` line (`gridbot.executor`, `_PLACE_SYM_RE`). Table 3's placement count uses `"Placing Limit" in msg` (`analyze.py:616`) on the **vendored** `rest_client` *attempt* line. The two differ on **two axes**: (a) **format** — different producers/loggers (`gridbot.executor` `Placed` vs `bybit_adapter.rest_client` `Placing Limit`); (b) **success vs attempt** — `Placed` fires only on confirmed placement, `Placing Limit` on every attempt (an attempt that errors/retries logs `Placing Limit` but no `Placed`). So Table 14's summed per-strat `placements` may differ from Table 3's window count in **either** direction is not expected — typically `<=` (attempts ≥ successes), but the format difference means they are not strictly comparable. Note both axes in the Table 14 footnote rather than forcing reconciliation.
+- **Reconciliation caveat (fills):** the per-strat `fills` here require both `_STRAT_PREFIX_RE` **and** `"Order filled"` on a `gridbot.runner` / `gridbot.orchestrator` line, whereas `analyze()`'s window `fills` list (`analyze.py:667`) matches `"Order filled" in l.message` with **no logger or strat-prefix filter**. The real line is `{strat_id}: Order filled: …` on `gridbot.runner` (`runner.py:582`), so the stricter per-strat filter is correct for attribution, but any unattributable / non-prefixed fill line is excluded. Therefore the **summed per-strat `fills` (Table 14) may be `<=` the window `fills` count in Table 2** — analogous to the placement caveat above; note it in the Table 14 footnote so a per-strat total below Table 2's count is not read as a bug.
+
+### 5.2 Sample record in `main()`
+
+After `analyze(lines)`, build one sample. The per-strat key set is the **union** of strats seen in `fills`, `placements`, and `pnl_per_strat` (Phase 5.1). Realized/pos_value come from `pnl_per_strat`, which `_analyze_pnl_per_strat` (`analyze.py:376–415`) **only populates for strats whose `gridcore.position` lines carry post-#135 USDT fields** (`_USDT_FIELDS_RE`); on a pre-#135 window (the Table 11 placeholder path, `analyze.py:1372–1375`) `pnl_per_strat` is empty even though fills/placements exist. So the USDT fields **must be None-guarded and emit `null` (not `0.0`)** when a strat is absent from `pnl_per_strat`, mirroring the `long_d or short_d` NET-row guard at `analyze.py:1394–1408`. `null` lets Table 14 distinguish "no USDT data this window" from "genuinely zero realized".
+
+```text
+sample = {
+  "window_start": _ts_key(lines[0].ts),
+  "window_end": _ts_key(lines[-1].ts),
+  "per_strat": {}
+}
+for strat_id in union(fills, placements, pnl_per_strat):
+    p = pnl_per_strat.get(strat_id, {})          # may be {}
+    long_d, short_d = p.get("long"), p.get("short")
+    if long_d or short_d:                          # at least one side has USDT data
+        realized = (long_d["realized"] if long_d else 0.0) + (short_d["realized"] if short_d else 0.0)
+        cum      = (long_d["cum_realized"] if long_d else 0.0) + (short_d["cum_realized"] if short_d else 0.0)
+        pos_val  = (long_d["pos_value"] if long_d else 0.0) + (short_d["pos_value"] if short_d else 0.0)
+    else:                                          # pre-#135 / no USDT line for this strat
+        realized = cum = pos_val = None
+    sample["per_strat"][strat_id] = {
+        "fills": fills.get(strat_id, 0),
+        "placements": placements.get(strat_id, 0),
+        "realized_usdt_net": realized,             # null when no USDT data
+        "cum_realized_usdt_net": cum,              # null when no USDT data
+        "pos_value_usdt": pos_val,                 # null when no USDT data
+    }
+```
+
+- NET sum logic mirrors Table 11 lines 1392–1408 (only sum sides actually present; absent side contributes 0.0, but **all-sides-absent → null**).
+- Table 14 render must treat `null` USDT fields as `—` (not `0.0000`) and `merge_activity` must preserve `null` (no `+`/`sum` over it).
+- Skip append if `not lines` (empty window).
+- `merge_activity(stored, sample, window_fingerprint)`: dedup **solely** on the microsecond `window_fingerprint` (`_fp_key` pair) vs `stored["last_applied_window"]` — if it matches, skip append; else append; if `len(samples) > max_samples` (default 720), drop oldest from front. After a successful defense/event/activity merge pass, set `last_applied_window` to the fingerprint (Phase 6). **Do NOT add a secondary `last sample has same (window_start, window_end)` check:** the sample's own `window_start`/`window_end` are written with `_ts_key` (second precision, lines ~220–221), so two genuinely distinct windows whose boundary lines fall within the same wall-clock second would spuriously match on that branch and SKIP the append — re-introducing the exact silent Table-14 under-count this fingerprint fix eliminates, just via the OR branch. The single microsecond-precision fingerprint guard is authoritative; the two guards must not disagree (see **Timestamp format**: `merge_activity` dedup uses `_fp_key` microsecond precision, never `_ts_key` second precision).
+
+### 5.3 Table 14 — render after Table 13
+
+- Compact view: last **up to 12** samples (or last 24h if sample timestamps parseable) showing per-strat `fills`, window duration → `fills/hour`, latest `cum_realized_usdt_net` and `pos_value_usdt`.
+- One summary row per strat across retained series (min/max fills/hour optional).
+- Placeholder: `(no activity samples yet)`.
+- Full series only in JSON (`health_state.activity.samples`).
+- **Footnote:** retention = `max_samples` (720) windows ≈ 30 days at the hourly cron cadence; proportionally shorter if invoked more frequently. Placement counts are symbol-attributed (see Phase 5.1) from the repo-owned `Placed …` success line (`gridbot.executor`); they are **not directly comparable** to Table 3's `Placing Limit` *attempt* count (different producer/format AND success-vs-attempt — see Phase 5.1 reconciliation caveat). Per-strat `fills` are strat-prefix-filtered and may sum `<=` Table 2's window fills count (unattributable / non-prefixed fill lines excluded — Phase 5.1 fills caveat). `null` realized/cum/pos_value cells render as `—` (pre-#135 window with no USDT data for that strat), distinct from a genuine `0.0000`.
+
+---
+
+## Phase 6 — `merge_health_state` orchestration
+
+Build `window_fingerprint = (_fp_key(lines[0].ts), _fp_key(lines[-1].ts))` when `lines` non-empty (microsecond precision — see **Timestamp format** / **Window fingerprint**; do **not** use `_ts_key` here or sub-second-apart distinct windows can collide); store the same pair in `last_applied_window` as `{window_start, window_end}`. `replay = (window_fingerprint == (stored["last_applied_window"]["window_start"], stored["last_applied_window"]["window_end"]))` when `last_applied_window` is non-null.
+
+Single function (or inline sequence in `main`) calling, in order:
+
+1. `merge_peaks_section` — always (extremum-safe)
+2. If not `replay`: `merge_defense_coverage` (defense events + `a["boost_per_strat"]`)
+3. If not `replay`: `merge_event_coverage` (`a` + `lines`)
+4. If not `replay`: `merge_activity` (sample dict); then set `last_applied_window = window_fingerprint`
+
+Update root `last_updated` / `last_window_end` only when `lines` is non-empty (same guard as cursor write). `last_applied_window` updates only when step 4 runs (additive merges applied).
+
+---
+
+## Phase 7 — `--json` and CLI
+
+### `to_json()` (lines 1438–1511)
+
+- Add top-level `"health_state": a.get("health_state")` (full merged object including all four sections).
+- Keep `"all_time_extremes"` for backward compatibility **or** alias to `health_state` peaks + tracking fields — prefer documenting both: `all_time_extremes` = peaks + `tracking_started` (same shape Table 8 uses today) to avoid breaking existing automation.
+
+### `parse_args()` / SKILL.md
+
+- Update `--no-state` help (lines 61–62) from cursor-only to: `Skip writing cursor and health_state.json (still merge for display/JSON).`
+- Clarify `--no-state`: skips **both** cursor write (lines 1546–1551) and `health_state.json` write; still computes merged state for tables and JSON. Required for fixed-window replays so durable ledgers are not inflated.
+
+---
+
+## Algorithms (step-by-step per run)
+
+1. `resolve_cutoff` → `load_window` → `analyze(lines)` (unchanged).
+2. `stored = import_legacy_peaks(load_health_state())`.
+3. Build window contributions: `window_peaks`, defense events, event timestamps, activity sample.
+4. `merged = merge_health_state(stored, contributions, now, window_end)`.
+5. Attach `a["merged_peaks"]`, `a["health_state"]`.
+6. `print(render(...))` — Tables 1–11 unchanged except Table 8 extra row; then 12–14.
+7. If `--json`, emit merged `health_state`.
+8. If not `--no-state` **and** `lines` **and not** `stored.get("_load_corrupt")` (Phase 1.1 — corrupt file was moved to `.corrupt`, fail closed; use `.get()` since the key is absent on the normal path — subscripting would `KeyError` every normal run, matching line 92): `save_health_state(merged)` (strip `_load_corrupt` first); on success only, write cursor. On save failure, do not write cursor and do not treat the run as having advanced durable state — the next cursor-based run re-reads the same slice and, without a persisted `last_applied_window`, additive merges (Tables 12–14) may increment again; peaks remain extremum-safe. On a corrupt load: skip save AND cursor write, leaving the `/tmp` cursor unadvanced so no data is lost. Empty window: no disk writes, no metadata bump.
+
+---
+
+## SKILL.md updates (Table 8 + new tables)
+
+- Replace Table 8 bullet (line 51): backed by `health_state.json` → `peaks` section; survives reboot; `--no-state` skips write only.
+- Add Table 12 / 13 / 14 bullets mirroring render semantics above.
+- Note `max_position_ratio` row in Table 8.
+- Document file path, `schema_version`, four sections, `max_samples` cap, legacy `/tmp` one-time import.
+
+---
+
+## Phase 8 — Unit tests (pytest)
+
+The merge/IO logic carries multiple silent-failure modes (microsecond replay-guard fingerprint, atomic write + cursor ordering, legacy `/tmp` import, null-vs-zero activity semantics, additive double-count on retry, corrupt-load fail-closed) that hourly manual cron inspection will not reliably catch. The project's own `.claude/rules/code-style.md` requires bug fixes to start with a reproducing test and to suggest tests after writing code. Add focused pytest unit tests around the **pure** merge/IO helpers using **synthetic** `LogLine` objects (constructed in-test), **not** the live `/tmp/gridbot.log`.
+
+**Location & run (tracking decision — explicit):** the **entire** `gridbot-health` skill — `analyze.py`, `SKILL.md`, and this new `test_analyze.py` — lives in the gitignored `.claude/` tree (`.gitignore:42` → `.claude/`; `git ls-files .claude/` returns 0 tracked files). Therefore `test_analyze.py` is **untracked BY DESIGN** and is a **LOCAL developer aid**, consistent with `analyze.py` itself being gitignored. It is **not** part of CI (the analyzer has no CI) and is **not** committed. Put it beside `analyze.py` at `.claude/skills/gridbot-health/test_analyze.py` (import `analyze` directly from the same dir). Run explicitly **on demand** via `uv run pytest .claude/skills/gridbot-health/test_analyze.py` (per CLAUDE.md — `uv run`, not bare `python -m pytest`); it does not join the workspace `testpaths`. **Escape hatch (out of scope here):** if an operator ever wants the analyzer + its test under version control, `git add -f .claude/skills/gridbot-health/{analyze.py,test_analyze.py}` force-adds past the ignore — explicitly not done in this feature. The **Files to change** row for `test_analyze.py` is annotated "(gitignored local-only test aid, not committed)" to keep the plan internally consistent: it is a local artifact, not a tracked source change.
+
+**Cases (one assertion-focused test each):**
+
+1. **`merge_peaks_section` extremum idempotency** — re-applying the *same* window does not worsen records; `min_*` keep the min, `max_position_ratio` max-merges (deepest long-heavy imbalance), `min_position_ratio` min-merges. A second identical apply leaves values unchanged.
+2. **`merge_event_coverage` additive** — `count += len(timestamps)`; `first_seen = min`, `last_seen = max` across two windows; missing keys initialize from the pre-seeded set. Include a `same_order_crosscheck_failed` case (F-EXT-4): an ERROR line containing `SAME ORDER … cross-check failed` increments **only** that key (not the verdict keys, not `error_other`), and a success-path `verdict=` same_order line does **not** touch `same_order_crosscheck_failed`.
+3. **`merge_defense_coverage` latched `boost_confirmed`** — both `_meta` flags (`defense_low_or_risk_ever`, `boost_ever_seen`) set across **different** windows ⇒ `boost_confirmed` becomes true and **stays** true; `_meta` keys are skipped by Table 12 render. Only `low_margin`/`risk_mgmt` rows carry `boost_confirmed`.
+4. **`merge_activity` null & retention** — pre-#135 strat (absent from `pnl_per_strat`) yields `realized_usdt_net=null`, distinct from a genuine `0.0`; `null` is preserved (never summed) across merges; `len(samples) > max_samples` evicts oldest from the front; exact-replay (same microsecond `_fp_key` pair) skips the append, but a **distinct** sub-second-apart window (different `.%f`) does **not** skip.
+5. **Replay guard** — identical `window_fingerprint` vs `stored["last_applied_window"]` skips all three additive merges (defense/event/activity unchanged) while `merge_peaks_section` still runs; a distinct fingerprint applies all of them and updates `last_applied_window`.
+6. **`load_health_state`** — (a) missing file **and no `.corrupt`** ⇒ default empty state, no `_load_corrupt`; (b) corrupt file (garbage / non-dict top level) ⇒ fail closed: bad file moved to `health_state.json.corrupt`, returned state flagged `_load_corrupt=True` (F-EXT-1); (c) legacy peaks-only file (`min_liq_distance` at root, no `schema_version`) ⇒ `import_legacy_peaks` wraps keys into `peaks`; (d) **persistent corrupt latch (F-EXT2-1):** main file **absent** but `health_state.json.corrupt` **present** ⇒ fail closed — returned state flagged `_load_corrupt=True`, and the `main()`-level contract is that **no** fresh empty `health_state.json` is written and the cursor is **not** advanced (assert save skipped / no new state file created); removing the `.corrupt` file (latch cleared) restores the normal first-run default-with-save-allowed path. Use `tmp_path` / monkeypatch of `HEALTH_STATE_PATH`/`SKILL_DIR` so no real skill dir is touched.
+7. **`save_health_state` atomic + failure propagation** — success writes via temp-file + `os.replace`; an unwritable path (monkeypatch to a bad dir, or patch `os.replace`/`open` to raise `OSError`) **raises / returns `False`** (does not swallow like `save_peaks`), and the `main()`-level contract is that the caller then skips the cursor write. Assert the failure signal is observable.
+8. **Config-first symbol map** (F-EXT-3) — `_config_symbol_map()` parses `conf/gridbot_test.yaml` strategies into `{LTCUSDT: ltcusdt_test, SOLUSDT: solusdt_test}`; a placement-only window (no `{strat_id}:` markers) still attributes `Placed Buy order: LTCUSDT …` to `ltcusdt_test` via the config map; an unreadable config falls back to the log-derived map without crashing.
+
+Keep the manual cron checks below as a complementary **integration** section.
+
+## Testing / verification (manual integration checks)
+
+- **Normal path:** two consecutive cron runs (cursor advances): Table 9 per-window only; Table 8/12/13 accumulate; Table 14 gains one sample per distinct window.
+- **Replay guard:** second run on the **same** window with cursor advanced (or duplicate window bounds): Tables 12–14 do not gain duplicate rows/samples (`last_applied_window` fingerprint); use `--no-state` for intentional fixed-`--since` replays.
+- **Partial persist failure (save OK, cursor fail):** simulate state save OK + cursor write skipped (or delete cursor after save): re-run on same log slice — Table 14 sample count unchanged, Table 12/13 counts unchanged, peaks may still update if window had new extremums (`last_applied_window` replay guard).
+- **Save failure then retry:** simulate `save_health_state` raising `OSError` (e.g. unwritable path) on first run with a non-empty window; confirm cursor not written. Fix permissions and re-run on the same slice — expect Tables 12–14 counts to **increase again** (known limitation: fingerprint only helps after a successful save). Mitigation: after fixing I/O, either accept one duplicate increment or delete/repair `health_state.json` additive sections before retry; use `--no-state` for inspection-only replays.
+- **Corrupt file fails closed:** pre-write garbage (e.g. `not json`) to `health_state.json`, run on a non-empty window. Expect: bad file moved to `health_state.json.corrupt`, stderr warning printed, **no** new `health_state.json` written (save skipped), cursor **not** advanced, and (after restoring a good state file) accumulated ledgers intact — never zeroed.
+- **Corrupt latch persists across runs:** after the corrupt-fail-closed run above (main file moved to `health_state.json.corrupt`), run again on a non-empty window with the main `health_state.json` **still absent** and `.corrupt` **still present**. Expect: distinct "missing but .corrupt present — refusing to re-initialize" stderr warning, **no** fresh empty `health_state.json` written (save skipped), cursor **not** advanced. Then remove/rename `.corrupt` (or restore a good state file) and confirm the next run resumes normal saving.
+- Delete `health_state.json`, keep `/tmp/gridbot-health-peaks.json`: first run seeds peaks from legacy file.
+- `--no-state`: file mtime unchanged; tables still show merged all-time data.
+- `--json`: `health_state` object present with all sections.
+- Reboot simulation: move state file outside `/tmp`, confirm `tracking_started` does not reset when `/tmp` cleared.

--- a/docs/features/0063_REVIEW.md
+++ b/docs/features/0063_REVIEW.md
@@ -1,0 +1,23 @@
+# Feature 0063 Code Review
+
+## Findings
+
+No blocking or actionable issues found in the redo review.
+
+The prior P2 finding is fixed: parseable-but-malformed scalar values in `health_state.json` no longer crash the cron run. The implementation now wraps `merge_health_state()` in a fail-closed backstop, quarantines malformed stored state when persistence is enabled, skips save/cursor advancement, and re-merges against a fresh default for display. `--no-state` still avoids disk mutation. The added tests cover both the scalar `activity.max_samples` and `event_coverage.*.count` failure modes.
+
+## Residual Risk
+
+The backstop catches broad merge exceptions and assumes window contributions are well-formed because they are computed from logs. That is reasonable for this feature, but a future bug inside contribution construction or merge code could be reported as malformed stored state. Current tests cover the intended corruption cases, so I do not see a required change here.
+
+## Notes
+
+- The implementation matches the plan’s major contracts: single durable `health_state.json`, legacy peaks import, microsecond replay fingerprint, `--no-state`, save-before-cursor ordering, Tables 12-14, JSON exposure, and `max_position_ratio`.
+- `analyze.py` is large, but the new feature code is grouped into clear helper sections. I do not see a refactor requirement for this scope.
+- The local test aid exists at `.claude/skills/gridbot-health/test_analyze.py` as planned; `.claude/` is gitignored, so it is intentionally not tracked.
+
+## Verification
+
+- `uv run pytest .claude/skills/gridbot-health/test_analyze.py -q` -> 39 passed.
+- `python3 -m py_compile .claude/skills/gridbot-health/analyze.py .claude/skills/gridbot-health/test_analyze.py` -> passed.
+- `python3 .claude/skills/gridbot-health/analyze.py --no-state --json` -> completed against the current log and emitted Tables 1-14 plus `health_state`.


### PR DESCRIPTION
## Summary

Feature 0063 makes the **gridbot-health** analyzer's monitoring state **durable across restarts**, replacing the disposable `/tmp/gridbot-health-peaks.json` with a single `health_state.json` beside the skill. It adds three durable ledgers and surfaces them as new tables, so multi-strat `mainnet_live` validation retains evidence of which safety branches ever fired across runs/reboots.

**Tracked deliverable:** the implementation lives in the **gitignored** `.claude/skills/gridbot-health/` tree by design (`.gitignore` → `.claude/`), so this PR contains the **plan + code review** docs — the tracked record of the design and its adversarial review. The code (`analyze.py`, `SKILL.md`, `test_analyze.py`) is a local skill, not committed.

## What the feature adds (in the gitignored skill)
- **`health_state.json`** (`schema_version: 1`): `peaks` (extremum), `defense_coverage` + `event_coverage` (additive ledgers), `activity` (append-only trend) + root metadata.
- **Tables 12–14**: liquidation-defense coverage, rare-event coverage, activity/realized trend; **Table 8** gains a `max_position_ratio` row.
- **Replay guard**: microsecond `(window_start, window_end)` fingerprint so re-processing a log slice can't inflate additive ledgers.
- **Fail-closed durability**: atomic temp-file + `os.replace`, save-before-cursor ordering, quarantine-to-`.corrupt` on unparseable / wrong-container / malformed-scalar (merge-time backstop) state, persistent `.corrupt` latch.
- **`--json` / `--no-state`**, config-first symbol attribution, null-vs-zero USDT semantics.

## Review
`docs/features/0063_REVIEW.md` records the review history. Adversarial multi-iteration review found and fixed: missing main()-level persistence tests, a malformed-numeric log-line crash class, parseable-but-mistyped state crashes (container + scalar), and a duplicated verdict-clustering DRY risk. One pre-existing, non-blocking Table 4 WS_GLITCH display-count inconsistency is documented (N6), not changed (out of scope). The P2 scalar-corruption finding is fixed via a uniform merge-time fail-closed backstop.

## Verification
- `uv run pytest .claude/skills/gridbot-health/test_analyze.py -q` → **39 passed**
- `python3 .claude/skills/gridbot-health/analyze.py --no-state --json` → emits Tables 1–14 + `health_state`

Closes #145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)