### PR TITLE
feat(0064): 110017 retry-storm self-heal + circuit-breaker (#149)

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -325,6 +325,14 @@ Pitfalls / invariants (all enforced + tested):
   resync — the position resync is the #149-critical healing step (closes the
   stale-mirror gap). Designed to be reused by the broader divergence detector
   (issue #151).
+- **Observability (review v3)**: `dirty_rest_refresh_failure_count` (monotonic
+  property; incremented when a dirty REST refresh's `get_positions` raises or
+  returns an unparseable size) is surfaced by the health sweep alongside the
+  breaker trip count — a persistent REST outage that blocks self-heal is visible
+  without per-occurrence ERROR spam. `_dirty_ws_mismatch_streak[direction]`
+  counts consecutive WS size mismatches while dirty (reset on match / episode
+  clear) and emits a WARNING every `_DIRTY_WS_MISMATCH_ALERT_THRESHOLD` (10)
+  mismatches — a WS feed stuck beyond the normal recovery window.
 - Config (all on `StrategyConfig`, default-on): `dirty_refresh_enabled`,
   `dirty_rest_refresh_min_interval_seconds`, `truncate_breaker_{max_consecutive,
   window_seconds,cooldown_seconds,reconcile}`. Constant

--- a/RULES.md
+++ b/RULES.md
@@ -255,6 +255,86 @@ make test-integration
 - **Decimal conversion safety**: Always use `Decimal(str(value))` — never bare `Decimal(value)` — when converting order dict fields (`price`, `qty`) or any variable that might be a float. `Decimal(0.5)` produces `0.500000000000000027...` which silently breaks equality checks. The `Decimal(str(...))` pattern is safe for strings, floats, and Decimals alike.
 - **Zero-size rejection is intentional, not a bug**: When `position_size == Decimal('0')` the reduce-only order is silently rejected (debug log only). This is bbu2-faithful — bbu2 expresses the same behavior implicitly via `position_size > limits_qty` arithmetic. A race can occur when the engine emits a close intent in the sub-tick window after a fill but before the position update lands; it self-heals on the next tick because the engine re-emits the same reduce-only intent every tick from scratch. **Do NOT "allow through on staleness"** — that would place orders against known-stale state and make things worse. If the position feed itself dies, fix it in the position-update path (heartbeat, REST reconcile), not here. See `runner.py:748-753`.
 
+### 110017 retry-storm self-heal + circuit-breaker (feature 0064, issue #149)
+
+The guard above is logically correct but trusts a **stale mirror**: during a WS
+outage `_long_position.size`/`_short_position.size` stay stale-high, so the strict
+`>` check passes and Bybit clamps the oversized reduce-only to zero → ErrCode
+**110017**. The engine re-emits that same close on (nearly) every `on_ticker`, so
+one divergence produced **535 identical rejected placements in <90min** (no
+circuit-breaker, retried via the queue each time). Two complementary mechanisms
+fix this; **do not collapse them into one**:
+
+1. **Dirty-mirror REST refresh BEFORE the guard (primary self-heal).** The first
+   110017 on a direction sets `_position_dirty[direction]=True`. On the *next*
+   reduce-only placement for that direction, `_refresh_position_size_from_rest`
+   REST-reads the true size into the mirror **before** `_is_good_to_place`, so the
+   *unchanged* guard rejects the oversized close locally (no submit, no second
+   110017). The storm collapses to one 110017. **The guard body is NOT modified
+   and there is NO qty-cap** — capping after a strict-`>` guard reading the same
+   source is a no-op; refreshing the source is the fix. Hedge-mode
+   reject-when-`position ≤ qty` convention is preserved (project memory).
+2. **`TruncateBreaker` (backstop).** Scope key `(side, price)` — NOT orderLinkId
+   (it carries a per-placement `-{millis}` suffix and never accumulates). After
+   N (default 3) 110017s within the window it trips: `is_blocked` drops further
+   intents for a cooldown, fires ONE forced reconcile, increments
+   `truncate_breaker_reconcile_count`. Bounds the undetected-divergence window and
+   residual races when the refresh can't heal (`dirty_refresh_enabled=False` /
+   `rest_client=None`).
+
+Pitfalls / invariants (all enforced + tested):
+- **Pipeline order in `_execute_place_intent` is load-bearing** (`runner.py`): resolve
+  qty → breaker `is_blocked` **first** (a tripped scope must not trigger a REST
+  refresh) → dirty refresh (gated by `dirty_refresh_enabled` as the **first**
+  term so it's a true kill-switch) → guard → submit → breaker bookkeeping.
+- **110017 is excluded from the retry queue** and **drops wire-`order_link_id`
+  reuse** (forces a fresh id next emission via `replace(order_link_id=None)`).
+  Reusing the id could surface as 110072 — which the breaker doesn't count and the
+  queue doesn't exclude — partially bypassing the backstop. Non-110017 failures
+  keep feature-0032 reuse + queue enqueue. Classifier is module-level
+  `executor.is_truncate_error()` (NOT a method — a `Mock(spec=IntentExecutor)`
+  auto-creates a truthy method and would misclassify every failure).
+- **Throttle uses a `None` sentinel** (`_last_dirty_rest_at`), not `0.0`: the first
+  dirty refresh always fires regardless of clock value (an init of `0.0` only
+  worked because real `time.monotonic()` is large; brittle under fake clocks).
+  Clock is injectable (`clock=` ctor arg) for tests.
+- **WS size write in `on_position_update` is gated while dirty** (only `.size`,
+  not ratio/liq/multipliers): exact WS==last-REST match clears dirty; a non-match
+  keeps the REST value authoritative (a stale WS frame must not reopen the storm);
+  no REST baseline yet (`_last_rest_position_size is None`) → WS passes through
+  normally (never restore a synthetic `0`, which would reject all closes when
+  refresh is disabled).
+- **Dirty clears only on a positive health signal**: a successful **reduce-only
+  close** (NOT an open — an open never exercises the position-size guard, so
+  clearing dirty on it would re-arm a 110017 on the next close), a forced
+  reconcile (`force=True`), or a WS-size match — or process restart. The 10s
+  throttle bounds REST while it stays dirty.
+- **Episode-scoped state invariant (`_clear_dirty`)**: `_position_dirty[d]`,
+  `_last_dirty_rest_at[d]`, and `_last_rest_position_size[d]` are reset *together*
+  on every dirty-clear path. Throttle + baseline are meaningful ONLY while dirty
+  is True, so a fresh episode always refreshes on its first placement and never
+  consults a prior episode's stale baseline. The REST refresh **arms the throttle
+  on every attempt (success OR failure)** — else a persistently failing
+  `get_positions` / `rest_client=None` re-fires every tick (the `None` sentinel
+  never advances).
+- **Forced reconcile** (`Orchestrator._force_reconcile_strat`) = `reconcile_reconnect`
+  (orders) **+** `_refresh_position_size_from_rest(force=True)` (position size —
+  the piece `reconcile_reconnect` does NOT do); rate-limited per
+  `truncate_breaker_cooldown_seconds` per strat. The two run in **independent
+  `try/except` blocks** so an order-reconcile failure never skips the position
+  resync — the position resync is the #149-critical healing step (closes the
+  stale-mirror gap). Designed to be reused by the broader divergence detector
+  (issue #151).
+- Config (all on `StrategyConfig`, default-on): `dirty_refresh_enabled`,
+  `dirty_rest_refresh_min_interval_seconds`, `truncate_breaker_{max_consecutive,
+  window_seconds,cooldown_seconds,reconcile}`. Constant
+  `bybit_adapter.error_codes.ORDER_QTY_TRUNCATED_TO_ZERO = 110017`.
+- Files: new `apps/gridbot/src/gridbot/truncate_breaker.py`,
+  `packages/bybit_adapter/src/bybit_adapter/error_codes.py`; touched
+  `runner.py`, `orchestrator.py`, `executor.py`, `config.py`. Tests:
+  `test_truncate_breaker.py`, `test_runner_truncate_storm.py`,
+  `TestForcedReconcile` in `test_orchestrator.py`.
+
 ### SAME ORDER detection
 
 - `StrategyRunner._check_same_orders_side()` compares tracked orders by `TrackedOrder.placed_ts` when both fills map to tracked orders; use fill `exchange_ts` only as a fallback for untracked/legacy events. Duplicate same-price orders can rest concurrently and fill more than 5s apart in thin markets, so fill-time-only windows silently miss the critical duplicate-placement bug.

--- a/apps/gridbot/src/gridbot/config.py
+++ b/apps/gridbot/src/gridbot/config.py
@@ -60,6 +60,46 @@ class StrategyConfig(BaseModel):
         ),
     )
 
+    # Feature 0064 — 110017 retry-storm self-heal + circuit-breaker (issue #149).
+    # All default-on so existing conf/*.yaml keep working unchanged.
+    dirty_refresh_enabled: bool = Field(
+        default=True,
+        description=(
+            "Master kill-switch for the dirty-mirror REST refresh-before-guard. "
+            "When True, a direction flagged dirty by a prior 110017 has its "
+            "position size REST-refreshed before _is_good_to_place so the guard "
+            "rejects oversized reduce-only closes against fresh data."
+        ),
+    )
+    dirty_rest_refresh_min_interval_seconds: float = Field(
+        default=10.0,
+        gt=0,
+        description=(
+            "Minimum seconds between REST get_positions calls per direction while "
+            "that direction is dirty — bounds REST when the guard keeps rejecting "
+            "per-ticker re-emissions."
+        ),
+    )
+    truncate_breaker_max_consecutive: int = Field(
+        default=3,
+        ge=1,
+        description="Trip the 110017 circuit-breaker after this many within the window.",
+    )
+    truncate_breaker_window_seconds: float = Field(
+        default=60.0,
+        gt=0,
+        description="Sliding window for counting consecutive 110017 errors per scope key.",
+    )
+    truncate_breaker_cooldown_seconds: float = Field(
+        default=60.0,
+        gt=0,
+        description="After a trip, drop further intents on that scope key for this long.",
+    )
+    truncate_breaker_reconcile: bool = Field(
+        default=True,
+        description="Trigger one forced position+order reconcile when the breaker trips.",
+    )
+
     # Mode
     shadow_mode: bool = Field(default=False, description="Log intents without executing")
 

--- a/apps/gridbot/src/gridbot/executor.py
+++ b/apps/gridbot/src/gridbot/executor.py
@@ -11,6 +11,7 @@ from datetime import datetime, UTC
 from typing import Callable, Optional
 
 from bybit_adapter.rest_client import BybitRestClient
+from bybit_adapter.error_codes import ORDER_QTY_TRUNCATED_TO_ZERO
 from gridcore.intents import PlaceLimitIntent, CancelIntent
 from gridcore.position import DirectionType
 from gridbot.order_link_id import make_order_link_id
@@ -23,6 +24,24 @@ AUTH_ERROR_CODES = {10003, 10004, 10005, 33004}
 
 # Matches both our _check_response format [NNNNN] and pybit's native format (ErrCode: NNNNN)
 _ERR_CODE_RE = re.compile(r"(?:\[(\d+)\]|\(ErrCode:\s*(\d+)\))")
+
+
+def is_truncate_error(error: Optional[str]) -> bool:
+    """Return True if an error string carries Bybit ErrCode 110017.
+
+    110017 ("orderQty will be truncated to zero") means a reduce-only qty was
+    clamped to zero against a smaller exchange-side position — the local mirror
+    diverged. Module-level (not a method) so callers branch on it without
+    routing through a mock executor instance (feature 0064). Reuses the shared
+    ``_ERR_CODE_RE`` so there is one regex for both wire formats.
+    """
+    if not error:
+        return False
+    match = _ERR_CODE_RE.search(error)
+    if match:
+        code = int(match.group(1) or match.group(2))
+        return code == ORDER_QTY_TRUNCATED_TO_ZERO
+    return False
 
 
 @dataclass

--- a/apps/gridbot/src/gridbot/orchestrator.py
+++ b/apps/gridbot/src/gridbot/orchestrator.py
@@ -991,13 +991,16 @@ class Orchestrator:
         try:
             self._auth_cooldown.sweep_expired(datetime.now(UTC))
 
-            # Feature 0064 — surface 110017 breaker trip counts without
-            # per-occurrence ERROR spam. Monotonic per runner lifetime.
+            # Feature 0064 — surface 110017 breaker trip counts and dirty REST
+            # refresh failures without per-occurrence ERROR spam. Monotonic per
+            # runner lifetime.
             for runner in self._runners.values():
                 trips = runner.truncate_breaker_reconcile_count
-                if trips > 0:
+                rest_failures = runner.dirty_rest_refresh_failure_count
+                if trips > 0 or rest_failures > 0:
                     logger.debug(
-                        "%s: 110017 breaker trips=%d", runner.strat_id, trips
+                        "%s: 110017 breaker trips=%d, dirty REST refresh failures=%d",
+                        runner.strat_id, trips, rest_failures,
                     )
 
             for account_name in list(self._public_ws.keys()):

--- a/apps/gridbot/src/gridbot/orchestrator.py
+++ b/apps/gridbot/src/gridbot/orchestrator.py
@@ -125,6 +125,10 @@ class Orchestrator:
         self._strategy_executors: dict[str, IntentExecutor] = {}  # strat_id -> executor
         self._reconcilers: dict[str, Reconciler] = {}  # account_name -> reconciler
         self._retry_queues: dict[str, RetryQueue] = {}  # strat_id -> queue
+        # Feature 0064 — rate-limit the breaker-triggered forced reconcile so a
+        # tripped breaker cannot itself spam REST during an outage. strat_id ->
+        # monotonic ts of the last forced reconcile.
+        self._force_reconcile_last_at: dict[str, float] = {}
 
         # Run tracking
         self._run_ids: dict[str, UUID] = {}  # strat_id -> run_id
@@ -741,6 +745,9 @@ class Orchestrator:
             on_retry_cancel_for_prefix=lambda prefix: retry_queue.cancel_for_prefix(prefix),
             on_unknown_order=self._request_immediate_order_sync,
             notifier=self._notifier,
+            # Feature 0064 — dirty-mirror REST refresh + breaker forced reconcile.
+            rest_client=self._rest_clients[account_name],
+            on_truncate_breaker_tripped=self._force_reconcile_strat,
         )
         self._runners[strat_id] = runner
         self._strategy_executors[strat_id] = executor
@@ -984,6 +991,15 @@ class Orchestrator:
         try:
             self._auth_cooldown.sweep_expired(datetime.now(UTC))
 
+            # Feature 0064 — surface 110017 breaker trip counts without
+            # per-occurrence ERROR spam. Monotonic per runner lifetime.
+            for runner in self._runners.values():
+                trips = runner.truncate_breaker_reconcile_count
+                if trips > 0:
+                    logger.debug(
+                        "%s: 110017 breaker trips=%d", runner.strat_id, trips
+                    )
+
             for account_name in list(self._public_ws.keys()):
                 # Check public WS
                 pub_ws = self._public_ws.get(account_name)
@@ -1160,6 +1176,63 @@ class Orchestrator:
         logger.info(
             "%s: Untracked order seen — fast-tracking order sync", strat_id,
         )
+
+    def _force_reconcile_strat(self, strat_id: str, direction: str) -> None:
+        """Breaker-triggered forced position + order reconcile (feature 0064).
+
+        Wired as the runner's ``on_truncate_breaker_tripped`` callback. Resyncs
+        the order book via ``reconcile_reconnect`` (handles untracked-on-exchange
+        / missing-in-memory) AND the position size via
+        ``_refresh_position_size_from_rest(force=True)`` — the piece
+        ``reconcile_reconnect`` does NOT do today — closing the stale-mirror gap
+        that defeated ``_is_good_to_place``. Rate-limited to at most once per
+        ``truncate_breaker_cooldown_seconds`` per strat so a tripped breaker
+        cannot itself spam REST during an outage. Designed to be reusable by the
+        broader divergence detector (issue #151).
+        """
+        runner = self._runners.get(strat_id)
+        if runner is None:
+            return
+        account_name = self._get_account_for_strategy(strat_id)
+        reconciler = self._reconcilers.get(account_name) if account_name else None
+
+        # Rate limit per strat using its configured cooldown.
+        cfg = next(
+            (c for c in self._config.strategies if c.strat_id == strat_id), None
+        )
+        cooldown = cfg.truncate_breaker_cooldown_seconds if cfg else 60.0
+        now = time.monotonic()
+        last = self._force_reconcile_last_at.get(strat_id)
+        if last is not None and (now - last) < cooldown:
+            logger.debug(
+                "%s: forced reconcile rate-limited (%.1fs since last < %.1fs)",
+                strat_id, now - last, cooldown,
+            )
+            return
+        self._force_reconcile_last_at[strat_id] = now
+
+        logger.warning(
+            "%s: 110017 breaker tripped — forcing %s position + order reconcile",
+            strat_id, direction,
+        )
+        if reconciler is not None:
+            try:
+                reconciler.reconcile_reconnect(runner)
+            except Exception as e:
+                self._notifier.alert_exception(
+                    f"forced reconcile orders {strat_id}", e,
+                    error_key=f"force_reconcile_orders_{strat_id}",
+                )
+        # Position-size resync is the #149-critical healing step — it closes the
+        # stale-mirror gap that defeats _is_good_to_place. Run it in its OWN
+        # try/except so an order-reconcile failure above never skips it (P2).
+        try:
+            runner._refresh_position_size_from_rest(direction, force=True)
+        except Exception as e:
+            self._notifier.alert_exception(
+                f"forced reconcile position {strat_id}", e,
+                error_key=f"force_reconcile_pos_{strat_id}",
+            )
 
     def _order_sync_once(self) -> None:
         """Single-shot order reconciliation sweep.

--- a/apps/gridbot/src/gridbot/runner.py
+++ b/apps/gridbot/src/gridbot/runner.py
@@ -1121,9 +1121,9 @@ class StrategyRunner:
         except Exception as e:
             self._dirty_rest_refresh_failure_count += 1
             logger.warning(
-                "%s: dirty REST refresh get_positions failed for %s: %s — "
+                "%s: dirty REST refresh get_positions failed for %s: %s: %s — "
                 "keeping in-memory mirror",
-                self.strat_id, direction, e,
+                self.strat_id, direction, type(e).__name__, e,
             )
             return
 
@@ -1141,12 +1141,12 @@ class StrategyRunner:
         else:
             try:
                 new_size = Decimal(str(entry.get("size", 0) or 0))
-            except (ArithmeticError, ValueError, TypeError):
+            except (ArithmeticError, ValueError, TypeError) as e:
                 self._dirty_rest_refresh_failure_count += 1
                 logger.warning(
-                    "%s: dirty REST refresh got unparseable size %r for %s — "
+                    "%s: dirty REST refresh got unparseable size %r (%s) for %s — "
                     "keeping in-memory mirror",
-                    self.strat_id, entry.get("size"), direction,
+                    self.strat_id, entry.get("size"), type(e).__name__, direction,
                 )
                 return
 

--- a/apps/gridbot/src/gridbot/runner.py
+++ b/apps/gridbot/src/gridbot/runner.py
@@ -88,6 +88,11 @@ _SAME_ORDER_REST_MAX_PAGES = 10
 # See docs/features/0046_PLAN.md and issue #94.
 _SAME_ORDER_WARN_THROTTLE_SEC = 60.0
 
+# Feature 0064 — emit a WARNING once a direction has had this many consecutive
+# WS position-size mismatches while dirty (REST baseline held each time). Signals
+# a WS feed stuck beyond the normal recovery window. Re-fires every multiple.
+_DIRTY_WS_MISMATCH_ALERT_THRESHOLD = 10
+
 
 @dataclass
 class _SameOrderDedupEntry:
@@ -270,6 +275,16 @@ class StrategyRunner:
         }
         # Monotonic count of breaker trips that fired a forced reconcile.
         self._truncate_breaker_reconcile_count: int = 0
+        # Observability (review v3): monotonic count of dirty REST refreshes that
+        # failed (get_positions raised / unparseable size) — surfaced by the
+        # health sweep so persistent REST issues blocking self-heal are visible.
+        self._dirty_rest_refresh_failure_count: int = 0
+        # Per-direction streak of consecutive WS size mismatches while dirty
+        # (reset on a match / episode clear). Drives a threshold WARNING.
+        self._dirty_ws_mismatch_streak: dict[str, int] = {
+            DirectionType.LONG: 0,
+            DirectionType.SHORT: 0,
+        }
 
         # Qty computation
         self._instrument_info = instrument_info
@@ -361,6 +376,17 @@ class StrategyRunner:
         signal without per-occurrence ERROR spam.
         """
         return self._truncate_breaker_reconcile_count
+
+    @property
+    def dirty_rest_refresh_failure_count(self) -> int:
+        """Number of dirty REST refreshes that failed (review v3 #1).
+
+        Incremented when ``get_positions`` raises or returns an unparseable
+        size during a dirty refresh. Monotonic for the runner lifetime; surfaced
+        by the health sweep so a persistent REST outage that blocks self-heal is
+        visible without per-occurrence ERROR spam.
+        """
+        return self._dirty_rest_refresh_failure_count
 
     @property
     def symbol(self) -> str:
@@ -1016,6 +1042,7 @@ class StrategyRunner:
         self._position_dirty[direction] = False
         self._last_dirty_rest_at[direction] = None
         self._last_rest_position_size[direction] = None
+        self._dirty_ws_mismatch_streak[direction] = 0
 
     def _apply_dirty_ws_size_gate(self, direction: str, ws_size: Decimal) -> Decimal:
         """Gate a WS position-size write while a direction is dirty (0064).
@@ -1040,11 +1067,24 @@ class StrategyRunner:
                 self.strat_id, ws_size, direction,
             )
             return ws_size
-        logger.debug(
-            "%s: ignoring non-matching WS size %s for dirty %s "
-            "(REST baseline %s stays authoritative)",
-            self.strat_id, ws_size, direction, baseline,
-        )
+        # Non-match while dirty: keep the REST-authoritative size and track the
+        # consecutive-mismatch streak (review v3 #2). A WARNING at each threshold
+        # multiple flags a WS feed stuck beyond the normal recovery window.
+        streak = self._dirty_ws_mismatch_streak[direction] + 1
+        self._dirty_ws_mismatch_streak[direction] = streak
+        if streak >= _DIRTY_WS_MISMATCH_ALERT_THRESHOLD and streak % _DIRTY_WS_MISMATCH_ALERT_THRESHOLD == 0:
+            logger.warning(
+                "%s: %d consecutive WS position-size mismatches for dirty %s "
+                "(REST baseline %s held) — WS feed may be stuck beyond the "
+                "normal recovery window",
+                self.strat_id, streak, direction, baseline,
+            )
+        else:
+            logger.debug(
+                "%s: ignoring non-matching WS size %s for dirty %s "
+                "(REST baseline %s stays authoritative, streak=%d)",
+                self.strat_id, ws_size, direction, baseline, streak,
+            )
         return baseline
 
     def _refresh_position_size_from_rest(
@@ -1079,6 +1119,7 @@ class StrategyRunner:
         try:
             positions = self._rest_client.get_positions(self._config.symbol)
         except Exception as e:
+            self._dirty_rest_refresh_failure_count += 1
             logger.warning(
                 "%s: dirty REST refresh get_positions failed for %s: %s — "
                 "keeping in-memory mirror",
@@ -1101,6 +1142,7 @@ class StrategyRunner:
             try:
                 new_size = Decimal(str(entry.get("size", 0) or 0))
             except (ArithmeticError, ValueError, TypeError):
+                self._dirty_rest_refresh_failure_count += 1
                 logger.warning(
                     "%s: dirty REST refresh got unparseable size %r for %s — "
                     "keeping in-memory mirror",

--- a/apps/gridbot/src/gridbot/runner.py
+++ b/apps/gridbot/src/gridbot/runner.py
@@ -10,6 +10,7 @@ The runner is responsible for:
 
 import logging
 import math
+import time
 from collections import deque
 from dataclasses import dataclass, field, replace
 from datetime import datetime, UTC, timedelta
@@ -18,6 +19,7 @@ from typing import Optional, Callable, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from gridbot.writers.grid_state_writer import GridStateWriter
+    from bybit_adapter.rest_client import BybitRestClient
 
 from gridcore import (
     GridEngine,
@@ -41,9 +43,10 @@ from gridcore import (
 )
 
 from gridbot.config import StrategyConfig
-from gridbot.executor import IntentExecutor
+from gridbot.executor import IntentExecutor, is_truncate_error
 from gridbot.notifier import Notifier
 from gridbot.order_link_id import make_order_link_id
+from gridbot.truncate_breaker import TruncateBreaker
 
 
 logger = logging.getLogger(__name__)
@@ -171,6 +174,10 @@ class StrategyRunner:
         on_unknown_order: Optional[Callable[[str], None]] = None,
         notifier: Optional[Notifier] = None,
         on_retry_cancel_for_prefix: Optional[Callable[[str], int]] = None,
+        rest_client: Optional["BybitRestClient"] = None,
+        truncate_breaker: Optional[TruncateBreaker] = None,
+        on_truncate_breaker_tripped: Optional[Callable[[str, str], None]] = None,
+        clock: Optional[Callable[[], float]] = None,
     ):
         """Initialize strategy runner.
 
@@ -192,6 +199,18 @@ class StrategyRunner:
             notifier: Alert notifier for same-order error Telegram alerts.
             on_retry_cancel_for_prefix: Optional callback to cancel queued
                 placement retries after reconcile proves the order was accepted.
+            rest_client: Optional Bybit REST client for the dirty-mirror
+                position refresh (feature 0064). When None (unit tests/dry-run)
+                the dirty path logs a WARNING and falls back to the in-memory
+                mirror; the circuit-breaker still bounds the storm.
+            truncate_breaker: Optional 110017 circuit-breaker (feature 0064).
+                When None, one is constructed from ``strategy_config``'s
+                ``truncate_breaker_*`` fields (owned per-runner).
+            on_truncate_breaker_tripped: Optional callback fired once per breaker
+                trip (args: strat_id, direction) — wired to the orchestrator's
+                forced position+order reconcile.
+            clock: Monotonic clock for breaker windows / dirty-refresh throttle.
+                Defaults to ``time.monotonic``; injectable for tests.
         """
         # 0047: if a DB writer is wired, account_id MUST be explicitly set —
         # the dummy default would FK-mismatch with replay's account scope
@@ -218,6 +237,39 @@ class StrategyRunner:
         self._on_unknown_order = on_unknown_order
         self._notifier = notifier
         self._on_retry_cancel_for_prefix = on_retry_cancel_for_prefix
+
+        # Feature 0064 — 110017 retry-storm self-heal + circuit-breaker (#149).
+        self._rest_client = rest_client
+        self._clock = clock or time.monotonic
+        self._on_truncate_breaker_tripped = on_truncate_breaker_tripped
+        self._truncate_breaker = truncate_breaker or TruncateBreaker(
+            max_consecutive=strategy_config.truncate_breaker_max_consecutive,
+            window_seconds=strategy_config.truncate_breaker_window_seconds,
+            cooldown_seconds=strategy_config.truncate_breaker_cooldown_seconds,
+        )
+        # Per-direction divergence flag: set on the first 110017 for a
+        # direction; while True the mirror size is REST-refreshed before the
+        # guard. Cleared by a positive health signal (successful place, forced
+        # reconcile, or a WS size that matches the last REST read).
+        self._position_dirty: dict[str, bool] = {
+            DirectionType.LONG: False,
+            DirectionType.SHORT: False,
+        }
+        # REST refresh throttle per direction. None = never refreshed → the
+        # first dirty refresh bypasses the throttle (clock-independent: an init
+        # of 0.0 was brittle under fake clocks where now=0).
+        self._last_dirty_rest_at: dict[str, Optional[float]] = {
+            DirectionType.LONG: None,
+            DirectionType.SHORT: None,
+        }
+        # Size written by the most recent REST refresh per direction. None = no
+        # baseline yet; the WS dirty-gate only activates once a baseline exists.
+        self._last_rest_position_size: dict[str, Optional[Decimal]] = {
+            DirectionType.LONG: None,
+            DirectionType.SHORT: None,
+        }
+        # Monotonic count of breaker trips that fired a forced reconcile.
+        self._truncate_breaker_reconcile_count: int = 0
 
         # Qty computation
         self._instrument_info = instrument_info
@@ -299,6 +351,16 @@ class StrategyRunner:
     def strat_id(self) -> str:
         """Strategy identifier."""
         return self._config.strat_id
+
+    @property
+    def truncate_breaker_reconcile_count(self) -> int:
+        """Number of 110017 breaker trips that fired a forced reconcile.
+
+        Monotonic for the runner lifetime (resets only on process restart).
+        Read by ``Orchestrator._health_check_once`` for an operator/metrics
+        signal without per-occurrence ERROR spam.
+        """
+        return self._truncate_breaker_reconcile_count
 
     @property
     def symbol(self) -> str:
@@ -670,9 +732,20 @@ class StrategyRunner:
             long_state = self._build_position_state(long_position, wallet_balance, DirectionType.LONG)
             short_state = self._build_position_state(short_position, wallet_balance, DirectionType.SHORT)
 
-            # Update position sizes (used by _is_good_to_place)
-            self._long_position.size = long_state.size if long_state else Decimal('0')
-            self._short_position.size = short_state.size if short_state else Decimal('0')
+            # Update position sizes (used by _is_good_to_place). While a
+            # direction is dirty (feature 0064), the size write is gated so a
+            # stale/mis-ordered WS frame cannot clobber the REST-authoritative
+            # mirror and reopen the 110017 storm. Only the `.size` field is
+            # gated; the position_ratio / liquidation / multiplier calcs below
+            # read the freshly-built WS long_state / short_state directly.
+            long_ws_size = long_state.size if long_state else Decimal('0')
+            short_ws_size = short_state.size if short_state else Decimal('0')
+            self._long_position.size = self._apply_dirty_ws_size_gate(
+                DirectionType.LONG, long_ws_size
+            )
+            self._short_position.size = self._apply_dirty_ws_size_gate(
+                DirectionType.SHORT, short_ws_size
+            )
 
             # Convert Decimal sizes to float: position_ratio is stored as float (position.py:98)
             # and mixing Decimal/float in division raises TypeError
@@ -930,6 +1003,131 @@ class StrategyRunner:
                     return t
         return None
 
+    def _clear_dirty(self, direction: str) -> None:
+        """Clear a direction's dirty episode and its episode-scoped state (0064).
+
+        Invariant: ``_last_dirty_rest_at[d]`` and ``_last_rest_position_size[d]``
+        are meaningful ONLY while ``_position_dirty[d]`` is True. Every
+        dirty-clear path (successful reduce-only close, WS-size match, forced
+        reconcile) resets all three so a stale baseline/throttle from one episode
+        never leaks into the next (F3): a fresh episode always refreshes on its
+        first placement and establishes its own baseline.
+        """
+        self._position_dirty[direction] = False
+        self._last_dirty_rest_at[direction] = None
+        self._last_rest_position_size[direction] = None
+
+    def _apply_dirty_ws_size_gate(self, direction: str, ws_size: Decimal) -> Decimal:
+        """Gate a WS position-size write while a direction is dirty (0064).
+
+        Steady state (not dirty) → write the WS size unchanged. While dirty and
+        a REST baseline exists: an exact match clears dirty (WS recovered and
+        agrees with REST); a non-match keeps the REST-authoritative size and
+        leaves dirty set (a stale WS frame must not reopen the storm). While
+        dirty but no baseline yet (no refresh has run — `rest_client=None` or
+        `dirty_refresh_enabled=False`) → write the WS size normally; the gate
+        only protects a value REST has actually established.
+        """
+        if not self._position_dirty.get(direction, False):
+            return ws_size
+        baseline = self._last_rest_position_size.get(direction)
+        if baseline is None:
+            return ws_size
+        if ws_size == baseline:
+            self._clear_dirty(direction)
+            logger.info(
+                "%s: WS size %s matches last REST read for %s — clearing dirty",
+                self.strat_id, ws_size, direction,
+            )
+            return ws_size
+        logger.debug(
+            "%s: ignoring non-matching WS size %s for dirty %s "
+            "(REST baseline %s stays authoritative)",
+            self.strat_id, ws_size, direction, baseline,
+        )
+        return baseline
+
+    def _refresh_position_size_from_rest(
+        self, direction: str, *, force: bool = False
+    ) -> None:
+        """Refresh ONE direction's mirror ``size`` from a fresh REST read (0064).
+
+        Used on the dirty path before the guard, and by the forced reconcile
+        (``force=True``). Filters the flat ``get_positions`` list by
+        ``positionIdx`` (hedge mode: 1=long, 2=short) itself — unlike
+        ``on_position_update``, which receives already-split long/short dicts.
+        A missing/zero entry sets the mirror to ``0`` (position now flat),
+        mirroring ``_build_position_state``/``on_position_update``. Only the
+        ``size`` field is touched (multipliers/liq are out of scope).
+        """
+        # Throttle the ATTEMPT (success or failure) so a persistently failing
+        # get_positions / rest_client=None cannot re-fire the refresh on every
+        # tick (F2). The force path bypasses the throttle and resets the whole
+        # episode below.
+        if not force:
+            self._last_dirty_rest_at[direction] = self._clock()
+
+        if self._rest_client is None:
+            logger.warning(
+                "%s: dirty REST refresh for %s requested but no rest_client — "
+                "falling back to in-memory mirror",
+                self.strat_id, direction,
+            )
+            return
+
+        position_idx = 1 if direction == DirectionType.LONG else 2
+        try:
+            positions = self._rest_client.get_positions(self._config.symbol)
+        except Exception as e:
+            logger.warning(
+                "%s: dirty REST refresh get_positions failed for %s: %s — "
+                "keeping in-memory mirror",
+                self.strat_id, direction, e,
+            )
+            return
+
+        def _matches(p: dict) -> bool:
+            try:
+                return int(p.get("positionIdx", -1)) == position_idx
+            except (TypeError, ValueError):
+                # Malformed positionIdx in a (possibly partial) entry: skip it
+                # rather than crash the hot path — degrade to the mirror.
+                return False
+
+        entry = next((p for p in positions if _matches(p)), None)
+        if entry is None:
+            new_size = Decimal("0")
+        else:
+            try:
+                new_size = Decimal(str(entry.get("size", 0) or 0))
+            except (ArithmeticError, ValueError, TypeError):
+                logger.warning(
+                    "%s: dirty REST refresh got unparseable size %r for %s — "
+                    "keeping in-memory mirror",
+                    self.strat_id, entry.get("size"), direction,
+                )
+                return
+
+        if direction == DirectionType.LONG:
+            old = self._long_position.size
+            self._long_position.size = new_size
+        else:
+            old = self._short_position.size
+            self._short_position.size = new_size
+
+        logger.info(
+            "%s: dirty REST position refresh %s size %s -> %s (force=%s)",
+            self.strat_id, direction, old, new_size, force,
+        )
+        if force:
+            # Forced reconcile is a positive health signal: clear the whole
+            # episode (dirty + throttle + baseline) — the mirror written above
+            # is now authoritative and dirty is over.
+            self._clear_dirty(direction)
+        else:
+            # Establish the REST baseline the WS gate consults for THIS episode.
+            self._last_rest_position_size[direction] = new_size
+
     def _is_good_to_place(self, intent: PlaceLimitIntent, limits: dict[str, list[dict]]) -> bool:
         """Check if order can be placed (exact-duplicate + reduce-only checks).
 
@@ -994,14 +1192,58 @@ class StrategyRunner:
         return replace(intent, order_link_id=wire_id)
 
     def _execute_place_intent(self, intent: PlaceLimitIntent, limits: dict[str, list[dict]]) -> None:
-        """Execute a place order intent."""
-        # Resolve qty (engine emits qty=0, we fill it in)
+        """Execute a place order intent.
+
+        Pipeline (feature 0064 — explicit order, do not reorder):
+        1. resolve qty → qty<=0 early return.
+        2. breaker ``is_blocked`` → early return (no REST, no guard, no submit
+           while a scope key is in cooldown).
+        3. dirty-mirror REST refresh (reduce-only only, throttled) BEFORE the
+           guard, so step 4 evaluates fresh size.
+        4. ``_is_good_to_place`` → unchanged guard (now reads the freshened
+           mirror); oversized reduce-only is rejected here, nothing submitted.
+        5. duplicate-track + wire-link-id (existing).
+        6. ``execute_place`` → post-submit breaker bookkeeping.
+        """
+        # Step 1 — resolve qty (engine emits qty=0, we fill it in)
         intent = self._resolve_qty(intent)
         if intent.qty <= 0:
             logger.debug(f"{self.strat_id}: Skipping order with qty<=0 at {intent.price}")
             return
 
-        # Check duplicate and reduce-only constraints (bbu2 _is_good_to_place)
+        now = self._clock()
+
+        # Step 2 — circuit-breaker: drop while this scope key is in cooldown.
+        # Sits first so a tripped scope never triggers a REST refresh on
+        # per-ticker re-emission during cooldown.
+        if self._truncate_breaker.is_blocked(intent.side, intent.price, now):
+            logger.debug(
+                f"{self.strat_id}: 110017 breaker tripped — dropping "
+                f"{intent.side} @ {intent.price}"
+            )
+            return
+
+        # Step 3 — dirty-mirror REST refresh before the guard (reduce-only only).
+        # `dirty_refresh_enabled` is the FIRST term so flipping it off is a true
+        # kill-switch. intent.direction is the position being closed (a
+        # reduce-only Sell → LONG), so no side→direction inversion here.
+        if (
+            self._config.dirty_refresh_enabled
+            and intent.reduce_only
+            and self._position_dirty.get(intent.direction, False)
+        ):
+            last = self._last_dirty_rest_at.get(intent.direction)
+            interval = self._config.dirty_rest_refresh_min_interval_seconds
+            if last is None or (now - last) >= interval:
+                self._refresh_position_size_from_rest(intent.direction)
+            else:
+                logger.debug(
+                    f"{self.strat_id}: dirty REST refresh throttled for "
+                    f"{intent.direction} (last={last}, now={now})"
+                )
+
+        # Step 4 — duplicate + reduce-only guard (bbu2 _is_good_to_place,
+        # unchanged body; now reading the freshened-when-dirty mirror).
         if not self._is_good_to_place(intent, limits):
             logger.debug(
                 f"{self.strat_id}: Skipping order at {intent.price} - "
@@ -1009,9 +1251,8 @@ class StrategyRunner:
             )
             return
 
+        # Step 5 — duplicate-track + wire-link-id assignment (existing).
         reusable_order_link_id = None
-
-        # Check for duplicate
         if intent.client_order_id in self._tracked_orders:
             tracked = self._tracked_orders[intent.client_order_id]
             if tracked.status in ("pending", "placed"):
@@ -1039,15 +1280,60 @@ class StrategyRunner:
         )
         self._tracked_orders[assigned.client_order_id] = tracked
 
-        # Execute
+        # Step 6 — execute + breaker bookkeeping
         result = self._executor.execute_place(assigned)
 
         if result.success:
             tracked.mark_placed(result.order_id)
-        else:
-            tracked.mark_failed()
+            self._truncate_breaker.record_success(intent.side, intent.price)
+            # Only a successful reduce-only CLOSE proves position >= qty (it
+            # exercised the guard against fresh-enough state and Bybit accepted
+            # it). A successful OPEN on the same direction proves nothing about
+            # position-size divergence, so it must NOT clear dirty (F1) — else
+            # interleaved opens re-arm one 110017 per open until the breaker
+            # trips, defeating the silent self-heal.
+            if intent.reduce_only:
+                self._clear_dirty(intent.direction)  # divergence healed
+            return
+
+        tracked.mark_failed()
+
+        if not is_truncate_error(result.error):
+            # Non-110017 failure → existing retry-queue behaviour (feature 0032
+            # wire-id reuse preserved via the failed-tracked-order path above).
             if self._on_intent_failed:
                 self._on_intent_failed(assigned, result.error)
+            return
+
+        # --- 110017 (orderQty truncated to zero) handling ---
+        # Mark the direction dirty so the NEXT placement REST-refreshes the
+        # mirror before the guard (self-heal), even before the breaker trips.
+        self._position_dirty[intent.direction] = True
+
+        tripped = self._truncate_breaker.record_110017(intent.side, intent.price, now)
+
+        # Drop the wire-id reuse for 110017: the order was never created on
+        # Bybit (hard reject), so the feature-0032 reuse rationale (avoid a
+        # duplicate on an *ambiguous* outcome) does not apply. Reusing it could
+        # surface as 110072 — which the breaker does not count and the retry
+        # queue does not exclude — partially bypassing the backstop. Clearing
+        # the tracked intent's order_link_id forces a fresh id next emission.
+        tracked.intent = replace(tracked.intent, order_link_id=None)
+
+        # Do NOT enqueue 110017 to the retry queue — retrying is pointless
+        # (same qty, same clamp) and is part of the storm.
+
+        if tripped:
+            logger.warning(
+                "%s: 110017 circuit-breaker tripped for %s @ %s — dropping "
+                "intents for %.0fs (trip #%d)",
+                self.strat_id, intent.side, intent.price,
+                self._config.truncate_breaker_cooldown_seconds,
+                self._truncate_breaker_reconcile_count + 1,
+            )
+            self._truncate_breaker_reconcile_count += 1
+            if self._config.truncate_breaker_reconcile and self._on_truncate_breaker_tripped:
+                self._on_truncate_breaker_tripped(self.strat_id, intent.direction)
 
     def _execute_cancel_intent(self, intent: CancelIntent) -> None:
         """Execute a cancel order intent."""

--- a/apps/gridbot/src/gridbot/truncate_breaker.py
+++ b/apps/gridbot/src/gridbot/truncate_breaker.py
@@ -56,6 +56,10 @@ class TruncateBreaker:
 
     @staticmethod
     def _key(side: str, price: Decimal) -> ScopeKey:
+        # NOT keyed by orderLinkId: it carries a per-placement -{millis} suffix
+        # (feature 0032), so it changes every retry and the breaker would never
+        # accumulate. (side, price) is stable across per-tick re-emission of the
+        # same grid-level close.
         return (side, price)
 
     def is_blocked(self, side: str, price: Decimal, now: float) -> bool:

--- a/apps/gridbot/src/gridbot/truncate_breaker.py
+++ b/apps/gridbot/src/gridbot/truncate_breaker.py
@@ -1,0 +1,111 @@
+"""110017 circuit-breaker (feature 0064, issue #149).
+
+Bounds the blast radius of an ErrCode 110017 ("orderQty will be truncated to
+zero") retry storm. The engine re-emits the same logical reduce-only close on
+(nearly) every ``on_ticker`` while price sits at a grid level; without a gate
+that produced 535 identical rejected placements in <90min during the
+2026-05-30 incident.
+
+Design mirrors ``RetryQueue``: no background thread, no internal clock. The
+owner (``StrategyRunner``) passes ``now`` into each call, so the breaker is
+trivially testable with a virtual clock and free of ``time`` coupling.
+
+Scope key is ``(side, price)`` — NOT ``orderLinkId`` (which carries a
+per-placement ``-{millis}`` suffix and changes every retry, so it would never
+accumulate). ``(side, price)`` is stable across per-tick re-emission of the
+same grid-level close and matches the verbatim rejected payload identity.
+``reduce_only`` is implicit: 110017 only occurs on reduce-only orders.
+"""
+
+import logging
+from collections import deque
+from decimal import Decimal
+from typing import Deque, Dict, Tuple
+
+
+logger = logging.getLogger(__name__)
+
+# (side, price) — price kept as Decimal so equal values of differing scale
+# (84.5 == 84.50) collide on one key (Python guarantees equal Decimals hash
+# equal).
+ScopeKey = Tuple[str, Decimal]
+
+
+class TruncateBreaker:
+    """Sliding-window trip/cooldown gate keyed by ``(side, price)``."""
+
+    def __init__(
+        self,
+        max_consecutive: int = 3,
+        window_seconds: float = 60.0,
+        cooldown_seconds: float = 60.0,
+    ):
+        """Initialize the breaker.
+
+        Args:
+            max_consecutive: Trip after this many 110017s within ``window_seconds``.
+            window_seconds: Sliding window for counting events per scope key.
+            cooldown_seconds: After a trip, ``is_blocked`` returns True for this
+                long on that scope key.
+        """
+        self._max = max_consecutive
+        self._window = window_seconds
+        self._cooldown = cooldown_seconds
+        self._events: Dict[ScopeKey, Deque[float]] = {}
+        self._tripped_until: Dict[ScopeKey, float] = {}
+
+    @staticmethod
+    def _key(side: str, price: Decimal) -> ScopeKey:
+        return (side, price)
+
+    def is_blocked(self, side: str, price: Decimal, now: float) -> bool:
+        """True if this scope key is in an active cooldown (drop the intent).
+
+        On cooldown expiry, clears the trip and the timestamp deque (fresh
+        start) and returns False.
+        """
+        key = self._key(side, price)
+        until = self._tripped_until.get(key)
+        if until is None:
+            return False
+        if now < until:
+            return True
+        # Cooldown expired: reset this scope key entirely.
+        del self._tripped_until[key]
+        self._events.pop(key, None)
+        return False
+
+    def record_110017(self, side: str, price: Decimal, now: float) -> bool:
+        """Record one 110017; return True only on the first-trip edge.
+
+        - In-cooldown no-op (P2-a): if the scope key is currently tripped, return
+          False WITHOUT appending, re-arming the trip, or signalling reconcile.
+          A tripped scope stays silently blocked until cooldown expiry.
+        - Otherwise append ``now``, evict timestamps older than the window, and
+          trip (return True) when the count reaches ``max_consecutive``.
+        """
+        key = self._key(side, price)
+        until = self._tripped_until.get(key)
+        if until is not None:
+            if now < until:
+                return False  # in-cooldown no-op
+            # Expired trip lingering (is_blocked normally clears it first): reset.
+            del self._tripped_until[key]
+            self._events.pop(key, None)
+
+        dq = self._events.setdefault(key, deque())
+        dq.append(now)
+        cutoff = now - self._window
+        while dq and dq[0] < cutoff:
+            dq.popleft()
+
+        if len(dq) >= self._max:
+            self._tripped_until[key] = now + self._cooldown
+            return True
+        return False
+
+    def record_success(self, side: str, price: Decimal) -> None:
+        """A successful place at this scope means divergence healed: reset it."""
+        key = self._key(side, price)
+        self._events.pop(key, None)
+        self._tripped_until.pop(key, None)

--- a/apps/gridbot/tests/test_config.py
+++ b/apps/gridbot/tests/test_config.py
@@ -61,6 +61,57 @@ class TestStrategyConfig:
         assert strategy.grid_step == 0.2  # default
         assert strategy.shadow_mode is False  # default
 
+    def test_truncate_breaker_defaults(self):
+        """Feature 0064 — dirty-refresh + circuit-breaker config defaults."""
+        strategy = StrategyConfig(
+            strat_id="btc_main",
+            account="main",
+            symbol="BTCUSDT",
+            tick_size=Decimal("0.1"),
+        )
+        assert strategy.dirty_refresh_enabled is True
+        assert strategy.dirty_rest_refresh_min_interval_seconds == 10.0
+        assert strategy.truncate_breaker_max_consecutive == 3
+        assert strategy.truncate_breaker_window_seconds == 60.0
+        assert strategy.truncate_breaker_cooldown_seconds == 60.0
+        assert strategy.truncate_breaker_reconcile is True
+
+    def test_truncate_breaker_overrides(self):
+        """Feature 0064 — config values are overridable from YAML."""
+        strategy = StrategyConfig(
+            strat_id="btc_main",
+            account="main",
+            symbol="BTCUSDT",
+            tick_size=Decimal("0.1"),
+            dirty_refresh_enabled=False,
+            dirty_rest_refresh_min_interval_seconds=5.0,
+            truncate_breaker_max_consecutive=5,
+            truncate_breaker_window_seconds=30.0,
+            truncate_breaker_cooldown_seconds=120.0,
+            truncate_breaker_reconcile=False,
+        )
+        assert strategy.dirty_refresh_enabled is False
+        assert strategy.dirty_rest_refresh_min_interval_seconds == 5.0
+        assert strategy.truncate_breaker_max_consecutive == 5
+        assert strategy.truncate_breaker_window_seconds == 30.0
+        assert strategy.truncate_breaker_cooldown_seconds == 120.0
+        assert strategy.truncate_breaker_reconcile is False
+
+    def test_truncate_breaker_invalid_values_rejected(self):
+        """Feature 0064 — pydantic enforces the declared constraints (F6)."""
+        base = dict(
+            strat_id="btc_main", account="main", symbol="BTCUSDT",
+            tick_size=Decimal("0.1"),
+        )
+        with pytest.raises(ValidationError):
+            StrategyConfig(**base, truncate_breaker_max_consecutive=0)  # ge=1
+        with pytest.raises(ValidationError):
+            StrategyConfig(**base, truncate_breaker_window_seconds=0)  # gt=0
+        with pytest.raises(ValidationError):
+            StrategyConfig(**base, truncate_breaker_cooldown_seconds=-1)  # gt=0
+        with pytest.raises(ValidationError):
+            StrategyConfig(**base, dirty_rest_refresh_min_interval_seconds=0)  # gt=0
+
     def test_increase_same_position_on_low_margin_defaults_false(self):
         """Test low-margin equal-position boost flag defaults off."""
         strategy = StrategyConfig(

--- a/apps/gridbot/tests/test_executor.py
+++ b/apps/gridbot/tests/test_executor.py
@@ -7,7 +7,39 @@ from unittest.mock import Mock, MagicMock
 import pytest
 
 from gridcore.intents import PlaceLimitIntent, CancelIntent
-from gridbot.executor import IntentExecutor, OrderResult, CancelResult, AUTH_ERROR_CODES
+from gridbot.executor import (
+    IntentExecutor,
+    OrderResult,
+    CancelResult,
+    AUTH_ERROR_CODES,
+    is_truncate_error,
+)
+from bybit_adapter.error_codes import ORDER_QTY_TRUNCATED_TO_ZERO
+
+
+class TestIsTruncateError:
+    """Feature 0064 — classify ErrCode 110017 ('orderQty will be truncated to zero')."""
+
+    def test_constant_is_110017(self):
+        assert ORDER_QTY_TRUNCATED_TO_ZERO == 110017
+
+    def test_detects_check_response_format(self):
+        # _check_response format: "[110017] ..."
+        err = "Bybit API error in place_order: [110017] orderQty will be truncated to zero"
+        assert is_truncate_error(err) is True
+
+    def test_detects_pybit_native_format(self):
+        # pybit native: "(ErrCode: 110017) ..."
+        err = "place_order failed (ErrCode: 110017) orderQty will be truncated to zero"
+        assert is_truncate_error(err) is True
+
+    def test_other_error_code_is_not_truncate(self):
+        assert is_truncate_error("Bybit API error: [110001] params error") is False
+        assert is_truncate_error("Connection timeout") is False
+
+    def test_none_and_empty_are_not_truncate(self):
+        assert is_truncate_error(None) is False
+        assert is_truncate_error("") is False
 
 
 @pytest.fixture

--- a/apps/gridbot/tests/test_orchestrator.py
+++ b/apps/gridbot/tests/test_orchestrator.py
@@ -779,6 +779,7 @@ class TestOrchestratorTick:
         mock_runner = Mock()
         mock_runner.strat_id = "btcusdt_test"
         mock_runner.symbol = "BTCUSDT"
+        mock_runner.truncate_breaker_reconcile_count = 0  # 0064 health sweep reads this
         orchestrator._runners = {"btcusdt_test": mock_runner}
 
         ev1, ev2 = Mock(), Mock()
@@ -808,6 +809,7 @@ class TestOrchestratorTick:
         mock_runner = Mock()
         mock_runner.strat_id = "btcusdt_test"
         mock_runner.symbol = "BTCUSDT"
+        mock_runner.truncate_breaker_reconcile_count = 0  # 0064 health sweep reads this
         orchestrator._runners = {"btcusdt_test": mock_runner}
 
         ev1 = Mock()
@@ -837,6 +839,7 @@ class TestOrchestratorTick:
         mock_runner = Mock()
         mock_runner.strat_id = "btcusdt_test"
         mock_runner.symbol = "BTCUSDT"
+        mock_runner.truncate_breaker_reconcile_count = 0  # 0064 health sweep reads this
         orchestrator._runners = {"btcusdt_test": mock_runner}
         orchestrator._symbol_to_runners = {"BTCUSDT": [mock_runner]}
 
@@ -876,6 +879,7 @@ class TestOrchestratorTick:
         mock_runner = Mock()
         mock_runner.strat_id = "btcusdt_test"
         mock_runner.symbol = "BTCUSDT"
+        mock_runner.truncate_breaker_reconcile_count = 0  # 0064 health sweep reads this
         mock_runner.on_execution.side_effect = ValueError("boom")
         orchestrator._runners = {"btcusdt_test": mock_runner}
         orchestrator._symbol_to_runners = {"BTCUSDT": [mock_runner]}
@@ -919,6 +923,7 @@ class TestOrchestratorWsPositionDrain:
         mock_runner.strat_id = "btcusdt_test"
         mock_runner.symbol = "BTCUSDT"
         mock_runner.engine.last_close = 42500.0
+        mock_runner.truncate_breaker_reconcile_count = 0  # 0064 health sweep reads this
         orchestrator._runners = {"btcusdt_test": mock_runner}
         orchestrator._account_to_runners = {"test_account": [mock_runner]}
         orchestrator._symbol_to_runners = {"BTCUSDT": [mock_runner]}
@@ -1071,6 +1076,7 @@ class TestOrchestratorWsPositionDrain:
         mock_runner.strat_id = "btcusdt_test"
         mock_runner.symbol = "BTCUSDT"
         mock_runner.engine.last_close = 42500.0
+        mock_runner.truncate_breaker_reconcile_count = 0  # 0064 health sweep reads this
         mock_runner.on_position_update.side_effect = ValueError("boom")
         orch._runners = {"btcusdt_test": mock_runner}
         orch._account_to_runners = {"test_account": [mock_runner]}
@@ -1229,6 +1235,7 @@ class TestOrchestratorTickPeriodicCheckIsolation:
         mock_runner = Mock()
         mock_runner.strat_id = "btcusdt_test"
         mock_runner.symbol = "BTCUSDT"
+        mock_runner.truncate_breaker_reconcile_count = 0  # 0064 health sweep reads this
         orchestrator._runners = {"btcusdt_test": mock_runner}
         orchestrator._symbol_to_runners = {"BTCUSDT": [mock_runner]}
 
@@ -3658,3 +3665,73 @@ class TestOnWsDisconnect:
             time.sleep(0.01)
 
         assert notifier.alert_exception.called
+
+
+class TestForcedReconcile:
+    """Feature 0064 — breaker-tripped forced position+order reconcile."""
+
+    def _wire(self, gridbot_config):
+        orchestrator = Orchestrator(gridbot_config)
+        runner = Mock()
+        runner.strat_id = "btcusdt_test"
+        reconciler = Mock()
+        reconciler.reconcile_reconnect = MagicMock(return_value=ReconciliationResult())
+        orchestrator._runners["btcusdt_test"] = runner
+        orchestrator._reconcilers["test_account"] = reconciler
+        return orchestrator, runner, reconciler
+
+    def test_force_reconcile_calls_reconcile_and_position_refresh(self, gridbot_config):
+        orchestrator, runner, reconciler = self._wire(gridbot_config)
+
+        orchestrator._force_reconcile_strat("btcusdt_test", "long")
+
+        reconciler.reconcile_reconnect.assert_called_once_with(runner)
+        runner._refresh_position_size_from_rest.assert_called_once_with("long", force=True)
+
+    def test_force_reconcile_rate_limited(self, gridbot_config, monkeypatch):
+        clock = {"now": 1000.0}
+        monkeypatch.setattr("gridbot.orchestrator.time.monotonic", lambda: clock["now"])
+        orchestrator, runner, reconciler = self._wire(gridbot_config)
+
+        orchestrator._force_reconcile_strat("btcusdt_test", "long")
+        orchestrator._force_reconcile_strat("btcusdt_test", "long")  # within cooldown
+        assert reconciler.reconcile_reconnect.call_count == 1  # rate-limited
+
+        clock["now"] = 1000.0 + 61.0  # past the 60s default cooldown
+        orchestrator._force_reconcile_strat("btcusdt_test", "long")
+        assert reconciler.reconcile_reconnect.call_count == 2
+
+    def test_force_reconcile_missing_runner_is_noop(self, gridbot_config):
+        orchestrator = Orchestrator(gridbot_config)
+        # No runner/reconciler wired — must not raise.
+        orchestrator._force_reconcile_strat("nonexistent", "long")
+
+    def test_force_reconcile_exception_is_caught_and_alerted(self, gridbot_config):
+        """F6 + P2: a raising order-reconcile is caught/alerted AND the
+        #149-critical position resync still runs (independent try blocks)."""
+        orchestrator, runner, reconciler = self._wire(gridbot_config)
+        notifier = Mock()
+        orchestrator._notifier = notifier
+        reconciler.reconcile_reconnect.side_effect = Exception("boom")
+
+        orchestrator._force_reconcile_strat("btcusdt_test", "long")  # must not raise
+
+        notifier.alert_exception.assert_called_once()
+        assert "force_reconcile" in notifier.alert_exception.call_args.kwargs.get("error_key", "")
+        # P2: order-reconcile failure must NOT skip the position resync.
+        runner._refresh_position_size_from_rest.assert_called_once_with("long", force=True)
+
+    def test_health_check_logs_breaker_trip_count(self, gridbot_config, caplog):
+        orchestrator = Orchestrator(gridbot_config)
+        runner = Mock()
+        runner.strat_id = "btcusdt_test"
+        runner.truncate_breaker_reconcile_count = 2
+        orchestrator._runners["btcusdt_test"] = runner
+
+        with caplog.at_level("DEBUG", logger="gridbot.orchestrator"):
+            orchestrator._health_check_once()
+
+        assert any(
+            "breaker" in r.message.lower() or "trip" in r.message.lower()
+            for r in caplog.records
+        )

--- a/apps/gridbot/tests/test_orchestrator.py
+++ b/apps/gridbot/tests/test_orchestrator.py
@@ -780,6 +780,7 @@ class TestOrchestratorTick:
         mock_runner.strat_id = "btcusdt_test"
         mock_runner.symbol = "BTCUSDT"
         mock_runner.truncate_breaker_reconcile_count = 0  # 0064 health sweep reads this
+        mock_runner.dirty_rest_refresh_failure_count = 0  # 0064 health sweep reads this
         orchestrator._runners = {"btcusdt_test": mock_runner}
 
         ev1, ev2 = Mock(), Mock()
@@ -810,6 +811,7 @@ class TestOrchestratorTick:
         mock_runner.strat_id = "btcusdt_test"
         mock_runner.symbol = "BTCUSDT"
         mock_runner.truncate_breaker_reconcile_count = 0  # 0064 health sweep reads this
+        mock_runner.dirty_rest_refresh_failure_count = 0  # 0064 health sweep reads this
         orchestrator._runners = {"btcusdt_test": mock_runner}
 
         ev1 = Mock()
@@ -840,6 +842,7 @@ class TestOrchestratorTick:
         mock_runner.strat_id = "btcusdt_test"
         mock_runner.symbol = "BTCUSDT"
         mock_runner.truncate_breaker_reconcile_count = 0  # 0064 health sweep reads this
+        mock_runner.dirty_rest_refresh_failure_count = 0  # 0064 health sweep reads this
         orchestrator._runners = {"btcusdt_test": mock_runner}
         orchestrator._symbol_to_runners = {"BTCUSDT": [mock_runner]}
 
@@ -880,6 +883,7 @@ class TestOrchestratorTick:
         mock_runner.strat_id = "btcusdt_test"
         mock_runner.symbol = "BTCUSDT"
         mock_runner.truncate_breaker_reconcile_count = 0  # 0064 health sweep reads this
+        mock_runner.dirty_rest_refresh_failure_count = 0  # 0064 health sweep reads this
         mock_runner.on_execution.side_effect = ValueError("boom")
         orchestrator._runners = {"btcusdt_test": mock_runner}
         orchestrator._symbol_to_runners = {"BTCUSDT": [mock_runner]}
@@ -924,6 +928,7 @@ class TestOrchestratorWsPositionDrain:
         mock_runner.symbol = "BTCUSDT"
         mock_runner.engine.last_close = 42500.0
         mock_runner.truncate_breaker_reconcile_count = 0  # 0064 health sweep reads this
+        mock_runner.dirty_rest_refresh_failure_count = 0  # 0064 health sweep reads this
         orchestrator._runners = {"btcusdt_test": mock_runner}
         orchestrator._account_to_runners = {"test_account": [mock_runner]}
         orchestrator._symbol_to_runners = {"BTCUSDT": [mock_runner]}
@@ -1077,6 +1082,7 @@ class TestOrchestratorWsPositionDrain:
         mock_runner.symbol = "BTCUSDT"
         mock_runner.engine.last_close = 42500.0
         mock_runner.truncate_breaker_reconcile_count = 0  # 0064 health sweep reads this
+        mock_runner.dirty_rest_refresh_failure_count = 0  # 0064 health sweep reads this
         mock_runner.on_position_update.side_effect = ValueError("boom")
         orch._runners = {"btcusdt_test": mock_runner}
         orch._account_to_runners = {"test_account": [mock_runner]}
@@ -1236,6 +1242,7 @@ class TestOrchestratorTickPeriodicCheckIsolation:
         mock_runner.strat_id = "btcusdt_test"
         mock_runner.symbol = "BTCUSDT"
         mock_runner.truncate_breaker_reconcile_count = 0  # 0064 health sweep reads this
+        mock_runner.dirty_rest_refresh_failure_count = 0  # 0064 health sweep reads this
         orchestrator._runners = {"btcusdt_test": mock_runner}
         orchestrator._symbol_to_runners = {"BTCUSDT": [mock_runner]}
 
@@ -3726,12 +3733,29 @@ class TestForcedReconcile:
         runner = Mock()
         runner.strat_id = "btcusdt_test"
         runner.truncate_breaker_reconcile_count = 2
+        runner.dirty_rest_refresh_failure_count = 0
         orchestrator._runners["btcusdt_test"] = runner
 
         with caplog.at_level("DEBUG", logger="gridbot.orchestrator"):
             orchestrator._health_check_once()
 
         assert any(
-            "breaker" in r.message.lower() or "trip" in r.message.lower()
+            "breaker" in r.getMessage().lower() or "trip" in r.getMessage().lower()
             for r in caplog.records
+        )
+
+    def test_health_check_logs_rest_refresh_failures(self, gridbot_config, caplog):
+        """Review v3 #1: persistent dirty REST refresh failures are surfaced."""
+        orchestrator = Orchestrator(gridbot_config)
+        runner = Mock()
+        runner.strat_id = "btcusdt_test"
+        runner.truncate_breaker_reconcile_count = 0
+        runner.dirty_rest_refresh_failure_count = 4
+        orchestrator._runners["btcusdt_test"] = runner
+
+        with caplog.at_level("DEBUG", logger="gridbot.orchestrator"):
+            orchestrator._health_check_once()
+
+        assert any(
+            "refresh failures=4" in r.getMessage() for r in caplog.records
         )

--- a/apps/gridbot/tests/test_runner_truncate_storm.py
+++ b/apps/gridbot/tests/test_runner_truncate_storm.py
@@ -1,0 +1,605 @@
+"""Feature 0064 — 110017 retry-storm self-heal + circuit-breaker (issue #149).
+
+Two post-fix paths are tested separately because they have different
+preconditions:
+  - primary self-heal: dirty-mirror REST refresh BEFORE the guard, so the
+    unchanged strict-`>` guard rejects an oversized reduce-only close locally
+    (no submit, no second 110017, breaker never trips).
+  - backstop: when the refresh cannot heal (disabled / no rest client / REST
+    still stale), the circuit-breaker bounds the storm after N 110017s.
+"""
+
+from dataclasses import replace
+from decimal import Decimal
+from unittest.mock import Mock, MagicMock
+
+import pytest
+
+from gridcore import InstrumentInfo
+from gridcore.intents import PlaceLimitIntent
+from gridcore.position import DirectionType
+
+from gridbot.config import StrategyConfig
+from gridbot.executor import IntentExecutor, OrderResult
+from gridbot.runner import StrategyRunner
+from gridbot.truncate_breaker import TruncateBreaker
+
+EMPTY_LIMITS: dict[str, list[dict]] = {"long": [], "short": []}
+
+TRUNCATE_ERROR = (
+    "Bybit API error in place_order: [110017] orderQty will be truncated to zero"
+)
+
+
+def _reduce_only_sell(price="84.51", qty="0.1"):
+    """A reduce-only Sell closing a LONG position (direction='long')."""
+    return PlaceLimitIntent.create(
+        symbol="SOLUSDT",
+        side="Sell",
+        price=Decimal(price),
+        qty=Decimal(qty),
+        grid_level=3,
+        direction="long",
+        reduce_only=True,
+    )
+
+
+def _positions(size, position_idx=1):
+    """Raw Bybit get_positions() flat list with one hedge-mode entry."""
+    return [
+        {
+            "symbol": "SOLUSDT",
+            "positionIdx": position_idx,
+            "side": "Buy" if position_idx == 1 else "Sell",
+            "size": str(size),
+            "avgPrice": "84.0",
+        }
+    ]
+
+
+@pytest.fixture
+def clock():
+    """Mutable virtual clock; default pinned at 0.0 (proves clock-independence)."""
+    return {"now": 0.0}
+
+
+@pytest.fixture
+def strategy_config():
+    return StrategyConfig(
+        strat_id="solusdt_test",
+        account="test_account",
+        symbol="SOLUSDT",
+        tick_size=Decimal("0.01"),
+        grid_count=30,
+        grid_step=0.3,
+        dirty_rest_refresh_min_interval_seconds=10.0,
+        truncate_breaker_max_consecutive=3,
+        truncate_breaker_window_seconds=60.0,
+        truncate_breaker_cooldown_seconds=60.0,
+    )
+
+
+@pytest.fixture
+def instrument_info():
+    return InstrumentInfo(
+        symbol="SOLUSDT",
+        qty_step=Decimal("0.01"),
+        tick_size=Decimal("0.01"),
+        min_qty=Decimal("0.01"),
+        max_qty=Decimal("10000"),
+    )
+
+
+@pytest.fixture
+def mock_executor():
+    executor = Mock(spec=IntentExecutor)
+    executor.shadow_mode = False
+    executor.auth_cooldown = False
+    executor.execute_place = MagicMock(
+        return_value=OrderResult(success=True, order_id="order_1")
+    )
+    return executor
+
+
+@pytest.fixture
+def mock_rest_client():
+    client = Mock()
+    client.get_positions = MagicMock(return_value=_positions("0.05"))
+    return client
+
+
+@pytest.fixture
+def reconcile_calls():
+    return []
+
+
+@pytest.fixture
+def runner(strategy_config, mock_executor, instrument_info, mock_rest_client, clock, reconcile_calls):
+    r = StrategyRunner(
+        strategy_config=strategy_config,
+        executor=mock_executor,
+        instrument_info=instrument_info,
+        rest_client=mock_rest_client,
+        clock=lambda: clock["now"],
+        on_truncate_breaker_tripped=lambda sid, direction: reconcile_calls.append((sid, direction)),
+    )
+    r._wallet_balance = Decimal("10000")
+    return r
+
+
+# --------------------------------------------------------------------------
+# Reproducing tests — the storm and its two post-fix paths
+# --------------------------------------------------------------------------
+
+def test_110017_storm_self_heals_after_one_failure(runner, mock_executor, mock_rest_client, clock):
+    """Primary path (#149 fix): storm collapses to exactly one 110017.
+
+    Tick 1: stale-high mirror passes the guard → 110017 → dirty set.
+    Tick 2+: pre-guard REST refresh corrects the mirror → guard rejects
+    locally → execute_place is never called again; 110017 never enqueued;
+    breaker records one event and does NOT trip.
+    """
+    enqueued = []
+    runner._on_intent_failed = lambda intent, error: enqueued.append((intent, error))
+
+    mock_executor.execute_place.return_value = OrderResult(success=False, error=TRUNCATE_ERROR)
+    mock_rest_client.get_positions.return_value = _positions("0.05")  # actual small
+    runner._long_position.size = Decimal("0.2")  # stale-high
+
+    intent = _reduce_only_sell(qty="0.1")
+    for _ in range(5):  # per-tick re-emission
+        runner._execute_place_intent(replace(intent), EMPTY_LIMITS)
+
+    assert mock_executor.execute_place.call_count == 1  # storm collapsed
+    assert mock_rest_client.get_positions.call_count == 1  # tick-2 refresh, then throttled
+    assert enqueued == []  # 110017 never enqueued to retry queue
+    assert runner._position_dirty[DirectionType.LONG] is True
+    assert runner.truncate_breaker_reconcile_count == 0  # did not trip
+
+
+def test_tick2_refresh_fires_at_clock_zero(runner, mock_executor, mock_rest_client, clock):
+    """Clock-independence (P2): the first dirty refresh fires even at now=0.
+
+    Proves the `_last_dirty_rest_at is None` sentinel bypasses the throttle,
+    not a large real monotonic clock.
+    """
+    clock["now"] = 0.0
+    mock_executor.execute_place.return_value = OrderResult(success=False, error=TRUNCATE_ERROR)
+    mock_rest_client.get_positions.return_value = _positions("0.05")
+    runner._long_position.size = Decimal("0.2")
+
+    intent = _reduce_only_sell(qty="0.1")
+    runner._execute_place_intent(replace(intent), EMPTY_LIMITS)  # tick 1: 110017 → dirty
+    assert mock_rest_client.get_positions.call_count == 0
+    runner._execute_place_intent(replace(intent), EMPTY_LIMITS)  # tick 2: refresh fires at now=0
+    assert mock_rest_client.get_positions.call_count == 1
+
+
+def test_breaker_bounds_storm_when_refresh_cannot_heal(
+    strategy_config, mock_executor, instrument_info, mock_rest_client, clock, reconcile_calls
+):
+    """Backstop path: refresh disabled → breaker trips and bounds the storm."""
+    cfg = strategy_config.model_copy(update={"dirty_refresh_enabled": False})
+    r = StrategyRunner(
+        strategy_config=cfg,
+        executor=mock_executor,
+        instrument_info=instrument_info,
+        rest_client=mock_rest_client,
+        clock=lambda: clock["now"],
+        on_truncate_breaker_tripped=lambda sid, d: reconcile_calls.append((sid, d)),
+    )
+    r._wallet_balance = Decimal("10000")
+    r._long_position.size = Decimal("0.2")  # stays stale (no refresh)
+
+    enqueued = []
+    r._on_intent_failed = lambda intent, error: enqueued.append((intent, error))
+    mock_executor.execute_place.return_value = OrderResult(success=False, error=TRUNCATE_ERROR)
+
+    intent = _reduce_only_sell(qty="0.1")
+    for _ in range(8):
+        r._execute_place_intent(replace(intent), EMPTY_LIMITS)
+
+    # Guard keeps passing (stale mirror) → submits until the breaker trips at N=3
+    assert mock_executor.execute_place.call_count == 3
+    assert r.truncate_breaker_reconcile_count == 1  # one trip
+    assert reconcile_calls == [("solusdt_test", DirectionType.LONG)]  # forced reconcile once
+    assert enqueued == []  # 110017 never enqueued
+    assert mock_rest_client.get_positions.call_count == 0  # refresh disabled
+
+
+def test_breaker_bounds_storm_when_rest_client_none(
+    strategy_config, mock_executor, instrument_info, clock, reconcile_calls
+):
+    """Backstop path #2 (P3.1): rest_client=None can't heal → breaker bounds it.
+
+    dirty_refresh_enabled stays True (default), so the refresh IS attempted each
+    dirty tick but returns early (no client) leaving the mirror stale — the guard
+    keeps passing until the breaker trips.
+    """
+    r = StrategyRunner(
+        strategy_config=strategy_config,
+        executor=mock_executor,
+        instrument_info=instrument_info,
+        rest_client=None,
+        clock=lambda: clock["now"],
+        on_truncate_breaker_tripped=lambda sid, d: reconcile_calls.append((sid, d)),
+    )
+    r._wallet_balance = Decimal("10000")
+    r._long_position.size = Decimal("0.2")  # stale-high, no REST to correct it
+    enqueued = []
+    r._on_intent_failed = lambda intent, error: enqueued.append((intent, error))
+    mock_executor.execute_place.return_value = OrderResult(success=False, error=TRUNCATE_ERROR)
+
+    intent = _reduce_only_sell(qty="0.1")
+    for _ in range(8):
+        r._execute_place_intent(replace(intent), EMPTY_LIMITS)
+
+    assert mock_executor.execute_place.call_count == 3  # trips at N=3
+    assert r.truncate_breaker_reconcile_count == 1
+    assert reconcile_calls == [("solusdt_test", DirectionType.LONG)]
+    assert enqueued == []  # 110017 never enqueued
+
+
+# --------------------------------------------------------------------------
+# Phase 2 — dirty-mirror refresh before the guard
+# --------------------------------------------------------------------------
+
+def test_first_110017_sets_position_dirty(runner, mock_executor):
+    mock_executor.execute_place.return_value = OrderResult(success=False, error=TRUNCATE_ERROR)
+    runner._long_position.size = Decimal("0.2")
+    runner._execute_place_intent(_reduce_only_sell(qty="0.1"), EMPTY_LIMITS)
+    assert runner._position_dirty[DirectionType.LONG] is True
+
+
+def test_dirty_refresh_before_guard_rejects_oversized_close(runner, mock_executor, mock_rest_client):
+    runner._long_position.size = Decimal("0.2")  # stale-high
+    mock_executor.execute_place.return_value = OrderResult(success=False, error=TRUNCATE_ERROR)
+    mock_rest_client.get_positions.return_value = _positions("0.05")  # actual
+
+    intent = _reduce_only_sell(qty="0.1")
+    runner._execute_place_intent(replace(intent), EMPTY_LIMITS)  # 110017 → dirty
+    runner._execute_place_intent(replace(intent), EMPTY_LIMITS)  # refresh → guard rejects
+
+    assert runner._long_position.size == Decimal("0.05")
+    assert mock_executor.execute_place.call_count == 1
+
+
+def test_dirty_refresh_unblocks_legit_close_when_actual_sufficient(runner, mock_executor, mock_rest_client):
+    """Stale-low mirror would wrongly reject; refresh unblocks the close."""
+    runner._position_dirty[DirectionType.LONG] = True  # a prior 110017 dirtied it
+    runner._long_position.size = Decimal("0.05")  # stale-low
+    mock_rest_client.get_positions.return_value = _positions("0.2")  # actual high
+    mock_executor.execute_place.return_value = OrderResult(success=True, order_id="ok")
+
+    runner._execute_place_intent(_reduce_only_sell(qty="0.1"), EMPTY_LIMITS)
+
+    assert runner._long_position.size == Decimal("0.2")
+    assert mock_executor.execute_place.call_count == 1
+    submitted = mock_executor.execute_place.call_args.args[0]
+    assert submitted.qty == Decimal("0.1")  # unchanged qty — no cap
+
+
+def test_dirty_rest_refresh_rate_limited(runner, mock_rest_client, clock):
+    """Within the throttle window, only one REST refresh fires."""
+    clock["now"] = 5.0
+    runner._position_dirty[DirectionType.LONG] = True
+    runner._long_position.size = Decimal("0.2")
+    mock_rest_client.get_positions.return_value = _positions("0.05")
+
+    intent = _reduce_only_sell(qty="0.1")
+    for _ in range(5):
+        runner._execute_place_intent(replace(intent), EMPTY_LIMITS)
+
+    assert mock_rest_client.get_positions.call_count == 1
+
+
+def test_refresh_position_size_updates_local_mirror(runner, mock_rest_client):
+    mock_rest_client.get_positions.return_value = _positions("0.05", position_idx=1)
+    runner._refresh_position_size_from_rest(DirectionType.LONG)
+    assert runner._long_position.size == Decimal("0.05")
+    assert runner._last_rest_position_size[DirectionType.LONG] == Decimal("0.05")
+
+
+def test_refresh_position_size_short_side(runner, mock_rest_client):
+    """P3.2: short-side refresh filters positionIdx==2 (parity with long)."""
+    mock_rest_client.get_positions.return_value = _positions("0.07", position_idx=2)
+    runner._refresh_position_size_from_rest(DirectionType.SHORT)
+    assert runner._short_position.size == Decimal("0.07")
+    assert runner._last_rest_position_size[DirectionType.SHORT] == Decimal("0.07")
+
+
+def test_refresh_position_size_handles_flat_position(runner, mock_rest_client):
+    # No matching positionIdx entry → flat
+    mock_rest_client.get_positions.return_value = []
+    runner._long_position.size = Decimal("0.2")
+    runner._refresh_position_size_from_rest(DirectionType.LONG)
+    assert runner._long_position.size == Decimal("0")
+    # size="0" entry → flat
+    mock_rest_client.get_positions.return_value = _positions("0", position_idx=1)
+    runner._short_position.size = Decimal("0.2")
+    runner._refresh_position_size_from_rest(DirectionType.SHORT)
+    assert runner._short_position.size == Decimal("0")
+
+
+def test_refresh_position_size_force_true_resets_dirty_state(runner, mock_rest_client):
+    """force=True (forced reconcile) clears dirty + resets the throttle sentinel.
+
+    Validates the state mutations on a REAL runner (the orchestrator test only
+    asserts the call is made with force=True against a mocked runner).
+    """
+    runner._position_dirty[DirectionType.LONG] = True
+    runner._last_dirty_rest_at[DirectionType.LONG] = 5.0
+    runner._last_rest_position_size[DirectionType.LONG] = Decimal("0.2")
+    mock_rest_client.get_positions.return_value = _positions("0.05")
+
+    runner._refresh_position_size_from_rest(DirectionType.LONG, force=True)
+
+    assert runner._long_position.size == Decimal("0.05")  # mirror written
+    # force clears the whole episode (F3): baseline + throttle reset to None so
+    # the prior episode's state never leaks into the next.
+    assert runner._position_dirty[DirectionType.LONG] is False
+    assert runner._last_dirty_rest_at[DirectionType.LONG] is None
+    assert runner._last_rest_position_size[DirectionType.LONG] is None
+
+
+def test_refresh_position_size_non_force_does_not_clear_dirty(runner, mock_rest_client, clock):
+    """Non-force dirty refresh updates throttle ts but leaves dirty set."""
+    clock["now"] = 7.0
+    runner._position_dirty[DirectionType.LONG] = True
+    mock_rest_client.get_positions.return_value = _positions("0.05")
+
+    runner._refresh_position_size_from_rest(DirectionType.LONG)
+
+    assert runner._position_dirty[DirectionType.LONG] is True
+    assert runner._last_dirty_rest_at[DirectionType.LONG] == 7.0
+
+
+def test_refresh_position_size_skips_malformed_position_idx(runner, mock_rest_client):
+    """A malformed positionIdx entry is skipped, not crashed on (degrades)."""
+    mock_rest_client.get_positions.return_value = [
+        {"positionIdx": "garbage", "size": "9.9"},  # unparseable idx → skipped
+        {"positionIdx": 1, "size": "0.05"},          # valid long entry
+    ]
+    runner._refresh_position_size_from_rest(DirectionType.LONG)
+    assert runner._long_position.size == Decimal("0.05")
+
+
+def test_refresh_position_size_no_rest_client_falls_back(
+    strategy_config, mock_executor, instrument_info, clock, caplog
+):
+    r = StrategyRunner(
+        strategy_config=strategy_config,
+        executor=mock_executor,
+        instrument_info=instrument_info,
+        rest_client=None,
+        clock=lambda: clock["now"],
+    )
+    r._long_position.size = Decimal("0.2")
+    with caplog.at_level("WARNING"):
+        r._refresh_position_size_from_rest(DirectionType.LONG)
+    assert r._long_position.size == Decimal("0.2")  # unchanged
+    assert any("rest" in rec.message.lower() for rec in caplog.records)
+
+
+# --------------------------------------------------------------------------
+# Phase 3 — circuit-breaker wiring in the runner
+# --------------------------------------------------------------------------
+
+def test_110017_retry_uses_fresh_order_link_id(
+    strategy_config, mock_executor, instrument_info, mock_rest_client, clock, monkeypatch
+):
+    """Backstop: after a 110017 the next emission mints a FRESH wire id.
+
+    Contrast with feature 0032: a non-110017 failure still reuses the id.
+    """
+    minted: list[str] = []
+
+    def fake_make(client_order_id):
+        link = f"{client_order_id}-mint-{len(minted)}"
+        minted.append(link)
+        return link
+
+    monkeypatch.setattr("gridbot.runner.make_order_link_id", fake_make)
+    cfg = strategy_config.model_copy(update={"dirty_refresh_enabled": False})
+    r = StrategyRunner(
+        strategy_config=cfg,
+        executor=mock_executor,
+        instrument_info=instrument_info,
+        rest_client=mock_rest_client,
+        clock=lambda: clock["now"],
+    )
+    r._wallet_balance = Decimal("10000")
+    r._long_position.size = Decimal("0.2")  # stale → guard keeps passing
+    mock_executor.execute_place.return_value = OrderResult(success=False, error=TRUNCATE_ERROR)
+
+    intent = _reduce_only_sell(qty="0.1")
+    r._execute_place_intent(replace(intent), EMPTY_LIMITS)
+    first = mock_executor.execute_place.call_args.args[0]
+    r._execute_place_intent(replace(intent), EMPTY_LIMITS)
+    second = mock_executor.execute_place.call_args.args[0]
+
+    assert second.order_link_id != first.order_link_id  # fresh id, not reused
+
+
+def test_non_110017_failure_still_reuses_wire_id_and_enqueues(
+    strategy_config, mock_executor, instrument_info, mock_rest_client, clock, monkeypatch
+):
+    """Guardrail: a network failure keeps feature-0032 reuse + retry-queue enqueue."""
+    minted: list[str] = []
+
+    def fake_make(client_order_id):
+        link = f"{client_order_id}-mint-{len(minted)}"
+        minted.append(link)
+        return link
+
+    monkeypatch.setattr("gridbot.runner.make_order_link_id", fake_make)
+    r = StrategyRunner(
+        strategy_config=strategy_config,
+        executor=mock_executor,
+        instrument_info=instrument_info,
+        rest_client=mock_rest_client,
+        clock=lambda: clock["now"],
+    )
+    r._wallet_balance = Decimal("10000")
+    enqueued = []
+    r._on_intent_failed = lambda intent, error: enqueued.append((intent, error))
+    mock_executor.execute_place.return_value = OrderResult(success=False, error="Connection timeout")
+
+    intent = PlaceLimitIntent.create(
+        symbol="SOLUSDT", side="Buy", price=Decimal("84.0"),
+        qty=Decimal("0.1"), grid_level=3, direction="long", reduce_only=False,
+    )
+    r._execute_place_intent(replace(intent), EMPTY_LIMITS)
+    first = mock_executor.execute_place.call_args.args[0]
+    r._execute_place_intent(replace(intent), EMPTY_LIMITS)
+    second = mock_executor.execute_place.call_args.args[0]
+
+    assert second.order_link_id == first.order_link_id  # reuse preserved
+    assert len(enqueued) == 2  # both enqueued to retry queue
+
+
+def test_breaker_blocks_before_refresh_on_tripped_scope(runner, mock_executor, mock_rest_client):
+    """A tripped scope drops the intent at is_blocked — no REST refresh."""
+    mock_executor.execute_place.return_value = OrderResult(success=False, error=TRUNCATE_ERROR)
+    runner._long_position.size = Decimal("0.2")
+    # Pre-trip the breaker on this scope key
+    runner._truncate_breaker._tripped_until[("Sell", Decimal("84.51"))] = 999.0
+    runner._position_dirty[DirectionType.LONG] = True
+
+    runner._execute_place_intent(_reduce_only_sell(qty="0.1"), EMPTY_LIMITS)
+
+    assert mock_executor.execute_place.call_count == 0
+    assert mock_rest_client.get_positions.call_count == 0  # blocked before refresh
+
+
+def test_successful_open_does_not_clear_dirty(runner, mock_executor):
+    """F1: a successful OPEN (Buy, not reduce-only) must NOT clear dirty.
+
+    Opens always pass the guard and prove nothing about position-size
+    divergence; clearing dirty here would re-arm a 110017 on the next close.
+    """
+    runner._position_dirty[DirectionType.LONG] = True
+    runner._last_rest_position_size[DirectionType.LONG] = Decimal("0.5")
+    mock_executor.execute_place.return_value = OrderResult(success=True, order_id="ok")
+    open_intent = PlaceLimitIntent.create(
+        symbol="SOLUSDT", side="Buy", price=Decimal("80.0"),
+        qty=Decimal("0.1"), grid_level=2, direction="long", reduce_only=False,
+    )
+    runner._execute_place_intent(open_intent, EMPTY_LIMITS)
+    assert mock_executor.execute_place.call_count == 1  # open was placed
+    assert runner._position_dirty[DirectionType.LONG] is True  # NOT cleared
+
+
+def test_dirty_refresh_throttle_armed_on_failed_refresh(runner, mock_rest_client, clock):
+    """F2: a failed refresh still arms the throttle (sentinel leaves None)."""
+    clock["now"] = 3.0
+    runner._position_dirty[DirectionType.LONG] = True
+    mock_rest_client.get_positions.side_effect = Exception("REST down")
+    runner._refresh_position_size_from_rest(DirectionType.LONG)
+    assert runner._last_dirty_rest_at[DirectionType.LONG] == 3.0  # stamped despite failure
+
+
+def test_failed_refresh_does_not_refire_every_tick(runner, mock_executor, mock_rest_client, clock):
+    """F2 regression: persistent get_positions failure + guard-reject must not
+    re-fire get_positions every tick (the unbounded case where the breaker
+    never trips because nothing is submitted)."""
+    clock["now"] = 100.0
+    runner._position_dirty[DirectionType.LONG] = True
+    runner._long_position.size = Decimal("0.05")  # stale-low → guard rejects
+    mock_rest_client.get_positions.side_effect = Exception("REST down")
+
+    intent = _reduce_only_sell(qty="0.1")
+    for _ in range(5):
+        runner._execute_place_intent(replace(intent), EMPTY_LIMITS)
+
+    assert mock_rest_client.get_positions.call_count == 1  # throttled after first attempt
+    assert mock_executor.execute_place.call_count == 0  # guard rejected, nothing submitted
+
+
+def test_successful_close_resets_rest_baseline(runner, mock_executor, mock_rest_client):
+    """F3: clearing dirty on a successful close resets the REST baseline."""
+    runner._position_dirty[DirectionType.LONG] = True
+    runner._last_dirty_rest_at[DirectionType.LONG] = None
+    mock_rest_client.get_positions.return_value = _positions("0.5")  # ample
+    mock_executor.execute_place.return_value = OrderResult(success=True, order_id="ok")
+
+    runner._execute_place_intent(_reduce_only_sell(qty="0.1"), EMPTY_LIMITS)
+
+    assert runner._position_dirty[DirectionType.LONG] is False
+    assert runner._last_rest_position_size[DirectionType.LONG] is None  # baseline reset
+    assert runner._last_dirty_rest_at[DirectionType.LONG] is None
+
+
+def test_successful_place_clears_dirty(runner, mock_executor, mock_rest_client):
+    runner._position_dirty[DirectionType.LONG] = True
+    runner._long_position.size = Decimal("0.5")
+    # REST agrees the position is large → pre-guard refresh keeps mirror 0.5,
+    # guard passes (0.5 > 0.1), place succeeds → dirty cleared.
+    mock_rest_client.get_positions.return_value = _positions("0.5")
+    mock_executor.execute_place.return_value = OrderResult(success=True, order_id="ok")
+    runner._execute_place_intent(_reduce_only_sell(qty="0.1"), EMPTY_LIMITS)
+    assert runner._position_dirty[DirectionType.LONG] is False
+    assert mock_executor.execute_place.call_count == 1
+
+
+# --------------------------------------------------------------------------
+# Phase 3 — dirty-window WS gate + WS-match clear (on_position_update)
+# --------------------------------------------------------------------------
+
+def _ws_pos(size):
+    return {
+        "size": str(size),
+        "avgPrice": "84.0",
+        "liqPrice": "0",
+        "unrealisedPnl": "0",
+        "cumRealisedPnl": "0",
+        "curRealisedPnl": "0",
+    }
+
+
+def test_ws_match_clears_dirty(runner):
+    runner._position_dirty[DirectionType.LONG] = True
+    runner._last_rest_position_size[DirectionType.LONG] = Decimal("0.05")
+    runner._last_dirty_rest_at[DirectionType.LONG] = 5.0
+
+    runner.on_position_update(_ws_pos("0.05"), None, 10000.0, 84.0)
+    assert runner._position_dirty[DirectionType.LONG] is False
+    assert runner._last_dirty_rest_at[DirectionType.LONG] is None
+    assert runner._last_rest_position_size[DirectionType.LONG] is None  # F3: baseline reset
+
+
+def test_ws_nonmatch_keeps_dirty(runner):
+    runner._position_dirty[DirectionType.LONG] = True
+    runner._last_rest_position_size[DirectionType.LONG] = Decimal("0.05")
+
+    runner.on_position_update(_ws_pos("0.07"), None, 10000.0, 84.0)
+    assert runner._position_dirty[DirectionType.LONG] is True
+    assert runner._long_position.size == Decimal("0.05")  # WS ignored, REST authoritative
+
+
+def test_stale_ws_after_rest_refresh_does_not_reopen_storm(runner, mock_executor, mock_rest_client, clock):
+    """Dangerous interleaving: a stale WS frame must not reopen the storm."""
+    clock["now"] = 0.0
+    runner._position_dirty[DirectionType.LONG] = True
+    mock_rest_client.get_positions.return_value = _positions("0.05")
+    runner._refresh_position_size_from_rest(DirectionType.LONG)  # mirror → 0.05, baseline 0.05
+    assert runner._long_position.size == Decimal("0.05")
+
+    # Stale WS frame says 0.2 (≠ last REST) → must be ignored
+    runner.on_position_update(_ws_pos("0.2"), None, 10000.0, 84.0)
+    assert runner._long_position.size == Decimal("0.05")
+    assert runner._position_dirty[DirectionType.LONG] is True
+
+    # Re-emit reduce-only within throttle → guard rejects, no submit
+    mock_executor.execute_place.return_value = OrderResult(success=False, error=TRUNCATE_ERROR)
+    runner._execute_place_intent(_reduce_only_sell(qty="0.1"), EMPTY_LIMITS)
+    assert mock_executor.execute_place.call_count == 0
+
+
+def test_dirty_ws_gate_inactive_without_rest_baseline(runner):
+    """No REST baseline → the gate must NOT zero/restore; WS passes through."""
+    runner._position_dirty[DirectionType.LONG] = True
+    runner._last_rest_position_size[DirectionType.LONG] = None  # no refresh ran
+
+    runner.on_position_update(_ws_pos("0.05"), None, 10000.0, 84.0)
+    assert runner._long_position.size == Decimal("0.05")  # legit WS size written

--- a/apps/gridbot/tests/test_runner_truncate_storm.py
+++ b/apps/gridbot/tests/test_runner_truncate_storm.py
@@ -603,3 +603,74 @@ def test_dirty_ws_gate_inactive_without_rest_baseline(runner):
 
     runner.on_position_update(_ws_pos("0.05"), None, 10000.0, 84.0)
     assert runner._long_position.size == Decimal("0.05")  # legit WS size written
+
+
+# --------------------------------------------------------------------------
+# Review v3 #1/#2 — observability metrics
+# --------------------------------------------------------------------------
+
+def test_rest_refresh_failure_count_increments_on_get_positions_error(runner, mock_rest_client):
+    """#1: a get_positions failure during dirty refresh increments the metric."""
+    runner._position_dirty[DirectionType.LONG] = True
+    mock_rest_client.get_positions.side_effect = Exception("REST down")
+    runner._refresh_position_size_from_rest(DirectionType.LONG)
+    assert runner.dirty_rest_refresh_failure_count == 1
+    runner._refresh_position_size_from_rest(DirectionType.LONG)
+    assert runner.dirty_rest_refresh_failure_count == 2
+
+
+def test_rest_refresh_failure_count_increments_on_unparseable_size(runner, mock_rest_client):
+    """#1: an unparseable size also counts as a refresh failure."""
+    mock_rest_client.get_positions.return_value = [{"positionIdx": 1, "size": "not-a-number"}]
+    runner._refresh_position_size_from_rest(DirectionType.LONG)
+    assert runner.dirty_rest_refresh_failure_count == 1
+
+
+def test_rest_refresh_failure_count_not_incremented_on_success(runner, mock_rest_client):
+    mock_rest_client.get_positions.return_value = _positions("0.05")
+    runner._refresh_position_size_from_rest(DirectionType.LONG)
+    assert runner.dirty_rest_refresh_failure_count == 0
+
+
+def test_no_rest_client_does_not_increment_failure_count(
+    strategy_config, mock_executor, instrument_info, clock
+):
+    """#1: rest_client=None is a static dry-run state, not a REST failure."""
+    r = StrategyRunner(
+        strategy_config=strategy_config, executor=mock_executor,
+        instrument_info=instrument_info, rest_client=None, clock=lambda: clock["now"],
+    )
+    r._refresh_position_size_from_rest(DirectionType.LONG)
+    assert r.dirty_rest_refresh_failure_count == 0
+
+
+def test_ws_mismatch_streak_increments_while_dirty(runner):
+    """#2: consecutive non-matching WS frames during dirty increment the streak."""
+    runner._position_dirty[DirectionType.LONG] = True
+    runner._last_rest_position_size[DirectionType.LONG] = Decimal("0.05")
+    for _ in range(3):
+        runner.on_position_update(_ws_pos("0.07"), None, 10000.0, 84.0)
+    assert runner._dirty_ws_mismatch_streak[DirectionType.LONG] == 3
+    assert runner._position_dirty[DirectionType.LONG] is True  # still dirty
+
+
+def test_ws_match_resets_mismatch_streak(runner):
+    """#2: a matching WS frame ends the episode and resets the streak."""
+    runner._position_dirty[DirectionType.LONG] = True
+    runner._last_rest_position_size[DirectionType.LONG] = Decimal("0.05")
+    runner.on_position_update(_ws_pos("0.07"), None, 10000.0, 84.0)  # mismatch → 1
+    assert runner._dirty_ws_mismatch_streak[DirectionType.LONG] == 1
+    runner.on_position_update(_ws_pos("0.05"), None, 10000.0, 84.0)  # match → clear + reset
+    assert runner._dirty_ws_mismatch_streak[DirectionType.LONG] == 0
+    assert runner._position_dirty[DirectionType.LONG] is False
+
+
+def test_ws_mismatch_warns_at_threshold(runner, monkeypatch, caplog):
+    """#2: a WARNING fires once the mismatch streak reaches the threshold."""
+    monkeypatch.setattr("gridbot.runner._DIRTY_WS_MISMATCH_ALERT_THRESHOLD", 3)
+    runner._position_dirty[DirectionType.LONG] = True
+    runner._last_rest_position_size[DirectionType.LONG] = Decimal("0.05")
+    with caplog.at_level("WARNING"):
+        for _ in range(3):
+            runner.on_position_update(_ws_pos("0.07"), None, 10000.0, 84.0)
+    assert any("consecutive WS" in rec.getMessage() for rec in caplog.records)

--- a/apps/gridbot/tests/test_truncate_breaker.py
+++ b/apps/gridbot/tests/test_truncate_breaker.py
@@ -1,0 +1,117 @@
+"""Tests for the 110017 circuit-breaker (feature 0064).
+
+The breaker is poll-free and clock-injected: callers pass ``now`` to
+``is_blocked`` / ``record_110017`` so tests drive a virtual clock directly.
+Scope key is ``(side, price)`` — stable across the engine's per-tick
+re-emission of the same grid-level reduce-only close.
+"""
+
+from decimal import Decimal
+
+import pytest
+
+from gridbot.truncate_breaker import TruncateBreaker
+
+
+SELL = "Sell"
+PRICE = Decimal("84.51")
+
+
+@pytest.fixture
+def breaker():
+    return TruncateBreaker(
+        max_consecutive=3,
+        window_seconds=60.0,
+        cooldown_seconds=60.0,
+    )
+
+
+def test_breaker_trips_after_n_within_window(breaker):
+    assert breaker.record_110017(SELL, PRICE, now=0.0) is False
+    assert breaker.record_110017(SELL, PRICE, now=1.0) is False
+    # 3rd within window → trip (first-trip edge True)
+    assert breaker.record_110017(SELL, PRICE, now=2.0) is True
+    assert breaker.is_blocked(SELL, PRICE, now=3.0) is True
+
+
+def test_breaker_does_not_trip_below_n(breaker):
+    assert breaker.record_110017(SELL, PRICE, now=0.0) is False
+    assert breaker.record_110017(SELL, PRICE, now=1.0) is False
+    assert breaker.is_blocked(SELL, PRICE, now=2.0) is False
+
+
+def test_breaker_no_retrip_during_cooldown(breaker):
+    """P2-a: a scope already tripped stays silently blocked.
+
+    record_110017 on an already-tripped scope returns False, does NOT append
+    to the deque, does NOT re-arm the trip, and the caller must not re-fire
+    reconcile (proven here by the stable return value).
+    """
+    breaker.record_110017(SELL, PRICE, now=0.0)
+    breaker.record_110017(SELL, PRICE, now=1.0)
+    assert breaker.record_110017(SELL, PRICE, now=2.0) is True  # trip
+    # Further 110017s while tripped → no-op, return False
+    assert breaker.record_110017(SELL, PRICE, now=3.0) is False
+    assert breaker.record_110017(SELL, PRICE, now=30.0) is False
+    # Still blocked through the original cooldown window (tripped at 2.0 + 60)
+    assert breaker.is_blocked(SELL, PRICE, now=59.0) is True
+    # The no-op record at 3.0/30.0 must NOT have extended cooldown past 62.0
+    assert breaker.is_blocked(SELL, PRICE, now=62.5) is False
+
+
+def test_breaker_window_eviction(breaker):
+    """A slow drip outside the window never trips (old timestamps evicted)."""
+    breaker.record_110017(SELL, PRICE, now=0.0)
+    breaker.record_110017(SELL, PRICE, now=40.0)
+    # 80.0 is >60 after the first event → first evicted; only 2 in window
+    assert breaker.record_110017(SELL, PRICE, now=80.0) is False
+    assert breaker.is_blocked(SELL, PRICE, now=81.0) is False
+
+
+def test_breaker_cooldown_expiry_resets(breaker):
+    breaker.record_110017(SELL, PRICE, now=0.0)
+    breaker.record_110017(SELL, PRICE, now=1.0)
+    assert breaker.record_110017(SELL, PRICE, now=2.0) is True  # trip at 2.0+60
+    assert breaker.is_blocked(SELL, PRICE, now=61.0) is True
+    # After cooldown, no longer blocked and the deque is cleared (fresh start)
+    assert breaker.is_blocked(SELL, PRICE, now=62.1) is False
+    # Fresh start: a single new 110017 does not immediately re-trip
+    assert breaker.record_110017(SELL, PRICE, now=63.0) is False
+
+
+def test_breaker_success_resets_scope_key(breaker):
+    breaker.record_110017(SELL, PRICE, now=0.0)
+    breaker.record_110017(SELL, PRICE, now=1.0)
+    breaker.record_success(SELL, PRICE)
+    # Deque cleared → next two 110017s do not trip on the 2nd
+    assert breaker.record_110017(SELL, PRICE, now=2.0) is False
+    assert breaker.record_110017(SELL, PRICE, now=3.0) is False
+    assert breaker.is_blocked(SELL, PRICE, now=4.0) is False
+
+
+def test_breaker_success_clears_active_trip(breaker):
+    breaker.record_110017(SELL, PRICE, now=0.0)
+    breaker.record_110017(SELL, PRICE, now=1.0)
+    assert breaker.record_110017(SELL, PRICE, now=2.0) is True
+    breaker.record_success(SELL, PRICE)
+    assert breaker.is_blocked(SELL, PRICE, now=3.0) is False
+
+
+def test_breaker_scope_keys_independent(breaker):
+    """Tripping Sell@84.51 must not block Buy@84.51 or Sell@84.52."""
+    breaker.record_110017(SELL, PRICE, now=0.0)
+    breaker.record_110017(SELL, PRICE, now=1.0)
+    assert breaker.record_110017(SELL, PRICE, now=2.0) is True
+    assert breaker.is_blocked(SELL, PRICE, now=3.0) is True
+    # Different side, same price
+    assert breaker.is_blocked("Buy", PRICE, now=3.0) is False
+    # Same side, different price
+    assert breaker.is_blocked(SELL, Decimal("84.52"), now=3.0) is False
+
+
+def test_breaker_price_key_normalized_decimal(breaker):
+    """Equal Decimals that differ in scale map to the same scope key."""
+    breaker.record_110017(SELL, Decimal("84.5"), now=0.0)
+    breaker.record_110017(SELL, Decimal("84.50"), now=1.0)
+    # Both should land on the same key → 3rd trips
+    assert breaker.record_110017(SELL, Decimal("84.500"), now=2.0) is True

--- a/docs/features/0064_PLAN.md
+++ b/docs/features/0064_PLAN.md
@@ -1,0 +1,616 @@
+# Feature 0064 — Circuit-breaker + dirty-mirror REST refresh for 110017 retry storm (issue #149)
+
+## Context
+
+After ~5h of intermittent WS disconnects on 2026-05-30, the bot's local SOL
+long-position state drifted from the exchange. Reduce-only close-long *sell*
+orders were sized from the stale local view (`qty=0.1 SOL`), exceeding the
+actual exchange position. Bybit clamps reduce-only qty to the current
+exchange-side position size; when the position is smaller than the intent the
+clamp drops to zero → **ErrCode 110017 "orderQty will be truncated to zero"**.
+The bot re-emitted and re-submitted the same rejected intent **535× in <90min**
+with no circuit-breaker, no 110017-specific backoff, and no forced reconcile.
+All occurrences were SOLUSDT; zero on LTCUSDT. Not a safety issue in the
+observed instance, but a degradation pattern that flooded logs (270/340 ERROR
+lines) and wasted bandwidth during incident recovery.
+
+Verbatim rejected payload:
+`POST /v5/order/create {category: linear, symbol: SOLUSDT, side: Sell, orderType: Limit, qty: "0.1", reduceOnly: true, positionIdx: 1, price: "84.51"} → ErrCode 110017 "orderQty will be truncated to zero"`.
+Note `qty=0.1` is **not** below SOL's min qty step (0.01); the truncation is
+**dynamic** — Bybit clamps reduce-only qty to the current exchange-side
+position; if position < 0.1 the clamp → zero.
+
+**Out of scope** (explicitly): the underlying WS instability (network/host
+issue), the co-occurring 110072 duplicate-orderLinkId errors, and the broader
+auto state-divergence detector (tracked separately as issue #151 / a future
+feature — see "Relationship to #151" below). This feature targets only the
+110017 retry-storm symptom and its at-source cause.
+
+## Root cause — `_is_good_to_place` trusts a stale mirror
+
+`StrategyRunner._is_good_to_place` (`apps/gridbot/src/gridbot/runner.py:933-982`)
+already guards reduce-only orders against position size:
+
+- Line 972-973 reads `self._long_position.size` / `self._short_position.size`.
+- Line 975-980 rejects when `position_size == 0`.
+- Line 982 returns `position_size > (intent.qty + reduce_only_qty)` (**strict `>`**).
+
+The guard is *logically correct*; it failed only because its **data source was
+stale**. `_long_position.size` / `_short_position.size` are populated by
+`on_position_update` (`runner.py:647-744`, lines 674-675) from **WebSocket**
+position data via `PositionFetcher.get_position_from_ws`. During the WS outage
+the local size was **stale and non-zero** (local `0.x` while the exchange was
+smaller). So `position_size == 0` was false and `position_size > intent.qty +
+reduce_only_qty` evaluated true against the **stale-high** mirror — the order
+passed the guard and was sent, and Bybit clamped it to zero.
+
+Key consequence: **in steady state (mirror accurate) the guard already prevents
+110017** — `position > qty` is an accurate comparison and no oversized
+reduce-only is ever submitted. 110017 only occurs under **divergence**
+(stale-high mirror). Therefore the fix is not to re-size the order, but to make
+the guard's data source **fresh when divergence is suspected**, so the guard
+rejects the oversized close itself (no submit, no clamp). This honours
+Direction 2's stated goal ("never submit a qty Bybit would clamp to zero")
+while preserving the **intentional** reduce-only reject-when-`position ≤ qty`
+convention (project memory: do not change it, do not replace it with a
+cap-and-submit).
+
+## Why a qty-cap was rejected (design note)
+
+The issue's Direction 2 proposed capping qty to `min(intent_qty, REST
+position)` and submitting the capped order. This was evaluated and **not
+adopted**, because:
+
+- With the cap running **after** the strict-`>` guard and reading the **same**
+  position source, the cap is a no-op: the guard passes ⟺ `available >
+  intent.qty`, the cap shrinks ⟺ `available < intent.qty` — mutually
+  exclusive. The cap can only ever shrink an order that the guard already
+  rejected.
+- The only arrangement that makes the cap "work" is the guard reading **stale**
+  data while the cap reads **fresh** data — fragile, and it would re-introduce
+  the stale-mirror-feeds-the-guard problem this feature exists to remove.
+- Cap-and-submit of `qty == position` is exactly what the intentional
+  reject-when-`position ≤ qty` convention rejects; adopting it would silently
+  change live grid-closing behaviour (drain a sub-close-size remainder instead
+  of leaving it).
+
+Refreshing the mirror **before** the guard achieves Direction 2's goal through
+the existing reject path with accurate data, with fewer moving parts and no
+convention change.
+
+## Why the storm reached 535× despite RetryQueue capping at 3
+
+`RetryQueue` (`apps/gridbot/src/gridbot/retry_queue.py`) caps a *single* enqueued
+intent at `max_attempts=3` / `max_elapsed_seconds=30` (wired in
+`orchestrator.py:719-724`). The 535 count is **not** one item retried 535×.
+It is the **engine re-emitting the same logical intent on (nearly) every
+`on_ticker`** (book-touch fires each tick while price sits at that grid level):
+each emission flows `on_ticker` → `_execute_intents` → `_execute_place_intent`
+(`runner.py:996-1050`) → `execute_place` fails → `on_intent_failed` →
+**fresh `RetryQueue.add`** (`orchestrator.py:740`). So the fix must live at the
+**per-(strat, side, price) placement gate**, not inside RetryQueue.
+
+## Decision: two complementary mechanisms (refresh-before-guard + breaker)
+
+1. **Dirty-mirror REST refresh before the guard (Direction 2, reframed — primary
+   self-heal).** The first 110017 on a direction sets `_position_dirty[direction]`.
+   On the next reduce-only placement for that direction, REST-refresh the mirror
+   (throttled) **before** `_is_good_to_place`, so the guard evaluates against
+   fresh size and correctly rejects the oversized close — no submit, no 110017.
+   The storm collapses to ~one 110017 per divergence event.
+2. **110017 circuit-breaker (Direction 1 — bounded-blast-radius backstop).** For
+   the undetected-divergence window (before dirty is set) and residual races
+   after refresh: after N 110017s on the same scope key within the window, stop
+   re-submitting that intent for a cooldown window, exclude 110017 from the retry
+   queue, emit one WARNING, and trigger one forced position+order reconcile.
+
+Conventions preserved: **hedge-mode reduce-only rejection on small positions
+stays** (`_is_good_to_place`, untouched logic — only its data source is
+freshened when dirty); **per-direction sequential dispatch stays** (long fully
+then short fully); **`amount_multiplier` stays forward-only** (no cancel-replace
+of existing orders; this feature only refreshes state and drops/blocks
+intents).
+
+---
+
+## Phase 1 — Data layer (config + error-code constant)
+
+### `apps/gridbot/src/gridbot/config.py`
+- Add a typed config block (on `StrategyConfig`, ~`config.py:26`, with defaults
+  so existing `conf/*.yaml` keep working):
+  - `dirty_refresh_enabled: bool = True` (master toggle for refresh-before-guard)
+  - `dirty_rest_refresh_min_interval_seconds: float = 10.0` (min gap between
+    `get_positions` calls per direction while `_position_dirty` is True — prevents
+    per-ticker REST storms when the guard keeps rejecting after a refresh)
+  - `truncate_breaker_max_consecutive: int = 3` (N — trip after ≥3)
+  - `truncate_breaker_window_seconds: float = 60.0`
+  - `truncate_breaker_cooldown_seconds: float = 60.0` (drop-intent window after trip)
+  - `truncate_breaker_reconcile: bool = True` (trigger forced reconcile on trip)
+- These thread through `GridbotConfig` (`config.py:110`) into `_init_strategy`.
+
+### `packages/bybit_adapter/src/bybit_adapter/__init__.py` (or a small `error_codes.py`)
+- Define a shared constant `ORDER_QTY_TRUNCATED_TO_ZERO = 110017` so both the
+  executor classifier and any future divergence detector reference one symbol,
+  not a magic literal. (Mirror of the existing `AUTH_ERROR_CODES` set in
+  `apps/gridbot/src/gridbot/executor.py:22`.)
+
+> **No qty-cap, no `floor_qty` helper.** The earlier cap design is dropped (see
+> "Why a qty-cap was rejected"). `InstrumentInfo` is **not** modified by this
+> feature.
+
+---
+
+## Phase 2 — Dirty-mirror REST refresh before the guard (primary self-heal)
+
+Goal: when a direction is `_position_dirty` (a prior 110017 proved its mirror
+diverged), refresh `_long_position.size` / `_short_position.size` from a fresh
+REST read **before** `_is_good_to_place` runs, so the unchanged strict-`>` guard
+decides against accurate data. This both **rejects** an oversized close (the
+#149 case: actual `0.05` < intent `0.1` → guard rejects, no submit) and
+**unblocks** a legitimate close the stale-low mirror would have wrongly rejected
+(actual high → guard passes → submit at intent qty). The guard logic is
+untouched; only its inputs are freshened.
+
+### `_position_dirty` source-of-truth and refresh throttling
+- **Steady state** (`_position_dirty[direction]` is False): use the in-memory
+  mirror; no REST on the hot path.
+- **Suspect state** (`_position_dirty[direction]` is True, set on the **first**
+  110017 for that direction — see Phase 3): before the guard, call
+  `_refresh_position_size_from_rest(direction)` when
+  `_last_dirty_rest_at[direction] is None` **(first dirty refresh — always fires,
+  throttle bypassed)** **or** `now - _last_dirty_rest_at[direction] >=
+  dirty_rest_refresh_min_interval_seconds` (store
+  `_last_dirty_rest_at: dict[str, Optional[float]]` on the runner, init **`None`**
+  = never refreshed; set to `now` on each refresh; reset to `None` when dirty
+  clears). The `None` sentinel makes the **"first dirty attempt always
+  refreshes"** invariant **clock-independent** — an init of `0.0` only happened
+  to work because real `time.monotonic()` is large, and was brittle under fake
+  clocks (`now=0` ⇒ `0 - 0.0 >= 10` is False ⇒ no first refresh). Between
+  refreshes the guard reads the size written by the last refresh — no
+  `get_positions`. Log DEBUG on a skipped (throttled) refresh. This bounds REST:
+  after the mirror is corrected once, every per-tick re-emission re-uses the
+  corrected size and the guard keeps rejecting without new REST calls.
+- A `force=True` refresh (used by the forced reconcile on breaker trip) bypasses
+  the throttle and resets `_last_dirty_rest_at[direction] = None`.
+
+### `apps/gridbot/src/gridbot/runner.py`
+
+#### `_refresh_position_size_from_rest(direction, *, force=False)` (single, unambiguous signature)
+Uses `self._rest_client` (the runner gains an optional REST client — see below).
+Refreshes **one** direction's `size` only (not multipliers/liq — out of scope);
+logs at INFO with the before/after delta. Steps:
+1. If `self._rest_client is None` (tests/dry-run): log WARNING, return without
+   change (fall back to the existing mirror).
+2. Call `self._rest_client.get_positions(symbol)` → a **flat `list[dict]`** of
+   raw Bybit position dicts (`rest_client.py:314-341`); it does **not** key by
+   `positionIdx`/side, so the helper filters it itself (NOT `on_position_update`,
+   which is fed already-split long/short dicts by the orchestrator's
+   `PositionFetcher`).
+3. Select the entry whose `positionIdx` matches `direction` (hedge mode: `1` =
+   long, `2` = short). Read `size` (`Decimal(str(entry.get("size", 0) or 0))`).
+4. If **no matching entry** exists, or the matched entry's `size` is `0`/absent
+   (position now flat), set the mirror size to `Decimal("0")` — mirroring
+   `_build_position_state` returning `None` at `size == 0` (`runner.py:833-834`)
+   and `on_position_update` setting `.size = 0` on `None` (`runner.py:674-675`).
+5. Assign `self._long_position.size` / `self._short_position.size` accordingly.
+6. Record `_last_rest_position_size[direction]` = the size just written (the
+   WS-match dirty-clear compares against this).
+
+#### REST client injection (required for the dirty-path refresh)
+`StrategyRunner` today has no REST client. Add an optional constructor arg
+`rest_client: Optional[BybitRestClient] = None` (TYPE_CHECKING import). Wire it
+in `orchestrator._init_strategy` (`orchestrator.py:733-744`) to the same client
+the executor uses (`self._rest_clients[account_name]`). When `None` (unit
+tests), the dirty path logs WARNING and falls back to the mirror.
+
+#### `_execute_place_intent` pipeline (explicit order — do not reorder)
+All new gates run inside `_execute_place_intent` (`runner.py:996-1050`):
+
+1. `_resolve_qty` → existing `qty <= 0` early return (`runner.py:1000-1002`).
+2. **`_truncate_breaker.is_blocked(side, price, now)`** → early return (Phase 3;
+   no REST, no guard, no submit while tripped). Sits **first** so a tripped scope
+   never triggers a REST refresh on per-ticker re-emission during cooldown.
+3. **Dirty refresh (reduce-only only):** if `strategy_config.dirty_refresh_enabled`
+   and `intent.reduce_only` and `_position_dirty[intent.direction]` and the
+   throttle interval has elapsed → `_refresh_position_size_from_rest(intent.direction)`.
+   This runs **before** the guard so step 4 reads fresh size. The
+   `dirty_refresh_enabled` gate is read from config and must be the **first**
+   term so flipping it off is a true kill-switch (the refresh is skipped and the
+   guard falls back to the mirror). (`intent.direction` is the position direction
+   being closed — for a reduce-only Sell it is `LONG` — so no side→direction
+   inversion is needed here; see Phase 3 for the breaker scope-key, which keys on
+   the wire `side`.)
+4. **`_is_good_to_place`** → unchanged guard, now reading the (freshened-when-
+   dirty) mirror. Oversized reduce-only is rejected here; nothing is submitted.
+5. Duplicate-track / wire-link-id / track-order (existing, unchanged).
+6. `execute_place` → post-submit breaker bookkeeping (Phase 3).
+
+> **P1-a closed:** the refresh is step 3, the guard is step 4 — the guard can no
+> longer short-circuit (`position_size == 0` or strict `>`) on a stale mirror
+> before the refresh runs.
+
+### `_is_good_to_place` and the within-batch `limits` snapshot — unchanged
+This feature does **not** modify `_is_good_to_place`'s body, including its
+`reduce_only_qty` summation over the `limits` snapshot (`runner.py:952-966`). The
+RULES.md:2144 invariant — `_execute_intents` re-fetches `limits` via
+`get_limit_orders()` after every place (`runner.py:889,900`) so two reduce-only
+closes in one batch don't over-cover the position — is **pre-existing and
+preserved**; we add no new consumer of `limits`. (No cap means no new
+`available` computation that could double-spend.)
+
+---
+
+## Phase 3 — 110017 circuit-breaker (backstop)
+
+Goal: detect repeated 110017 on the same scope key and, after N within the
+window, (a) stop re-submitting that intent for a cooldown window, (b) trigger
+one forced position+order reconcile, (c) emit a single WARNING and increment a
+counter (no per-occurrence ERROR spam).
+
+### Scope key
+`(strat_id, side, price)` — chosen over `orderLinkId` because the wire
+orderLinkId carries a per-placement `-{millis}` suffix
+(`executor.py:178-182`, feature 0032), so it changes every retry and would never
+accumulate. `(strat_id, side, price)` is stable across the engine's per-tick
+re-emission of the same grid-level close order and matches the verbatim payload
+identity (Sell @ 84.51). `reduce_only` is implicitly true (110017 only occurs on
+reduce-only).
+
+### Detection point
+`IntentExecutor.execute_place` already parses error codes with `_ERR_CODE_RE`
+(`executor.py:25`, matches `[110017]` produced by `rest_client._check_response`,
+`rest_client.py:869-884`). The 110017 result surfaces back to the runner: the
+executor returns `OrderResult(success=False, error=...)`
+(`executor.py:208-215`); the runner sees it at `runner.py:1045-1050`. Add a small
+classifier helper on the executor (reusing `_ERR_CODE_RE` + the shared
+`ORDER_QTY_TRUNCATED_TO_ZERO`) so the runner can branch on 110017 without
+re-implementing the regex.
+
+### `TruncateBreaker` (new file `apps/gridbot/src/gridbot/truncate_breaker.py`)
+Modeled on `RetryQueue`'s no-thread/poll-free design, owned per-runner. Holds
+`dict[scope_key] -> deque[timestamps]` plus `dict[scope_key] -> tripped_until`.
+
+Algorithm (step-by-step):
+1. `is_blocked(side, price, now) -> bool`: if `scope_key` has a `tripped_until`
+   and `now < tripped_until`, return True (caller drops the intent this tick).
+   On `now >= tripped_until`, clear the trip and the timestamp deque (reset),
+   return False.
+2. `record_110017(side, price, now) -> bool` (returns the **first-trip edge**):
+   - **In-cooldown no-op (P2-a):** if `scope_key` is currently tripped
+     (`tripped_until` set and `now < tripped_until`), return `False`
+     **without** appending to the deque, re-arming the trip, re-logging, or
+     touching the reconcile counter. A scope already tripped stays silently
+     blocked until cooldown expiry; further 110017s on it are ignored.
+   - Otherwise append `now`; evict timestamps older than `window_seconds`. If
+     `len(deque) >= max_consecutive`, set `tripped_until = now +
+     cooldown_seconds` and return `True` (first-trip edge). Else return `False`.
+3. `record_success(side, price)`: clear the deque + any trip for that key (a
+   successful place at that price means divergence healed; reset the breaker).
+
+(There is no `record_suppressed` — the dirty path no longer skips submits; the
+guard rejects, and a rejected-by-guard intent never reaches `execute_place`, so
+it produces no 110017 to record.)
+
+### `_position_dirty` and reconcile-counter lifecycle
+
+| Event | `_position_dirty[direction]` | `_truncate_breaker_reconcile_count` |
+|-------|------------------------------|-------------------------------------|
+| Runner init | `{LONG: False, SHORT: False}` | `0` |
+| **First 110017** for that direction (any scope key on that side) | Set `True` immediately (before the breaker trip check) | unchanged |
+| Successful `execute_place` at any price on that direction's close side | Clear `False` for that direction | unchanged |
+| Breaker trip (`record_110017` returns `True`) | stays `True` | `+= 1` |
+| Subsequent 110017 while tripped (in-cooldown no-op) | stays `True` | unchanged |
+| `_force_reconcile_strat` completes (orders + forced REST position refresh) | Clear `False`; reset `_last_dirty_rest_at[direction]=None` | unchanged |
+| `on_position_update` where the incoming WS size for that direction **equals** `_last_rest_position_size[direction]` (exact `Decimal` match) | Clear `False` + reset `_last_dirty_rest_at[direction]=None` (WS recovered and agrees with REST; stops the dormant-dirty heartbeat) | unchanged |
+| `on_position_update` with a **non-matching** WS size while dirty **and a REST baseline exists** (`_last_rest_position_size[dir] is not None`) | stays `True`; the WS write is **ignored** (mirror restored to `_last_rest_position_size`) so a stale WS frame cannot reopen the storm | unchanged |
+| `on_position_update` while dirty but **no REST baseline yet** (`_last_rest_position_size[dir] is None`) | stays `True`; WS write **passes through normally** (no synthetic-zero gate) | unchanged |
+
+**Storage:** both live on `StrategyRunner`:
+- `_position_dirty: dict[str, bool]` keyed by `DirectionType.LONG` /
+  `DirectionType.SHORT`.
+- `_last_dirty_rest_at: dict[str, Optional[float]]` (REST throttle, Phase 2; init
+  `None` = never refreshed → the first dirty refresh bypasses the throttle; set
+  to `now` per refresh, reset to `None` when dirty clears).
+- `_truncate_breaker_reconcile_count: int` — incremented once per breaker trip
+  that fires forced reconcile; exposed read-only via a property.
+- `_last_rest_position_size: dict[str, Optional[Decimal]]` keyed by direction
+  (init **`None`** = no REST baseline yet) — set to the size written by the most
+  recent `_refresh_position_size_from_rest` per direction. The WS-match /
+  ignore-non-matching dirty logic (below) is applied **only once this is not
+  `None`** (a successful REST refresh has established a baseline); before that,
+  WS updates pass through normally. Using `None` (not a synthetic `0`) avoids
+  treating a legitimate non-zero WS size as "non-matching" against a fake `0`
+  baseline and zeroing the mirror — which would otherwise reject all reduce-only
+  closes on a dirtied direction when `dirty_refresh_enabled=False` /
+  `rest_client=None` (no refresh ever populates the baseline).
+
+**Dormant-dirty policy (explicit).** In the main #149 case the second attempt
+refreshes the mirror and the guard **rejects locally** — so there is no
+successful `execute_place` (path "success"), and the breaker never trips
+(path "forced reconcile"), because no oversized order is submitted to produce a
+new 110017. If WS also stays down, `on_position_update` (path "WS-match") does
+not fire either. `_position_dirty[direction]` therefore **intentionally stays
+True**, and the throttled refresh re-reads REST every
+`dirty_rest_refresh_min_interval_seconds` (default 10s, ≤6 reads/min/direction)
+while the grid keeps re-emitting that close. This is the desired
+**keep-until-health-signal** behaviour: dirty is an "under investigation" state,
+not a fault, and the 10s heartbeat keeps the guard accurate during a sustained
+outage rather than risking a re-storm by clearing early (clearing after each
+refresh would let the mirror re-drift via stale WS updates and re-open the
+storm). Dirty clears only on a positive health signal — a successful place
+(real fill), a forced reconcile (breaker trip), or a WS-size match — or on
+process restart. The throttle bounds the cost; no separate clear-after-refresh
+path is added.
+
+**Health read path:** `Orchestrator._health_check_once` (or a helper it calls)
+iterates `self._runners.values()` and logs at DEBUG when
+`runner.truncate_breaker_reconcile_count > 0`. Gives operators/metrics a trip
+count without per-occurrence ERROR spam. Counter is monotonic for the runner
+lifetime (resets only on process restart).
+
+### Wiring in `runner.py`
+- Step 2 of the pipeline: `is_blocked` early return **before** refresh/guard.
+- After `execute_place` returns (step 6):
+  - On `result.success`: `breaker.record_success(side, price)`; clear
+    `_position_dirty[intent.direction]` (divergence healed).
+  - On failure where the executor classifier flags 110017
+    (`ORDER_QTY_TRUNCATED_TO_ZERO`):
+    - **Immediately** set `_position_dirty[intent.direction] = True` (enables the
+      REST-backed refresh on the **next** placement attempt, even before the
+      breaker trips). `intent.direction` is the position direction for the
+      reduce-only order, so no inversion is needed at this site.
+    - `tripped = breaker.record_110017(side, price, now)`.
+    - **Do NOT enqueue 110017 failures to the retry queue** (currently
+      `runner.py:1049-1050` enqueues every failure). Guard the
+      `on_intent_failed` call so 110017 is excluded — retrying it via the queue
+      is pointless (same qty, same clamp) and is part of the storm. Network /
+      110001 / other codes still enqueue as today.
+    - **Drop the failed order's reusable wire `order_link_id` for 110017.** A
+      110017 (`truncated to zero`) is a *hard reject* — the order was **never
+      created** on Bybit — so the feature-0032 orderLinkId-reuse rationale
+      (avoid a duplicate when a place's outcome is *ambiguous*,
+      `runner.py:1022-1027`) does not apply here. Reusing the id is unnecessary
+      and, if Bybit reserves rejected ids (exchange-side behaviour we cannot
+      verify from the repo; the #149 incident did show 5× 110072 co-occurring),
+      it would surface as 110072 — a code the breaker does **not** count and the
+      retry queue does **not** exclude, partially bypassing the backstop. So on
+      a confirmed 110017 failure, do **not** mark the tracked order's
+      `order_link_id` reusable (force a fresh id on the next emission).
+      **Mechanism:** the reuse path (`runner.py:1022-1027`) only reuses when a
+      *failed* tracked order has a non-None `intent.order_link_id`; so on a
+      confirmed 110017, after `tracked.mark_failed()`, set `tracked.intent =
+      replace(tracked.intent, order_link_id=None)` (clears the reuse trigger →
+      `_assign_wire_link_id` mints a fresh id next time). Equivalent: `del
+      self._tracked_orders[intent.client_order_id]` (drop the failed entry); the
+      `replace` form is preferred — it keeps failed-status tracking and only
+      drops the wire id. This
+      keeps every backstop re-submission classified as 110017 and removes the
+      110072 uncertainty. Only the backstop path is affected; the primary
+      self-heal rejects at the guard (step 4) before the reuse code (step 5) is
+      reached. (110072 itself stays out of scope; this only prevents the
+      backstop from *spawning* it.)
+    - If `tripped`: emit one `logger.warning` (scope key + count + cooldown),
+      increment `_truncate_breaker_reconcile_count`, and if
+      `truncate_breaker_reconcile` is set, fire the forced-reconcile callback.
+
+### Dirty-window WS handling + WS-match clear (in `on_position_update`)
+`on_position_update` (`runner.py:647-744`) today writes `_long_position.size` /
+`_short_position.size` **unconditionally** from the WS payload (lines 674-675).
+While a direction is dirty, a stale/mis-ordered WS frame would overwrite the
+REST-authoritative size and — because the next reduce-only attempt **inside the
+10s throttle skips REST** — `_is_good_to_place` would run against the clobbered
+stale value and **reopen the storm**. So the size write is **gated per
+direction** by the dirty flag (the gate replaces the unconditional write at
+lines 674-675):
+- For each direction, let `ws_size` be the WS payload size (`0` when that side is
+  flat).
+- **If `_position_dirty[direction]` and `_last_rest_position_size[direction] is
+  not None`** (a REST baseline exists):
+  - `ws_size == _last_rest_position_size[direction]` (exact `Decimal` match) → WS
+    has recovered and agrees with the last authoritative REST read: write
+    `ws_size`, **clear** `_position_dirty[direction] = False`, reset
+    `_last_dirty_rest_at[direction] = None`. (Stops the dormant-dirty heartbeat.)
+  - Else (non-matching) → **do NOT overwrite**; restore the mirror to
+    `_last_rest_position_size[direction]` so the REST value stays authoritative
+    for the guard, leave dirty set, log DEBUG. The throttled refresh (≤ every
+    10s) updates `_last_rest_position_size`, so a genuinely-changed position is
+    picked up within the throttle window.
+- **Otherwise** (not dirty, **or** dirty but no REST baseline yet — a WS frame
+  arrived before the first refresh, or `dirty_refresh_enabled=False` /
+  `rest_client=None` so no refresh ever runs): write `ws_size` normally
+  (unchanged steady-state behaviour). The gate only protects a value REST has
+  actually established; with no baseline the bot stays WS-driven and the breaker
+  remains the storm backstop.
+
+No tolerance — both sizes are exchange-sourced and match exactly when
+consistent. **Scope note:** only the **size** field consumed by
+`_is_good_to_place` is gated. The `position_ratio` / `liquidation_price` /
+`amount_multiplier` calculations in `on_position_update` read the freshly-built
+WS `long_state` / `short_state` directly (not the mirror `.size`), so they are
+unaffected by this gate; their WS staleness during a divergence window is
+pre-existing and healed by the forced reconcile / WS recovery (out of scope for
+#149).
+
+### Forced reconcile trigger
+- The runner does not hold the `Reconciler`; the orchestrator does
+  (`orchestrator._reconcilers`, `orchestrator.py:126,287-289,1174-1180`). Add an
+  `on_truncate_breaker_tripped: Optional[Callable[[str, str], None]]` runner
+  callback (args: `strat_id`, `direction`), wired in `_init_strategy`
+  (`orchestrator.py:740-742` block) to an orchestrator method
+  `_force_reconcile_strat(strat_id, direction)` that:
+  1. Looks up the account's `Reconciler` and `BybitRestClient`.
+  2. Calls `reconciler.reconcile_reconnect(runner)` (`reconciler.py:148-215`) to
+     resync the **order** book (handles "untracked on exchange" / "missing in
+     memory").
+  3. Calls `runner._refresh_position_size_from_rest(direction, force=True)`
+     (Phase 2) to resync the **position size** — the piece `reconcile_reconnect`
+     does NOT do today (it only touches orders). This closes the stale-mirror
+     gap that defeated `_is_good_to_place`.
+  4. Is rate-limited (at most once per `cooldown_seconds` per strat) so a tripped
+     breaker cannot itself spam REST during an outage.
+
+### Per-direction sequential dispatch is preserved
+The breaker gate sits inside the existing per-intent placement path
+(`_execute_place_intent`), invoked in the engine's per-direction sequential
+order. The breaker only *drops* intents; it never reorders or merges across
+directions (project memory). Long-side and short-side scope keys are independent
+(`side` is part of the key).
+
+---
+
+## Files changed / created (summary)
+
+| File | Change |
+|------|--------|
+| `apps/gridbot/src/gridbot/config.py` | Add `dirty_refresh_enabled`, `dirty_rest_refresh_min_interval_seconds`, and the four `truncate_breaker_*` fields to `StrategyConfig` (`:26`); thread through `GridbotConfig` (`:110`). |
+| `packages/bybit_adapter/src/bybit_adapter/__init__.py` (or new `error_codes.py`) | `ORDER_QTY_TRUNCATED_TO_ZERO = 110017` constant. |
+| `apps/gridbot/src/gridbot/truncate_breaker.py` | **New.** `TruncateBreaker` (scope key, sliding window, trip/cooldown, in-cooldown no-op on `record_110017`, reset-on-success). |
+| `apps/gridbot/src/gridbot/runner.py` | `rest_client` ctor arg; `_position_dirty`, `_last_dirty_rest_at`, `_last_rest_position_size`, `_truncate_breaker_reconcile_count` (+ read-only property); `_refresh_position_size_from_rest(direction, *, force=False)` (filters flat REST list by `positionIdx`, handles flat-position, throttled unless `force`, records `_last_rest_position_size`); explicit pipeline in `_execute_place_intent` (`:996-1050`) — breaker `is_blocked` → dirty refresh (before guard, gated by `dirty_refresh_enabled`) → `_is_good_to_place` → submit; set `_position_dirty[intent.direction]` on 110017; exclude 110017 from retry-queue enqueue; drop wire-`order_link_id` reuse on a 110017 (fresh id on retry); WS-match dirty-clear in `on_position_update`; `on_truncate_breaker_tripped` callback. **No change to `_is_good_to_place` body; no qty cap.** |
+| `apps/gridbot/src/gridbot/executor.py` | Add a 110017 classifier helper (reuse `_ERR_CODE_RE` `:25` + `ORDER_QTY_TRUNCATED_TO_ZERO`) so the runner branches on 110017 without re-implementing the regex. |
+| `apps/gridbot/src/gridbot/orchestrator.py` | Construct `TruncateBreaker` per runner in `_init_strategy` (`:700-745`); pass `rest_client=self._rest_clients[account_name]` into `StrategyRunner`; add `_force_reconcile_strat` (orders via `reconcile_reconnect` + `_refresh_position_size_from_rest(force=True)`, rate-limited); wire `on_truncate_breaker_tripped` (alongside `:740-742`); pass threshold config through; read `truncate_breaker_reconcile_count` in `_health_check_once`. |
+| `packages/bybit_adapter/src/bybit_adapter/rest_client.py` | None expected — `get_positions` (`:314-341`) and `get_open_orders` (`:625`) already suffice. |
+
+---
+
+## Tests to add (bug-fix starts with a reproducing test — repo convention)
+
+### Reproducing test (write first, must fail before the fix)
+The bug is the storm: pre-fix the same re-emitted intent calls `execute_place`
+every tick and enqueues to the retry queue every time. The **two post-fix paths
+are tested separately** — they have different preconditions (self-heal vs
+no-heal) and conflating them is incorrect (the breaker does **not** trip on the
+primary path, because the guard rejects locally and no second 110017 is ever
+produced).
+
+- `apps/gridbot/tests/test_runner_truncate_storm.py::test_110017_storm_self_heals_after_one_failure`
+  (primary path — the #149 fix)
+  - Stub executor `execute_place` returns
+    `OrderResult(success=False, error="Bybit API error in place_order: [110017] orderQty will be truncated to zero")`
+    for a reduce-only Sell @ fixed price; stub `get_positions` returns the
+    **actual** small position (`positionIdx=1`, size `0.05`).
+  - Drive the same reduce-only intent (qty `0.1`) N+ times (per-tick re-emission).
+  - **Assert (pre-fix)** `execute_place` is called once per tick (storm) and the
+    intent is enqueued to the retry queue each time.
+  - **Assert (post-fix, `dirty_refresh_enabled=True`)** `execute_place` is called
+    **exactly once** (tick 1: stale mirror passes the guard → 110017 → dirty
+    set); from tick 2 the pre-guard refresh corrects the mirror and
+    `_is_good_to_place` rejects locally, so `execute_place` is **not** called
+    again; the 110017 is **never** enqueued; the breaker records exactly one
+    event and does **not** trip. (Storm collapses to one 110017.)
+  - **Clock-independence assertion (P2):** pin a fake monotonic clock at `now=0`
+    and assert the tick-2 refresh **still fires** (`get_positions` called once)
+    — proving the first dirty refresh bypasses the throttle via the
+    `_last_dirty_rest_at[direction] is None` sentinel, not via a large real
+    clock.
+- `apps/gridbot/tests/test_runner_truncate_storm.py::test_breaker_bounds_storm_when_refresh_cannot_heal`
+  (backstop path)
+  - Same stub executor (always 110017), but the refresh **cannot heal**: set
+    `dirty_refresh_enabled=False` (or `rest_client=None`, or stub `get_positions`
+    still returns the stale-high size). The mirror stays stale-high → the guard
+    keeps passing → each tick re-submits and 110017s.
+  - **Assert** after `truncate_breaker_max_consecutive` 110017s within the window,
+    `is_blocked` drops further attempts (no `execute_place`) until cooldown
+    expires; the trip counter increments exactly once per trip; 110017 is
+    **never** enqueued; and on trip the forced reconcile fires once. (Proves the
+    backstop when self-heal is disabled/unavailable.)
+
+### Phase 2 — dirty-mirror refresh before the guard
+- `test_first_110017_sets_position_dirty`: a single 110017 (below trip threshold)
+  sets `_position_dirty[intent.direction] = True`.
+- `test_dirty_refresh_before_guard_rejects_oversized_close` (P1-a / P1-b core):
+  stale mirror long `0.2`, intent reduce-only Sell `qty=0.1`; first attempt
+  passes the guard (`0.2 > 0.1`) and 110017s → dirty set. Stub
+  `get_positions` returns the **actual** long size `0.05` (`positionIdx=1`).
+  Second attempt: `_refresh_position_size_from_rest` runs **before** the guard,
+  mirror → `0.05`, the guard now rejects (`0.05 > 0.1` is False), and
+  `execute_place` is **not** called again. Proves the storm self-heals after one
+  110017 with the guard convention intact.
+- `test_dirty_refresh_unblocks_legit_close_when_actual_sufficient`: stale-low
+  mirror `0.05`, actual REST `0.2`, intent `0.1`; after refresh the guard passes
+  and `execute_place` is called with the unchanged `qty=0.1` (refresh-before-
+  guard also fixes wrongful rejection from a stale-low mirror).
+- `test_dirty_rest_refresh_rate_limited`: `_position_dirty=True`; drive **N**
+  per-tick re-emissions within `dirty_rest_refresh_min_interval_seconds`. Assert
+  `get_positions` is called **once**, not N times (guard re-uses the corrected
+  size between refreshes).
+- `test_refresh_position_size_updates_local_mirror`: stub `get_positions` returns
+  a flat list with a `positionIdx=1` entry of size `0.05`; after refresh
+  `_long_position.size == Decimal("0.05")`. Verifies flat-list filtering by
+  `positionIdx`.
+- `test_refresh_position_size_handles_flat_position` (P1-5): stub `get_positions`
+  returns an empty list or a `positionIdx=1` entry with `size="0"`; after refresh
+  `_long_position.size == Decimal("0")` (flat / no-match → size 0).
+- `test_refresh_position_size_no_rest_client_falls_back`: `rest_client=None` →
+  WARNING, mirror unchanged.
+
+### Phase 3 — circuit-breaker
+- `test_breaker_trips_after_n_within_window` / `…_does_not_trip_below_n`.
+- `test_breaker_no_retrip_during_cooldown` (P2-a): trip the breaker, then call
+  `record_110017` again before `tripped_until`; assert it returns `False`, does
+  **not** append to the deque, does **not** re-arm `tripped_until`, and the
+  reconcile counter does **not** increment a second time.
+- `test_breaker_window_eviction`: timestamps older than `window_seconds` drop out
+  so a slow drip never trips.
+- `test_breaker_cooldown_expiry_resets`: after `cooldown_seconds`, `is_blocked`
+  returns False and the deque is cleared.
+- `test_breaker_success_resets_scope_key`: a successful place clears the deque and
+  any trip.
+- `test_breaker_scope_keys_independent`: Sell@84.51 tripping does not block
+  Buy@84.51 or Sell@84.52.
+- `test_110017_retry_uses_fresh_order_link_id`: after a 110017 failure on the
+  backstop path (refresh can't heal), the next emission of the same intent is
+  assigned a **fresh** wire `order_link_id` rather than the failed tracked
+  order's id, so re-submissions keep classifying as 110017 and never degrade to
+  110072. Contrast: a non-110017 failure (e.g. network) still reuses the id as
+  today (feature 0032 unchanged).
+- `test_breaker_blocks_before_refresh_on_tripped_scope`: after trip, per-tick
+  re-emission hits `is_blocked` at pipeline step 2 — `get_positions` is **not**
+  called during cooldown.
+
+### Reconcile wiring
+- `test_breaker_trip_triggers_forced_reconcile`: on trip, orchestrator's
+  `_force_reconcile_strat` is invoked once, calls `reconcile_reconnect` and
+  `_refresh_position_size_from_rest(..., force=True)`, and is rate-limited (a
+  second trip within cooldown does not re-call REST).
+- `test_ws_match_clears_dirty`: with `_position_dirty[LONG]=True` and
+  `_last_rest_position_size[LONG]=0.05` (from a prior refresh), an
+  `on_position_update` delivering WS long size `0.05` clears
+  `_position_dirty[LONG]` and resets `_last_dirty_rest_at[LONG]`; a WS size of
+  `0.07` leaves dirty set (no premature clear on a still-diverging update).
+- `test_stale_ws_after_rest_refresh_does_not_reopen_storm` (P1 regression — the
+  dangerous interleaving): `_position_dirty[LONG]=True`, refresh REST → mirror
+  `0.05`, `_last_rest_position_size[LONG]=0.05`; deliver a **stale**
+  `on_position_update` with WS long size `0.2` (≠ last REST) → assert
+  `_long_position.size` stays `0.05` (WS write ignored, dirty still True); then
+  re-emit the reduce-only intent (qty `0.1`) **within** the throttle window →
+  assert `_is_good_to_place` rejects (`0.05 > 0.1` is False) and `execute_place`
+  is **not** called (storm not reopened by the stale WS frame).
+- `test_dirty_ws_gate_inactive_without_rest_baseline` (P2 no-baseline guardrail):
+  `_position_dirty[LONG]=True` and `_last_rest_position_size[LONG] is None` (no
+  refresh has run — e.g. `dirty_refresh_enabled=False` or `rest_client=None`); an
+  `on_position_update` with WS long size `0.05` **writes** `0.05` to the mirror
+  (the gate is inactive without a baseline — it must **not** restore a synthetic
+  `0` or drop the legit WS size). Guards against the synthetic-zero regression
+  that would reject all reduce-only closes on a dirtied direction.
+
+### Guardrail regressions (existing behavior must not break)
+- `_is_good_to_place` existing tests still pass (small-position reduce-only
+  rejection preserved; body unchanged).
+- Non-110017 failures (e.g. simulated 110001/network) still enqueue to the retry
+  queue and are unaffected by the breaker.
+
+---
+
+## Relationship to issue #151 (auto state-divergence detector)
+
+Issue #151 / a future feature implements a broader state-divergence detector
+(REST-failure spike, reconciler retry-budget exhaustion, position delta,
+post-WS-silence enforcement) that triggers a full forced reconcile without
+operator restart. This feature (#149) is intentionally narrower: it stops the
+**110017 retry storm** at source (refresh-before-guard so the guard rejects
+accurately) and bounds repeated rejects (circuit-breaker), reusing
+`reconcile_reconnect` + a new position-size refresh as its healing action. The
+`_force_reconcile_strat` orchestrator method and the
+`truncate_breaker_reconcile_count` counter introduced here are designed to be
+reused by #151's detector (shared entry point), so the two features compose
+rather than duplicate.

--- a/docs/features/0064_REVIEW.md
+++ b/docs/features/0064_REVIEW.md
@@ -1,0 +1,123 @@
+# Feature 0064 Code Review (redo)
+
+## Summary
+
+Re-reviewed after the P2 fix and follow-up tests. The implementation matches `docs/features/0064_PLAN.md` for issue #149: dirty-mirror REST refresh before the unchanged `_is_good_to_place` guard, `TruncateBreaker` backstop, shared `ORDER_QTY_TRUNCATED_TO_ZERO`, orchestrator forced reconcile, and WS size gating while dirty. No qty-cap; reduce-only strict-`>` semantics preserved.
+
+**Verdict:** No blocking or actionable issues. Ready to merge.
+
+---
+
+## Plan compliance
+
+| Plan item | Status |
+|-----------|--------|
+| `StrategyConfig` fields with safe defaults | Done |
+| `ORDER_QTY_TRUNCATED_TO_ZERO` in `bybit_adapter` | Done |
+| `is_truncate_error()` (module-level, `_ERR_CODE_RE`) | Done |
+| Pipeline: breaker → dirty refresh → guard → submit | Done |
+| `_position_dirty` on first 110017; exclude from retry queue | Done |
+| Fresh wire `order_link_id` after 110017 | Done |
+| REST refresh by `positionIdx` (camelCase API fields) | Done |
+| `_last_dirty_rest_at is None` first-refresh sentinel | Done |
+| WS gate + no-baseline pass-through | Done |
+| Successful reduce-only clears dirty; open does not (F1) | Done |
+| `_force_reconcile_strat`: orders + position refresh, rate-limited | Done |
+| Health sweep logs `truncate_breaker_reconcile_count` | Done |
+| `_is_good_to_place` body unchanged | Confirmed |
+| `RULES.md` updated | Done |
+
+**Scope key:** Plan text uses `(strat_id, side, price)`; code uses `(side, price)` on a per-runner `TruncateBreaker` — correct (one runner per `strat_id`).
+
+---
+
+## Findings
+
+No blocking or actionable issues.
+
+### Previously P2 — resolved
+
+`_force_reconcile_strat` now uses **independent** `try/except` blocks: order reconcile failure is alerted (`force_reconcile_orders_{strat_id}`) but no longer skips `_refresh_position_size_from_rest(..., force=True)`. Position refresh failures get a separate alert (`force_reconcile_pos_{strat_id}`).
+
+```1218:1235:apps/gridbot/src/gridbot/orchestrator.py
+        if reconciler is not None:
+            try:
+                reconciler.reconcile_reconnect(runner)
+            except Exception as e:
+                self._notifier.alert_exception(
+                    f"forced reconcile orders {strat_id}", e,
+                    error_key=f"force_reconcile_orders_{strat_id}",
+                )
+        # Position-size resync is the #149-critical healing step ...
+        try:
+            runner._refresh_position_size_from_rest(direction, force=True)
+        except Exception as e:
+            self._notifier.alert_exception(
+                f"forced reconcile position {strat_id}", e,
+                error_key=f"force_reconcile_pos_{strat_id}",
+            )
+```
+
+`test_force_reconcile_exception_is_caught_and_alerted` asserts the position resync still runs when `reconcile_reconnect` raises.
+
+### Previously P3 — resolved
+
+- **`rest_client=None` backstop:** `test_breaker_bounds_storm_when_rest_client_none` — dirty refresh attempted but cannot heal; breaker trips at N=3.
+- **Short-side REST refresh:** `test_refresh_position_size_short_side` — `positionIdx==2` parity with long.
+
+---
+
+## Data alignment
+
+- `get_positions` returns camelCase Bybit dicts (`positionIdx`, `size`) — consistent with WS / `_build_position_state`.
+- Sizes treated as non-negative magnitudes; malformed `positionIdx` entries skipped without crashing the hot path.
+- `is_truncate_error` matches `[110017]` from `rest_client._check_response` and pybit `(ErrCode: …)` via `_ERR_CODE_RE`.
+
+---
+
+## Code quality
+
+- Clear module split (`truncate_breaker.py`, `_clear_dirty`, `_apply_dirty_ws_size_gate`, `_refresh_position_size_from_rest`).
+- No over-engineering; throttle-on-attempt (F2) and episode-scoped `_clear_dirty` (F3) are intentional and tested.
+- Style matches `RetryQueue` (injected `now`, poll-free breaker).
+
+---
+
+## Tests
+
+| Area | Coverage |
+|------|----------|
+| Storm collapse (primary) | `test_110017_storm_self_heals_after_one_failure`, clock-zero refresh |
+| Backstop (disabled refresh) | `test_breaker_bounds_storm_when_refresh_cannot_heal` |
+| Backstop (`rest_client=None`) | `test_breaker_bounds_storm_when_rest_client_none` |
+| Phase 2 refresh/guard | Including `test_refresh_position_size_short_side` |
+| Breaker unit | `test_truncate_breaker.py` (9 tests) |
+| WS gate / stale WS | Match, non-match, no-baseline, stale-WS regression |
+| Wire-id / retry guardrails | 110017 fresh id; non-110017 reuse + enqueue |
+| Orchestrator reconcile | `TestForcedReconcile` incl. P2 order-fail + position refresh |
+| Config / classifier | Defaults, overrides, validation, `TestIsTruncateError` |
+
+Tests are isolated (mocks, virtual clock), fast, and name intent clearly.
+
+---
+
+## Verification
+
+```text
+uv run pytest apps/gridbot/tests/test_truncate_breaker.py \
+  apps/gridbot/tests/test_runner_truncate_storm.py \
+  apps/gridbot/tests/test_config.py::TestStrategyConfig::test_truncate_breaker_defaults \
+  apps/gridbot/tests/test_config.py::TestStrategyConfig::test_truncate_breaker_overrides \
+  apps/gridbot/tests/test_config.py::TestStrategyConfig::test_truncate_breaker_invalid_values_rejected \
+  apps/gridbot/tests/test_executor.py::TestIsTruncateError \
+  apps/gridbot/tests/test_orchestrator.py::TestForcedReconcile -q
+→ 49 passed
+```
+
+---
+
+## Residual risk (informational only)
+
+- **Dormant dirty + throttled REST heartbeat** while WS is down is intentional; throttle bounds cost.
+- **Ratio/liq/multipliers** still read fresh WS state during a dirty window (pre-existing, out of scope for #149).
+- `_force_reconcile_strat` is per-strat rate-limited — sufficient for 0064; issue #151 may extend reuse.

--- a/packages/bybit_adapter/src/bybit_adapter/__init__.py
+++ b/packages/bybit_adapter/src/bybit_adapter/__init__.py
@@ -15,6 +15,7 @@ from bybit_adapter.ws_client import (
 )
 from bybit_adapter.rest_client import BybitRestClient
 from bybit_adapter.rate_limiter import RateLimiter, RateLimitConfig
+from bybit_adapter.error_codes import ORDER_QTY_TRUNCATED_TO_ZERO
 
 __all__ = [
     "BybitNormalizer",
@@ -24,4 +25,5 @@ __all__ = [
     "BybitRestClient",
     "RateLimiter",
     "RateLimitConfig",
+    "ORDER_QTY_TRUNCATED_TO_ZERO",
 ]

--- a/packages/bybit_adapter/src/bybit_adapter/error_codes.py
+++ b/packages/bybit_adapter/src/bybit_adapter/error_codes.py
@@ -3,6 +3,9 @@
 Centralises numeric ErrCode literals so classifiers and divergence
 detectors reference one symbol instead of a magic number. Mirrors the
 ``AUTH_ERROR_CODES`` set kept in ``gridbot.executor``.
+
+Bybit error-code reference (look up new codes / wording here):
+https://bybit-exchange.github.io/docs/v5/error
 """
 
 # ErrCode 110017 "orderQty will be truncated to zero": Bybit dynamically

--- a/packages/bybit_adapter/src/bybit_adapter/error_codes.py
+++ b/packages/bybit_adapter/src/bybit_adapter/error_codes.py
@@ -1,0 +1,13 @@
+"""Shared Bybit error-code constants.
+
+Centralises numeric ErrCode literals so classifiers and divergence
+detectors reference one symbol instead of a magic number. Mirrors the
+``AUTH_ERROR_CODES`` set kept in ``gridbot.executor``.
+"""
+
+# ErrCode 110017 "orderQty will be truncated to zero": Bybit dynamically
+# clamps a reduce-only qty to the current exchange-side position size; when
+# the position is smaller than the intent the clamp drops to zero and the
+# order is rejected. Surfaces during local-mirror divergence (feature 0064,
+# issue #149).
+ORDER_QTY_TRUNCATED_TO_ZERO = 110017

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -34,6 +34,9 @@ Plan: docs/features/0064_PLAN.md  |  Branch: feature/0064-truncate-breaker-dirty
   - #1 `dirty_rest_refresh_failure_count` metric (REST refresh failures) + health-sweep surfacing
   - #2 `_dirty_ws_mismatch_streak` + threshold WARNING (WS feed stuck) — reset via `_clear_dirty`
   - +8 tests; full suite 2401 passed. (bot #3 already covered; #4/#5 not requested.)
+- [x] PR #157 bot review round 2 — APPROVED, no P0/P1; user requested #1-#4 (cosmetic):
+  - #1/#2 exception `type(e).__name__` in dirty-refresh WARNINGs; #3 Bybit error-code doc link in `error_codes.py`; #4 inline comment on breaker scope key. (#5 already covered.)
+  - No behavior change; full suite 2401 passed.
 
 ## What could break (revisit after impl)
 - Mock(spec=IntentExecutor) auto-creating truthy methods → classifier kept module-level

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -30,6 +30,10 @@ Plan: docs/features/0064_PLAN.md  |  Branch: feature/0064-truncate-breaker-dirty
 - [x] Update RULES.md — added "110017 retry-storm self-heal + circuit-breaker" section
 - [x] docs/features/0064_REVIEW.md findings — F1 (dirty-clear close-only), F2 (throttle on every attempt), F3 (`_clear_dirty` episode-scoped reset), F4 (dead test cond), F6 (negative tests) applied; F5 declined (plan-sanctioned, optional).
 - [x] Review v3 findings — P2 (split forced-reconcile try blocks so position resync survives an order-reconcile failure) applied + test; P3.1 (`rest_client=None` backstop test) + P3.2 (short-side refresh test) added; P3.3 non-issue. Full suite 2393 passed.
+- [x] PR #157 bot review (await-review) — APPROVED, no P0/P1; user requested fix of P2 #1 + #2:
+  - #1 `dirty_rest_refresh_failure_count` metric (REST refresh failures) + health-sweep surfacing
+  - #2 `_dirty_ws_mismatch_streak` + threshold WARNING (WS feed stuck) — reset via `_clear_dirty`
+  - +8 tests; full suite 2401 passed. (bot #3 already covered; #4/#5 not requested.)
 
 ## What could break (revisit after impl)
 - Mock(spec=IntentExecutor) auto-creating truthy methods → classifier kept module-level

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,37 @@
+# Feature 0064 — 110017 retry-storm: dirty-mirror REST refresh + circuit-breaker
+
+Plan: docs/features/0064_PLAN.md  |  Branch: feature/0064-truncate-breaker-dirty-refresh
+
+## Phase 1 — Data layer
+- [x] `bybit_adapter/error_codes.py`: `ORDER_QTY_TRUNCATED_TO_ZERO = 110017` (+ re-export in `__init__`)
+- [x] `executor.py`: `is_truncate_error()` classifier (module-level fn; reuse `_ERR_CODE_RE`)
+- [x] `config.py` StrategyConfig: `dirty_refresh_enabled`, `dirty_rest_refresh_min_interval_seconds`, `truncate_breaker_{max_consecutive,window_seconds,cooldown_seconds,reconcile}`
+
+## Phase 2/3 — TruncateBreaker
+- [x] `truncate_breaker.py`: scope-key sliding window, trip/cooldown, in-cooldown no-op, reset-on-success
+
+## Phase 2 — runner dirty-mirror refresh
+- [x] ctor: `rest_client`, `truncate_breaker`, `on_truncate_breaker_tripped`, `clock`
+- [x] state: `_position_dirty`, `_last_dirty_rest_at`, `_last_rest_position_size`, `_truncate_breaker_reconcile_count` (+ property)
+- [x] `_refresh_position_size_from_rest(direction, *, force=False)`
+- [x] `_execute_place_intent` pipeline: is_blocked → dirty-refresh → guard → submit → breaker bookkeeping
+- [x] exclude 110017 from retry queue; drop wire-id reuse on 110017
+- [x] `on_position_update`: dirty WS gate + WS-match clear
+
+## Phase 3 — orchestrator wiring
+- [x] pass `rest_client`; wire `on_truncate_breaker_tripped` → `_force_reconcile_strat`
+- [x] `_force_reconcile_strat` (orders reconcile + force position refresh, rate-limited)
+- [x] `_health_check_once`: DEBUG log trip counts
+
+## Verification
+- [x] All new tests pass (TDD: red → green) — 40 new tests
+- [x] Full repo suite green — 2382 passed, 3 skipped
+- [x] Adversarial review pass — 2 confirmed (P3 positionIdx hardening, P2 force=True test), 1 rejected; both addressed
+- [x] Update RULES.md — added "110017 retry-storm self-heal + circuit-breaker" section
+- [x] docs/features/0064_REVIEW.md findings — F1 (dirty-clear close-only), F2 (throttle on every attempt), F3 (`_clear_dirty` episode-scoped reset), F4 (dead test cond), F6 (negative tests) applied; F5 declined (plan-sanctioned, optional).
+- [x] Review v3 findings — P2 (split forced-reconcile try blocks so position resync survives an order-reconcile failure) applied + test; P3.1 (`rest_client=None` backstop test) + P3.2 (short-side refresh test) added; P3.3 non-issue. Full suite 2393 passed.
+
+## What could break (revisit after impl)
+- Mock(spec=IntentExecutor) auto-creating truthy methods → classifier kept module-level
+- DirectionType is StrEnum ('long'/'short'); dict keys interop with intent.direction str
+- position_ratio/liq calc reads WS state, not gated mirror (intentional, out of scope)


### PR DESCRIPTION
## Summary
Fixes the SOLUSDT **110017 "orderQty will be truncated to zero"** retry storm (issue #149): after a WS outage left the local position mirror stale-high, the bot re-emitted ~535 identical rejected reduce-only closes in <90min.

Two complementary mechanisms — **no qty-cap, `_is_good_to_place` body unchanged**:

1. **Dirty-mirror REST refresh before the guard (primary self-heal).** First 110017 marks the direction dirty; the next reduce-only placement REST-refreshes the true size so the unchanged strict-`>` guard rejects the oversized close locally. Storm collapses to one 110017.
2. **`TruncateBreaker` backstop.** `(side, price)` scope key, sliding-window trip/cooldown, in-cooldown no-op. Bounds the undetected window / when the refresh can't heal. On trip: drop intents for the cooldown, fire one rate-limited forced reconcile (orders + force position resync in **independent** try blocks), increment a health-surfaced trip counter.

Also: 110017 excluded from the retry queue; wire-`orderLinkId` reuse dropped on 110017 (fresh id next emission → avoids 110072); WS size write gated while dirty (match clears dirty, non-match keeps REST authoritative, no-baseline passes through); episode-scoped `_clear_dirty` invariant; throttle armed on every refresh attempt; shared `ORDER_QTY_TRUNCATED_TO_ZERO` + module-level `is_truncate_error`.

## Config (all default-on, per `StrategyConfig`)
`dirty_refresh_enabled`, `dirty_rest_refresh_min_interval_seconds`, `truncate_breaker_{max_consecutive,window_seconds,cooldown_seconds,reconcile}`.

## Conventions preserved
Hedge-mode reduce-only reject on small positions, per-direction sequential dispatch, `amount_multiplier` forward-only, feature-0032 orderLinkId reuse for non-110017 failures.

## Files
New: `truncate_breaker.py`, `error_codes.py`. Touched: `runner.py`, `orchestrator.py`, `executor.py`, `config.py`, `bybit_adapter/__init__.py`, `RULES.md`.

## Tests
47 new tests (breaker unit, both storm paths, dirty refresh/guard, WS gate, wire-id/retry-queue guardrails, forced reconcile, config/classifier). **Full suite: 2393 passed, 3 skipped.**

## Review
Plan + two adversarial review rounds in `docs/features/0064_{PLAN,REVIEW}.md`; all findings (F1–F4, F6, P2, P3.1/P3.2) resolved; F5 (orchestrator→runner private call) deliberately left as plan-specified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)