### PR TITLE
feat(0066): 110007 low-balance storm fix — preflight + WS wallet feed + chase (#159)

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -343,6 +343,151 @@ Pitfalls / invariants (all enforced + tested):
   `test_truncate_breaker.py`, `test_runner_truncate_storm.py`,
   `TestForcedReconcile` in `test_orchestrator.py`.
 
+### 110007 low-balance preflight + chase-close (feature 0066, issue #159)
+
+Defends against the **110007 "available balance not enough"** retry storm that
+hit under a low-balance + long-heavy state (the risk-mgmt rule grew the losing
+short with mult=2.0; the grown open exceeded free margin → 110007 every attempt
+→ retry-queue amplification). Three layers + a bug-fix, all additive:
+
+- **Margin observability (default-on, no behavior change).**
+  `position_fetcher.WalletSnapshot` carries `available_balance` /
+  `total_available_balance` / `total_maintenance_margin` (extracted from the
+  same `get_wallet_balance()` REST response — **no extra API call**; the
+  `_wallet_cache` now holds the snapshot, `get_wallet_balance` reads
+  `.wallet_balance`). `PositionState` gains `initial_margin`/`maintenance_margin`
+  (Bybit `positionIM`/`positionMM`, **dollar amounts** — kept SEPARATE from the
+  `margin` ratio, see "Margin Ratio vs Bybit positionIM — Critical Distinction").
+  The per-tick `Position
+  update` INFO heartbeat is **extended** (not changed) with `avail=` /
+  `total_avail=` / `total_mm=`; the gridbot-health analyzer parses those and
+  tracks a `min_available_balance` all-time peak.
+  - **UTA empty-string trap**: Bybit mainnet sends `""` for unused numeric
+    fields (`availableToWithdraw` on cross-margin). Parse with
+    `position_fetcher._float_or_zero` (None/`""` → 0.0); `.get(k, 0)` only
+    handles *missing* keys.
+  - **`available_balance` fallback chain** (`_snapshot_from_wallet_account_row`):
+    prefer the UTA-v5 per-coin `availableToWithdraw`; when it is absent/empty,
+    fall back to the **legacy `availableBalance`** coin field (UTA 1.0 / some
+    cross-margin coins surface free margin only there — **must mirror
+    `recorder.py:404-408`** so the two parsers can't drift); then fall back to the
+    account-level `total_available_balance`. Missing this legacy field would let a
+    funded account parse free margin as 0 → on the provider path a fresh 0 blocks
+    ALL opens (halts trading), on the no-provider path it fail-opens.
+- **Preflight balance check (default-on, the storm-stopper).** In
+  `_is_good_to_place`, BEFORE the `if not intent.reduce_only: return True`
+  early-return: for OPEN orders only, reject locally when
+  `available_balance < (qty*price/leverage) * (1 + buffer)`. **Reduce-only
+  always bypasses** (frees margin, can't 110007). **Fail-open** when
+  `available_balance <= 0` (no data yet) — never block all opens on a transient
+  gap. Leverage via `_effective_leverage(direction)`: live per-direction
+  leverage (captured in `_build_position_state` into `self._leverage`, kept OUT
+  of `PositionState.leverage` so the risk-multiplier upnl calc + backtest parity
+  are untouched) else `assumed_leverage`. Bias leverage LOW — under-estimating
+  only over-rejects affordable opens, never lets an unaffordable one through.
+- **Retry-queue 110007 guard (default-on).** In `_execute_place_intent`, a
+  110007 on an open order is **dropped, not enqueued** (mirrors the 0064 "do NOT
+  enqueue 110017" decision). It is **stateless — no breaker, no cooldown**; the
+  preflight re-gates on the next tick once balance recovers. `INSUFFICIENT_BALANCE
+  = 110007` + `executor.is_insufficient_balance()` (sibling of
+  `is_truncate_error`).
+- **moderate_liq_risk bug-fix (3a, default-on).** Under low-balance the
+  `moderate_liq_risk` arm SKIPS the 0.5 close-throttle (`position.py`, both long
+  and short branches) — that throttle slowed the margin-freeing closes and
+  deadlocked the bot. `low_balance` is threaded into `calculate_amount_multiplier`
+  + the rule helpers (default False = byte-for-byte pre-0066). The kill-switch
+  (`moderate_liq_low_balance_fix_enabled`) is applied in the RUNNER (it passes
+  `low_balance=False` when off) because `position.py` is gridcore and cannot read
+  gridbot config. This deviates from the bbu2-derived rule ONLY under the new
+  low-balance condition.
+- **Chase-close (3b, default-OFF).** When low-balance AND `position_ratio`
+  extreme, cancel resting grow-side opens for the dominant side and place a
+  reduce-only **post-only** close near the touch to trim it without slippage.
+  Post-only support is new and additive: `PlaceLimitIntent.post_only`
+  (`compare=False`, NOT in `_IDENTITY_PARAMS` → id/dedup unchanged), threaded
+  via `executor.execute_place` → `rest_client.place_order(time_in_force=...)`
+  (default `"GTC"` == today's implicit behavior).
+  - **Dispatch — stash-and-drain**: `on_position_update` holds no `limits`
+    snapshot and never dispatches, so the chase decision only mutates state +
+    appends to `self._pending_chase_intents`; `_drain_pending_chase_intents()`
+    at the top of `on_ticker`/`on_execution`/`on_order_update` feeds the buffer
+    through the existing `_execute_intents(..., get_limit_orders())`.
+  - State machine `IDLE→CHASING→IDLE`. Maker-safe pricing: **Sell above / Buy
+    below** the touch (post-only never crosses — note this is the OPPOSITE of an
+    aggressive taker peg). Chase qty is half the dominant size (rounded), kept
+    strictly below position size so the reduce-only guard passes. Cancel-replace
+    on drift acts on the chase order ONLY — explicitly exempt from the
+    forward-only `amount_multiplier` invariant (it is not a grid order). Exit
+    has hysteresis (`chase_close_hysteresis`) to avoid flapping.
+- **Single source of truth**: `_is_low_balance(total_position_value)` (avail > 0
+  AND avail < total_position_value * `low_balance_fraction`), recomputed each
+  `on_position_update` into `self._low_balance`; 3a and 3b each apply their own
+  kill-switch on top.
+- **Real-time wallet feed (Phase 4, default-on).** The preflight's free-margin
+  signal would otherwise lag up to `wallet_cache_interval` (300s, REST-cached),
+  so the bot subscribes the private WS **`wallet`** topic (account-level free
+  margin — `totalAvailableBalance` / per-coin `availableToWithdraw` — is NOT in
+  the `position` topic, which carries only per-position `positionIM`/`positionMM`).
+  `ws_client` already supports `on_wallet`; orchestrator just wires it.
+  - `position_fetcher._wallet_ws_data[acct] = (snapshot, ts)` is written ONLY by
+    `on_wallet_message` on the **WS thread** (single GIL-atomic assignment, no
+    lock, mirrors `_position_ws_data`); it NEVER touches `_wallet_cache` (the
+    main-thread-guarded REST cache). `on_wallet_message` **never raises on the WS
+    thread** and validates **structurally** (needs `data[0]` + a USDT coin row) —
+    a valid row is written **even when `available_balance==0`** (a funded account
+    with no free margin is a REAL signal; do NOT use an all-zero skip heuristic).
+  - **Shared parser** `_snapshot_from_wallet_account_row(row)` (returns `None` on
+    no-USDT) is called by BOTH `_fetch_wallet_snapshot` (REST `list[0]`) and
+    `on_wallet_message` (WS `data[0]`) — same V5 shape, one parser, no field drift.
+  - **Hot path uses `peek_wallet_snapshot(acct) -> (snapshot, age) | None`**:
+    non-blocking, NEVER fetches, returns the **newest of {WS slot, REST cache} by
+    timestamp** (a stale WS slot must NOT shadow a fresher REST entry). The
+    background `get_wallet_snapshot` keeps its WS-if-fresh-else-REST(-fetch) form;
+    only `peek` feeds the preflight (injected as the runner `wallet_provider`).
+  - **Preflight balance source = freshness, not positivity.** Provider wired: a
+    FRESH peek (`age < wallet_ws_max_age_seconds`) is **authoritative even at 0**
+    (fresh-zero blocks every open); a stale / `None` / **raising** peek →
+    **fail-open** (never falls back to the equally-stale `_available_balance`
+    latch; a raising provider is caught + throttled-WARNING and never aborts
+    dispatch). No provider (kill-switch off / unit tests) → legacy
+    `_available_balance` path with the `>0`-means-data rule. Logic lives in
+    `runner._preflight_available_balance` / `_preflight_blocks_open`.
+  - **`wallet_ws_enabled=False` is a FULL kill-switch**: skips BOTH the `on_wallet`
+    wiring AND the `wallet_provider` injection → genuine pre-Phase-4 behavior
+    (position-cadence balance, REST TTL, no age-bounding, no fail-open-on-stale).
+    Not "WS off but REST still age-bounded".
+  - Caveat: staleness is **bounded to `wallet_ws_max_age_seconds`, then
+    fail-open** — NOT "eliminated". The INFO `avail=` heartbeat is written on the
+    position-drain cadence and is NOT a reliable WS-freshness signal; validate via
+    the **DEBUG WS-vs-REST source/age log** emitted at every `get_wallet_snapshot`
+    return path (`served from WS (age=…)` / `served from REST …`).
+  - **Predicate freshness (review F1):** the low-balance PREDICATE
+    (`_is_low_balance`, used by 3a moderate_liq + 3b chase) reads the SAME
+    `wallet_provider` peek as the preflight via `_predicate_available_balance`
+    (fresh peek authoritative — a fresh 0 = real no-free-margin = low-balance;
+    stale/None/raising → falls back to the position-cadence `_available_balance`
+    latch, where a 0 still means "no data"). So chase and preflight now share one
+    freshness — this resolves the plan rollout §3 chase-enable prerequisite.
+    Additive: no provider (backtest / `wallet_ws_enabled=False`) keeps the exact
+    pre-Phase-4 latch behavior.
+- Config — **`GridbotConfig`** (Phase 4, not `StrategyConfig`):
+  `wallet_ws_enabled` (True), `wallet_ws_max_age_seconds` (45.0, `gt=0`).
+- Config (`StrategyConfig`, all default preserve behavior):
+  `preflight_balance_check_enabled` (True), `preflight_balance_buffer` (0.05),
+  `assumed_leverage` (1.0), `low_balance_fraction` (0.10),
+  `moderate_liq_low_balance_fix_enabled` (True), `chase_close_enabled` (**False**),
+  `chase_position_ratio_threshold` (5.0), `chase_offset_pct` (0.0007),
+  `chase_replace_drift_pct` (0.0010), `chase_close_hysteresis` (0.1).
+- Files touched: `position.py`, `intents.py`, `error_codes.py`,
+  `rest_client.py`, `runner.py`, `position_fetcher.py`, `orchestrator.py`,
+  `executor.py`, `config.py`, gridbot-health `analyze.py`. Tests:
+  `test_runner_lowbalance_storm.py`, `test_position_low_balance.py`, plus 3b.0
+  surface in `test_intents.py` / `test_executor.py` / `test_rest_client.py`; Phase-4
+  WS-wallet/peek/provider surface in `test_position_fetcher.py` /
+  `test_runner_lowbalance_storm.py` / `test_orchestrator.py`.
+  Promote `chase_close_enabled` to on only after one live low-balance stress
+  event confirms the dominant side decreases without market-order slippage.
+
 ### SAME ORDER detection
 
 - `StrategyRunner._check_same_orders_side()` compares tracked orders by `TrackedOrder.placed_ts` when both fills map to tracked orders; use fill `exchange_ts` only as a fallback for untracked/legacy events. Duplicate same-price orders can rest concurrently and fill more than 5s apart in thin markets, so fill-time-only windows silently miss the critical duplicate-placement bug.

--- a/apps/gridbot/src/gridbot/config.py
+++ b/apps/gridbot/src/gridbot/config.py
@@ -100,6 +100,97 @@ class StrategyConfig(BaseModel):
         description="Trigger one forced position+order reconcile when the breaker trips.",
     )
 
+    # Feature 0066 — 110007 low-balance preflight + retry-queue guard (issue #159).
+    # All default-on so existing conf/*.yaml keep working unchanged.
+    preflight_balance_check_enabled: bool = Field(
+        default=True,
+        description=(
+            "Master kill-switch for the low-balance preflight. When True, an "
+            "OPEN (non-reduce-only) order is rejected locally in "
+            "_is_good_to_place when est_cost = qty*price/leverage exceeds "
+            "available_balance*(1+buffer) — preventing the 110007 retry storm. "
+            "Reduce-only orders always bypass the check (they free margin)."
+        ),
+    )
+    preflight_balance_buffer: float = Field(
+        default=0.05,
+        ge=0,
+        description=(
+            "Fractional safety margin on the preflight est_cost so fee/funding/"
+            "rounding slack near the affordability boundary does not still 110007."
+        ),
+    )
+    assumed_leverage: float = Field(
+        default=1.0,
+        gt=0,
+        description=(
+            "Fallback leverage for the preflight est_cost when no live exchange "
+            "leverage has been observed for the direction. Bias LOW: an "
+            "under-estimate only over-rejects affordable opens, never lets an "
+            "unaffordable one through."
+        ),
+    )
+    # Low-balance predicate (shared by the moderate_liq_risk fix + chase-close).
+    low_balance_fraction: float = Field(
+        default=0.10,
+        gt=0,
+        description=(
+            "Low-balance is True when available_balance is positive but below "
+            "total_position_value * this fraction. Drives the moderate_liq_risk "
+            "fix (3a) and chase-close (3b) — feature 0066 / issue #159."
+        ),
+    )
+    moderate_liq_low_balance_fix_enabled: bool = Field(
+        default=True,
+        description=(
+            "Kill-switch for the moderate_liq_risk low-balance fix. When True and "
+            "low-balance, the moderate_liq_risk arm SKIPS the 0.5 close-throttle "
+            "so margin-freeing closes are not slowed (the issue #159 deadlock). "
+            "When False the arm is byte-for-byte the pre-0066 behavior."
+        ),
+    )
+    # Chase-close active defense (feature 0066 / issue #159). Default OFF — it
+    # actively places orders; promote to on only after the regression suite plus
+    # one live low-balance stress event confirms the dominant side decreases.
+    chase_close_enabled: bool = Field(
+        default=False,
+        description=(
+            "Kill-switch for chase-close. When True AND low-balance AND the "
+            "position_ratio is extreme, the bot cancels resting grow-side opens "
+            "for the dominant side and places a reduce-only post-only close near "
+            "the touch to trim it without market-order slippage."
+        ),
+    )
+    chase_position_ratio_threshold: float = Field(
+        default=5.0,
+        gt=0,
+        description=(
+            "Chase enters when low-balance and position_ratio > this (long "
+            "dominant) or < 1/this (short dominant)."
+        ),
+    )
+    chase_offset_pct: float = Field(
+        default=0.0007,
+        gt=0,
+        description=(
+            "Chase order offset from the touch (maker-safe: Sell above / Buy "
+            "below). Issue #159 suggested the 0.0005–0.0010 band."
+        ),
+    )
+    chase_replace_drift_pct: float = Field(
+        default=0.0010,
+        gt=0,
+        description="Cancel-replace the chase order when price drifts more than this from it.",
+    )
+    chase_close_hysteresis: float = Field(
+        default=0.1,
+        ge=0,
+        description=(
+            "Ratio re-entry margin so the chase exits only after the imbalance "
+            "recovers past the threshold by this fraction (anti-flap)."
+        ),
+    )
+
     # Mode
     shadow_mode: bool = Field(default=False, description="Log intents without executing")
 
@@ -176,6 +267,29 @@ class GridbotConfig(BaseModel):
     wallet_cache_interval: float = Field(
         default=300.0,
         description="Seconds to cache wallet balance (0 to disable caching)",
+    )
+    # Feature 0066 (issue #159) — real-time wallet via the WS `wallet` topic.
+    wallet_ws_enabled: bool = Field(
+        default=True,
+        description=(
+            "Phase-4 master kill-switch for the real-time wallet WS feed. When "
+            "True, the private WS subscribes the `wallet` topic and the runner's "
+            "preflight reads a non-blocking, age-bounded peek of free margin. "
+            "When False, BOTH the WS subscription AND the runner wallet_provider "
+            "are skipped — the preflight reverts to the pre-Phase-4 "
+            "position-cadence `_available_balance` path (no age-bounding)."
+        ),
+    )
+    wallet_ws_max_age_seconds: float = Field(
+        default=45.0,
+        gt=0,
+        description=(
+            "Max age of a WS/REST wallet snapshot the preflight will trust "
+            "before failing open. Bounds how long a silently-dead WS may pin a "
+            "stale slot; well under wallet_cache_interval (300s). A quiet-but-"
+            "healthy WS falling back to REST is harmless (an unchanging balance "
+            "is still accurate)."
+        ),
     )
     rest_fetch_timeout: float = Field(
         default=10.0,

--- a/apps/gridbot/src/gridbot/executor.py
+++ b/apps/gridbot/src/gridbot/executor.py
@@ -11,7 +11,10 @@ from datetime import datetime, UTC
 from typing import Callable, Optional
 
 from bybit_adapter.rest_client import BybitRestClient
-from bybit_adapter.error_codes import ORDER_QTY_TRUNCATED_TO_ZERO
+from bybit_adapter.error_codes import (
+    INSUFFICIENT_BALANCE,
+    ORDER_QTY_TRUNCATED_TO_ZERO,
+)
 from gridcore.intents import PlaceLimitIntent, CancelIntent
 from gridcore.position import DirectionType
 from gridbot.order_link_id import make_order_link_id
@@ -41,6 +44,24 @@ def is_truncate_error(error: Optional[str]) -> bool:
     if match:
         code = int(match.group(1) or match.group(2))
         return code == ORDER_QTY_TRUNCATED_TO_ZERO
+    return False
+
+
+def is_insufficient_balance(error: Optional[str]) -> bool:
+    """Return True if an error string carries Bybit ErrCode 110007.
+
+    110007 ("available balance not enough for new order") means the account's
+    free margin cannot cover an OPEN order. Module-level (mirrors
+    ``is_truncate_error``) so the runner branches on it without routing through
+    a mock executor instance — feature 0066 / issue #159. Reuses the shared
+    ``_ERR_CODE_RE`` for both wire formats.
+    """
+    if not error:
+        return False
+    match = _ERR_CODE_RE.search(error)
+    if match:
+        code = int(match.group(1) or match.group(2))
+        return code == INSUFFICIENT_BALANCE
     return False
 
 
@@ -208,6 +229,9 @@ class IntentExecutor:
                 reduce_only=intent.reduce_only,
                 position_idx=position_idx,
                 order_link_id=unique_link_id,
+                # Feature 0066 (issue #159): maker-only for chase-close orders.
+                # Default GTC == today's implicit behavior for every other order.
+                time_in_force="PostOnly" if intent.post_only else "GTC",
             )
 
             order_id = result.get("orderId")

--- a/apps/gridbot/src/gridbot/orchestrator.py
+++ b/apps/gridbot/src/gridbot/orchestrator.py
@@ -199,6 +199,7 @@ class Orchestrator:
             wallet_cache_interval=self._config.wallet_cache_interval,
             position_check_interval=self._config.position_check_interval,
             on_position_changed=self._on_position,
+            wallet_ws_max_age_seconds=self._config.wallet_ws_max_age_seconds,
         )
 
         # Auth-cooldown subsystem. Constructed eagerly for the same reason
@@ -445,7 +446,8 @@ class Orchestrator:
             account_slot = self._latest_position.get(account_name)
             if not account_slot:
                 continue
-            wallet_balance = self._position_fetcher.get_wallet_balance(account_name)
+            wallet = self._position_fetcher.get_wallet_snapshot(account_name)
+            wallet_balance = wallet.wallet_balance
             for runner in runners:
                 snapshot = account_slot.get(runner.symbol)
                 if snapshot is None:
@@ -463,6 +465,9 @@ class Orchestrator:
                         last_close=_runner_market_price(
                             runner, self._latest_ticker.get(runner.symbol)
                         ),
+                        available_balance=wallet.available_balance,
+                        total_available_balance=wallet.total_available_balance,
+                        total_maintenance_margin=wallet.total_maintenance_margin,
                     )
                 except Exception as e:
                     logger.error(
@@ -688,6 +693,14 @@ class Orchestrator:
             ),
             on_disconnect=lambda ts, a=name: self._on_ws_disconnect(a, "public", ts),
         )
+        # Feature 0066 Phase 4: subscribe the real-time `wallet` topic only when
+        # the kill-switch is on. PrivateWebSocketClient subscribes wallet_stream
+        # solely when on_wallet is set, so None here = no subscription (the full
+        # Phase-4 kill-switch — the wallet_provider is also skipped below).
+        on_wallet = (
+            (lambda msg, a=name: self._position_fetcher.on_wallet_message(a, msg))
+            if self._config.wallet_ws_enabled else None
+        )
         self._private_ws[name] = PrivateWebSocketClient(
             api_key=account_config.api_key,
             api_secret=account_config.api_secret,
@@ -695,6 +708,7 @@ class Orchestrator:
             on_position=lambda msg, a=name: self._position_fetcher.on_position_message(a, msg),
             on_order=lambda msg, a=name: self._on_order(a, msg),
             on_execution=lambda msg, a=name: self._on_execution(a, msg),
+            on_wallet=on_wallet,
             on_disconnect=lambda ts, a=name: self._on_ws_disconnect(a, "private", ts),
             message_gap_watchdog_enabled=False,
         )
@@ -733,6 +747,15 @@ class Orchestrator:
             strategy_config.symbol, account_name
         )
 
+        # Feature 0066 Phase 4: inject the NON-BLOCKING peek_wallet_snapshot
+        # reader as the preflight's real-time free-margin source. Skipped (None)
+        # when wallet_ws_enabled is off → the runner takes the legacy
+        # position-cadence _available_balance path (full Phase-4 kill-switch).
+        wallet_provider = (
+            (lambda acct=account_name: self._position_fetcher.peek_wallet_snapshot(acct))
+            if self._config.wallet_ws_enabled else None
+        )
+
         # Create runner
         runner = StrategyRunner(
             strategy_config=strategy_config,
@@ -748,6 +771,9 @@ class Orchestrator:
             # Feature 0064 — dirty-mirror REST refresh + breaker forced reconcile.
             rest_client=self._rest_clients[account_name],
             on_truncate_breaker_tripped=self._force_reconcile_strat,
+            # Feature 0066 Phase 4 — real-time wallet preflight source.
+            wallet_provider=wallet_provider,
+            wallet_ws_max_age_seconds=self._config.wallet_ws_max_age_seconds,
         )
         self._runners[strat_id] = runner
         self._strategy_executors[strat_id] = executor

--- a/apps/gridbot/src/gridbot/position_fetcher.py
+++ b/apps/gridbot/src/gridbot/position_fetcher.py
@@ -9,15 +9,23 @@ Thread model:
 - `on_position_message` runs on the pybit WS background thread and
   only mutates `_position_ws_data` via GIL-atomic `setdefault` +
   single assignment.
+- `on_wallet_message` (feature 0066 Phase 4) ALSO runs on the pybit WS
+  background thread. It writes `_wallet_ws_data[account] = (snapshot, ts)`
+  via a single GIL-atomic dict assignment, holds no lock, and NEVER
+  touches `_wallet_cache` (the main-thread-guarded REST cache). It never
+  raises on the WS thread — a malformed frame is dropped (last good kept).
 - All other methods run on the main polling thread and are the sole
   reader/writer of `_wallet_cache`, `_last_position_fetch`, and
-  `_position_fetch_rotation_index`. `get_wallet_balance` enforces
-  main-thread-only access at runtime.
+  `_position_fetch_rotation_index`. `get_wallet_balance` /
+  `get_wallet_snapshot` enforce main-thread-only access at runtime.
+  `peek_wallet_snapshot` is a non-blocking main-thread reader of both
+  caches (never fetches) used by the hot order-dispatch path.
 """
 
 import logging
 import threading
 import time
+from dataclasses import dataclass
 from datetime import datetime, UTC
 from typing import Callable, Optional
 
@@ -31,6 +39,43 @@ logger = logging.getLogger(__name__)
 _POSITION_FETCH_SLOW_THRESHOLD = 2.0  # log a warning if REST position fetch takes longer
 _POSITION_TICK_BASE = 15.0  # base cadence for the steady-state position-fetch rotation tick (seconds)
 _POSITION_STARTUP_HARD_CAP = 60.0  # hard ceiling on the startup batch; exceeding aborts startup
+
+
+def _float_or_zero(value) -> float:
+    """Parse a Bybit numeric field to float, treating None/'' as 0.0.
+
+    Bybit mainnet UTA sends empty strings for unused numeric fields (e.g.
+    ``availableToWithdraw`` on cross-margin or dust coins), which ``float('')``
+    would raise on. See RULES.md pitfall #20 (``Decimal("")`` raises
+    ``decimal.InvalidOperation`` — same empty-string trap, Decimal variant).
+    """
+    if value in (None, ""):
+        return 0.0
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+@dataclass(frozen=True)
+class WalletSnapshot:
+    """Account wallet/margin snapshot (feature 0066 / issue #159).
+
+    Extends the bare ``walletBalance`` float the fetcher used to surface with
+    the account-level free-margin and maintenance-margin fields needed to
+    detect a low-balance state BEFORE Bybit returns 110007. All values are
+    USDT floats; missing/empty Bybit fields fall back to 0.0.
+
+    ``available_balance`` is the USDT free balance for new orders: the per-coin
+    ``availableToWithdraw`` when present, else the account-level
+    ``totalAvailableBalance`` (UTA cross-margin reports the free figure on the
+    account row and leaves the per-coin field empty).
+    """
+
+    wallet_balance: float = 0.0
+    available_balance: float = 0.0
+    total_available_balance: float = 0.0
+    total_maintenance_margin: float = 0.0
 
 
 class StartupTimeoutError(RuntimeError):
@@ -59,6 +104,7 @@ class PositionFetcher:
         wallet_cache_interval: float,
         position_check_interval: float,
         on_position_changed: Optional[Callable[[str, str], None]] = None,
+        wallet_ws_max_age_seconds: float = 45.0,
     ):
         # Dicts are held by reference; Orchestrator mutates them in place
         # during _init_account, and those updates are visible here.
@@ -67,6 +113,10 @@ class PositionFetcher:
         self._notifier = notifier
         self._wallet_cache_interval = wallet_cache_interval
         self._position_check_interval = position_check_interval
+        # Feature 0066 Phase 4: freshness window for the WS wallet feed. A WS
+        # slot older than this is treated as stale by get_wallet_snapshot (falls
+        # back to REST); the preflight applies the same bound to peek results.
+        self._wallet_ws_max_age_seconds = wallet_ws_max_age_seconds
         # Optional WS-thread notification: called once per (account, symbol)
         # after on_position_message has written the cache. Orchestrator uses
         # this to coalesce a snapshot for the main-loop drain (feature 0023).
@@ -77,16 +127,28 @@ class PositionFetcher:
         # HTTP REST is used only as fallback when WebSocket data is not available
         self._position_ws_data: dict[str, dict[str, dict[str, dict]]] = {}
 
-        # Wallet balance cache: account_name -> (balance, timestamp)
+        # Wallet snapshot cache: account_name -> (WalletSnapshot, timestamp).
+        # Holds the full snapshot (balance + account-level margin) since
+        # feature 0066; get_wallet_balance reads `.wallet_balance` off it.
         #
         # Thread safety: accessed ONLY from the main polling loop, via
-        # get_wallet_balance / _fetch_wallet_balance. get_wallet_balance
-        # raises RuntimeError if called from any non-main thread. The main
-        # loop is the sole reader/writer, so no lock is required.
+        # get_wallet_snapshot / get_wallet_balance / _fetch_wallet_snapshot.
+        # get_wallet_snapshot raises RuntimeError if called from any non-main
+        # thread. The main loop is the sole reader/writer, so no lock is
+        # required.
         #
         # Do NOT touch this from WS callbacks — they run in pybit threads
         # and would trip the guard.
-        self._wallet_cache: dict[str, tuple[float, datetime]] = {}
+        self._wallet_cache: dict[str, tuple[WalletSnapshot, datetime]] = {}
+
+        # WS wallet snapshot cache: account_name -> (WalletSnapshot, receive_ts)
+        # (feature 0066 Phase 4). Written ONLY by on_wallet_message on the pybit
+        # WS thread via a single GIL-atomic assignment (no lock — mirrors
+        # _position_ws_data). Read on the main thread by get_wallet_snapshot
+        # (WS-primary within the freshness window) and peek_wallet_snapshot
+        # (non-blocking hot-path read). Distinct from _wallet_cache (REST); the
+        # WS thread NEVER touches _wallet_cache.
+        self._wallet_ws_data: dict[str, tuple[WalletSnapshot, datetime]] = {}
 
         # Per-account timestamp of the last completed REST position fetch
         # (time.monotonic). Steady-state rotation uses this to enforce a
@@ -208,11 +270,74 @@ class PositionFetcher:
             return None
         return symbol_cache.get(side)
 
-    def get_wallet_balance(self, account_name: str) -> float:
-        """Get wallet balance, using cache if available.
+    def get_wallet_snapshot(self, account_name: str) -> WalletSnapshot:
+        """Get wallet snapshot (balance + account-level margin), using cache.
 
-        Single-thread polling loop: no locking required — the main loop
-        is the only reader/writer of `_wallet_cache`.
+        Single-thread polling loop: no locking required — the main loop is the
+        only reader/writer of `_wallet_cache`. Feature 0066 / issue #159.
+
+        Args:
+            account_name: Account name.
+
+        Returns:
+            WalletSnapshot for the account.
+        """
+        if threading.current_thread() is not threading.main_thread():
+            raise RuntimeError(
+                "get_wallet_snapshot touches _wallet_cache; must run on main thread"
+            )
+        # Feature 0066 Phase 4: WS-primary within the freshness window. A WS slot
+        # newer than wallet_ws_max_age_seconds is authoritative (and skips a REST
+        # round-trip); a stale or absent slot falls through to the REST cache.
+        # This is the BACKGROUND reader (rotation / quiet-window backstop) — the
+        # hot order path uses the non-blocking peek_wallet_snapshot instead.
+        # Ops (review F3): a DEBUG line at each return path records WS-vs-REST
+        # source + slot age — the signal to validate WS freshness in rollout. The
+        # INFO `Position update` heartbeat `avail=` lags on the position-drain
+        # cadence and is NOT a reliable freshness signal.
+        ws_entry = self._wallet_ws_data.get(account_name)
+        if ws_entry is not None:
+            ws_snapshot, ws_ts = ws_entry
+            age = (datetime.now(UTC) - ws_ts).total_seconds()
+            if age < self._wallet_ws_max_age_seconds:
+                logger.debug(
+                    "wallet snapshot for %s served from WS (age=%.1fs)",
+                    account_name, age,
+                )
+                return ws_snapshot
+        # Check if caching is disabled
+        if self._wallet_cache_interval <= 0:
+            logger.debug(
+                "wallet snapshot for %s served from REST fetch (cache disabled)",
+                account_name,
+            )
+            return self._fetch_wallet_snapshot(account_name)
+
+        cached = self._wallet_cache.get(account_name)
+        if cached:
+            snapshot, timestamp = cached
+            age = (datetime.now(UTC) - timestamp).total_seconds()
+            if age < self._wallet_cache_interval:
+                logger.debug(
+                    "wallet snapshot for %s served from REST cache (age=%.1fs)",
+                    account_name, age,
+                )
+                return snapshot
+
+        # Cache miss or expired - fetch fresh
+        logger.debug(
+            "wallet snapshot for %s served from REST fetch (cache miss/expired)",
+            account_name,
+        )
+        snapshot = self._fetch_wallet_snapshot(account_name)
+        self._wallet_cache[account_name] = (snapshot, datetime.now(UTC))
+        return snapshot
+
+    def get_wallet_balance(self, account_name: str) -> float:
+        """Get wallet balance in USDT, using cache if available.
+
+        Back-compat thin wrapper over ``get_wallet_snapshot`` (feature 0066);
+        both share the same ``_wallet_cache`` + TTL + main-thread guard.
 
         Args:
             account_name: Account name.
@@ -220,28 +345,15 @@ class PositionFetcher:
         Returns:
             Wallet balance in USDT.
         """
-        if threading.current_thread() is not threading.main_thread():
-            raise RuntimeError(
-                "_get_wallet_balance touches _wallet_cache; must run on main thread"
-            )
-        # Check if caching is disabled
-        if self._wallet_cache_interval <= 0:
-            return self._fetch_wallet_balance(account_name)
+        return self.get_wallet_snapshot(account_name).wallet_balance
 
-        cached = self._wallet_cache.get(account_name)
-        if cached:
-            balance, timestamp = cached
-            age = (datetime.now(UTC) - timestamp).total_seconds()
-            if age < self._wallet_cache_interval:
-                return balance
+    def _fetch_wallet_snapshot(self, account_name: str) -> WalletSnapshot:
+        """Fetch a wallet snapshot from REST API (one call).
 
-        # Cache miss or expired - fetch fresh
-        balance = self._fetch_wallet_balance(account_name)
-        self._wallet_cache[account_name] = (balance, datetime.now(UTC))
-        return balance
-
-    def _fetch_wallet_balance(self, account_name: str) -> float:
-        """Fetch wallet balance from REST API.
+        Account-level free-margin / maintenance-margin live on the account row
+        (``totalAvailableBalance`` / ``totalMaintenanceMargin``); per-coin
+        ``walletBalance`` / ``availableToWithdraw`` live on the USDT coin row.
+        Empty Bybit strings are coerced to 0.0 (UTA dust / cross-margin).
 
         pybit's HTTP() caps every request at `rest_fetch_timeout` seconds
         (plumbed through in P1), so no explicit timeout wrapper is needed.
@@ -250,19 +362,130 @@ class PositionFetcher:
             account_name: Account name.
 
         Returns:
-            Wallet balance in USDT.
+            WalletSnapshot (all-zero when no USDT coin is present).
         """
         rest_client = self._rest_clients[account_name]
         wallet = rest_client.get_wallet_balance()
 
         for account in wallet.get("list", []):
-            for coin in account.get("coin", []):
-                # USDT-margined only: look for USDT coin in unified wallet
-                if coin.get("coin") == "USDT":
-                    return float(coin.get("walletBalance", 0))
+            snapshot = self._snapshot_from_wallet_account_row(account)
+            if snapshot is not None:
+                return snapshot
 
         logger.warning("No USDT balance found in wallet response for %s: %s", account_name, wallet)
-        return 0.0
+        return WalletSnapshot()
+
+    @staticmethod
+    def _snapshot_from_wallet_account_row(account: dict) -> Optional[WalletSnapshot]:
+        """Parse a Bybit wallet account row → WalletSnapshot (feature 0066 P3).
+
+        Shared by ``_fetch_wallet_snapshot`` (REST ``result['list'][0]``) and
+        ``on_wallet_message`` (WS ``msg['data'][0]``) — the two rows have the
+        same Bybit V5 shape, so one parser prevents REST/WS field drift.
+
+        Account-level free-margin / maintenance-margin live on the account row
+        (``totalAvailableBalance`` / ``totalMaintenanceMargin``); per-coin
+        ``walletBalance`` / ``availableToWithdraw`` live on the USDT coin row.
+        Empty Bybit strings are coerced to 0.0 (UTA dust / cross-margin).
+
+        Returns ``None`` when the row carries no USDT coin — the caller decides:
+        ``_fetch_wallet_snapshot`` logs a WARNING + returns all-zero; the WS
+        handler keeps the last good slot.
+        """
+        total_available = _float_or_zero(account.get("totalAvailableBalance"))
+        total_mm = _float_or_zero(account.get("totalMaintenanceMargin"))
+        for coin in account.get("coin", []):
+            # USDT-margined only: look for USDT coin in unified wallet
+            if coin.get("coin") == "USDT":
+                wallet_balance = _float_or_zero(coin.get("walletBalance"))
+                # UTA v5 reports per-coin free margin as `availableToWithdraw`;
+                # legacy UTA 1.0 / some cross-margin coins surface it only as
+                # `availableBalance`. Prefer the v5 field; fall back to the legacy
+                # coin field when v5 is absent/empty (mirrors recorder.py:404-408
+                # — keep the two parsers consistent). Then fall back to the
+                # account-level total for UTA cross-margin (per-coin empty).
+                raw_available = coin.get("availableToWithdraw")
+                if raw_available in (None, "") and "availableBalance" in coin:
+                    raw_available = coin.get("availableBalance")
+                available = _float_or_zero(raw_available)
+                if available == 0.0:
+                    available = total_available
+                return WalletSnapshot(
+                    wallet_balance=wallet_balance,
+                    available_balance=available,
+                    total_available_balance=total_available,
+                    total_maintenance_margin=total_mm,
+                )
+        return None
+
+    def on_wallet_message(self, account_name: str, message: dict) -> None:
+        """Handle wallet WebSocket message (runs in pybit WS thread).
+
+        Stores the latest account-level free-margin snapshot + receive timestamp
+        into ``_wallet_ws_data`` as the real-time source for the low-balance
+        preflight (feature 0066 Phase 4 / issue #159).
+
+        Structural validation only: a frame missing ``data[0]`` / the USDT coin
+        (or that fails to parse) is dropped with NO write (keep last good) and
+        NEVER raises on the WS thread. A valid row IS written even when
+        ``available_balance`` parses to 0 — a funded account with no free margin
+        (``wallet_balance > 0``) is a REAL low-balance signal, not "no data";
+        gating on an all-zero heuristic would mask it (review P2-malformed).
+
+        Bybit V5 wallet frame (see event_saver ``wallet_writer``):
+        ``{"topic":"wallet","creationTime":<ms>,"data":[{<account row>,
+        "coin":[{"coin":"USDT","walletBalance":...,"availableToWithdraw":...}]}]}``
+
+        Thread-safety: the single ``_wallet_ws_data[account] = (...)`` assignment
+        is GIL-atomic (mirrors ``_position_ws_data``); no lock. The WS thread
+        NEVER touches ``_wallet_cache`` (the main-thread-guarded REST cache).
+        """
+        try:
+            data = message.get("data") or []
+            if not data:
+                return  # partial / empty frame → keep last good
+            snapshot = self._snapshot_from_wallet_account_row(data[0])
+            if snapshot is None:
+                return  # no USDT coin row → keep last good
+            self._wallet_ws_data[account_name] = (snapshot, datetime.now(UTC))
+        except Exception as e:
+            # A malformed frame must never escape the WS thread.
+            self._notifier.alert_exception("_on_wallet", e, error_key="ws_on_wallet")
+
+    def peek_wallet_snapshot(
+        self, account_name: str
+    ) -> Optional[tuple[WalletSnapshot, float]]:
+        """Non-blocking read of the freshest wallet snapshot (feature 0066 P4).
+
+        Returns ``(snapshot, age_seconds)`` for the genuinely newest of the WS
+        slot and the REST cache, compared by their write timestamps: both
+        present → newer wins; only one present → that one; neither → ``None``.
+        NEVER fetches — safe to call on the hot order-dispatch path every tick.
+
+        Applies NO freshness threshold itself; the caller (the runner's
+        preflight) bounds the returned age against ``wallet_ws_max_age_seconds``.
+
+        review P2: a stale WS slot must NOT shadow a more-recently-rotated REST
+        entry, so the choice is by timestamp — never "prefer WS unconditionally".
+        Both ``_wallet_ws_data`` and ``_wallet_cache`` stamp ``datetime.now(UTC)``
+        on write, so the timestamps are directly comparable.
+        """
+        ws_entry = self._wallet_ws_data.get(account_name)
+        rest_entry = self._wallet_cache.get(account_name)
+        if ws_entry is None and rest_entry is None:
+            return None
+        if rest_entry is None:
+            snapshot, ts = ws_entry
+        elif ws_entry is None:
+            snapshot, ts = rest_entry
+        else:
+            snapshot, ts = ws_entry if ws_entry[1] >= rest_entry[1] else rest_entry
+        age = (datetime.now(UTC) - ts).total_seconds()
+        return snapshot, age
+
+    def _fetch_wallet_balance(self, account_name: str) -> float:
+        """Back-compat: USDT walletBalance float from a fresh REST snapshot."""
+        return self._fetch_wallet_snapshot(account_name).wallet_balance
 
     def fetch_and_update(self, *, startup: bool = False) -> None:
         """Fetch positions and wallet balance, then update runners.
@@ -363,9 +586,12 @@ class PositionFetcher:
         try:
             rest_client = self._rest_clients[account_name]
 
-            # Fetch wallet balance (cached to reduce API calls).
+            # Fetch wallet snapshot (cached to reduce API calls) — balance plus
+            # the account-level free-margin signal for the low-balance preflight
+            # (feature 0066 / issue #159).
             # pybit's HTTP(timeout=...) caps the request; no extra wrapper.
-            wallet_balance = self.get_wallet_balance(account_name)
+            wallet = self.get_wallet_snapshot(account_name)
+            wallet_balance = wallet.wallet_balance
 
             # Lazy REST positions (fetched on demand if WS data is missing).
             rest_positions = None
@@ -400,6 +626,9 @@ class PositionFetcher:
                         short_position=short_pos,
                         wallet_balance=wallet_balance,
                         last_close=runner.engine.last_close,
+                        available_balance=wallet.available_balance,
+                        total_available_balance=wallet.total_available_balance,
+                        total_maintenance_margin=wallet.total_maintenance_margin,
                     )
                 except Exception as e:
                     logger.error(

--- a/apps/gridbot/src/gridbot/runner.py
+++ b/apps/gridbot/src/gridbot/runner.py
@@ -20,6 +20,13 @@ from typing import Optional, Callable, TYPE_CHECKING
 if TYPE_CHECKING:
     from gridbot.writers.grid_state_writer import GridStateWriter
     from bybit_adapter.rest_client import BybitRestClient
+    # Annotation-only: importing position_fetcher at runtime would be circular
+    # (position_fetcher imports StrategyRunner).
+    from gridbot.position_fetcher import WalletSnapshot
+
+# Provider returns (snapshot, age_seconds) or None — the non-blocking
+# peek_wallet_snapshot reader injected for the Phase-4 preflight (feature 0066).
+WalletProvider = Callable[[], "Optional[tuple[WalletSnapshot, float]]"]
 
 from gridcore import (
     GridEngine,
@@ -43,7 +50,11 @@ from gridcore import (
 )
 
 from gridbot.config import StrategyConfig
-from gridbot.executor import IntentExecutor, is_truncate_error
+from gridbot.executor import (
+    IntentExecutor,
+    is_insufficient_balance,
+    is_truncate_error,
+)
 from gridbot.notifier import Notifier
 from gridbot.order_link_id import make_order_link_id
 from gridbot.truncate_breaker import TruncateBreaker
@@ -183,6 +194,8 @@ class StrategyRunner:
         truncate_breaker: Optional[TruncateBreaker] = None,
         on_truncate_breaker_tripped: Optional[Callable[[str, str], None]] = None,
         clock: Optional[Callable[[], float]] = None,
+        wallet_provider: Optional["WalletProvider"] = None,
+        wallet_ws_max_age_seconds: float = 45.0,
     ):
         """Initialize strategy runner.
 
@@ -216,6 +229,15 @@ class StrategyRunner:
                 forced position+order reconcile.
             clock: Monotonic clock for breaker windows / dirty-refresh throttle.
                 Defaults to ``time.monotonic``; injectable for tests.
+            wallet_provider: Optional non-blocking reader returning
+                ``(WalletSnapshot, age_seconds)`` or ``None`` — the orchestrator
+                wires ``position_fetcher.peek_wallet_snapshot`` here (feature 0066
+                Phase 4). When set, the preflight reads a FRESH, age-bounded free
+                margin from it (authoritative even at 0; stale/None/raise →
+                fail-open). When ``None`` (unit tests / ``wallet_ws_enabled=False``)
+                the preflight uses the position-cadence ``_available_balance``.
+            wallet_ws_max_age_seconds: Max age (s) of a provider peek the preflight
+                will trust before failing open (feature 0066 Phase 4).
         """
         # 0047: if a DB writer is wired, account_id MUST be explicitly set —
         # the dummy default would FK-mismatch with replay's account scope
@@ -292,6 +314,43 @@ class StrategyRunner:
             strategy_config.amount, instrument_info
         )
         self._wallet_balance: Decimal = Decimal("0")
+
+        # Feature 0066 (issue #159) — account-level balance/margin signal for
+        # the low-balance preflight + chase-close. Populated by
+        # on_position_update from the wallet snapshot; 0 = no data yet (the
+        # preflight fails open). `_available_balance` is the free-margin figure
+        # the preflight checks; the other two are observability.
+        self._available_balance: Decimal = Decimal("0")
+        self._total_available_balance: Decimal = Decimal("0")
+        self._total_maintenance_margin: Decimal = Decimal("0")
+        # Raw low-balance predicate (single source of truth, recomputed each
+        # on_position_update), shared by the moderate_liq_risk fix (3a) and
+        # chase-close (3b). Each consumer applies its own kill-switch.
+        self._low_balance: bool = False
+        # Chase-close state machine (feature 0066 / issue #159, default OFF).
+        # The decision runs in on_position_update (which holds no `limits`
+        # snapshot and never dispatches) and only appends intents to
+        # `_pending_chase_intents`; they are drained on the next dispatch tick.
+        self._chase_state: str = "IDLE"  # "IDLE" | "CHASING"
+        self._chase_direction: Optional[str] = None
+        self._chase_order: Optional[dict] = None  # {client_order_id, price, side}
+        self._pending_chase_intents: list[PlaceLimitIntent | CancelIntent] = []
+        # Per-direction live exchange leverage, captured in
+        # _build_position_state and used by the preflight's
+        # est_cost = qty*price/leverage. Kept SEPARATE from
+        # PositionState.leverage (which feeds the risk-multiplier upnl calc and
+        # must stay at its default to preserve backtest parity).
+        self._leverage: dict[str, float] = {}
+
+        # Feature 0066 Phase 4 — real-time wallet provider for the preflight.
+        # `_wallet_provider` is the non-blocking peek_wallet_snapshot reader (or
+        # None on the legacy / kill-switched path); `_wallet_ws_max_age_seconds`
+        # bounds how fresh a peek must be to be trusted (else fail-open).
+        self._wallet_provider = wallet_provider
+        self._wallet_ws_max_age_seconds = wallet_ws_max_age_seconds
+        # Monotonic timestamp of the last provider-error WARNING (throttle so a
+        # persistently-raising provider can't flood the log on the hot path).
+        self._last_wallet_provider_error_log: float = 0.0
 
         # Restore full grid if available and config matches
         restored_grid = self._load_grid_state()
@@ -570,6 +629,10 @@ class StrategyRunner:
             Exception: Re-raised after logging so orchestrator can handle notification.
         """
         try:
+            # Feature 0066 — drain any buffered chase-close intents first (they
+            # were decided in on_position_update, which holds no limits snapshot).
+            self._drain_pending_chase_intents()
+
             # Always pass ticker to engine (keeps last_close fresh for risk calcs)
             limit_orders = self.get_limit_orders()
             intents = self._engine.on_event(event, limit_orders)
@@ -619,6 +682,9 @@ class StrategyRunner:
             Exception: Re-raised after logging so orchestrator can handle notification.
         """
         try:
+            # Feature 0066 — drain buffered chase-close intents first.
+            self._drain_pending_chase_intents()
+
             # Reset the per-event phantom drop flag. _check_same_orders may
             # set it to True via _diagnostic_rest_check_executions when this
             # event is the WS_GLITCH-confirmed phantom side of a SAME ORDER
@@ -697,6 +763,9 @@ class StrategyRunner:
             Exception: Re-raised after logging so orchestrator can handle notification.
         """
         try:
+            # Feature 0066 — drain buffered chase-close intents first.
+            self._drain_pending_chase_intents()
+
             # Update tracked order status
             tracked = self._find_tracked_order(event.order_link_id, event.order_id)
             if tracked:
@@ -738,6 +807,9 @@ class StrategyRunner:
         short_position: Optional[dict],
         wallet_balance: float,
         last_close: Optional[float],
+        available_balance: Optional[float] = None,
+        total_available_balance: Optional[float] = None,
+        total_maintenance_margin: Optional[float] = None,
     ) -> None:
         """Update position state and recalculate multipliers.
 
@@ -746,6 +818,12 @@ class StrategyRunner:
             short_position: Short position data from exchange.
             wallet_balance: Current wallet balance.
             last_close: Current price, or None when no ticker has been seen yet.
+            available_balance: USDT free balance for new orders (feature 0066);
+                None (default) leaves the stored value unchanged so existing
+                callers/tests keep working and the preflight fails open.
+            total_available_balance: Account-level free margin (observability).
+            total_maintenance_margin: Account-level maintenance margin
+                (observability).
 
         Raises:
             Exception: Re-raised after logging so orchestrator can handle notification.
@@ -753,6 +831,15 @@ class StrategyRunner:
         try:
             # Store wallet balance for qty computation
             self._wallet_balance = Decimal(str(wallet_balance))
+
+            # Feature 0066 — store the account-level balance signal when the
+            # caller provides it (None defaults preserve old callers/tests).
+            if available_balance is not None:
+                self._available_balance = Decimal(str(available_balance))
+            if total_available_balance is not None:
+                self._total_available_balance = Decimal(str(total_available_balance))
+            if total_maintenance_margin is not None:
+                self._total_maintenance_margin = Decimal(str(total_maintenance_margin))
 
             # Build PositionState objects
             long_state = self._build_position_state(long_position, wallet_balance, DirectionType.LONG)
@@ -811,6 +898,22 @@ class StrategyRunner:
                 return
             price = float(last_close) if last_close is not None else 0.0
 
+            # Feature 0066 (issue #159) — low-balance predicate (single source of
+            # truth, shared by the moderate_liq_risk fix and chase-close). The 3a
+            # fix is gated by its own kill-switch here so that when disabled the
+            # multiplier calc is byte-for-byte the pre-0066 behavior (and backtest
+            # parity holds, since the backtest path never feeds available_balance).
+            total_position_value = Decimal("0")
+            if long_state:
+                total_position_value += long_state.position_value
+            if short_state:
+                total_position_value += short_state.position_value
+            self._low_balance = self._is_low_balance(total_position_value)
+            moderate_low_balance = (
+                self._low_balance
+                and self._config.moderate_liq_low_balance_fix_enabled
+            )
+
             # Reset both positions once before calculating (bbu2 pattern)
             self._long_position.reset_amount_multiplier()
             self._short_position.reset_amount_multiplier()
@@ -821,13 +924,13 @@ class StrategyRunner:
             if long_state:
                 opposite = short_state or PositionState(direction=DirectionType.SHORT)
                 self._long_position.calculate_amount_multiplier(
-                    long_state, opposite, price
+                    long_state, opposite, price, low_balance=moderate_low_balance
                 )
 
             if short_state:
                 opposite = long_state or PositionState(direction=DirectionType.LONG)
                 self._short_position.calculate_amount_multiplier(
-                    short_state, opposite, price
+                    short_state, opposite, price, low_balance=moderate_low_balance
                 )
 
             self._last_position_check = datetime.now(UTC)
@@ -837,8 +940,16 @@ class StrategyRunner:
             logger.info(
                 f"{self.strat_id}: Position update - ratio={position_ratio:.2f}, "
                 f"long_mult=Buy:{long_mult['Buy']:.2f}/Sell:{long_mult['Sell']:.2f}, "
-                f"short_mult=Buy:{short_mult['Buy']:.2f}/Sell:{short_mult['Sell']:.2f}"
+                f"short_mult=Buy:{short_mult['Buy']:.2f}/Sell:{short_mult['Sell']:.2f}, "
+                f"avail={self._available_balance:.2f} "
+                f"total_avail={self._total_available_balance:.2f} "
+                f"total_mm={self._total_maintenance_margin:.2f}"
             )
+
+            # Feature 0066 (issue #159) — chase-close decision (default OFF).
+            # Buffers intents only; the next dispatch tick drains them. Runs
+            # last so it sees the freshest ratio/balance/sizes.
+            self._evaluate_chase(price, position_ratio)
         except Exception as e:
             logger.error(f"{self.strat_id}: Error in on_position_update: {e}", exc_info=True)
             raise
@@ -940,6 +1051,20 @@ class StrategyRunner:
         # = the Bybit Web UI "Realized" column.
         cum_realized_pnl = float(position_data.get("cumRealisedPnl", 0) or 0)
         cur_realized_pnl = float(position_data.get("curRealisedPnl", 0) or 0)
+        # Bybit positionIM / positionMM: per-position Initial / Maintenance
+        # Margin in USDT (dollar amounts) — feature 0066 / issue #159.
+        initial_margin = Decimal(str(position_data.get("positionIM", 0) or 0))
+        maintenance_margin = Decimal(str(position_data.get("positionMM", 0) or 0))
+
+        # Capture live exchange leverage for the preflight est_cost (feature
+        # 0066). Stored OUT of PositionState.leverage so the risk-multiplier
+        # upnl calc (position.py) is unaffected and backtest parity holds.
+        lev_raw = position_data.get("leverage")
+        if lev_raw not in (None, ""):
+            try:
+                self._leverage[direction] = float(lev_raw)
+            except (TypeError, ValueError):
+                pass
 
         # Calculate margin
         size_d = Decimal(str(size))
@@ -955,6 +1080,8 @@ class StrategyRunner:
             margin=margin,
             liquidation_price=Decimal(str(liq_price)),
             position_value=position_value,
+            initial_margin=initial_margin,
+            maintenance_margin=maintenance_margin,
             cum_realized_pnl=Decimal(str(cum_realized_pnl)),
             cur_realized_pnl=Decimal(str(cur_realized_pnl)),
         )
@@ -1170,6 +1297,345 @@ class StrategyRunner:
             # Establish the REST baseline the WS gate consults for THIS episode.
             self._last_rest_position_size[direction] = new_size
 
+    def _predicate_available_balance(self) -> tuple[Decimal, bool]:
+        """Free margin for the low-balance PREDICATE (3a moderate_liq + 3b chase).
+
+        review F1 / Phase 4: align the predicate's freshness with the preflight by
+        reading the same non-blocking ``wallet_provider`` when wired, so chase and
+        preflight share one freshness (plan rollout §3 prerequisite). Returns
+        ``(available, authoritative)``:
+
+        - ``authoritative=True`` — a FRESH provider peek (``age <
+          wallet_ws_max_age_seconds``); its value is real even at 0 (no free
+          margin), so the caller treats 0 as the most extreme low-balance state.
+        - ``authoritative=False`` — the position-cadence ``_available_balance``
+          latch (provider absent / stale / raised); a 0 here means "no data yet"
+          and the caller must NOT trigger defenses on it.
+
+        Additive: no provider (unit tests / backtest / ``wallet_ws_enabled=False``)
+        returns the latch with ``authoritative=False`` — exact pre-Phase-4 behavior.
+        Never raises (a predicate read must not abort ``on_position_update``).
+        Note this is INTENTIONALLY different from the preflight's stale handling:
+        the preflight fails OPEN on a stale/None peek, whereas the predicate falls
+        back to the latch (its best-available position-cadence value).
+        """
+        if self._wallet_provider is not None:
+            try:
+                peek = self._wallet_provider()
+            except Exception:
+                peek = None  # provider error → fall back to the latch
+            if peek is not None:
+                snapshot, age = peek
+                if age < self._wallet_ws_max_age_seconds:
+                    return Decimal(str(snapshot.available_balance)), True
+        return self._available_balance, False
+
+    def _is_low_balance(self, total_position_value: Decimal) -> bool:
+        """Low-balance predicate (feature 0066 / issue #159).
+
+        Single source of truth shared by the moderate_liq_risk fix (3a) and
+        chase-close (3b). True when free margin is small relative to total
+        position value (``available < total_position_value *
+        low_balance_fraction``). The balance source shares the preflight's
+        freshness via ``_predicate_available_balance`` (review F1).
+
+        A FRESH provider 0 (genuinely no free margin) is the most extreme
+        low-balance state → True. A latch 0 (provider absent/stale) means "no
+        data yet" → False, so neither defense acts on stale/absent data. No
+        position to measure against → False.
+        """
+        avail, authoritative = self._predicate_available_balance()
+        if total_position_value <= 0:
+            return False
+        if avail <= 0:
+            return authoritative  # fresh 0 = real (low); latch 0 = no data (not)
+        frac = Decimal(str(self._config.low_balance_fraction))
+        return avail < total_position_value * frac
+
+    def _effective_leverage(self, direction: str) -> Decimal:
+        """Leverage for the preflight est_cost (feature 0066 / issue #159).
+
+        Prefer the live exchange leverage captured per-direction in
+        ``_build_position_state``; fall back to the conservative
+        ``assumed_leverage`` config when none has been observed. Bias LOW:
+        under-estimating leverage only over-rejects affordable opens, it never
+        lets an unaffordable one through.
+        """
+        lev = self._leverage.get(direction)
+        if lev is None or lev <= 0:
+            lev = self._config.assumed_leverage
+        return Decimal(str(lev))
+
+    def _preflight_available_balance(self, intent: PlaceLimitIntent) -> Optional[Decimal]:
+        """Resolve the free-margin figure the open-order preflight checks.
+
+        Returns the Decimal available balance to test against, or ``None`` to
+        FAIL OPEN (skip the check). Two paths (feature 0066 Phase 2 base + P4):
+
+        - **Provider wired (Phase 4):** read the non-blocking peek. A FRESH peek
+          (``age < wallet_ws_max_age_seconds``) is AUTHORITATIVE even at 0 (a
+          real "no free margin" signal that must block every open); a stale /
+          ``None`` / raising peek → fail-open. Never falls back to
+          ``_available_balance`` — the latch reads the same WS/REST caches and is
+          never fresher, so a stale peek means the latch is stale too. A raising
+          provider is caught (throttled WARNING) and must never abort dispatch.
+        - **No provider (legacy / ``wallet_ws_enabled=False``):** use the
+          position-cadence ``_available_balance``; ``> 0`` means data (check it),
+          ``<= 0`` means no data yet → fail-open.
+        """
+        if self._wallet_provider is not None:
+            try:
+                peek = self._wallet_provider()
+            except Exception as e:
+                now = self._clock()
+                if now - self._last_wallet_provider_error_log >= 60.0:
+                    self._last_wallet_provider_error_log = now
+                    logger.warning(
+                        "%s: wallet_provider raised (%s); preflight fails open",
+                        self.strat_id, e,
+                    )
+                return None  # a balance read must never abort order dispatch
+            if peek is None:
+                return None  # no cached snapshot → fail-open
+            snapshot, age = peek
+            if age >= self._wallet_ws_max_age_seconds:
+                # Stale → fail-open. Do NOT trust the stale peek and do NOT fall
+                # back to the (equally-stale) _available_balance latch.
+                return None
+            # Fresh: authoritative, even when 0 (no free margin → blocks opens).
+            return Decimal(str(snapshot.available_balance))
+
+        # No provider: legacy position-cadence latch; 0 = no data yet → fail-open.
+        avail = self._available_balance
+        if avail <= 0:
+            return None
+        return avail
+
+    def _preflight_blocks_open(self, intent: PlaceLimitIntent) -> bool:
+        """True if this OPEN order is unaffordable and must be blocked locally.
+
+        Caller gates on ``not intent.reduce_only`` and
+        ``preflight_balance_check_enabled``. Resolves the balance source via
+        ``_preflight_available_balance`` (fail-open → ``None`` → not blocked),
+        then applies the leverage-adjusted ``est_cost`` + buffer affordability
+        test (``est_cost = qty*price/leverage``; over-conservative leverage only
+        ever over-rejects, never lets an unaffordable open through).
+        """
+        avail = self._preflight_available_balance(intent)
+        if avail is None:
+            logger.debug(
+                "%s: preflight skipped (no fresh balance data) for %s %s",
+                self.strat_id, intent.direction, intent.side,
+            )
+            return False
+        leverage = max(self._effective_leverage(intent.direction), Decimal("1"))
+        est_cost = (intent.qty * intent.price) / leverage
+        buffer = Decimal(str(self._config.preflight_balance_buffer))
+        if avail < est_cost * (Decimal("1") + buffer):
+            # DEBUG, not INFO: this fires once per blocked open intent on the hot
+            # dispatch path, and by design fires for every unaffordable grid level
+            # on every ticker tick for the whole duration of the low-balance state
+            # (a blocked open never rests, so it is re-emitted next tick). INFO
+            # here would be sustained log spam precisely during the storm. Matches
+            # every sibling per-intent drop (qty<=0 / 110017 breaker / the generic
+            # `_is_good_to_place` rejection), all DEBUG. The low-balance state stays
+            # observable at INFO via the per-tick `Position update` heartbeat
+            # (avail= / total_avail=).
+            logger.debug(
+                "%s: LowBalanceSkip %s %s qty=%s price=%s "
+                "est_cost=%.4f avail=%.4f buffer=%s",
+                self.strat_id, intent.direction, intent.side,
+                intent.qty, intent.price, float(est_cost),
+                float(avail), buffer,
+            )
+            return True
+        return False
+
+    # ---- Feature 0066 (issue #159) — chase-close active defense (default OFF) ----
+
+    def _drain_pending_chase_intents(self) -> None:
+        """Dispatch chase intents buffered by on_position_update.
+
+        Called at the top of on_ticker / on_execution / on_order_update — the
+        only sites that hold a `limits` snapshot and call _execute_intents. The
+        buffer is reused through the existing dispatch path (cancel-before-place,
+        per-place limits refresh, reduce-only guard) with zero new dispatch code.
+        """
+        if not self._pending_chase_intents:
+            return
+        buffered = self._pending_chase_intents
+        self._pending_chase_intents = []
+        self._execute_intents(buffered, self.get_limit_orders())
+
+    def _dominant_size(self, direction: str) -> Decimal:
+        return (self._long_position.size if direction == DirectionType.LONG
+                else self._short_position.size)
+
+    def _evaluate_chase(self, price: float, position_ratio: float) -> None:
+        """Chase-close decision. Mutates chase state + appends intents to the
+        buffer ONLY (never dispatches — on_position_update has no limits)."""
+        if not self._config.chase_close_enabled or price <= 0:
+            return
+        thr = self._config.chase_position_ratio_threshold
+        if thr <= 0:
+            return
+        hyst = self._config.chase_close_hysteresis
+
+        dominant: Optional[str] = None
+        if self._low_balance:
+            if position_ratio > thr:
+                dominant = DirectionType.LONG
+            elif position_ratio < (1.0 / thr):
+                dominant = DirectionType.SHORT
+
+        if self._chase_state == "IDLE":
+            if dominant is not None:
+                self._enter_chase(dominant, price)
+            return
+
+        # CHASING — exit if conditions cleared, else re-peg on drift.
+        if self._should_exit_chase(position_ratio, thr, hyst):
+            self._exit_chase()
+            return
+        self._repeg_chase_if_drifted(price)
+
+    def _build_chase_order(
+        self, direction: str, close_side: str, price: float, size: Decimal
+    ) -> Optional[PlaceLimitIntent]:
+        """Build a reduce-only, post-only close near the touch for the dominant
+        side. Maker-safe pricing (Sell above / Buy below) so post-only never
+        crosses/rejects. Qty is half the dominant size (rounded to qty_step),
+        which stays strictly below position_size so the reduce-only guard passes."""
+        offset = Decimal(str(self._config.chase_offset_pct))
+        p = Decimal(str(price))
+        chase_price = (p * (Decimal("1") + offset) if close_side == "Sell"
+                       else p * (Decimal("1") - offset))
+        qty = size / Decimal("2")
+        if self._instrument_info:
+            chase_price = self._instrument_info.round_price(chase_price)
+            qty = self._instrument_info.round_qty(qty)
+            if qty < self._instrument_info.min_qty:
+                return None
+        if qty <= 0 or qty >= size:
+            return None
+        return PlaceLimitIntent.create(
+            symbol=self._config.symbol, side=close_side, price=chase_price,
+            qty=qty, grid_level=-1, direction=direction,
+            reduce_only=True, post_only=True,
+        )
+
+    def _enter_chase(self, direction: str, price: float) -> None:
+        size = self._dominant_size(direction)
+        if size <= 0:
+            return  # nothing to trim
+        chase = self._build_chase_order(
+            direction, "Sell" if direction == DirectionType.LONG else "Buy", price, size
+        )
+        if chase is None:
+            return  # position too small to trim safely
+        # Cancel resting grow-side opens for the dominant direction (stop adding
+        # to the side we are trying to shrink). This is a deliberate,
+        # balance-driven cancel — distinct from the forward-only multiplier rule.
+        grow_side = "Buy" if direction == DirectionType.LONG else "Sell"
+        for tracked in list(self._tracked_orders.values()):
+            ti = tracked.intent
+            if (tracked.status == "placed" and tracked.order_id and ti is not None
+                    and not ti.reduce_only and ti.direction == direction
+                    and ti.side == grow_side):
+                self._pending_chase_intents.append(CancelIntent(
+                    symbol=self._config.symbol, order_id=tracked.order_id,
+                    reason="chase_close", price=ti.price, side=ti.side,
+                ))
+        self._pending_chase_intents.append(chase)
+        self._chase_state = "CHASING"
+        self._chase_direction = direction
+        self._chase_order = {
+            "client_order_id": chase.client_order_id,
+            "price": chase.price,
+            "side": chase.side,
+        }
+        logger.info(
+            "%s: chase-close ENTER %s close=%s price=%s qty=%s",
+            self.strat_id, direction, chase.side, chase.price, chase.qty,
+        )
+
+    def _should_exit_chase(self, position_ratio: float, thr: float, hyst: float) -> bool:
+        if not self._low_balance:
+            return True
+        d = self._chase_direction
+        if d is None or self._dominant_size(d) <= 0:
+            return True  # dominant position flat
+        if d == DirectionType.LONG:
+            return position_ratio < thr * (1.0 - hyst)
+        return position_ratio > (1.0 / thr) * (1.0 + hyst)
+
+    def _retire_live_chase_order(self, reason: str) -> None:
+        """Retire the current chase order on exit / re-peg.
+
+        Two cases (a chase decision can fire on several `on_position_update`s
+        before the next dispatch tick drains the buffer):
+        - the chase place is still BUFFERED (never dispatched) → just drop it
+          from the buffer; there is nothing resting on the exchange. Without
+          this it would dispatch and rest as an orphan after the state machine
+          has already moved on.
+        - the chase order was already DISPATCHED and is resting → cancel it by
+          exchange order_id.
+        """
+        if not self._chase_order:
+            return
+        coid = self._chase_order["client_order_id"]
+        before = len(self._pending_chase_intents)
+        self._pending_chase_intents = [
+            i for i in self._pending_chase_intents
+            if not (isinstance(i, PlaceLimitIntent) and i.client_order_id == coid)
+        ]
+        if len(self._pending_chase_intents) != before:
+            return  # was still buffered → dropped, nothing to cancel on-exchange
+        tracked = self._tracked_orders.get(coid)
+        if tracked and tracked.order_id and tracked.status == "placed":
+            self._pending_chase_intents.append(CancelIntent(
+                symbol=self._config.symbol, order_id=tracked.order_id,
+                reason=reason, price=self._chase_order["price"],
+                side=self._chase_order["side"],
+            ))
+
+    def _repeg_chase_if_drifted(self, price: float) -> None:
+        if not self._chase_order:
+            return
+        ref = self._chase_order["price"]
+        if ref <= 0:
+            return
+        rel = abs(Decimal(str(price)) - ref) / ref
+        if rel <= Decimal(str(self._config.chase_replace_drift_pct)):
+            return
+        # Cancel-replace the chase order ONLY (explicitly exempt from the
+        # forward-only invariant — it acts on its own order, not grid orders).
+        self._retire_live_chase_order("chase_replace")
+        size = self._dominant_size(self._chase_direction)
+        new_chase = self._build_chase_order(
+            self._chase_direction, self._chase_order["side"], price, size
+        )
+        if new_chase is None:
+            self._exit_chase()
+            return
+        self._pending_chase_intents.append(new_chase)
+        self._chase_order = {
+            "client_order_id": new_chase.client_order_id,
+            "price": new_chase.price,
+            "side": new_chase.side,
+        }
+        logger.info(
+            "%s: chase-close REPEG %s price=%s",
+            self.strat_id, self._chase_direction, new_chase.price,
+        )
+
+    def _exit_chase(self) -> None:
+        self._retire_live_chase_order("chase_exit")
+        logger.info("%s: chase-close EXIT %s", self.strat_id, self._chase_direction)
+        self._chase_state = "IDLE"
+        self._chase_direction = None
+        self._chase_order = None
+
     def _is_good_to_place(self, intent: PlaceLimitIntent, limits: dict[str, list[dict]]) -> bool:
         """Check if order can be placed (exact-duplicate + reduce-only checks).
 
@@ -1204,6 +1670,16 @@ class StrategyRunner:
             # Sum reduce_only qty for position-size check
             if order['reduceOnly'] and order['side'] == close_side:
                 reduce_only_qty += Decimal(str(order['qty']))
+
+        # Feature 0066 (issue #159) — low-balance preflight for OPEN orders.
+        # Reject locally an open order the account can't afford so Bybit never
+        # returns 110007 and the retry queue is never fed (the storm). Reduce-only
+        # orders are exempt (they free margin) and fall through to the existing
+        # reduce-only guard below.
+        if (not intent.reduce_only
+                and self._config.preflight_balance_check_enabled
+                and self._preflight_blocks_open(intent)):
+            return False
 
         if not intent.reduce_only:
             return True
@@ -1339,6 +1815,25 @@ class StrategyRunner:
             return
 
         tracked.mark_failed()
+
+        # Feature 0066 (issue #159) — 110007 "available balance not enough" on an
+        # OPEN order: do NOT enqueue to the retry queue. A boundary race (balance
+        # moved between the preflight read and submit) can still surface 110007;
+        # retrying the same/grown qty against the same exhausted balance just
+        # re-storms. Drop it (log once) — the preflight re-gates on the next tick
+        # once balance recovers. Mirrors the 0064 "do NOT enqueue 110017"
+        # decision. Scoped to OPEN orders (not reduce_only) to match the spec —
+        # reduce-only closes do not 110007 (Bybit accepts them under exhausted
+        # balance), so a reduce-only failure here is some other condition and
+        # keeps the normal retry path rather than being silently dropped.
+        # Stateless: no breaker.
+        if not intent.reduce_only and is_insufficient_balance(result.error):
+            logger.warning(
+                "%s: 110007 available-balance-not-enough on %s %s @ %s — "
+                "dropping (not enqueued); preflight re-gates next tick",
+                self.strat_id, intent.direction, intent.side, intent.price,
+            )
+            return
 
         if not is_truncate_error(result.error):
             # Non-110017 failure → existing retry-queue behaviour (feature 0032

--- a/apps/gridbot/tests/test_executor.py
+++ b/apps/gridbot/tests/test_executor.py
@@ -13,8 +13,9 @@ from gridbot.executor import (
     CancelResult,
     AUTH_ERROR_CODES,
     is_truncate_error,
+    is_insufficient_balance,
 )
-from bybit_adapter.error_codes import ORDER_QTY_TRUNCATED_TO_ZERO
+from bybit_adapter.error_codes import ORDER_QTY_TRUNCATED_TO_ZERO, INSUFFICIENT_BALANCE
 
 
 class TestIsTruncateError:
@@ -40,6 +41,38 @@ class TestIsTruncateError:
     def test_none_and_empty_are_not_truncate(self):
         assert is_truncate_error(None) is False
         assert is_truncate_error("") is False
+
+
+class TestIsInsufficientBalance:
+    """Feature 0066 — classify ErrCode 110007 ('available balance not enough').
+
+    The load-bearing classifier for the retry-queue no-enqueue storm guard
+    (runner._execute_place_intent). Mirrors TestIsTruncateError; the live storm
+    came from REAL Bybit responses, so BOTH wire formats must be covered.
+    """
+
+    def test_constant_is_110007(self):
+        assert INSUFFICIENT_BALANCE == 110007
+
+    def test_detects_check_response_format(self):
+        # _check_response format: "[110007] ..."
+        err = "Bybit API error in place_order: [110007] ab not enough for new order"
+        assert is_insufficient_balance(err) is True
+
+    def test_detects_pybit_native_format(self):
+        # pybit native: "(ErrCode: 110007) ..." — the form a real live error takes.
+        err = "place_order failed (ErrCode: 110007) ab not enough for new order"
+        assert is_insufficient_balance(err) is True
+
+    def test_other_error_code_is_not_insufficient_balance(self):
+        # 110017 (the sibling truncate code) must NOT classify as 110007.
+        assert is_insufficient_balance("Bybit API error: [110017] truncated") is False
+        assert is_insufficient_balance("Bybit API error: [110001] params error") is False
+        assert is_insufficient_balance("Connection timeout") is False
+
+    def test_none_and_empty_are_not_insufficient_balance(self):
+        assert is_insufficient_balance(None) is False
+        assert is_insufficient_balance("") is False
 
 
 @pytest.fixture
@@ -148,6 +181,7 @@ class TestExecutorPlaceOrder:
             "price": "50000.0",
             "reduce_only": False,
             "position_idx": 1,  # long direction
+            "time_in_force": "GTC",  # default (non-post-only) — feature 0066
         }
         assert order_link_id.startswith(f"{place_intent.client_order_id}-")
         assert order_link_id.partition("-")[2].isdigit()
@@ -181,10 +215,28 @@ class TestExecutorPlaceOrder:
             "price": "50000.0",
             "reduce_only": False,
             "position_idx": 2,  # short direction
+            "time_in_force": "GTC",  # default (non-post-only) — feature 0066
         }
         assert order_link_id.startswith(f"{intent.client_order_id}-")
         assert order_link_id.partition("-")[2].isdigit()
         assert result.order_link_id == order_link_id
+
+    def test_post_only_intent_passes_postonly_tif(self, executor, mock_rest_client):
+        """Feature 0066: post_only=True → place_order time_in_force='PostOnly'."""
+        intent = PlaceLimitIntent.create(
+            symbol="BTCUSDT", side="Sell", price=Decimal("50000.0"),
+            qty=Decimal("0.001"), grid_level=10, direction="short",
+            reduce_only=True, post_only=True,
+        )
+        executor.execute_place(intent)
+        _, kwargs = mock_rest_client.place_order.call_args
+        assert kwargs["time_in_force"] == "PostOnly"
+
+    def test_default_intent_passes_gtc_tif(self, executor, mock_rest_client, place_intent):
+        """Default (post_only=False) → time_in_force='GTC' (today's behavior)."""
+        executor.execute_place(place_intent)
+        _, kwargs = mock_rest_client.place_order.call_args
+        assert kwargs["time_in_force"] == "GTC"
 
     def test_execute_place_passes_orderLinkId_from_client_order_id(
         self, executor, mock_rest_client

--- a/apps/gridbot/tests/test_orchestrator.py
+++ b/apps/gridbot/tests/test_orchestrator.py
@@ -12,6 +12,7 @@ from gridcore import EventType, TickerEvent
 from gridbot.config import GridbotConfig, AccountConfig, StrategyConfig
 from gridbot.notifier import Notifier
 from gridbot.orchestrator import Orchestrator
+from gridbot.position_fetcher import WalletSnapshot
 from gridbot.reconciler import ReconciliationResult
 from grid_db.identity import account_id_for
 
@@ -157,6 +158,113 @@ class TestOrchestratorInit:
 
         assert "btcusdt_test" in orchestrator._runners
         assert "btcusdt_test" in orchestrator._retry_queues
+
+    @patch("gridbot.orchestrator.BybitRestClient")
+    @patch("gridbot.orchestrator.PublicWebSocketClient")
+    @patch("gridbot.orchestrator.PrivateWebSocketClient")
+    def test_init_account_wires_on_wallet(
+        self,
+        mock_private_ws,
+        mock_public_ws,
+        mock_rest_client,
+        gridbot_config,
+        account_config,
+    ):
+        """Phase 4: on_wallet routes to position_fetcher.on_wallet_message."""
+        orchestrator = Orchestrator(gridbot_config)
+        orchestrator._position_fetcher.on_wallet_message = MagicMock()
+        orchestrator._init_account(account_config)
+
+        priv_kwargs = mock_private_ws.call_args.kwargs
+        assert priv_kwargs.get("on_wallet") is not None
+        msg = {"topic": "wallet", "data": [{"coin": []}]}
+        priv_kwargs["on_wallet"](msg)
+        orchestrator._position_fetcher.on_wallet_message.assert_called_once_with(
+            "test_account", msg
+        )
+
+    @patch("gridbot.orchestrator.BybitRestClient")
+    @patch("gridbot.orchestrator.PublicWebSocketClient")
+    @patch("gridbot.orchestrator.PrivateWebSocketClient")
+    def test_init_account_skips_on_wallet_when_disabled(
+        self,
+        mock_private_ws,
+        mock_public_ws,
+        mock_rest_client,
+        account_config,
+        strategy_config,
+    ):
+        """wallet_ws_enabled=False → no on_wallet (full Phase-4 kill-switch)."""
+        cfg = GridbotConfig(
+            accounts=[account_config], strategies=[strategy_config],
+            database_url="sqlite:///:memory:", wallet_ws_enabled=False,
+        )
+        orchestrator = Orchestrator(cfg)
+        orchestrator._init_account(account_config)
+        priv_kwargs = mock_private_ws.call_args.kwargs
+        assert priv_kwargs.get("on_wallet") is None
+
+    @patch("gridbot.orchestrator.BybitRestClient")
+    @patch("gridbot.orchestrator.PublicWebSocketClient")
+    @patch("gridbot.orchestrator.PrivateWebSocketClient")
+    def test_init_strategy_injects_wallet_provider(
+        self,
+        mock_private_ws,
+        mock_public_ws,
+        mock_rest_client,
+        gridbot_config,
+        account_config,
+        strategy_config,
+    ):
+        """Phase 4: runner gets a non-blocking peek_wallet_snapshot provider."""
+        orchestrator = Orchestrator(gridbot_config)
+        orchestrator._position_fetcher.peek_wallet_snapshot = MagicMock(
+            return_value=(WalletSnapshot(available_balance=42.0), 1.0)
+        )
+        orchestrator._init_account(account_config)
+        orchestrator._init_strategy(strategy_config)
+
+        runner = orchestrator._runners["btcusdt_test"]
+        assert runner._wallet_provider is not None
+        result = runner._wallet_provider()
+        orchestrator._position_fetcher.peek_wallet_snapshot.assert_called_once_with(
+            "test_account"
+        )
+        assert result[0].available_balance == 42.0
+
+    @patch("gridbot.orchestrator.BybitRestClient")
+    @patch("gridbot.orchestrator.PublicWebSocketClient")
+    @patch("gridbot.orchestrator.PrivateWebSocketClient")
+    def test_init_strategy_no_provider_when_disabled(
+        self,
+        mock_private_ws,
+        mock_public_ws,
+        mock_rest_client,
+        account_config,
+        strategy_config,
+    ):
+        """wallet_ws_enabled=False → runner has no provider (legacy path)."""
+        cfg = GridbotConfig(
+            accounts=[account_config], strategies=[strategy_config],
+            database_url="sqlite:///:memory:", wallet_ws_enabled=False,
+        )
+        orchestrator = Orchestrator(cfg)
+        orchestrator._init_account(account_config)
+        orchestrator._init_strategy(strategy_config)
+        assert orchestrator._runners["btcusdt_test"]._wallet_provider is None
+
+
+class TestPhase4Config:
+    """Phase 4 (review P8) — GridbotConfig wallet-WS fields."""
+
+    def test_defaults(self):
+        cfg = GridbotConfig()
+        assert cfg.wallet_ws_enabled is True
+        assert cfg.wallet_ws_max_age_seconds == 45.0
+
+    def test_max_age_must_be_positive(self):
+        with pytest.raises(Exception):
+            GridbotConfig(wallet_ws_max_age_seconds=0.0)
 
 
 class TestOrchestratorRouting:
@@ -384,8 +492,8 @@ class TestOrchestratorLifecycle:
         orchestrator._init_strategy(strategy_config)
         orchestrator._build_routing_maps()
 
-        # Mock wallet balance to raise (startup warns and continues)
-        orchestrator._position_fetcher.get_wallet_balance = Mock(
+        # Mock wallet snapshot to raise (startup warns and continues)
+        orchestrator._position_fetcher.get_wallet_snapshot = Mock(
             side_effect=TimeoutError("REST hung")
         )
 
@@ -935,7 +1043,9 @@ class TestOrchestratorWsPositionDrain:
 
         # Stub wallet fetch — real impl raises from non-main thread guards
         # in some paths and we want a deterministic value here.
-        orchestrator._position_fetcher.get_wallet_balance = Mock(return_value=1000.0)
+        orchestrator._position_fetcher.get_wallet_snapshot = Mock(
+            return_value=WalletSnapshot(wallet_balance=1000.0)
+        )
         return orchestrator, mock_runner
 
     @staticmethod
@@ -1087,7 +1197,9 @@ class TestOrchestratorWsPositionDrain:
         orch._runners = {"btcusdt_test": mock_runner}
         orch._account_to_runners = {"test_account": [mock_runner]}
         orch._symbol_to_runners = {"BTCUSDT": [mock_runner]}
-        orch._position_fetcher.get_wallet_balance = Mock(return_value=1000.0)
+        orch._position_fetcher.get_wallet_snapshot = Mock(
+            return_value=WalletSnapshot(wallet_balance=1000.0)
+        )
 
         self._push_ws(orch, "BTCUSDT", long_size="0.3", short_size="0.2")
         orch._tick()  # must not raise
@@ -1359,6 +1471,9 @@ class TestOrchestratorPositionCheck:
             short_position=short_pos,
             wallet_balance=10000.0,
             last_close=42000.0,
+            available_balance=0.0,
+            total_available_balance=0.0,
+            total_maintenance_margin=0.0,
         )
         rest_client.get_positions.assert_not_called()
 
@@ -1401,6 +1516,9 @@ class TestOrchestratorPositionCheck:
             short_position=short_pos_rest,
             wallet_balance=5000.0,
             last_close=42000.0,
+            available_balance=0.0,
+            total_available_balance=0.0,
+            total_maintenance_margin=0.0,
         )
 
     @patch("gridbot.orchestrator.BybitRestClient")
@@ -3060,8 +3178,8 @@ class TestOrchestratorWalletCache:
         rest_client.get_wallet_balance.assert_called_once()
 
         assert "test_account" in orchestrator._position_fetcher._wallet_cache
-        cached_balance, _ = orchestrator._position_fetcher._wallet_cache["test_account"]
-        assert cached_balance == 5000.0
+        cached_snap, _ = orchestrator._position_fetcher._wallet_cache["test_account"]
+        assert cached_snap.wallet_balance == 5000.0
 
     @patch("gridbot.orchestrator.BybitRestClient")
     @patch("gridbot.orchestrator.PublicWebSocketClient")
@@ -3076,7 +3194,7 @@ class TestOrchestratorWalletCache:
         orchestrator = Orchestrator(gridbot_config)
         orchestrator._init_account(account_config)
 
-        orchestrator._position_fetcher._wallet_cache["test_account"] = (10000.0, datetime.now(UTC))
+        orchestrator._position_fetcher._wallet_cache["test_account"] = (WalletSnapshot(wallet_balance=10000.0), datetime.now(UTC))
 
         rest_client = orchestrator._rest_clients["test_account"]
         rest_client.get_wallet_balance.return_value = {
@@ -3101,7 +3219,7 @@ class TestOrchestratorWalletCache:
         orchestrator._init_account(account_config)
 
         old_timestamp = datetime.now(UTC) - timedelta(seconds=400)
-        orchestrator._position_fetcher._wallet_cache["test_account"] = (5000.0, old_timestamp)
+        orchestrator._position_fetcher._wallet_cache["test_account"] = (WalletSnapshot(wallet_balance=5000.0), old_timestamp)
 
         rest_client = orchestrator._rest_clients["test_account"]
         rest_client.get_wallet_balance.return_value = {
@@ -3112,8 +3230,8 @@ class TestOrchestratorWalletCache:
         assert balance == 7500.0
         rest_client.get_wallet_balance.assert_called_once()
 
-        cached_balance, _ = orchestrator._position_fetcher._wallet_cache["test_account"]
-        assert cached_balance == 7500.0
+        cached_snap, _ = orchestrator._position_fetcher._wallet_cache["test_account"]
+        assert cached_snap.wallet_balance == 7500.0
 
     @patch("gridbot.orchestrator.BybitRestClient")
     @patch("gridbot.orchestrator.PublicWebSocketClient")
@@ -3133,7 +3251,7 @@ class TestOrchestratorWalletCache:
         orchestrator = Orchestrator(config)
         orchestrator._init_account(account_config)
 
-        orchestrator._position_fetcher._wallet_cache["test_account"] = (5000.0, datetime.now(UTC))
+        orchestrator._position_fetcher._wallet_cache["test_account"] = (WalletSnapshot(wallet_balance=5000.0), datetime.now(UTC))
 
         rest_client = orchestrator._rest_clients["test_account"]
         rest_client.get_wallet_balance.return_value = {

--- a/apps/gridbot/tests/test_position_fetcher.py
+++ b/apps/gridbot/tests/test_position_fetcher.py
@@ -17,6 +17,7 @@ from gridbot.notifier import Notifier
 from gridbot.position_fetcher import (
     PositionFetcher,
     StartupTimeoutError,
+    WalletSnapshot,
     _POSITION_FETCH_SLOW_THRESHOLD,
     _POSITION_STARTUP_HARD_CAP,
 )
@@ -30,6 +31,7 @@ def _make_fetcher(
     wallet_cache_interval=300.0,
     position_check_interval=60.0,
     on_position_changed=None,
+    wallet_ws_max_age_seconds=45.0,
 ):
     return PositionFetcher(
         rest_clients=rest_clients if rest_clients is not None else {},
@@ -38,6 +40,7 @@ def _make_fetcher(
         wallet_cache_interval=wallet_cache_interval,
         position_check_interval=position_check_interval,
         on_position_changed=on_position_changed,
+        wallet_ws_max_age_seconds=wallet_ws_max_age_seconds,
     )
 
 
@@ -209,7 +212,7 @@ class TestGetWalletBalance:
         fetcher = _make_fetcher(
             rest_clients={"a": rest}, wallet_cache_interval=300.0,
         )
-        fetcher._wallet_cache["a"] = (10000.0, datetime.now(UTC))
+        fetcher._wallet_cache["a"] = (WalletSnapshot(wallet_balance=10000.0), datetime.now(UTC))
 
         assert fetcher.get_wallet_balance("a") == 10000.0
         rest.get_wallet_balance.assert_not_called()
@@ -222,12 +225,12 @@ class TestGetWalletBalance:
         fetcher = _make_fetcher(
             rest_clients={"a": rest}, wallet_cache_interval=300.0,
         )
-        fetcher._wallet_cache["a"] = (5000.0, datetime.now(UTC) - timedelta(seconds=400))
+        fetcher._wallet_cache["a"] = (WalletSnapshot(wallet_balance=5000.0), datetime.now(UTC) - timedelta(seconds=400))
 
         assert fetcher.get_wallet_balance("a") == 7500.0
         rest.get_wallet_balance.assert_called_once()
-        cached_balance, _ = fetcher._wallet_cache["a"]
-        assert cached_balance == 7500.0
+        cached_snap, _ = fetcher._wallet_cache["a"]
+        assert cached_snap.wallet_balance == 7500.0
 
     def test_disabled_when_interval_zero_always_fetches(self):
         rest = Mock()
@@ -238,7 +241,7 @@ class TestGetWalletBalance:
             rest_clients={"a": rest}, wallet_cache_interval=0.0,
         )
         # Pre-seed cache; should be ignored.
-        fetcher._wallet_cache["a"] = (5000.0, datetime.now(UTC))
+        fetcher._wallet_cache["a"] = (WalletSnapshot(wallet_balance=5000.0), datetime.now(UTC))
 
         assert fetcher.get_wallet_balance("a") == 8000.0
         rest.get_wallet_balance.assert_called_once()
@@ -410,6 +413,9 @@ class TestFetchAndUpdate:
             short_position=short_pos,
             wallet_balance=10000.0,
             last_close=42000.0,
+            available_balance=0.0,
+            total_available_balance=0.0,
+            total_maintenance_margin=0.0,
         )
         rest.get_positions.assert_called_once()
 
@@ -427,6 +433,9 @@ class TestFetchAndUpdate:
             short_position=short_pos,
             wallet_balance=10000.0,
             last_close=42000.0,
+            available_balance=0.0,
+            total_available_balance=0.0,
+            total_maintenance_margin=0.0,
         )
         rest.get_positions.assert_not_called()
 
@@ -446,4 +455,356 @@ class TestFetchAndUpdate:
             short_position=short_pos,
             wallet_balance=10000.0,
             last_close=None,
+            available_balance=0.0,
+            total_available_balance=0.0,
+            total_maintenance_margin=0.0,
         )
+
+
+class TestWalletSnapshot:
+    """Feature 0066 (issue #159) — wallet snapshot extraction."""
+
+    def test_extracts_account_and_coin_fields(self):
+        rest = Mock()
+        rest.get_wallet_balance.return_value = {
+            "list": [{
+                "totalAvailableBalance": "1234.5",
+                "totalMaintenanceMargin": "30.25",
+                "coin": [
+                    {"coin": "USDT", "walletBalance": "5000",
+                     "availableToWithdraw": "900"},
+                ],
+            }]
+        }
+        fetcher = _make_fetcher(rest_clients={"a": rest}, wallet_cache_interval=0.0)
+        snap = fetcher.get_wallet_snapshot("a")
+        assert snap.wallet_balance == 5000.0
+        assert snap.available_balance == 900.0
+        assert snap.total_available_balance == 1234.5
+        assert snap.total_maintenance_margin == 30.25
+        # Back-compat float accessor still works.
+        assert fetcher._fetch_wallet_snapshot("a").wallet_balance == 5000.0
+
+    def test_empty_string_fields_coerced_to_zero(self):
+        """Bybit mainnet UTA sends '' for unused numeric fields (RULES.md)."""
+        rest = Mock()
+        rest.get_wallet_balance.return_value = {
+            "list": [{
+                "totalAvailableBalance": "",
+                "totalMaintenanceMargin": "",
+                "coin": [
+                    {"coin": "USDT", "walletBalance": "5000",
+                     "availableToWithdraw": ""},
+                ],
+            }]
+        }
+        fetcher = _make_fetcher(rest_clients={"a": rest}, wallet_cache_interval=0.0)
+        snap = fetcher.get_wallet_snapshot("a")
+        assert snap.wallet_balance == 5000.0
+        assert snap.available_balance == 0.0
+        assert snap.total_available_balance == 0.0
+        assert snap.total_maintenance_margin == 0.0
+
+    def test_available_falls_back_to_account_total_when_coin_empty(self):
+        """UTA cross-margin: empty per-coin field → account-level free margin."""
+        rest = Mock()
+        rest.get_wallet_balance.return_value = {
+            "list": [{
+                "totalAvailableBalance": "777.0",
+                "coin": [
+                    {"coin": "USDT", "walletBalance": "5000",
+                     "availableToWithdraw": ""},
+                ],
+            }]
+        }
+        fetcher = _make_fetcher(rest_clients={"a": rest}, wallet_cache_interval=0.0)
+        snap = fetcher.get_wallet_snapshot("a")
+        assert snap.available_balance == 777.0
+
+    def test_no_usdt_returns_zero_snapshot(self):
+        rest = Mock()
+        rest.get_wallet_balance.return_value = {"list": [{"coin": []}]}
+        fetcher = _make_fetcher(rest_clients={"a": rest}, wallet_cache_interval=0.0)
+        assert fetcher.get_wallet_snapshot("a") == WalletSnapshot()
+
+
+class TestSnapshotFromWalletAccountRow:
+    """Phase 4 (review P3) — shared parser for REST list[0] / WS data[0]."""
+
+    def test_maps_account_and_coin_fields(self):
+        fetcher = _make_fetcher()
+        row = {
+            "totalAvailableBalance": "1234.5",
+            "totalMaintenanceMargin": "30.25",
+            "coin": [
+                {"coin": "USDT", "walletBalance": "5000",
+                 "availableToWithdraw": "900"},
+            ],
+        }
+        snap = fetcher._snapshot_from_wallet_account_row(row)
+        assert snap == WalletSnapshot(
+            wallet_balance=5000.0,
+            available_balance=900.0,
+            total_available_balance=1234.5,
+            total_maintenance_margin=30.25,
+        )
+
+    def test_account_total_fallback_when_coin_empty(self):
+        fetcher = _make_fetcher()
+        row = {
+            "totalAvailableBalance": "777.0",
+            "coin": [
+                {"coin": "USDT", "walletBalance": "5000",
+                 "availableToWithdraw": ""},
+            ],
+        }
+        snap = fetcher._snapshot_from_wallet_account_row(row)
+        assert snap.available_balance == 777.0
+
+    def test_no_usdt_coin_returns_none(self):
+        fetcher = _make_fetcher()
+        assert fetcher._snapshot_from_wallet_account_row({"coin": []}) is None
+
+    def test_zero_coin_available_collapses_to_account_total(self):
+        """Documented UTA semantics: a per-coin availableToWithdraw of "0" is
+        indistinguishable from "" and collapses to the account-level free margin.
+        Locks the fallback so it can't silently drift (review test-gap)."""
+        fetcher = _make_fetcher()
+        row = {
+            "totalAvailableBalance": "500",
+            "coin": [{"coin": "USDT", "walletBalance": "100",
+                      "availableToWithdraw": "0"}],
+        }
+        snap = fetcher._snapshot_from_wallet_account_row(row)
+        assert snap.available_balance == 500.0  # account total, not the per-coin 0
+
+    def test_legacy_available_balance_used_when_v5_field_absent(self):
+        """review round-4 F1: legacy UTA 1.0 / cross-margin coins surface free
+        margin only as `availableBalance`; parser must fall back to it (mirrors
+        recorder.py) so the preflight doesn't misread free margin as 0."""
+        fetcher = _make_fetcher()
+        row = {
+            "coin": [{"coin": "USDT", "walletBalance": "5000",
+                      "availableBalance": "321.0"}],  # no availableToWithdraw key
+        }
+        snap = fetcher._snapshot_from_wallet_account_row(row)
+        assert snap.available_balance == 321.0
+
+    def test_legacy_available_balance_used_when_v5_field_empty(self):
+        fetcher = _make_fetcher()
+        row = {
+            "coin": [{"coin": "USDT", "walletBalance": "5000",
+                      "availableToWithdraw": "", "availableBalance": "150.5"}],
+        }
+        snap = fetcher._snapshot_from_wallet_account_row(row)
+        assert snap.available_balance == 150.5
+
+    def test_v5_availableToWithdraw_preferred_over_legacy_field(self):
+        """When the v5 field is present and non-empty it wins over the legacy one."""
+        fetcher = _make_fetcher()
+        row = {
+            "coin": [{"coin": "USDT", "walletBalance": "5000",
+                      "availableToWithdraw": "900", "availableBalance": "111"}],
+        }
+        snap = fetcher._snapshot_from_wallet_account_row(row)
+        assert snap.available_balance == 900.0
+
+    def test_same_dict_yields_same_result_rest_or_ws(self):
+        """A single account-row dict parses identically regardless of source."""
+        fetcher = _make_fetcher()
+        row = {
+            "totalAvailableBalance": "100.0",
+            "coin": [{"coin": "USDT", "walletBalance": "200",
+                      "availableToWithdraw": "50"}],
+        }
+        # REST path uses list[0]; WS path uses data[0] — same dict.
+        assert (fetcher._snapshot_from_wallet_account_row(row)
+                == fetcher._snapshot_from_wallet_account_row(row))
+
+
+class TestOnWalletMessage:
+    """Phase 4 — WS `wallet` topic handler (runs on the WS thread)."""
+
+    def _frame(self, *, wallet_balance="5000", available="120",
+               total_available="777.0"):
+        return {
+            "topic": "wallet",
+            "creationTime": 1704067200000,
+            "data": [{
+                "totalAvailableBalance": total_available,
+                "coin": [{"coin": "USDT", "walletBalance": wallet_balance,
+                          "availableToWithdraw": available}],
+            }],
+        }
+
+    def test_populates_ws_snapshot(self):
+        fetcher = _make_fetcher()
+        fetcher.on_wallet_message("a", self._frame())
+        snap, ts = fetcher._wallet_ws_data["a"]
+        assert snap.wallet_balance == 5000.0
+        assert snap.available_balance == 120.0
+        assert isinstance(ts, datetime)
+
+    def test_skips_missing_data_keeps_last_good(self):
+        fetcher = _make_fetcher()
+        prior = (WalletSnapshot(available_balance=99.0), datetime.now(UTC))
+        fetcher._wallet_ws_data["a"] = prior
+        fetcher.on_wallet_message("a", {"topic": "wallet"})  # no data key
+        assert fetcher._wallet_ws_data["a"] is prior
+
+    def test_skips_no_usdt_coin_keeps_last_good(self):
+        fetcher = _make_fetcher()
+        prior = (WalletSnapshot(available_balance=99.0), datetime.now(UTC))
+        fetcher._wallet_ws_data["a"] = prior
+        fetcher.on_wallet_message("a", {"data": [{"coin": []}]})
+        assert fetcher._wallet_ws_data["a"] is prior
+
+    def test_writes_valid_row_with_zero_available_not_masked(self):
+        """A funded account with 0 free margin (wallet>0) is a REAL signal —
+        written, not skipped by an all-zero heuristic (review P2-malformed)."""
+        fetcher = _make_fetcher()
+        fetcher.on_wallet_message("a", {
+            "data": [{"coin": [{"coin": "USDT", "walletBalance": "100",
+                                "availableToWithdraw": "0"}]}],
+        })
+        snap, _ = fetcher._wallet_ws_data["a"]
+        assert snap.wallet_balance == 100.0
+        assert snap.available_balance == 0.0
+
+    def test_writes_legacy_available_balance_field(self):
+        """review round-4 F1: WS frame whose USDT coin carries only the legacy
+        `availableBalance` is parsed via the shared parser → free margin captured."""
+        fetcher = _make_fetcher()
+        fetcher.on_wallet_message("a", {
+            "data": [{"coin": [{"coin": "USDT", "walletBalance": "5000",
+                                "availableBalance": "75.0"}]}],
+        })
+        snap, _ = fetcher._wallet_ws_data["a"]
+        assert snap.available_balance == 75.0
+
+    def test_never_raises_on_parse_error(self):
+        """Malformed frame must not raise on the WS thread (no write), and the
+        swallowed error IS surfaced to the operator (mirrors on_position_message)."""
+        notifier = Mock(spec=Notifier)
+        fetcher = _make_fetcher(notifier=notifier)
+        fetcher.on_wallet_message("a", {"data": "not-a-list"})  # data[0] → str
+        assert "a" not in fetcher._wallet_ws_data
+        notifier.alert_exception.assert_called_once()
+        assert notifier.alert_exception.call_args[0][0] == "_on_wallet"
+        assert notifier.alert_exception.call_args.kwargs.get("error_key") == "ws_on_wallet"
+
+
+class TestPeekWalletSnapshot:
+    """Phase 4 — non-blocking hot-path reader (newest of WS / REST by ts)."""
+
+    def test_returns_none_when_no_data(self):
+        fetcher = _make_fetcher()
+        assert fetcher.peek_wallet_snapshot("a") is None
+
+    def test_non_blocking_never_fetches(self):
+        rest = Mock()
+        fetcher = _make_fetcher(rest_clients={"a": rest})
+        fetcher._wallet_ws_data["a"] = (
+            WalletSnapshot(available_balance=100.0), datetime.now(UTC))
+        snap, age = fetcher.peek_wallet_snapshot("a")
+        assert snap.available_balance == 100.0
+        assert age >= 0.0
+        rest.get_wallet_balance.assert_not_called()
+
+    def test_prefers_newer_rest_over_stale_ws(self):
+        """review P2: a stale WS slot must NOT shadow a fresher REST entry."""
+        fetcher = _make_fetcher()
+        now = datetime.now(UTC)
+        fetcher._wallet_ws_data["a"] = (
+            WalletSnapshot(available_balance=999.0), now - timedelta(seconds=120))
+        fetcher._wallet_cache["a"] = (
+            WalletSnapshot(available_balance=5.0), now - timedelta(seconds=1))
+        snap, age = fetcher.peek_wallet_snapshot("a")
+        assert snap.available_balance == 5.0  # the fresher REST one
+        assert age < 60.0
+
+    def test_prefers_newer_ws_over_older_rest(self):
+        fetcher = _make_fetcher()
+        now = datetime.now(UTC)
+        fetcher._wallet_ws_data["a"] = (
+            WalletSnapshot(available_balance=5.0), now - timedelta(seconds=1))
+        fetcher._wallet_cache["a"] = (
+            WalletSnapshot(available_balance=999.0), now - timedelta(seconds=120))
+        snap, age = fetcher.peek_wallet_snapshot("a")
+        assert snap.available_balance == 5.0  # the fresher WS one
+        assert age < 60.0
+
+    def test_returns_only_present_source(self):
+        fetcher = _make_fetcher()
+        now = datetime.now(UTC)
+        fetcher._wallet_cache["a"] = (WalletSnapshot(available_balance=7.0), now)
+        snap, _ = fetcher.peek_wallet_snapshot("a")
+        assert snap.available_balance == 7.0
+
+
+class TestGetWalletSnapshotWsPrimary:
+    """Phase 4 — background reader: WS within window, else REST (may fetch)."""
+
+    def test_ws_primary_when_fresh(self):
+        rest = Mock()
+        fetcher = _make_fetcher(rest_clients={"a": rest},
+                                wallet_ws_max_age_seconds=45.0)
+        fetcher._wallet_ws_data["a"] = (
+            WalletSnapshot(available_balance=42.0), datetime.now(UTC))
+        snap = fetcher.get_wallet_snapshot("a")
+        assert snap.available_balance == 42.0
+        rest.get_wallet_balance.assert_not_called()
+
+    def test_rest_when_ws_stale(self):
+        rest = Mock()
+        rest.get_wallet_balance.return_value = {
+            "list": [{"coin": [{"coin": "USDT", "walletBalance": "5000",
+                                "availableToWithdraw": "100"}]}]
+        }
+        fetcher = _make_fetcher(rest_clients={"a": rest},
+                                wallet_ws_max_age_seconds=45.0,
+                                wallet_cache_interval=300.0)
+        fetcher._wallet_ws_data["a"] = (
+            WalletSnapshot(available_balance=42.0),
+            datetime.now(UTC) - timedelta(seconds=100))  # stale WS
+        snap = fetcher.get_wallet_snapshot("a")
+        assert snap.wallet_balance == 5000.0  # fell through to REST
+        rest.get_wallet_balance.assert_called_once()
+
+    def test_rest_when_no_ws(self):
+        rest = Mock()
+        rest.get_wallet_balance.return_value = {
+            "list": [{"coin": [{"coin": "USDT", "walletBalance": "8000",
+                                "availableToWithdraw": "200"}]}]
+        }
+        fetcher = _make_fetcher(rest_clients={"a": rest},
+                                wallet_cache_interval=0.0)
+        snap = fetcher.get_wallet_snapshot("a")
+        assert snap.wallet_balance == 8000.0
+        rest.get_wallet_balance.assert_called_once()
+
+    def test_logs_ws_source_with_age_when_fresh(self, caplog):
+        """review F3: DEBUG ops log identifies the WS source + slot age — the
+        signal to validate WS freshness in rollout (the INFO heartbeat lags)."""
+        rest = Mock()
+        fetcher = _make_fetcher(rest_clients={"a": rest},
+                                wallet_ws_max_age_seconds=45.0)
+        fetcher._wallet_ws_data["a"] = (
+            WalletSnapshot(available_balance=42.0), datetime.now(UTC))
+        with caplog.at_level(logging.DEBUG, logger="gridbot.position_fetcher"):
+            fetcher.get_wallet_snapshot("a")
+        assert any("WS" in r.getMessage() and "age=" in r.getMessage()
+                   for r in caplog.records)
+
+    def test_logs_rest_source_when_ws_stale_or_absent(self, caplog):
+        """review F3: DEBUG ops log identifies the REST fallback source."""
+        rest = Mock()
+        rest.get_wallet_balance.return_value = {
+            "list": [{"coin": [{"coin": "USDT", "walletBalance": "8000",
+                                "availableToWithdraw": "200"}]}]
+        }
+        fetcher = _make_fetcher(rest_clients={"a": rest},
+                                wallet_cache_interval=0.0)
+        with caplog.at_level(logging.DEBUG, logger="gridbot.position_fetcher"):
+            fetcher.get_wallet_snapshot("a")
+        assert any("REST" in r.getMessage() for r in caplog.records)

--- a/apps/gridbot/tests/test_runner_lowbalance_storm.py
+++ b/apps/gridbot/tests/test_runner_lowbalance_storm.py
@@ -1,0 +1,733 @@
+"""Feature 0066 — 110007 'available balance not enough' storm fix (issue #159).
+
+Reproducing test + Phase 2 preflight/guard suite. The bot stormed because a
+grown open-short (risk-management rule, mult=2.0) exceeded available balance →
+Bybit 110007 on every submit → each failure enqueued to the retry queue.
+
+The Phase 2 fix is a preflight balance check in ``_is_good_to_place`` (open
+orders only; reduce-only bypasses) plus a retry-queue 110007 no-enqueue guard
+in ``_execute_place_intent`` (mirrors the 0064 'do NOT enqueue 110017'
+decision). These tests exercise ``_execute_place_intent`` / ``_is_good_to_place``
+directly, the same way ``test_runner_truncate_storm.py`` does.
+"""
+
+from dataclasses import replace
+from decimal import Decimal
+from unittest.mock import Mock, MagicMock
+
+import pytest
+
+from gridcore import InstrumentInfo
+from gridcore.intents import CancelIntent, PlaceLimitIntent
+from gridcore.position import DirectionType
+
+from gridbot.config import StrategyConfig
+from gridbot.executor import IntentExecutor, OrderResult
+from gridbot.position_fetcher import WalletSnapshot
+from gridbot.runner import StrategyRunner, TrackedOrder
+
+EMPTY_LIMITS: dict[str, list[dict]] = {"long": [], "short": []}
+
+# Bybit 110007 wire format (matches executor._ERR_CODE_RE: `[NNNNN]`).
+INSUFFICIENT_BALANCE_ERROR = (
+    "Bybit API error in place_order: [110007] ab not enough for new order"
+)
+
+
+def _open_short(price="100.0", qty="1.0"):
+    """A grown open-short Sell (the order that stormed): reduce_only=False."""
+    return PlaceLimitIntent.create(
+        symbol="SOLUSDT",
+        side="Sell",
+        price=Decimal(price),
+        qty=Decimal(qty),
+        grid_level=3,
+        direction="short",
+        reduce_only=False,
+    )
+
+
+@pytest.fixture
+def strategy_config():
+    return StrategyConfig(
+        strat_id="solusdt_test",
+        account="test_account",
+        symbol="SOLUSDT",
+        tick_size=Decimal("0.01"),
+        grid_count=30,
+        grid_step=0.3,
+    )
+
+
+@pytest.fixture
+def instrument_info():
+    return InstrumentInfo(
+        symbol="SOLUSDT",
+        qty_step=Decimal("0.01"),
+        tick_size=Decimal("0.01"),
+        min_qty=Decimal("0.01"),
+        max_qty=Decimal("10000"),
+    )
+
+
+@pytest.fixture
+def mock_executor():
+    executor = Mock(spec=IntentExecutor)
+    executor.shadow_mode = False
+    executor.auth_cooldown = False
+    executor.execute_place = MagicMock(
+        return_value=OrderResult(success=True, order_id="order_1")
+    )
+    return executor
+
+
+@pytest.fixture
+def runner(strategy_config, mock_executor, instrument_info):
+    r = StrategyRunner(
+        strategy_config=strategy_config,
+        executor=mock_executor,
+        instrument_info=instrument_info,
+        rest_client=None,
+        clock=lambda: 0.0,
+    )
+    r._wallet_balance = Decimal("10000")
+    return r
+
+
+# --------------------------------------------------------------------------
+# Reproducing test — must FAIL before Phase 2, PASS after.
+# --------------------------------------------------------------------------
+
+def test_110007_storm_blocked_by_preflight(runner, mock_executor):
+    """Low-balance + grown open-short → preflight rejects locally.
+
+    Pre-fix: the open is submitted, Bybit returns 110007, the failure is
+    enqueued to the retry queue (the storm). Post-fix: ``_is_good_to_place``
+    rejects the open before submit → zero placements, zero retry-queue adds.
+    """
+    enqueued = []
+    runner._on_intent_failed = lambda intent, error: enqueued.append((intent, error))
+
+    # est_cost = qty*price/leverage = 1.0*100/1.0 = 100 ≫ available 5.
+    runner._available_balance = Decimal("5")
+    mock_executor.execute_place.return_value = OrderResult(
+        success=False, error=INSUFFICIENT_BALANCE_ERROR
+    )
+
+    intent = _open_short(price="100.0", qty="1.0")
+    for _ in range(5):  # per-tick re-emission
+        runner._execute_place_intent(replace(intent), EMPTY_LIMITS)
+
+    assert mock_executor.execute_place.call_count == 0  # never submitted
+    assert enqueued == []  # never enqueued to the retry queue
+
+
+# --------------------------------------------------------------------------
+# Phase 1 — observability data layer
+# --------------------------------------------------------------------------
+
+def _long_pos(size="1.0", **extra):
+    pos = {
+        "size": size, "avgPrice": "100", "liqPrice": "80",
+        "unrealisedPnl": "0", "cumRealisedPnl": "0", "curRealisedPnl": "0",
+    }
+    pos.update(extra)
+    return pos
+
+
+def test_build_position_state_carries_im_mm_and_leverage(runner):
+    state = runner._build_position_state(
+        _long_pos(size="1.5", positionIM="150.5", positionMM="7.25", leverage="10"),
+        10000.0,
+        DirectionType.LONG,
+    )
+    assert state.initial_margin == Decimal("150.5")
+    assert state.maintenance_margin == Decimal("7.25")
+    # Live leverage captured for the preflight — but NOT onto PositionState.leverage
+    # (which must keep its default to preserve the risk-multiplier upnl calc).
+    assert runner._leverage[DirectionType.LONG] == 10.0
+    assert state.leverage == 1
+
+
+def test_build_position_state_missing_im_mm_defaults_zero(runner):
+    state = runner._build_position_state(_long_pos(size="1.0"), 10000.0, DirectionType.LONG)
+    assert state.initial_margin == Decimal("0")
+    assert state.maintenance_margin == Decimal("0")
+
+
+def test_position_update_log_has_balance_tokens(runner, caplog):
+    with caplog.at_level("INFO"):
+        runner.on_position_update(
+            _long_pos(size="1.0"), None, 10000.0, 100.0,
+            available_balance=1234.5,
+            total_available_balance=2000.0,
+            total_maintenance_margin=15.0,
+        )
+    line = next(r.getMessage() for r in caplog.records
+                if "Position update -" in r.getMessage())
+    # Heartbeat shape preserved (existing tokens) + new ones appended.
+    assert "ratio=" in line and "long_mult=" in line and "short_mult=" in line
+    assert "avail=1234.50" in line
+    assert "total_avail=2000.00" in line
+    assert "total_mm=15.00" in line
+
+
+def test_position_update_balance_defaults_preserve_state(runner):
+    """Omitting the new kwargs (old callers) leaves stored balance untouched."""
+    runner._available_balance = Decimal("500")
+    runner.on_position_update(_long_pos(size="1.0"), None, 10000.0, 100.0)
+    assert runner._available_balance == Decimal("500")
+
+
+# --------------------------------------------------------------------------
+# Phase 2 — preflight balance check (_is_good_to_place)
+# --------------------------------------------------------------------------
+
+def test_preflight_blocks_unaffordable_open(runner):
+    runner._available_balance = Decimal("5")  # est_cost=100 ≫ 5
+    assert runner._is_good_to_place(_open_short(price="100.0", qty="1.0"), EMPTY_LIMITS) is False
+
+
+def test_preflight_allows_affordable_open(runner):
+    runner._available_balance = Decimal("200")  # 200 ≥ 100*1.05
+    assert runner._is_good_to_place(_open_short(price="100.0", qty="1.0"), EMPTY_LIMITS) is True
+
+
+def test_preflight_bypassed_for_reduce_only(runner):
+    """Reduce-only skips the preflight (frees margin) → only the size guard."""
+    runner._available_balance = Decimal("1")  # would block an open
+    runner._short_position.size = Decimal("5")
+    close_short = PlaceLimitIntent.create(
+        symbol="SOLUSDT", side="Buy", price=Decimal("100.0"), qty=Decimal("1.0"),
+        grid_level=3, direction="short", reduce_only=True,
+    )
+    # Passes the size guard (5 > 1) and is NOT blocked by the low-balance preflight.
+    assert runner._is_good_to_place(close_short, EMPTY_LIMITS) is True
+
+
+def test_preflight_fail_open_when_no_balance_data(runner):
+    """avail == 0 (no data yet) → skip the check, behave as before the fix."""
+    runner._available_balance = Decimal("0")
+    assert runner._is_good_to_place(_open_short(price="100.0", qty="1.0"), EMPTY_LIMITS) is True
+
+
+def test_preflight_live_leverage_makes_open_affordable(runner):
+    """est_cost = qty*price/leverage: live 10x leverage clears an open that 1x blocks."""
+    runner._available_balance = Decimal("15")
+    intent = _open_short(price="100.0", qty="1.0")  # notional 100
+    # Default (assumed 1x): est_cost 100 > 15 → blocked.
+    assert runner._is_good_to_place(intent, EMPTY_LIMITS) is False
+    # Live 10x: est_cost 10, 15 ≥ 10*1.05 → allowed.
+    runner._leverage["short"] = 10.0
+    assert runner._is_good_to_place(intent, EMPTY_LIMITS) is True
+
+
+def test_preflight_buffer_boundary(runner):
+    """At exactly est_cost the buffer still rejects; just above it passes."""
+    intent = _open_short(price="100.0", qty="1.0")  # est_cost=100 at 1x
+    runner._available_balance = Decimal("100")   # 100 < 100*1.05
+    assert runner._is_good_to_place(intent, EMPTY_LIMITS) is False
+    runner._available_balance = Decimal("106")   # 106 ≥ 105
+    assert runner._is_good_to_place(intent, EMPTY_LIMITS) is True
+
+
+def test_preflight_disabled_via_killswitch(strategy_config, mock_executor, instrument_info):
+    cfg = strategy_config.model_copy(update={"preflight_balance_check_enabled": False})
+    r = StrategyRunner(
+        strategy_config=cfg, executor=mock_executor,
+        instrument_info=instrument_info, rest_client=None, clock=lambda: 0.0,
+    )
+    r._available_balance = Decimal("5")  # would block if enabled
+    assert r._is_good_to_place(_open_short(price="100.0", qty="1.0"), EMPTY_LIMITS) is True
+
+
+# --------------------------------------------------------------------------
+# Phase 2 — retry-queue 110007 guard (_execute_place_intent)
+# --------------------------------------------------------------------------
+
+def test_110007_not_enqueued_to_retry_queue(runner, mock_executor):
+    """Boundary race: a submitted open that 110007s is dropped, not enqueued."""
+    enqueued = []
+    runner._on_intent_failed = lambda intent, error: enqueued.append((intent, error))
+    runner._available_balance = Decimal("0")  # fail-open so the order is submitted
+    mock_executor.execute_place.return_value = OrderResult(
+        success=False, error=INSUFFICIENT_BALANCE_ERROR
+    )
+    runner._execute_place_intent(_open_short(price="100.0", qty="1.0"), EMPTY_LIMITS)
+    assert mock_executor.execute_place.call_count == 1  # it WAS submitted (race)
+    assert enqueued == []  # but not enqueued
+
+
+def test_non_110007_failure_still_enqueues(runner, mock_executor):
+    """Guardrail: the 110007 drop must not swallow other failures."""
+    enqueued = []
+    runner._on_intent_failed = lambda intent, error: enqueued.append((intent, error))
+    runner._available_balance = Decimal("0")  # fail-open so the order is submitted
+    mock_executor.execute_place.return_value = OrderResult(
+        success=False, error="Connection timeout"
+    )
+    runner._execute_place_intent(_open_short(price="100.0", qty="1.0"), EMPTY_LIMITS)
+    assert len(enqueued) == 1  # ordinary failure still retried
+
+
+# --------------------------------------------------------------------------
+# Phase 3a — low-balance predicate + moderate_liq_risk fix wiring
+# --------------------------------------------------------------------------
+
+def test_low_balance_predicate(runner):
+    # frac default 0.10: low-balance when avail < total_position_value*0.10.
+    runner._available_balance = Decimal("5")
+    assert runner._is_low_balance(Decimal("100")) is True   # 5 < 10
+    runner._available_balance = Decimal("50")
+    assert runner._is_low_balance(Decimal("100")) is False  # 50 ≥ 10
+    runner._available_balance = Decimal("0")
+    assert runner._is_low_balance(Decimal("100")) is False  # no data → False
+    runner._available_balance = Decimal("5")
+    assert runner._is_low_balance(Decimal("0")) is False    # no position → False
+
+
+def test_on_position_update_sets_low_balance_flag(runner):
+    # long size 1 @ entry 100 → position_value 100; avail 5 < 10 → low-balance.
+    runner.on_position_update(_long_pos(size="1.0"), None, 10000.0, 100.0,
+                              available_balance=5.0)
+    assert runner._low_balance is True
+
+
+def test_on_position_update_low_balance_false_when_ample(runner):
+    runner.on_position_update(_long_pos(size="1.0"), None, 10000.0, 100.0,
+                              available_balance=50.0)
+    assert runner._low_balance is False
+
+
+# --------------------------------------------------------------------------
+# Phase 3b — chase-close active defense (default OFF)
+# --------------------------------------------------------------------------
+
+@pytest.fixture
+def chase_runner(strategy_config, mock_executor, instrument_info):
+    cfg = strategy_config.model_copy(update={
+        "chase_close_enabled": True,
+        "chase_position_ratio_threshold": 5.0,
+        "chase_offset_pct": 0.001,
+        "chase_replace_drift_pct": 0.001,
+        "chase_close_hysteresis": 0.1,
+    })
+    r = StrategyRunner(
+        strategy_config=cfg, executor=mock_executor,
+        instrument_info=instrument_info, rest_client=None, clock=lambda: 0.0,
+    )
+    r._wallet_balance = Decimal("10000")
+    return r
+
+
+def _places(buf):
+    return [i for i in buf if isinstance(i, PlaceLimitIntent)]
+
+
+def _cancels(buf):
+    return [i for i in buf if isinstance(i, CancelIntent)]
+
+
+def test_chase_disabled_by_default(runner):
+    """Default config has chase_close_enabled=False → never enters."""
+    runner._low_balance = True
+    runner._long_position.size = Decimal("10")
+    runner._evaluate_chase(price=100.0, position_ratio=8.0)
+    assert runner._chase_state == "IDLE"
+    assert runner._pending_chase_intents == []
+
+
+def test_chase_enters_buffers_intents_only(chase_runner):
+    chase_runner._low_balance = True
+    chase_runner._long_position.size = Decimal("10")
+    chase_runner._evaluate_chase(price=100.0, position_ratio=8.0)  # long dominant
+    assert chase_runner._chase_state == "CHASING"
+    assert chase_runner._chase_direction == "long"
+    places = _places(chase_runner._pending_chase_intents)
+    assert len(places) == 1
+    assert places[0].reduce_only is True and places[0].post_only is True
+    assert places[0].side == "Sell"  # close a long
+
+
+def test_chase_places_reduce_only_post_only_at_maker_offset(chase_runner):
+    chase_runner._low_balance = True
+    chase_runner._long_position.size = Decimal("10")
+    chase_runner._evaluate_chase(100.0, 8.0)
+    place = _places(chase_runner._pending_chase_intents)[0]
+    assert place.price == Decimal("100.10")  # 100*(1+0.001), maker-safe above
+    assert place.qty == Decimal("5")          # half of 10, < position size
+
+
+def test_chase_short_dominant_buys_below(chase_runner):
+    chase_runner._low_balance = True
+    chase_runner._short_position.size = Decimal("10")
+    chase_runner._evaluate_chase(100.0, 0.1)  # short dominant (ratio < 1/5)
+    place = _places(chase_runner._pending_chase_intents)[0]
+    assert place.side == "Buy"               # close a short
+    assert place.price == Decimal("99.90")   # 100*(1-0.001), maker-safe below
+    assert chase_runner._chase_direction == "short"
+
+
+def test_chase_cancels_grow_side_orders_on_entry(chase_runner):
+    chase_runner._low_balance = True
+    chase_runner._long_position.size = Decimal("10")
+    open_buy = PlaceLimitIntent.create(
+        symbol="SOLUSDT", side="Buy", price=Decimal("95"), qty=Decimal("1"),
+        grid_level=2, direction="long", reduce_only=False,
+    )
+    chase_runner._tracked_orders[open_buy.client_order_id] = TrackedOrder(
+        client_order_id=open_buy.client_order_id, intent=open_buy,
+        status="placed", order_id="oid-1",
+    )
+    chase_runner._evaluate_chase(100.0, 8.0)
+    assert any(c.order_id == "oid-1" for c in _cancels(chase_runner._pending_chase_intents))
+
+
+def test_chase_intents_drained_dispatches_and_clears(chase_runner, mock_executor):
+    chase_runner._low_balance = True
+    chase_runner._long_position.size = Decimal("10")
+    chase_runner._evaluate_chase(100.0, 8.0)
+    assert chase_runner._pending_chase_intents  # buffered, not dispatched
+    chase_runner._drain_pending_chase_intents()
+    assert chase_runner._pending_chase_intents == []  # cleared
+    assert mock_executor.execute_place.call_count == 1
+    submitted = mock_executor.execute_place.call_args.args[0]
+    assert submitted.reduce_only is True and submitted.post_only is True
+
+
+def test_chase_qty_stays_below_position_size(chase_runner):
+    intent = chase_runner._build_chase_order("long", "Sell", 100.0, Decimal("10"))
+    assert intent.qty < Decimal("10")  # never over-closes (reduce-only guard safe)
+
+
+def test_chase_no_order_for_untrimmable_tiny_position(chase_runner):
+    # size == one qty_step → half rounds back up to size → no safe trim.
+    assert chase_runner._build_chase_order("long", "Sell", 100.0, Decimal("0.01")) is None
+
+
+def test_chase_replaces_on_drift(chase_runner):
+    chase_runner._low_balance = True
+    chase_runner._long_position.size = Decimal("10")
+    chase_runner._evaluate_chase(100.0, 8.0)  # enter at ~100.10
+    first_price = chase_runner._chase_order["price"]
+    coid = chase_runner._chase_order["client_order_id"]
+    chase_runner._tracked_orders[coid] = TrackedOrder(
+        client_order_id=coid, intent=None, status="placed", order_id="chase-1",
+    )
+    chase_runner._pending_chase_intents.clear()  # ignore entry intents
+    chase_runner._evaluate_chase(110.0, 8.0)  # price drifted ~10% → re-peg
+    assert any(c.order_id == "chase-1" for c in _cancels(chase_runner._pending_chase_intents))
+    assert len(_places(chase_runner._pending_chase_intents)) == 1
+    assert chase_runner._chase_order["price"] != first_price
+
+
+def test_chase_exits_on_balance_recovery(chase_runner):
+    chase_runner._low_balance = True
+    chase_runner._long_position.size = Decimal("10")
+    chase_runner._evaluate_chase(100.0, 8.0)
+    assert chase_runner._chase_state == "CHASING"
+    chase_runner._low_balance = False  # balance recovered
+    chase_runner._evaluate_chase(100.0, 8.0)
+    assert chase_runner._chase_state == "IDLE"
+
+
+def test_chase_hysteresis_no_flap_then_exit(chase_runner):
+    chase_runner._low_balance = True
+    chase_runner._long_position.size = Decimal("10")
+    chase_runner._evaluate_chase(100.0, 8.0)
+    # ratio 4.8 is below threshold 5 but above exit floor 5*(1-0.1)=4.5 → stay.
+    chase_runner._evaluate_chase(100.0, 4.8)
+    assert chase_runner._chase_state == "CHASING"
+    # ratio 4.0 < 4.5 → exit.
+    chase_runner._evaluate_chase(100.0, 4.0)
+    assert chase_runner._chase_state == "IDLE"
+
+
+def test_chase_exit_before_drain_does_not_orphan_buffered_place(chase_runner):
+    """Exit before the buffered chase place is dispatched must drop it, not
+    leave an orphaned resting reduce-only order."""
+    chase_runner._low_balance = True
+    chase_runner._long_position.size = Decimal("10")
+    chase_runner._evaluate_chase(100.0, 8.0)            # enter → place buffered
+    assert len(_places(chase_runner._pending_chase_intents)) == 1
+    chase_runner._low_balance = False                   # balance recovers
+    chase_runner._evaluate_chase(100.0, 8.0)            # exit before any drain
+    assert _places(chase_runner._pending_chase_intents) == []  # no orphan
+    assert chase_runner._chase_state == "IDLE"
+
+
+def test_chase_repeg_before_drain_replaces_not_accumulates(chase_runner):
+    """Re-peg before drain replaces the still-buffered place (no accumulation)."""
+    chase_runner._low_balance = True
+    chase_runner._long_position.size = Decimal("10")
+    chase_runner._evaluate_chase(100.0, 8.0)   # buffered place at 100.10
+    chase_runner._evaluate_chase(110.0, 8.0)   # drift before drain → re-peg
+    places = _places(chase_runner._pending_chase_intents)
+    assert len(places) == 1                    # old buffered place replaced
+    assert places[0].price == Decimal("110.11")
+
+
+def test_chase_no_entry_when_position_too_small(chase_runner):
+    """_build_chase_order returns None for an untrimmable size → stay IDLE."""
+    chase_runner._low_balance = True
+    chase_runner._long_position.size = Decimal("0.01")  # one qty_step
+    chase_runner._evaluate_chase(100.0, 8.0)
+    assert chase_runner._chase_state == "IDLE"
+    assert chase_runner._pending_chase_intents == []
+
+
+def test_chase_does_not_cancel_reduce_only_grow_side_orders(chase_runner):
+    """Only non-reduce-only grow opens are cancelled on entry, not closes."""
+    chase_runner._low_balance = True
+    chase_runner._long_position.size = Decimal("10")
+    close_sell = PlaceLimitIntent.create(
+        symbol="SOLUSDT", side="Sell", price=Decimal("105"), qty=Decimal("1"),
+        grid_level=2, direction="long", reduce_only=True,
+    )
+    chase_runner._tracked_orders[close_sell.client_order_id] = TrackedOrder(
+        client_order_id=close_sell.client_order_id, intent=close_sell,
+        status="placed", order_id="ro-1",
+    )
+    chase_runner._evaluate_chase(100.0, 8.0)
+    assert not any(c.order_id == "ro-1" for c in _cancels(chase_runner._pending_chase_intents))
+
+
+def test_chase_no_entry_at_exact_threshold(chase_runner):
+    """Entry is strictly > threshold (and < 1/threshold), not ==."""
+    chase_runner._low_balance = True
+    chase_runner._long_position.size = Decimal("10")
+    chase_runner._evaluate_chase(100.0, 5.0)  # exactly threshold → no entry
+    assert chase_runner._chase_state == "IDLE"
+
+
+# --------------------------------------------------------------------------
+# Review F2 — moderate_liq_risk fix kill-switch wiring at the runner layer
+# --------------------------------------------------------------------------
+
+def test_moderate_liq_killswitch_off_keeps_throttle_under_low_balance(
+    strategy_config, mock_executor, instrument_info
+):
+    """Kill-switch OFF → runner passes low_balance=False, throttle still applies."""
+    cfg = strategy_config.model_copy(
+        update={"moderate_liq_low_balance_fix_enabled": False})
+    r = StrategyRunner(
+        strategy_config=cfg, executor=mock_executor,
+        instrument_info=instrument_info, rest_client=None, clock=lambda: 0.0,
+    )
+    r._wallet_balance = Decimal("10000")
+    # long liq_ratio = 82/100 = 0.82 → moderate_liq band; short present; low balance
+    # (avail 50 < total_position_value 1100 * 0.10).
+    r.on_position_update(_long_pos("10", liqPrice="82"), _long_pos("1", liqPrice="0"),
+                         10000.0, 100.0, available_balance=50.0)
+    assert r._low_balance is True
+    assert r._short_position.get_amount_multiplier()["Buy"] == 0.5  # throttle kept
+
+
+def test_moderate_liq_fix_on_skips_throttle_under_low_balance(runner):
+    """Default kill-switch ON → runner passes low_balance=True, throttle skipped."""
+    runner.on_position_update(_long_pos("10", liqPrice="82"), _long_pos("1", liqPrice="0"),
+                             10000.0, 100.0, available_balance=50.0)
+    assert runner._low_balance is True
+    assert runner._short_position.get_amount_multiplier()["Buy"] == 1.0  # not throttled
+
+
+# --------------------------------------------------------------------------
+# Review F4 — 110007 drop is OPEN-only; reduce-only failures keep retry path
+# --------------------------------------------------------------------------
+
+def test_reduce_only_110007_still_enqueues(runner, mock_executor):
+    enqueued = []
+    runner._on_intent_failed = lambda intent, error: enqueued.append((intent, error))
+    runner._short_position.size = Decimal("5")  # reduce-only guard passes (5 > 1)
+    close_short = PlaceLimitIntent.create(
+        symbol="SOLUSDT", side="Buy", price=Decimal("100.0"), qty=Decimal("1.0"),
+        grid_level=3, direction="short", reduce_only=True,
+    )
+    mock_executor.execute_place.return_value = OrderResult(
+        success=False, error=INSUFFICIENT_BALANCE_ERROR)
+    runner._execute_place_intent(close_short, EMPTY_LIMITS)
+    assert mock_executor.execute_place.call_count == 1  # reduce-only bypasses preflight
+    assert len(enqueued) == 1  # NOT dropped — kept on the normal retry path
+
+
+# --------------------------------------------------------------------------
+# Review coverage note — dedicated assumed_leverage fallback test
+# --------------------------------------------------------------------------
+
+def test_preflight_assumed_leverage_fallback(
+    runner, strategy_config, mock_executor, instrument_info
+):
+    intent = _open_short("100.0", "1.0")  # notional 100
+    # Default assumed_leverage 1.0, no live leverage captured → est_cost 100 > 25.
+    runner._available_balance = Decimal("25")
+    assert runner._is_good_to_place(intent, EMPTY_LIMITS) is False
+    # assumed_leverage 5 → est_cost 20; 25 >= 20*1.05 → allowed (fallback used).
+    cfg = strategy_config.model_copy(update={"assumed_leverage": 5.0})
+    r5 = StrategyRunner(
+        strategy_config=cfg, executor=mock_executor,
+        instrument_info=instrument_info, rest_client=None, clock=lambda: 0.0,
+    )
+    r5._available_balance = Decimal("25")
+    assert r5._is_good_to_place(intent, EMPTY_LIMITS) is True
+
+
+# --------------------------------------------------------------------------
+# Phase 4 — provider-fed preflight (fresh, non-blocking, fail-open)
+# --------------------------------------------------------------------------
+
+def _runner_with_provider(
+    strategy_config, mock_executor, instrument_info, provider,
+    max_age=45.0,
+):
+    return StrategyRunner(
+        strategy_config=strategy_config, executor=mock_executor,
+        instrument_info=instrument_info, rest_client=None, clock=lambda: 0.0,
+        wallet_provider=provider, wallet_ws_max_age_seconds=max_age,
+    )
+
+
+def test_preflight_uses_fresh_provider_value(
+    strategy_config, mock_executor, instrument_info
+):
+    """A fresh LOW provider balance blocks even when _available_balance is stale-high."""
+    provider = lambda: (WalletSnapshot(available_balance=5.0), 1.0)  # fresh, age 1s
+    r = _runner_with_provider(strategy_config, mock_executor, instrument_info, provider)
+    r._available_balance = Decimal("100000")  # stale-high — must be ignored
+    # est_cost = 100 ≫ fresh 5 → blocked via the provider value, not the latch.
+    assert r._is_good_to_place(_open_short("100.0", "1.0"), EMPTY_LIMITS) is False
+
+
+def test_preflight_blocks_on_fresh_zero_provider(
+    strategy_config, mock_executor, instrument_info
+):
+    """A FRESH peek of available_balance == 0 is authoritative → block (review P1).
+
+    The fresh zero means 'no free margin', NOT 'no data'; it must block every
+    open and must NOT be replaced by a stale-high _available_balance.
+    """
+    provider = lambda: (WalletSnapshot(available_balance=0.0), 1.0)  # fresh zero
+    r = _runner_with_provider(strategy_config, mock_executor, instrument_info, provider)
+    r._available_balance = Decimal("100000")  # stale-high — must not mask the zero
+    assert r._is_good_to_place(_open_short("100.0", "1.0"), EMPTY_LIMITS) is False
+
+
+def test_preflight_fails_open_when_peek_stale(
+    strategy_config, mock_executor, instrument_info
+):
+    """A STALE peek (age >= max_age) → fail-open; does NOT trust the stale peek
+    and does NOT fall back to _available_balance in the provider path (review P1).
+
+    Both the stale-peek value and _available_balance are set LOW (would block if
+    used); the open still passes, proving the check was skipped entirely.
+    """
+    provider = lambda: (WalletSnapshot(available_balance=5.0), 100.0)  # stale (>=45)
+    r = _runner_with_provider(strategy_config, mock_executor, instrument_info, provider)
+    r._available_balance = Decimal("5")  # also low — must NOT be used as fallback
+    assert r._is_good_to_place(_open_short("100.0", "1.0"), EMPTY_LIMITS) is True
+
+
+def test_preflight_fails_open_when_peek_none(
+    strategy_config, mock_executor, instrument_info
+):
+    """peek None (no WS, no REST cache) in the provider path → fail-open, no fallback."""
+    provider = lambda: None
+    r = _runner_with_provider(strategy_config, mock_executor, instrument_info, provider)
+    r._available_balance = Decimal("5")  # low — must NOT be used as fallback
+    assert r._is_good_to_place(_open_short("100.0", "1.0"), EMPTY_LIMITS) is True
+
+
+def test_preflight_provider_exception_fails_open(
+    strategy_config, mock_executor, instrument_info
+):
+    """Provider raising must be caught (never abort dispatch) → fail-open."""
+    def provider():
+        raise RuntimeError("boom")
+    r = _runner_with_provider(strategy_config, mock_executor, instrument_info, provider)
+    r._available_balance = Decimal("5")  # low — must NOT be used as fallback
+    assert r._is_good_to_place(_open_short("100.0", "1.0"), EMPTY_LIMITS) is True
+
+
+def test_preflight_fresh_provider_allows_affordable_open(
+    strategy_config, mock_executor, instrument_info
+):
+    """A fresh ample provider balance allows the open."""
+    provider = lambda: (WalletSnapshot(available_balance=200.0), 1.0)
+    r = _runner_with_provider(strategy_config, mock_executor, instrument_info, provider)
+    r._available_balance = Decimal("0")
+    assert r._is_good_to_place(_open_short("100.0", "1.0"), EMPTY_LIMITS) is True
+
+
+def test_preflight_no_provider_uses_available_balance(runner):
+    """No provider wired (legacy / wallet_ws_enabled=False) → _available_balance
+    path with the '>0 means data' rule (Phase-2 behavior preserved)."""
+    assert runner._wallet_provider is None
+    runner._available_balance = Decimal("5")  # est_cost 100 ≫ 5 → blocked
+    assert runner._is_good_to_place(_open_short("100.0", "1.0"), EMPTY_LIMITS) is False
+    runner._available_balance = Decimal("0")  # no data → fail-open
+    assert runner._is_good_to_place(_open_short("100.0", "1.0"), EMPTY_LIMITS) is True
+
+
+def test_storm_blocked_end_to_end_via_provider(
+    strategy_config, mock_executor, instrument_info
+):
+    """Production-path regression guard: a FRESH-LOW provider blocks the storm
+    end-to-end through ``_execute_place_intent`` → ``_is_good_to_place`` (the path
+    that ships with ``wallet_ws_enabled=True``), not only the legacy
+    ``_available_balance`` latch (covered by test_110007_storm_blocked_by_preflight).
+    """
+    provider = lambda: (WalletSnapshot(available_balance=5.0), 1.0)  # fresh, low
+    r = _runner_with_provider(strategy_config, mock_executor, instrument_info, provider)
+    enqueued = []
+    r._on_intent_failed = lambda intent, error: enqueued.append((intent, error))
+    r._available_balance = Decimal("100000")  # stale-high latch must NOT rescue the open
+    mock_executor.execute_place.return_value = OrderResult(
+        success=False, error=INSUFFICIENT_BALANCE_ERROR
+    )
+    intent = _open_short(price="100.0", qty="1.0")
+    for _ in range(5):  # per-tick re-emission
+        r._execute_place_intent(replace(intent), EMPTY_LIMITS)
+    assert mock_executor.execute_place.call_count == 0  # never submitted
+    assert enqueued == []  # never enqueued to the retry queue
+
+
+# --------------------------------------------------------------------------
+# Review F1 — low-balance PREDICATE shares the provider freshness with the
+# preflight (closes the chase/moderate_liq lag; plan rollout §3 prerequisite)
+# --------------------------------------------------------------------------
+
+def test_low_balance_predicate_uses_fresh_provider(
+    strategy_config, mock_executor, instrument_info
+):
+    """A FRESH provider value drives the predicate even when the latch is stale-high."""
+    provider = lambda: (WalletSnapshot(available_balance=5.0), 1.0)  # fresh, low
+    r = _runner_with_provider(strategy_config, mock_executor, instrument_info, provider)
+    r._available_balance = Decimal("100000")  # stale-high latch must be ignored
+    assert r._is_low_balance(Decimal("100")) is True  # 5 < 100*0.10
+
+
+def test_low_balance_predicate_fresh_zero_is_low_balance(
+    strategy_config, mock_executor, instrument_info
+):
+    """A FRESH provider zero = genuinely no free margin = the MOST extreme
+    low-balance state → True (NOT treated as 'no data' like a latch 0)."""
+    provider = lambda: (WalletSnapshot(available_balance=0.0), 1.0)  # fresh zero
+    r = _runner_with_provider(strategy_config, mock_executor, instrument_info, provider)
+    r._available_balance = Decimal("100000")  # stale-high latch must not mask it
+    assert r._is_low_balance(Decimal("100")) is True
+
+
+def test_low_balance_predicate_stale_provider_falls_back_to_latch(
+    strategy_config, mock_executor, instrument_info
+):
+    """A stale/None/raising provider falls back to the position-cadence latch
+    (best-available), unlike the preflight which fails open."""
+    stale = lambda: (WalletSnapshot(available_balance=1.0), 100.0)  # stale (>=45)
+    r = _runner_with_provider(strategy_config, mock_executor, instrument_info, stale)
+    r._available_balance = Decimal("50")  # latch ample → not low (50 >= 10)
+    assert r._is_low_balance(Decimal("100")) is False
+
+    def _raise():
+        raise RuntimeError("boom")
+    r2 = _runner_with_provider(strategy_config, mock_executor, instrument_info, _raise)
+    r2._available_balance = Decimal("5")  # latch low → low (5 < 10), no raise escapes
+    assert r2._is_low_balance(Decimal("100")) is True

--- a/docs/features/0066_PLAN.md
+++ b/docs/features/0066_PLAN.md
@@ -1,0 +1,842 @@
+# Feature 0066 — 110007 "available balance not enough" storm fix under low-balance + long-heavy state (issue #159)
+
+## Context
+
+On 2026-06-03 03:52:34 → 04:33:35 (~41 min) the live bot (account
+`mainnet_live`, Bybit linear perp, LTCUSDT + SOLUSDT) emitted 3547 ERRORs
+(~85/min sustained, peak 237/min @ 04:29): **110007** = 3483 ("available
+balance not enough for new order"), **110072** = 52 (OrderLinkedID duplicate,
+downstream of the 110007 retry), 12 no-code. Per symbol: LTCUSDT 2287, SOLUSDT
+1248. Per intent: open-short grow = 2587 (73.2%, the `risk_mgmt grow-losing-side`
+rule firing with mult=2.0), open-long grow = 948 (26.8%), **close (reduce-only)
+= 0** — Bybit accepts reduce-only when available balance is exhausted because
+those orders free margin.
+
+Root cause: at 03:52 the account was long-heavy (LTC long pos_value ~$766, SOL
+long ~$349). When the shared `position_ratio` crossed the short-branch
+`> 5.0` arm, the short Position raised its Sell multiplier to 2.0 (a
+risk-management rule, **not** martingale). The grown open-short qty exceeded
+available balance → 110007 on every attempt → each 110007 surfaces as a place
+exception, is classified non-110017, and is enqueued to the per-strat
+`RetryQueue` (`runner.py:1343-1347`) → retry storm. Compounding factor: the
+`moderate_liq_risk` long branch (`position.py:321-325`) halves the opposite
+short's **Buy** (close-short) orders (mult=0.5) so the short can grow as a
+hedge; under exhausted balance this actively slows the close-shorts that would
+free margin — a deadlock (can't grow short, won't close short fast enough).
+
+Why existing defenses didn't help: 0027 grow-losing-side **needs** margin
+(blocked by 110007); 0040 low-margin boost requires `total_margin <
+min_total_margin AND is_position_equal` (ratio was ~25, not equal); 0064
+TruncateBreaker + dirty-mirror target **110017** only; `moderate_liq_risk` was
+counterproductive. The bot has **no proactive low-balance signal** — it learns
+balance is exhausted only when Bybit returns 110007. It currently logs only
+`margin = positionValue / walletBalance` (a ratio); it does **not** extract
+`positionIM`/`positionMM` (per position) or `availableBalance` /
+`totalAvailableBalance` / `totalMaintenanceMargin` (per account).
+
+This feature implements the issue's 3-layer proposal plus the
+`moderate_liq_risk` bug-fix, in phases: a data/observability layer first, then
+two independent behavioral defenses. A **Phase 4** (real-time WS `wallet` feed)
+was added during review to remove the wallet-cache staleness that otherwise
+weakens the preflight — see Phase 4 and "Post-review revisions".
+
+### Grounding (verified file paths / functions)
+
+- `gridcore/position.py` (`packages/gridcore/src/gridcore/position.py`):
+  - `PositionState` dataclass — lines 32-54 (fields `size`, `entry_price`,
+    `unrealized_pnl`, `margin` [ratio], `liquidation_price`, `leverage`,
+    `position_value`, `cum_realized_pnl`, `cur_realized_pnl`).
+  - `RiskConfig` dataclass — lines 57-68.
+  - `Position.calculate_amount_multiplier` — lines 169-294; DEBUG log line at
+    277-292; calls `_apply_long_position_rules` / `_apply_short_position_rules`.
+  - `_apply_long_position_rules` — lines 296-340; **`moderate_liq_risk` arm at
+    321-325** (sets opposite short Buy mult=0.5).
+  - `_apply_short_position_rules` — lines 342-404; risk-mgmt `> 5.0` arm at
+    402-404 (sets own Sell mult=2.0 — the storm trigger); `> 2.0 AND upnl<0`
+    arm at 396-398; `moderate_liq_risk` arm at 381-385.
+- `apps/gridbot/src/gridbot/runner.py`:
+  - `on_position_update(long_position, short_position, wallet_balance, last_close)`
+    — lines 735-844; stores `self._wallet_balance`, builds states, logs the
+    `Position update` INFO line at 837-841.
+  - `_build_position_state(position_data, wallet_balance, direction)` — lines
+    924-960; maps Bybit position dict → `PositionState` (`size`, `avgPrice`,
+    `liqPrice`, `unrealisedPnl`, `cumRealisedPnl`, `curRealisedPnl`; computes
+    `position_value` + `margin` ratio).
+  - `_is_good_to_place(intent, limits)` — lines 1173-1222 (exact-dup + reduce-only
+    guard).
+  - `_execute_place_intent(intent, limits)` — lines 1236-1378 (6-step pipeline:
+    resolve qty → breaker → dirty refresh → guard → track → execute+bookkeeping).
+  - `_resolve_qty` — lines 863-922 (applies the risk multiplier to base qty).
+  - `__init__` — lines 170-368 (constructor; injects `rest_client`, `clock`,
+    `truncate_breaker`, `on_truncate_breaker_tripped`, `on_intent_failed`,
+    `_qty_calculator`).
+- `apps/gridbot/src/gridbot/position_fetcher.py`:
+  - `_fetch_wallet_balance(account_name)` — lines 243-265; **only extracts
+    `walletBalance` from the USDT coin** of `rest_client.get_wallet_balance()`.
+  - `get_wallet_balance(account_name)` — lines 211-241 (cache; returns float).
+  - `_fetch_one_account` — lines 353-422; calls `runner.on_position_update(...)`.
+  - `get_position_from_ws` — lines 186-209 (WS-primary cache read).
+- `packages/bybit_adapter/src/bybit_adapter/rest_client.py`:
+  `get_positions(symbol=None)` (line 314), `get_wallet_balance(account_type="UNIFIED")`
+  (line 343, returns the raw `{"list":[{"coin":[...]}]}` dict).
+- `apps/gridbot/src/gridbot/executor.py`:
+  `is_truncate_error(error)` (lines 29-46, regex `_ERR_CODE_RE` matches both
+  `[NNNNN]` and `(ErrCode: NNNNN)`); `execute_place` (167-234) returns
+  `OrderResult(success=False, error=str(e))` on any exception (110007 included).
+  `execute_place` calls `self._client.place_order(...)` at lines 202-211 with
+  `order_type="Limit"` and **no timeInForce/postOnly** — Phase 3b.0 threads
+  `time_in_force` here. `AUTH_ERROR_CODES = {10003,10004,10005,33004}`.
+- `packages/bybit_adapter/src/bybit_adapter/rest_client.py` `place_order` (line
+  462): request body at lines 504-506 sets `orderType` / `reduceOnly` only — **no
+  timeInForce/postOnly param** today; Phase 3b.0 adds `time_in_force: str = "GTC"`
+  → `params["timeInForce"]`.
+- `packages/gridcore/src/gridcore/intents.py` `PlaceLimitIntent` (frozen
+  dataclass, lines 42-126): fields at 56-64 (no post_only); `_IDENTITY_PARAMS =
+  ['symbol','side','price','direction']` (line 69) — `reduce_only`/`order_link_id`
+  are excluded from identity; Phase 3b.0 adds `post_only: bool = field(default=
+  False, compare=False)` (also excluded from identity) + a `create()` keyword.
+- **Dispatch sites (Phase 3b drain target):** `_execute_intents(intents, limits)`
+  (`runner.py:962-999`; cancels-before-places, per-place limits refresh at
+  988-999) is invoked **only** from `on_ticker` (602), `on_execution` (680), and
+  the sync path (728), each after `get_limit_orders()`. `on_position_update`
+  (735-844) updates state only and returns — it never dispatches and has no
+  `limits`. Phase 3b adds `self._pending_chase_intents` (buffered in
+  `on_position_update`) drained via `_drain_pending_chase_intents()` at the top of
+  the three dispatch ticks.
+- `packages/bybit_adapter/src/bybit_adapter/error_codes.py`: holds
+  `ORDER_QTY_TRUNCATED_TO_ZERO` (110017); **no 110007 constant yet**.
+- `apps/gridbot/src/gridbot/config.py`: `StrategyConfig` (line 26) with risk +
+  Feature-0064 fields (`dirty_refresh_enabled`, `truncate_breaker_*`).
+- `apps/gridbot/src/gridbot/retry_queue.py`: `RetryQueue.add(intent, error)` —
+  the storm amplifier; it does **not** exclude any error code today.
+- `.claude/skills/gridbot-health/analyze.py`: Table 11 = "Net P&L per strat
+  (USDT)" (line 2188); `_MAR_RE = re.compile(r"total_margin=([0-9.]+)")` (231);
+  Table 1 9-point checks (1653); all-time peaks include `min_total_margin`
+  (2065). This skill tree is gitignored — edits do **not** need a feature branch.
+
+---
+
+## Project invariants this plan must honor (verify against code as you implement)
+
+1. **Per-direction sequential dispatch is intentional** (long fully, then short
+   fully). Do NOT merge across directions. Layer 3 chase-close operates within a
+   single direction per decision; it does not interleave long/short dispatch.
+2. **`amount_multiplier` applies forward-only.** Risk-driven multiplier changes
+   affect NEW orders only — never cancel-replace existing grid orders solely
+   because a multiplier changed. Layer 3 legitimately cancel-replaces **its own
+   chase orders** on price drift; that is a distinct, narrowly-scoped mechanism,
+   not a multiplier-driven re-issue of grid orders.
+3. **Do NOT call mult=2.0 firings "martingale".** Use "risk-management rule" /
+   "risk-mgmt boost".
+4. **Hedge-mode reduce-only reject-when-`position_size ≤ qty` is correct** — do
+   not touch the `_is_good_to_place` reduce-only body (lines 1208-1222) except
+   the additive open-order preflight branch this plan inserts before it.
+5. **Reduce-only orders must always bypass the new preflight** (they free
+   margin and can't 110007). Only open (non-reduce-only) orders get the check.
+6. **Additive, default-on, kill-switchable.** Mirror Feature 0064: every new
+   `StrategyConfig` field has a default that preserves current behavior or
+   enables the fix conservatively, plus a master kill-switch per layer. Live
+   path stays safe; backtest/replay parity preserved.
+7. **Recording is a separate process** — do not add writers into gridbot. Layer 1
+   only logs + extends `PositionState`; the gridbot-health analyzer (read-only
+   log parser) consumes the new log fields.
+8. **Keep the per-tick `Position update` INFO heartbeat** (runner.py:837-841) —
+   extend it, do not remove or DEBUG-demote it.
+
+---
+
+## Phase 1 — Observability data layer (low risk, no behavior change)
+
+Goal: surface a proactive low-balance signal so Layers 2/3 (and operators) can
+detect "low-balance" before Bybit returns 110007.
+
+### 1a. Extend wallet extraction (`position_fetcher.py`)
+
+`_fetch_wallet_balance` currently returns a bare float (`walletBalance`). The
+account-level UTA fields (`totalAvailableBalance`, `totalMaintenanceMargin`,
+`totalEquity`) live at the **account row**, not the coin row; `availableBalance`
+is a per-coin field. Plan:
+
+- Add `_fetch_wallet_snapshot(account_name) -> WalletSnapshot` returning a small
+  frozen dataclass: `wallet_balance`, `available_balance` (USDT coin
+  `availableToWithdraw` / `availableBalance` — verify exact V5 key against a live
+  response; fall back to `walletBalance` when the field is absent/empty),
+  `total_available_balance`, `total_maintenance_margin` (account row), all
+  `float`, with `0.0` fallbacks and a single WARNING when the USDT coin / account
+  row is missing (reuse the existing log at line 264).
+- Keep `_fetch_wallet_balance` / `get_wallet_balance` returning the float for
+  backward compatibility; add `get_wallet_snapshot(account_name) -> WalletSnapshot`
+  alongside it, **sharing the same cache** (store the snapshot in `_wallet_cache`
+  instead of a bare float; `get_wallet_balance` reads `.wallet_balance`). Cache
+  key, TTL (`_wallet_cache_interval`), and the main-thread guard
+  (`threading.current_thread()` check, lines 223-226) are unchanged.
+
+> Bybit V5 field-name caveat: confirm the exact keys
+> (`availableToWithdraw` vs `availableBalance`, `totalAvailableBalance`,
+> `totalMaintenanceMargin`) against a captured live `get_wallet_balance()`
+> response before wiring; RULES.md "UTA wallet balance semantics (feature 0042)"
+> documents `total_available_balance` / `total_margin_balance` / `account_mm_rate`
+> as the recorder-side names — reuse those names for consistency.
+
+### 1b. Extend `PositionState` + `_build_position_state` (per-position margin $)
+
+- Add two fields to `PositionState` (`position.py`, after `position_value`):
+  `initial_margin: Decimal = Decimal('0')` and
+  `maintenance_margin: Decimal = Decimal('0')` (Bybit `positionIM` / `positionMM`,
+  **dollar amounts** — keep the existing `margin` ratio field untouched; RULES.md
+  "Margin Ratio vs Bybit positionIM" warns these are different quantities).
+- In `_build_position_state` (`runner.py:924-960`) read `position_data.get("positionIM", 0)`
+  and `positionMM` with the `Decimal(str(... or 0))` pattern (RULES.md decimal
+  safety) and populate the new fields.
+
+### 1c. Thread account-level balance into the runner
+
+- Extend `on_position_update` signature with optional keyword args
+  `available_balance: Optional[float] = None`,
+  `total_available_balance: Optional[float] = None`,
+  `total_maintenance_margin: Optional[float] = None` (defaults `None` so all
+  existing callers/tests keep working). Store them as `Decimal` on the runner:
+  `self._available_balance`, `self._total_available_balance`,
+  `self._total_maintenance_margin` (init in `__init__` to `Decimal('0')`).
+- `position_fetcher._fetch_one_account` (lines 397-403) passes the snapshot's
+  account-level fields through alongside `wallet_balance`.
+
+### 1d. Logging
+
+- Extend the per-tick `Position update` INFO line (`runner.py:837-841`) with
+  `avail=<available_balance> total_avail=<total_available_balance>
+  total_mm=<total_maintenance_margin>` (append; keep existing tokens and order so
+  the analyzer's `_MAR_RE`-style parsers don't break).
+- Extend the per-direction DEBUG line in `calculate_amount_multiplier`
+  (`position.py:277-292`) with `im_usdt=<initial_margin> mm_usdt=<maintenance_margin>`.
+
+### 1e. gridbot-health analyzer (read-only)
+
+- Add a parser for the three new `Position update` tokens
+  (`avail=`, `total_avail=`, `total_mm=`) and surface min/avg in the per-strat
+  position-metrics table; add an all-time peak `min_available_balance`. Follow
+  the existing `_MAR_RE` / `min_total_margin` peak pattern (analyze.py lines 231,
+  421, 2065). This is the only analyzer change; keep Table numbering stable.
+
+---
+
+## Phase 2 — Preflight balance check in `_is_good_to_place` (stops the storm)
+
+Goal: never **submit** an open order the account can't afford, so 110007 is
+never returned and the retry queue is never fed. This is the primary fix.
+
+### Algorithm (open orders only; reduce-only bypasses)
+
+Insert at the top of the reduce-only branch boundary in `_is_good_to_place`
+(`runner.py`), i.e. immediately before the existing `if not intent.reduce_only:
+return True` early-return at line 1208 — so the exact-duplicate scan above still
+runs, and reduce-only orders still hit the existing guard unchanged:
+
+```
+# Step P (preflight, open orders only):
+# NOTE: _is_good_to_place has signature (self, intent, limits) — there is NO
+# `config` param in scope. Strategy config is read via `self._config`
+# everywhere in the runner (runner.py:1273, 1278, 1346, 1377). Use that here.
+# NOTE: this is the Phase-2 BASE form (no-provider path). Phase 4 amends the
+# balance SOURCE: when a wallet_provider is wired, a FRESH peek is authoritative
+# (even available_balance==0 → blocks) and stale/None → fail-open; see
+# "Preflight reads fresh, non-blocking, fail-open". The `avail > 0` "0 = no data"
+# rule below applies only on the no-provider path.
+if not intent.reduce_only and self._config.preflight_balance_check_enabled:
+    avail = self._available_balance            # set by on_position_update (Phase 1c)
+    if avail > 0:                              # 0 = no data yet → fail-open, skip check
+        leverage = max(self._effective_leverage(intent.direction), 1)
+        est_cost = (intent.qty * intent.price) / Decimal(leverage)
+        buffer = Decimal(str(self._config.preflight_balance_buffer))   # e.g. 0.05
+        if avail < est_cost * (Decimal(1) + buffer):
+            log INFO "LowBalanceSkip" with strat_id, side, direction, qty,
+                price, est_cost, avail, buffer
+            return False
+# fall through to existing reduce-only / return-True logic
+```
+
+Detailed rules:
+
+1. **Reduce-only never reaches Step P** — the check is gated on
+   `not intent.reduce_only`. (Reduce-only continues to the existing guard at
+   lines 1211-1222 — unchanged.)
+2. **Fail-open when no balance data** (`avail <= 0`, i.e. Phase 1 data hasn't
+   arrived yet, or the account-level field is missing): skip the check and behave
+   exactly as today. This avoids blocking all opens on a transient wallet-fetch
+   gap. A DEBUG log notes the skip.
+3. **Leverage source.** `est_cost = qty * price / leverage`. `PositionState.leverage`
+   defaults to `1` and is **not** currently threaded from config, so a naive
+   `/leverage` would overstate cost ~Nx and over-reject. Add
+   `_effective_leverage(direction)`: prefer the live exchange `leverage` from the
+   most recent position dict (capture it in `_build_position_state` into a
+   per-direction `self._leverage[direction]`), else a new
+   `StrategyConfig.assumed_leverage` (default conservative, e.g. `1.0`).
+   `max(..., 1)` guards divide-by-zero. **Document that an over-conservative
+   leverage estimate only ever rejects affordable opens (never lets an
+   unaffordable one through) — bias the default toward safety (low leverage).**
+4. **Buffer.** `preflight_balance_buffer` (config, default e.g. `0.05`) keeps a
+   margin so fee/funding/rounding slack near the boundary doesn't still 110007.
+5. **No effect on reduce-only, cancels, or the 0064 dirty/breaker path.** Step P
+   sits inside `_is_good_to_place`, which is called at step 4 of
+   `_execute_place_intent` (after the 0064 breaker and dirty-refresh steps), so
+   the 110017 machinery is untouched.
+
+### Config (Phase 2)
+
+Add to `StrategyConfig` (mirroring the 0064 block, all default-on/safe):
+- `preflight_balance_check_enabled: bool = True` (master kill-switch).
+- `preflight_balance_buffer: float = 0.05` (`ge=0`).
+- `assumed_leverage: float = 1.0` (`gt=0`) — fallback when no live leverage.
+
+### Secondary hardening (retry-queue 110007 guard)
+
+Even with Step P, a 110007 can still occur on a boundary race (balance moved
+between fetch and submit). Add `INSUFFICIENT_BALANCE = 110007` to
+`error_codes.py` and a module-level `is_insufficient_balance(error)` in
+`executor.py` (reusing `_ERR_CODE_RE`, exactly like `is_truncate_error`). In
+`_execute_place_intent`, when an open order fails with 110007, **do not enqueue
+it to the retry queue** (retrying the same/grown qty against the same exhausted
+balance just re-storms) — log once at WARNING and return, mirroring the 0064
+"do NOT enqueue 110017" decision (runner.py:1365-1366). This bounds any residual
+storm to the per-tick re-emission cadence rather than the retry-queue amplifier.
+
+---
+
+## Phase 3 — Chase-close active defense + `moderate_liq_risk` bug-fix
+
+Two independent pieces. Either can ship without the other; both depend on
+Phase 1's `available_balance` signal.
+
+### 3a. `moderate_liq_risk` bug-fix (small, contained, in `position.py`)
+
+The long-branch `moderate_liq_risk` arm (`position.py:321-325`) sets the opposite
+short's **Buy** (close-short) multiplier to 0.5, slowing the very closes that
+free margin. Fix: make this arm **balance-aware**.
+
+- Thread a `low_balance: bool` flag into `calculate_amount_multiplier`
+  (computed by the runner — see below — and passed as a keyword arg, default
+  `False` so pure unit tests and backtest keep current behavior). The flag is
+  `True` when `available_balance > 0 AND available_balance < total_position_value
+  * low_balance_fraction` (or an absolute `low_balance_usdt` floor) — exact
+  predicate defined once in the runner and reused by 3a and 3b.
+- In the long-branch `moderate_liq_risk` arm: when `low_balance` is True, **skip
+  the mult=0.5 on the opposite short Buy** (no-op the hedge throttle) — and
+  optionally set the opposite long's **Sell** (close-long) to `1.5` to actively
+  trim the dominant long. Keep the existing 0.5 behavior when `low_balance` is
+  False. Mirror the symmetric concern in the short-branch `moderate_liq_risk`
+  arm (lines 381-385) for completeness.
+- Gate behind `StrategyConfig.moderate_liq_low_balance_fix_enabled: bool = True`
+  (kill-switch). When the flag path is inactive, the branch is byte-for-byte the
+  current behavior.
+
+> bbu2 fidelity note: this changes a documented bbu2-derived rule only under the
+> new low-balance condition; record the deviation in RULES.md (the existing
+> "Position Risk Management Module" / priority-order notes).
+
+### 3b. Chase-close state machine (active defense)
+
+When low-balance AND the dominant-side `position_ratio` is extreme (the storm
+regime), proactively reduce the dominant position with a **reduce-only**
+post-only limit near the touch, instead of fighting 110007 trying to grow the
+losing side. Reduce-only orders are exactly what Bybit still accepts under
+exhausted balance (0 close failures in the incident).
+
+#### 3b.0 — Post-only order-path support (prerequisite, additive)
+
+The current order path has **no post-only / timeInForce support** anywhere:
+`PlaceLimitIntent` (`gridcore/intents.py`) has no such field; `executor.execute_place`
+(`executor.py:202-211`) hardcodes `order_type="Limit"` with no timeInForce; and
+`rest_client.place_order` (`rest_client.py:462`, body at 504-506) has no
+timeInForce/postOnly parameter (it sends `orderType`/`reduceOnly` only). Post-only
+chase therefore requires these three **additive, default-off** changes (each
+default preserves current behavior, identity hash, and all existing callers):
+
+1. **`gridcore/intents.py` — `PlaceLimitIntent`**: add field
+   `post_only: bool = field(default=False, compare=False)` (NOT added to
+   `_IDENTITY_PARAMS`, mirroring `order_link_id` / `reduce_only` — so the
+   deterministic `client_order_id` and dedup behavior are unchanged). Update the
+   `create()` factory with a `post_only: bool = False` keyword that is passed
+   through to the constructor. Default `False` keeps every existing emit-site and
+   the frozen-dataclass identity intact.
+2. **`apps/gridbot/src/gridbot/executor.py` — `execute_place`**: thread
+   `time_in_force` through to `place_order`: pass
+   `time_in_force="PostOnly"` when `intent.post_only` else `"GTC"` (Bybit V5
+   default for Limit). Read `intent.post_only` with a `getattr(intent,
+   "post_only", False)` fallback only if needed for older intent shapes; since the
+   field has a default, a direct attribute read is fine.
+3. **`packages/bybit_adapter/src/bybit_adapter/rest_client.py` — `place_order`**:
+   add a `time_in_force: str = "GTC"` parameter and set
+   `params["timeInForce"] = time_in_force` in the request body (alongside the
+   existing `orderType` / `reduceOnly` at lines 504-506). Default `"GTC"` is
+   identical to today's implicit behavior (Bybit treats Limit as GTC when
+   timeInForce is omitted), so all current callers are byte-for-byte unchanged.
+
+Tests for 3b.0 (additive surface):
+- `test_place_limit_intent_post_only_default_false_preserves_identity`: two
+  intents differing only in `post_only` still hash to the same
+  `client_order_id` (post_only excluded from identity) and `==` comparison
+  ignores it.
+- `test_executor_passes_postonly_tif`: `intent.post_only=True` →
+  `place_order` called with `time_in_force="PostOnly"`; default intent →
+  `"GTC"`.
+- `test_rest_client_place_order_sets_time_in_force`: param threads into
+  `params["timeInForce"]`; default omitted-equivalent `"GTC"`.
+
+If 3b ships with `chase_close_enabled=False` (the default) and post-only is later
+deemed unnecessary, an alternative is to drop post-only and place a **plain
+reduce-only limit** at the offset (still frees margin, still 110007-safe — only
+risk is a taker fill if the offset crosses the touch). The plan adopts post-only
+to avoid that taker fill; the 3b.0 changes above are the required scope to do so.
+
+#### Dispatch mechanism — why chase cannot dispatch from `on_position_update`
+
+`on_position_update` (`runner.py:735-844`) does **NOT** dispatch any orders. It
+updates sizes / `position_ratio` / liquidation / multipliers, logs the heartbeat,
+sets `self._last_position_check`, and returns — all inside a `try/except` that
+re-raises. It has **no `limits` snapshot** and never calls `_execute_intents`.
+Order dispatch happens **only** from `on_ticker` (line 602), `on_execution`
+(line 680), and the order-sync path (line 728), each of which calls
+`_execute_intents(intents, limit_orders)` with a `limits` snapshot fetched via
+`get_limit_orders()`. `_execute_place_intent` → `_is_good_to_place` **requires** a
+`limits` dict (the reduce-only guard sums resting book qty from it), which
+`on_position_update` neither has nor fetches.
+
+Therefore chase uses a **stash-in-`on_position_update`, drain-on-next-dispatch-tick**
+pattern (preserves the "on_position_update updates state only" contract — invariant
+#8 / MEMORY heartbeat note — and per-direction sequential dispatch, invariant #1):
+
+1. In `on_position_update`, **after** multipliers are computed (so the freshest
+   ratio + balance are visible), run the **chase decision** (entry/while/exit
+   transitions below). The decision only **mutates chase state and appends the
+   resulting `CancelIntent` / `PlaceLimitIntent` objects to a runner-held buffer**
+   `self._pending_chase_intents: list[PlaceLimitIntent | CancelIntent]`. It does
+   NOT place/cancel anything and does NOT fetch limits here.
+2. At the **top of the next dispatch tick** — add a single drain helper
+   `_drain_pending_chase_intents()` called at the start of `on_ticker`,
+   `on_execution`, and the sync path **before** the engine produces its own
+   intents — pop the buffered chase intents and feed them through the **existing**
+   `_execute_intents(buffered, self.get_limit_orders())`. This reuses the
+   established cancel-before-place ordering, the per-place `limits` refresh
+   (runner.py:988-999), `_is_good_to_place`'s reduce-only guard, and the 0064
+   breaker/dirty path with **zero new dispatch code**. The chase
+   `PlaceLimitIntent` carries `reduce_only=True, post_only=True` so it bypasses
+   the Phase 2 open-preflight and is capped by the reduce-only guard.
+3. Idempotency: the buffer is cleared on drain; the chase state machine only
+   re-appends a place intent when entering CHASING or on a drift cancel-replace,
+   so a fill/no-op tick produces an empty buffer (no churn).
+
+State (per runner, per dominant direction):
+`IDLE -> CHASING -> IDLE`. Stored on the runner (init in `__init__` alongside the
+Phase-1c balance fields): `self._chase_state[direction]` (default `IDLE`),
+`self._chase_order` (the live chase wire id + price), `self._chase_entered_ts`,
+and `self._pending_chase_intents` (the drain buffer, default `[]`).
+
+Entry condition (evaluated once per `on_position_update`, after multipliers are
+computed, so it sees the freshest ratio + balance):
+- `self._config.chase_close_enabled` AND `low_balance` AND
+  `position_ratio` beyond `self._config.chase_position_ratio_threshold` (default
+  tuned above the risk-mgmt `> 5.0` arm, e.g. `5.0`) — identify the **dominant**
+  direction (long if `ratio > threshold`, short if `ratio < 1/threshold`).
+
+On entry (`IDLE -> CHASING`) — **append intents to `self._pending_chase_intents`,
+do not dispatch here**:
+1. **Cancel pending grow-side open orders** for the dominant side (the orders that
+   keep 110007-ing): append `CancelIntent`(s) for those resting grow orders. They
+   are drained through `_execute_cancel_intent` on the next tick; this is a
+   deliberate, balance-driven cancel of grow orders — distinct from the
+   forward-only multiplier rule (those grow orders are exactly what's wedged).
+2. Compute a chase price: **maker-safe** so post-only never crosses/rejects —
+   **Sell ABOVE / Buy BELOW** the touch, i.e. `current_price * (1 + chase_offset_pct)`
+   for a close-long Sell and `current_price * (1 - chase_offset_pct)` for a
+   close-short Buy. (This is the OPPOSITE of an aggressive taker peg; the issue's
+   "sell below / buy above" wording predated the post-only decision — see RULES
+   and Post-review F5.) Default `chase_offset_pct` in the 0.05–0.10% band, rounded via
+   `_instrument_info.round_price` / tick_size.
+3. Resolve a reduce-only close qty (close-dominant) and append a
+   `PlaceLimitIntent.create(..., reduce_only=True, post_only=True)`. It is capped
+   on drain by `_is_good_to_place`'s existing reduce-only guard so we never
+   over-close — preserving the `position_size ≤ qty` reject convention.
+
+While `CHASING` (each `on_position_update`):
+- If `current_price` drifted > `chase_replace_drift_pct` (default `0.10%`) from
+  the chase order's price: append a `CancelIntent` for the live chase order plus a
+  fresh chase `PlaceLimitIntent` at the new reference price to the buffer
+  (**cancel-replace the chase order**). This cancel-replace is scoped to the chase
+  order itself and is explicitly exempt from the forward-only invariant (invariant
+  #2). Update `self._chase_order` to the new price.
+- Re-arm only the chase order; do not touch grid orders.
+
+Exit condition (`CHASING -> IDLE`):
+- `available_balance` recovered (`not low_balance`) OR `position_ratio` dropped
+  back inside `[1/threshold, threshold]` (with a small hysteresis margin to avoid
+  flapping) OR the dominant position is flat. On exit: append a `CancelIntent` for
+  the live chase order (if still resting), clear chase state; normal grid resumes
+  on the next engine tick.
+
+Interaction guards:
+- Chase orders are reduce-only → they pass Phase 2 (open-only) untouched and the
+  existing reduce-only guard caps them.
+- Chase is per-direction and does not interleave with the other direction's
+  dispatch (invariant #1) — the buffer is fed to `_execute_intents` which already
+  preserves cancel-before-place + nearest-first ordering.
+- A single source of truth for `low_balance` and the dominant-direction
+  computation shared with 3a.
+
+### Config (Phase 3)
+
+Add to `StrategyConfig` (defaults conservative; chase **off by default** because
+it actively trades — promote to on after the regression suite + one live
+stress-event validation):
+- `moderate_liq_low_balance_fix_enabled: bool = True`.
+- `low_balance_fraction: float = ...` and/or `low_balance_usdt: float = ...`
+  (the low-balance predicate; pick one primary, document the other as optional).
+- `chase_close_enabled: bool = False` (kill-switch, default OFF).
+- `chase_position_ratio_threshold: float = 5.0`.
+- `chase_offset_pct: float` (default in 0.0005–0.0010), `chase_replace_drift_pct:
+  float = 0.0010`.
+- `chase_close_hysteresis: float` (ratio re-entry margin).
+
+---
+
+## Phase 4 — real-time wallet via WS `wallet` topic (resolves review F1)
+
+**Why (review finding F1).** The preflight and chase read `self._available_balance`,
+fed by `get_wallet_snapshot()` which is **REST-cached** (`wallet_cache_interval`,
+default **300s** in `GridbotConfig`, not overridden in `conf/`). The orchestrator
+WS-drain runs every tick with **fresh position sizes** but the **cached (≤300s
+stale) free margin**, so during a fast margin drawdown the preflight can keep
+passing unaffordable opens until the cache refreshes (degrading Phase 2 to the
+no-enqueue guard's per-tick bound). Bybit's account-level `availableBalance` /
+`totalAvailableBalance` is **NOT** in the `position` WS topic (that carries only
+per-position `positionIM`/`positionMM`) — it lives in a separate **`wallet`** WS
+topic the gridbot does not currently subscribe to. Feeding `available_balance`
+from that WS topic in real time attacks the staleness at the source — the hot-path
+read is then **age-bounded to `wallet_ws_max_age_seconds`** (then fail-open), not
+the 300s REST TTL (see "Effect"). Preferred over the REST
+cache-invalidation-on-110007 band-aid.
+
+### Grounding (verified)
+- `packages/bybit_adapter/src/bybit_adapter/ws_client.py`: `PrivateWebSocketClient`
+  already supports `on_wallet` + subscribes `wallet_stream` **only when
+  `on_wallet` is set** (`_handle_wallet` parses + calls `on_wallet(message)`).
+  **No adapter change needed.**
+- `apps/gridbot/src/gridbot/orchestrator.py` `_init_account` constructs
+  `PrivateWebSocketClient(on_position=…, on_order=…, on_execution=…,
+  on_disconnect=…)` — **no `on_wallet`**. Add it.
+- WS wallet frame shape (authoritative): `apps/event_saver/src/event_saver/writers/wallet_writer.py:218-232`
+  documents the Bybit V5 frame — `{topic:"wallet", creationTime:<ms, top-level>,
+  data:[{<account row> , coin:[{coin,walletBalance,availableToWithdraw,…}]}]}`.
+  So `msg["data"][0]` is the account row, **same shape as REST `result["list"][0]`**,
+  carrying `totalAvailableBalance` etc. Caveats from the recorder: the timestamp
+  is the **top-level `creationTime`** (V5 omits per-row `updateTime`); the recorder
+  stores `account_mm_rate` rather than `totalMaintenanceMargin`, so the WS row may
+  or may not carry `totalMaintenanceMargin` — `_float_or_zero` covers absence
+  (it's observability-only, not a preflight input). Cross-ref `WALLET_ACCOUNT_JSON_KEYS`.
+- `apps/gridbot/src/gridbot/position_fetcher.py`: mirror the existing WS-primary /
+  REST-fallback **position** pattern (`on_position_message` → `_position_ws_data`
+  GIL-atomic write; `get_position_from_ws` read).
+
+### Data layer
+- Add `self._wallet_ws_data: dict[str, tuple[WalletSnapshot, datetime]] = {}`
+  (account → latest WS snapshot **+ receive timestamp** — the timestamp drives the
+  freshness window, see below). Written **only** by the WS-thread callback via a
+  single GIL-atomic assignment (no lock — mirrors `_position_ws_data`). Distinct
+  from `_wallet_cache` (REST, main-thread-guarded), which stays as the fallback.
+
+### Shared parse helper (Phase-4 review P3 — DRY)
+- Extract `_snapshot_from_wallet_account_row(account_dict) -> WalletSnapshot` (the
+  account-level + USDT-coin extraction with `_float_or_zero` and the account-total
+  fallback) and call it from **both** `_fetch_wallet_snapshot` (REST `list[0]`) and
+  `on_wallet_message` (WS `data[0]`). One parser → no REST/WS field drift.
+
+### Algorithm
+- `on_wallet_message(account_name, msg)` (WS thread): **structurally validate** the
+  frame — require `msg["data"][0]` present with a USDT coin row; on missing /
+  unparseable → **no write** (keep last good), and **never raise on the WS thread**
+  (review P2-malformed). A *valid* account row is **written even if
+  `available_balance` parses to 0** — a funded low-free-margin account has
+  `wallet_balance > 0`, so it is **never** all-zero; a truly all-zero frame is a
+  partial frame or an empty (no-position, no-storm) account, safe to skip. This
+  replaces the earlier blanket "all-zero → skip" heuristic so a real signal is
+  never masked. Store `self._wallet_ws_data[account_name] =
+  (_snapshot_from_wallet_account_row(...), now_utc)` (atomic).
+- `get_wallet_snapshot(account_name)` (main thread, **MAY fetch — background /
+  rotation use only, NOT the hot order path**): WS-primary within the freshness
+  window (`now - ws_ts < wallet_ws_max_age_seconds`; review P2 — a timestamped
+  window survives a silent WS death without relying on `_on_ws_disconnect`, which
+  doesn't fire because the private WS is built `message_gap_watchdog_enabled=False`),
+  else the existing REST cache path (TTL `wallet_cache_interval`; may do a blocking
+  REST fetch on expiry). No clearing on disconnect.
+- `peek_wallet_snapshot(account_name) -> tuple[WalletSnapshot, float] | None`
+  (**non-blocking, NEVER fetches** — the hot-path reader): return the **genuinely
+  freshest cached snapshot by timestamp** + its age in seconds — i.e. compare the
+  WS slot ts and the REST `_wallet_cache` ts and return whichever is **newer**
+  (both present → newer wins; only one present → that one; neither → `None`).
+  **Do NOT prefer the WS slot when it's present-but-older** (review P2): a stale WS
+  slot must not shadow a more-recently-rotated REST entry, or the preflight would
+  fail open and miss a fresh REST low-balance signal. No freshness threshold inside
+  peek (it just returns newest + age); the **caller** (preflight) applies
+  `wallet_ws_max_age_seconds`. (Both `_wallet_ws_data` and `_wallet_cache` stamp
+  `datetime.now(UTC)` on write, so the timestamps are directly comparable.) Plain
+  dict reads; safe to call frequently. — `get_wallet_snapshot` above keeps its
+  WS-if-fresh-else-REST(-fetch) form for the background path; only `peek` feeds the
+  preflight, so the newest-by-ts rule is what guarantees hot-path correctness.
+
+### Preflight reads fresh, non-blocking, fail-open (review P1 + provider-error)
+- The orchestrator drain only calls `on_position_update` (which writes
+  `self._available_balance`) on a **position-seq change** (`orchestrator.py:455`
+  `if seq unchanged: continue`), so a wallet-only WS push would not reach the
+  runner. Fix: inject `wallet_provider: Callable[[], tuple[WalletSnapshot, float] |
+  None] | None = None` into `StrategyRunner.__init__`; `_init_strategy` wires
+  `wallet_provider=lambda: self._position_fetcher.peek_wallet_snapshot(account_name)`
+  — the **non-blocking** reader (review P1: never `get_wallet_snapshot`, which can
+  block / fetch / raise on the hot path, and whose REST fallback could hand back a
+  ≤`wallet_cache_interval` (300s)-stale value).
+- Balance source inside `_is_good_to_place` (open-order branch). **Freshness, not
+  positivity, decides whether we have data** (review P1 — a fresh `available_balance
+  == 0` is a real "no free margin" signal, NOT "no data"; gating on `> 0` would
+  mask it and fall back to stale-high data):
+  - **No provider wired** (unit tests / `wallet_ws_enabled=False`): legacy Phase-2
+    path — use `self._available_balance`; if `> 0` run the check, else fail-open.
+    (Here `0` still means "position update hasn't arrived" — there is no age to
+    consult.)
+  - **Provider wired:**
+    1. `try: peek = self._wallet_provider()` `except Exception: <throttled
+       WARNING>; peek = None` — a hot-path balance read must **never abort order
+       dispatch** (review provider-error).
+    2. If `peek` is **fresh** (`age < wallet_ws_max_age_seconds`): it is
+       **authoritative — run the check with `peek.available_balance` even when it
+       is 0** (a fresh zero free-margin → `0 < est_cost*(1+buffer)` → blocks every
+       open; reduce-only still bypasses and frees margin).
+    3. Else (`peek` is `None` or **stale**): **fail-open** (skip the check). Do
+       NOT fall back to `self._available_balance` in the provider path — peek reads
+       the same WS/REST caches and is never less fresh, so a stale peek means the
+       latched `_available_balance` is stale too. The no-enqueue guard backstops
+       any resulting 110007.
+- This bounds the preflight's balance staleness to `wallet_ws_max_age_seconds` in
+  **all** cases (WS *and* REST — review P1) and never blocks/raises on the hot path.
+  The background rotation (`_fetch_one_account` → `get_wallet_snapshot`) keeps
+  `_wallet_cache` current off the hot path. **Optional enhancement:** when `peek` is
+  stale/None, set a one-shot `request_wallet_refresh(account)` flag honored by the
+  next position-fetch tick (force a fresh REST, bypassing the TTL) — mirrors the
+  `_on_unknown_order` fast-track — to shorten the WS-dead REST-staleness window
+  without hot-path I/O.
+- The no-provider `self._available_balance` path keeps existing Phase-2 unit tests
+  working (they set `_available_balance`; no provider in unit tests). `_low_balance`
+  (chase/moderate_liq predicate) stays on the on_position_update cadence — see the
+  chase prerequisite in rollout (review P3).
+
+### Module doc (review P6)
+- Update the `position_fetcher.py` module docstring (currently: "only
+  `on_position_message` runs on the WS thread") to include `on_wallet_message` +
+  `_wallet_ws_data` write rules (WS thread, single GIL-atomic assignment, no lock,
+  never touches `_wallet_cache`).
+
+### Effect / caveat / ops (review P7)
+- `available_balance` reaches the preflight in real time whenever the wallet
+  stream pushes, and the hot-path read is **age-bounded to
+  `wallet_ws_max_age_seconds` in all cases** (WS or REST). So F1's 300s window
+  shrinks to `max_age`; beyond that the preflight **fails open** (rather than
+  trusting stale data) and the Phase-2 no-enqueue guard backstops. Not "staleness
+  eliminated" — "staleness bounded to `max_age`, then fail-open."
+- Bybit pushes `wallet` on balance-affecting events (fills, funding, realized).
+  Active grid trading fills frequently so it stays fresh; REST rotation remains the
+  quiet-window backstop. The cache-invalidation-on-110007 variant is **not** needed.
+- Ops: log (DEBUG) whether `get_wallet_snapshot` served WS (with slot age) vs REST
+  fallback — this is the signal to validate WS freshness in rollout §4. Note the
+  INFO heartbeat `avail=` is written in `on_position_update` (position-drain
+  cadence), so it is NOT a reliable WS-freshness signal and can lag the preflight.
+
+### Config (review P8 — GridbotConfig, not StrategyConfig)
+- `wallet_ws_enabled: bool = True` and `wallet_ws_max_age_seconds: float =
+  Field(default=45.0, gt=0)` (bounds how long a silently-dead WS may pin a stale
+  slot before falling back to REST; well under `wallet_cache_interval=300`; a
+  quiet-but-healthy WS falling back to REST is harmless since an unchanging
+  balance is still accurate) on **`GridbotConfig`** (next to `wallet_cache_interval`,
+  line 267), wired in `_init_account`.
+- **`wallet_ws_enabled=False` is a full Phase-4 kill-switch (review P2):** it skips
+  BOTH (a) wiring `on_wallet` (no WS subscription) AND (b) injecting the
+  `wallet_provider` into the runner. With no provider, the preflight takes the
+  **no-provider `_available_balance` path** — i.e. genuinely the pre-Phase-4
+  behavior (position-cadence balance, `wallet_cache_interval` REST TTL, NO
+  age-bounding and NO fail-open-on-stale). It does **not** mean "WS off but REST
+  still age-bounded via peek." (Phase-2 preflight + the per-strat
+  `preflight_balance_check_enabled` flag are untouched.)
+
+---
+
+## Post-review revisions (from `0066_REVIEW.md`)
+
+- **F4 (done):** the 110007 no-enqueue drop in `_execute_place_intent` is gated on
+  `not intent.reduce_only` (open-only, matches the spec; a reduce-only failure
+  keeps the normal retry path rather than being silently dropped). Test
+  `test_reduce_only_110007_still_enqueues`.
+- **F2 (done):** runner-level kill-switch tests for
+  `moderate_liq_low_balance_fix_enabled`
+  (`test_moderate_liq_killswitch_off_keeps_throttle_under_low_balance` +
+  `…_fix_on_skips_throttle_under_low_balance`), plus a dedicated
+  `test_preflight_assumed_leverage_fallback`.
+- **F3 (process):** the Phase-1e analyzer tests live under the gitignored
+  `.claude/skills/gridbot-health/` tree → not run by CI; run manually before live
+  validation (`uv run pytest .claude/skills/gridbot-health/test_analyze.py`).
+- **F1 (this Phase 4):** resolved by the WS `wallet` real-time feed above.
+- **F5:** optional plan items (1.5× close boost, `low_balance_usdt`) intentionally
+  omitted; chase pricing intentionally maker-safe (Sell-above/Buy-below) for
+  post-only — documented in `RULES.md`.
+
+---
+
+## Regression test strategy
+
+Repo convention (`.claude/rules/code-style.md`): a bug fix starts with a
+**reproducing test that fails before the fix**. New tests go under
+`apps/gridbot/tests/`; `gridcore` rule tests under the gridcore test tree. Run
+with `uv run pytest`, suites isolated (conftest conflicts — RULES.md).
+
+### Reproducing test (write first; must fail before Phase 2)
+- `test_runner_lowbalance_storm.py::test_110007_storm_blocked_by_preflight`:
+  simulate low-balance + long-heavy (set `_available_balance` small, build a
+  grown open-short intent via the `> 5.0` ratio arm). Before the fix the open is
+  submitted (executor would 110007 → enqueued); after, `_is_good_to_place`
+  returns False and nothing is submitted/enqueued. Assert zero placements and
+  zero retry-queue adds.
+
+### Phase 1 — observability
+- `test_wallet_snapshot_extracts_account_fields`: stub `get_wallet_balance`
+  response → snapshot carries `available_balance` / `total_available_balance` /
+  `total_maintenance_margin`; missing USDT coin → zeros + one WARNING.
+- `test_position_state_carries_im_mm`: `_build_position_state` populates
+  `initial_margin` / `maintenance_margin` from `positionIM` / `positionMM`.
+- `test_position_update_log_has_balance_tokens`: caplog asserts the INFO line
+  contains `avail=` / `total_avail=` / `total_mm=` and still contains the
+  pre-existing tokens (heartbeat-shape preserved).
+- analyzer: extend `.claude/skills/gridbot-health/test_analyze.py` with a sample
+  `Position update` line carrying the new tokens → parsed into the metrics table
+  + `min_available_balance` peak.
+
+### Phase 2 — preflight
+- `test_preflight_blocks_unaffordable_open` / `…_allows_affordable_open`.
+- `test_preflight_bypassed_for_reduce_only` (reduce-only always reaches the
+  existing guard).
+- `test_preflight_fail_open_when_no_balance_data` (no-provider path:
+  `_available_balance==0` → not blocked). With a `wallet_provider` wired (Phase 4 /
+  option C), fail-open is driven by the provider being **absent / stale / raising**
+  — NOT by a fresh `available_balance == 0` (a fresh zero is authoritative and
+  **blocks**, per Phase 4 / review P1; see `test_preflight_blocks_on_fresh_zero_provider`).
+- `test_preflight_leverage_applied` (live leverage vs `assumed_leverage`
+  fallback; over-conservative leverage never lets an unaffordable open through).
+- `test_preflight_buffer_boundary` (exactly-at-cost rejected with buffer).
+- `test_preflight_disabled_via_killswitch`.
+- `test_110007_not_enqueued_to_retry_queue` (secondary hardening).
+- Guardrail: existing `_is_good_to_place` reduce-only / small-position /
+  exact-duplicate tests still pass unchanged.
+
+### Phase 3 — chase-close + moderate_liq_risk fix
+- `test_moderate_liq_long_skips_close_throttle_under_low_balance` and the
+  `False`-flag case is byte-for-byte current behavior; symmetric short test.
+- `test_moderate_liq_fix_killswitch_preserves_current_behavior`.
+- `test_chase_enters_on_low_balance_and_extreme_ratio` (asserts entry only
+  buffers intents on `self._pending_chase_intents`; `on_position_update` itself
+  places/cancels nothing and fetches no limits).
+- `test_chase_intents_drained_on_next_ticker_tick` (buffered chase
+  cancel+place are dispatched via `_execute_intents` with a `get_limit_orders()`
+  snapshot on the next `on_ticker`/`on_execution`/sync tick; buffer cleared after
+  drain).
+- `test_chase_cancels_grow_side_orders_on_entry`.
+- `test_chase_places_reduce_only_post_only_at_offset` (price rounded to tick;
+  the buffered `PlaceLimitIntent` has `reduce_only=True` and `post_only=True`).
+- 3b.0 surface: `test_place_limit_intent_post_only_default_false_preserves_identity`,
+  `test_executor_passes_postonly_tif`, `test_rest_client_place_order_sets_time_in_force`
+  (see §3b.0).
+- `test_chase_replaces_on_drift` (cancel-replace only the chase order;
+  grid orders untouched — forward-only invariant intact).
+- `test_chase_exits_on_balance_recovery_or_ratio_drop` (+ hysteresis no-flap).
+- `test_chase_reduce_only_respects_position_size_guard` (never over-closes).
+- `test_chase_disabled_by_default` (`chase_close_enabled=False`).
+
+### Phase 4 — real-time WS wallet
+- `test_snapshot_from_wallet_account_row` (Phase-4 P3): the shared parser maps an
+  account-row dict (account-level fields + USDT coin) → `WalletSnapshot`, incl.
+  empty-string coercion + account-total fallback; the SAME dict yields the same
+  result whether it came from REST `list[0]` or WS `data[0]`.
+- `test_on_wallet_message_populates_ws_snapshot`: a recorded Bybit `wallet` WS frame
+  (fixture sourced from `wallet_writer.py` shape) → `_wallet_ws_data[account]`
+  carries `(snapshot, ts)`.
+- `test_on_wallet_message_skips_malformed_keeps_last_good`: missing `data[0]` / no
+  USDT coin / parse error → no write, no raise (off-main-thread ok). **And** a
+  valid row with `available_balance==0` but `wallet_balance>0` **is written** (not
+  masked) — the structural guard, not an all-zero heuristic (review P2-malformed).
+- `test_peek_wallet_snapshot_non_blocking`: returns `(snapshot, age)` for the
+  **newest-by-timestamp** of {WS slot, REST cache} (both present → newer wins;
+  only one → that one; neither → `None`); **never** calls
+  `rest_client.get_wallet_balance` (no fetch on the hot path).
+- `test_peek_prefers_newer_rest_over_stale_ws` (review P2): WS slot older than a
+  recently-rotated REST entry → peek returns the **REST** snapshot (not the stale
+  WS), so the preflight sees the fresh REST low-balance signal instead of failing
+  open.
+- `test_get_wallet_snapshot_ws_primary_when_fresh` / `…_rest_when_ws_stale` /
+  `…_rest_when_no_ws`: background reader — WS within window, else REST cache
+  (may fetch). (Not the hot-path reader.)
+- `test_preflight_uses_fresh_provider_value` (review P1/C): provider returns a
+  fresh LOW (>0) balance → open blocked even though `self._available_balance` is
+  stale-high.
+- `test_preflight_blocks_on_fresh_zero_provider` (review P1 — the key one): a
+  **fresh** peek with `available_balance == 0` → open **blocked** (authoritative
+  zero), NOT fail-open and NOT replaced by stale-high `_available_balance`.
+- `test_preflight_fails_open_when_peek_stale` (review P1): peek `age >=
+  wallet_ws_max_age_seconds` (or `None`) → **fail-open**; does NOT fall back to a
+  stale-high `_available_balance` in the provider path (set it high and assert the
+  open still passes via fail-open, not via trusting it).
+- `test_preflight_provider_exception_fails_open` (review provider-error): provider
+  raises → caught (throttled WARNING), order dispatch is **not** aborted → peek
+  treated as absent → fail-open.
+- `test_preflight_no_provider_uses_available_balance`: no provider wired (legacy /
+  `wallet_ws_enabled=False`) → `_available_balance` path with the `>0`-means-data
+  rule (Phase-2 tests unaffected).
+- orchestrator: `on_wallet` is wired on `PrivateWebSocketClient` → routes to
+  `position_fetcher.on_wallet_message`; `_init_strategy` injects the **non-blocking
+  `peek_wallet_snapshot`** provider; `wallet_ws_enabled=False` skips wiring
+  (REST-only fallback).
+
+### Backtest / replay parity
+- Confirm Phase 1 `PositionState` additions and the new `on_position_update`
+  kwargs are optional/default so the backtest path and replay seeding compile and
+  behave unchanged. If the backtest exercises `calculate_amount_multiplier`,
+  assert the new `low_balance=False` default keeps backtest multipliers identical
+  (no parity drift), and that the new `_is_good_to_place` open-preflight is
+  inert in backtest unless explicitly fed balance.
+
+---
+
+## Sequencing & rollout
+
+1. **Phase 1** (data layer) — merge first; pure observability, default-on, no
+   behavior change. Validate the new tokens appear in `/tmp/gridbot.log` and in
+   gridbot-health.
+2. **Phase 2** (preflight + retry-queue 110007 guard) — the storm-stopper;
+   default-on with kill-switch. This alone satisfies the primary acceptance
+   criterion (no 110007 retry storm).
+3. **Phase 3** (moderate_liq_risk fix default-on; chase-close default-OFF) — the
+   active defenses. Promote `chase_close_enabled` to on only after the regression
+   suite passes and one live low-balance stress event confirms the dominant
+   position decreases without market-order slippage. **HARD PREREQUISITE before
+   `chase_close_enabled=True` in prod (review P3):** `_low_balance` (the
+   chase/moderate_liq predicate) updates only on `on_position_update`
+   (position-drain cadence) — it lags the provider-fed preflight by up to one
+   position tick. Resolve this **explicitly before enabling chase**, one of:
+   (a) recompute `_low_balance` from the same non-blocking `wallet_provider` so
+   chase and preflight share one freshness, or (b) sign off the lag as an accepted,
+   documented risk. Do not enable chase while this is unresolved.
+4. **Phase 4** (real-time WS `wallet` feed) — makes the Phase-2 preflight balance
+   **age-bounded** (≤`wallet_ws_max_age_seconds`, then fail-open), shrinking F1's
+   300s window (not "always fresh"). Default-on (`wallet_ws_enabled=True`); validate the
+   wallet stream subscribes and `available_balance` updates between REST refreshes
+   — validate via the **DEBUG WS-vs-REST source/age log** (the INFO heartbeat
+   `avail=` lags on the position-drain cadence and is not a reliable signal).
+   Required before promoting `chase_close_enabled` on production.
+
+After Phases complete, update RULES.md (Position Risk Management notes, the
+"Margin Ratio vs positionIM" section, and a new "110007 low-balance preflight +
+chase-close (feature 0066, issue #159)" entry) with the low-balance predicate,
+the leverage-estimate safety bias, and the chase cancel-replace exemption to the
+forward-only rule.

--- a/docs/features/0066_REVIEW_01.md
+++ b/docs/features/0066_REVIEW_01.md
@@ -1,0 +1,199 @@
+# 0066 Code Review — 110007 Low-Balance Storm Fix (issue #159)
+
+## Summary
+
+The implementation matches the plan’s three phases in substance: observability (Phase 1), preflight + retry-queue guard (Phase 2, primary storm-stopper), and moderate_liq_risk fix + chase-close + post-only path (Phase 3). Project invariants are respected (per-direction dispatch, forward-only multipliers, reduce-only guard untouched, stash-and-drain chase, default-on kill-switches with chase default OFF). `RULES.md` documents the feature.
+
+**Verdict:** Ready to merge for Phase 1–2 storm protection; chase-close (3b) remains appropriately default-off until live validation. Address the P1 wallet-cache finding before promoting chase on production, or accept residual tick-rate 110007 until cache refreshes.
+
+---
+
+## Findings
+
+### F1 — Stale `available_balance` from wallet cache can weaken the preflight
+
+**Severity:** P1
+
+The preflight reads `self._available_balance`, updated when `on_position_update` receives wallet fields from `get_wallet_snapshot()`. That snapshot is cached for `wallet_cache_interval` (default **300s** in `GridbotConfig`), while WS position drains can run every orchestrator tick (~100ms) with **fresh position sizes** but **stale free margin**.
+
+During a fast margin drawdown (the incident shape), the bot can keep submitting grown opens against an overstated `available_balance` until the cache expires or the next rotation REST fetch. The secondary **110007 no-enqueue** guard bounds the retry storm, but Bybit may still see one submit per tick → ERROR spam and API load until balance data catches up.
+
+**Relevant code:**
+
+- `apps/gridbot/src/gridbot/position_fetcher.py` — `_wallet_cache` + TTL
+- `apps/gridbot/src/gridbot/orchestrator.py` — WS drain calls `get_wallet_snapshot` (cached)
+- `apps/gridbot/src/gridbot/runner.py` — `_is_good_to_place` preflight
+
+**Suggested fix (pick one):**
+
+1. Refresh wallet (bypass cache) when `_is_low_balance` transitions to True or when preflight would use `avail > 0` and last wallet fetch is older than N seconds; or
+2. Lower `wallet_cache_interval` in live config with documented rationale; or
+3. On 110007, zero or clamp `_available_balance` locally so the next tick’s preflight fail-closes until REST refresh.
+
+Add a regression test: cached high `available_balance` + fresh low position value → after a synthetic margin event, preflight must block without waiting 300s.
+
+---
+
+### F2 — Missing runner-level test for `moderate_liq_low_balance_fix_enabled` kill-switch
+
+**Severity:** P2
+
+The plan calls for `test_moderate_liq_fix_killswitch_preserves_current_behavior`. `packages/gridcore/tests/test_position_low_balance.py` covers the `low_balance` flag on `position.py` rule helpers, but **not** the runner wiring that sets `moderate_low_balance = self._low_balance and self._config.moderate_liq_low_balance_fix_enabled` (`runner.py:884–887`).
+
+Without a runner test, a refactor could pass `low_balance=True` while the kill-switch is ignored.
+
+**Suggested fix:** One test: set `_low_balance=True`, `moderate_liq_low_balance_fix_enabled=False`, drive `on_position_update` into the moderate_liq band, assert opposite close side still gets `0.5` throttle.
+
+---
+
+### F3 — Phase 1e analyzer coverage is local-only (gitignored)
+
+**Severity:** P3 (process)
+
+Phase 1e is implemented under `.claude/skills/gridbot-health/` (`_AVAIL_RE`, `min_available_balance` peak, tests in `test_analyze.py`). That tree is gitignored by design (see `0063_REVIEW.md`), so **CI does not verify** parser changes on merge.
+
+**Mitigation:** Run before live validation:
+
+```bash
+uv run pytest -q .claude/skills/gridbot-health/test_analyze.py -k min_available_balance
+```
+
+---
+
+### F4 — 110007 drop applies to all orders, not only opens
+
+**Severity:** P3
+
+Plan §Phase 2 secondary hardening: “when an **open** order fails with 110007”. `_execute_place_intent` drops any `is_insufficient_balance` failure without checking `intent.reduce_only` (`runner.py:1690–1696`). Incident data shows reduce-only did not 110007; behavior is safe but broader than specified. Optional tighten: only drop when `not intent.reduce_only`.
+
+---
+
+### F5 — Optional plan items correctly omitted or deferred
+
+**Severity:** informational
+
+| Plan item | Status |
+|-----------|--------|
+| Optional `1.5×` close-long boost under low_balance (3a) | Not implemented — plan said “optionally” |
+| `low_balance_usdt` absolute floor | Not implemented — `low_balance_fraction` only (plan allowed one primary) |
+| `chase_close_enabled` default OFF | Correct (`config.py`) |
+| Post-only path (3b.0) | Implemented + tested (`intents.py`, `executor.py`, `rest_client.py`) |
+| Chase pricing “sell below / buy above” | **Intentionally inverted** to maker-safe Sell-above / Buy-below for PostOnly — documented in `RULES.md` and `_build_chase_order` |
+
+---
+
+## Plan compliance checklist
+
+| Phase | Item | Status |
+|-------|------|--------|
+| 1a | `WalletSnapshot` + cache | Done |
+| 1b | `initial_margin` / `maintenance_margin` on `PositionState` | Done |
+| 1c | `on_position_update` optional balance kwargs | Done; wired from `position_fetcher` + orchestrator WS drain |
+| 1d | INFO heartbeat + DEBUG `im_usdt`/`mm_usdt` | Done |
+| 1e | gridbot-health parser | Done (gitignored) |
+| 2 | Preflight in `_is_good_to_place` (open-only, fail-open, leverage, buffer) | Done |
+| 2 | `INSUFFICIENT_BALANCE` + no retry enqueue | Done |
+| 3a | `moderate_liq_risk` skip throttle when low_balance | Done |
+| 3b | Chase stash-and-drain + state machine | Done |
+| 3b.0 | `post_only` / `timeInForce` | Done |
+| — | `RULES.md` update | Done |
+
+---
+
+## Coverage notes
+
+**Strong coverage**
+
+- `apps/gridbot/tests/test_runner_lowbalance_storm.py` — reproducing storm test, preflight matrix, 110007 enqueue guard, chase state machine (enter/drain/exit/hysteresis/orphan buffer), grow-side cancel semantics.
+- `apps/gridbot/tests/test_position_fetcher.py::TestWalletSnapshot` — UTA empty-string coercion, account-level fallback for `available_balance`.
+- `packages/gridcore/tests/test_position_low_balance.py` — moderate_liq long/short branches.
+- `packages/gridcore/tests/test_intents.py`, `apps/gridbot/tests/test_executor.py`, `packages/bybit_adapter/tests/test_rest_client.py` — post-only / TIF.
+
+**Gaps**
+
+- F1 stale-cache scenario (no test).
+- F2 moderate_liq kill-switch at runner layer (no test).
+- `assumed_leverage` fallback when `_leverage[direction]` is unset is exercised implicitly in `test_preflight_live_leverage_makes_open_affordable` (1x blocks, 10x passes) but not a dedicated `assumed_leverage=5` config test.
+
+Tests follow existing patterns (`test_runner_truncate_storm.py` style: direct `_is_good_to_place` / `_execute_place_intent`, mocked executor, `EMPTY_LIMITS`).
+
+---
+
+## Code quality / style
+
+- Matches 0064 patterns (config kill-switches, stateless 110007 drop mirroring 110017 policy).
+- `_leverage` kept separate from `PositionState.leverage` — correct for backtest parity (called out in code comments).
+- Chase `_retire_live_chase_order` correctly drops buffered places on exit-before-drain — good edge-case handling (`test_chase_exit_before_drain_does_not_orphan_buffered_place`).
+- No obvious snake_case / nesting mismatches in Bybit wallet parsing; `_float_or_zero` handles `""` sentinels.
+
+---
+
+## Verification
+
+```bash
+uv run pytest -q \
+  apps/gridbot/tests/test_runner_lowbalance_storm.py \
+  packages/gridcore/tests/test_position_low_balance.py \
+  apps/gridbot/tests/test_position_fetcher.py::TestWalletSnapshot \
+  packages/gridcore/tests/test_intents.py -k post_only \
+  apps/gridbot/tests/test_executor.py -k post_only \
+  packages/bybit_adapter/tests/test_rest_client.py -k time_in_force
+
+uv run pytest -q .claude/skills/gridbot-health/test_analyze.py -k min_available_balance
+```
+
+**Result:** 44 passed (tracked tree) + 2 passed (analyzer, local).
+
+Recommend also running `apps/gridbot/tests/test_orchestrator.py` WS-drain tests that assert `available_balance=` kwargs on `on_position_update` before live deploy.
+
+---
+
+## Plan review (round 2 — updated `0066_PLAN.md`, Phase 4)
+
+**Scope:** Plan only (not implementation). Reviews whether Phase 4 and post-review edits close the gaps from the first plan review.
+
+### Verdict
+
+**Approve for implementation.** Phase 4 is now complete enough to implement without reopening F1 architecture. The combination of **WS wallet cache + freshness window + `wallet_provider` at preflight time + shared parser** correctly addresses the original P1 (REST TTL + position-only drain), not just the 300s cache ceiling.
+
+### Prior findings — resolution
+
+| Prior gap | Status in updated plan |
+|-----------|-------------------------|
+| P1 — WS store ≠ runner refresh | **Closed** — option C: `wallet_provider` → `get_wallet_snapshot()` at `_is_good_to_place` time; test `test_preflight_reads_wallet_provider_fresh`. |
+| Disconnect clear / “mirror position” | **Closed** — dropped; **timestamped freshness window** (`wallet_ws_max_age_seconds`) with grounded rationale (private WS `message_gap_watchdog_enabled=False`). |
+| DRY REST/WS parser | **Closed** — `_snapshot_from_wallet_account_row` + `test_snapshot_from_wallet_account_row`. |
+| WS fixture / shape | **Closed** — cites `wallet_writer.py:218-232`, recorded-frame test. |
+| All-zero overwrite (F5) | **Closed** — no write on malformed or all-zero parse. |
+| `GridbotConfig` kill-switch | **Closed** — `wallet_ws_enabled` + `wallet_ws_max_age_seconds` on `GridbotConfig`. |
+| Module doc / ops DEBUG | **Closed** — explicit steps. |
+
+### Remaining nits (non-blocking)
+
+1. **P3 — Chase + `_low_balance` cadence** — Plan correctly keeps `_low_balance` on `on_position_update` while preflight uses `wallet_provider`. When promoting `chase_close_enabled`, consider also feeding the low-balance predicate from `wallet_provider()` (or document that chase may lag one position tick vs preflight; acceptable only while chase stays default-OFF until Phase 4 is live-validated).
+
+2. **P3 — Intro still says “3-layer”** (line 37) while the body is four phases — cosmetic doc fix.
+
+3. **P3 — §3b chase price** still says “sell below / buy above” (lines 441–443) but Post-review / RULES use maker-safe Sell-above/Buy-below — add one sentence in §3b so implementers do not revert PostOnly pricing.
+
+4. **P3 — Default `wallet_ws_max_age_seconds`** — Plan says “small multiple of position cadence” but no numeric default (e.g. 30–45s vs `position_check_interval` ~63s). Pick a default in the plan or config Field description to avoid bikeshedding at implement time.
+
+5. **P3 — Preflight `Decimal` conversion** — `wallet_provider().available_balance` is `float`; implementation should use the same `Decimal(str(...))` path as `on_position_update` (obvious, not spelled in plan).
+
+6. **P3 — Ops rollout §4** — Heartbeat `avail=` still updates on position-drain cadence; use the planned **DEBUG WS-vs-REST** log for “freshness faster than `wallet_cache_interval`”, not only the INFO heartbeat.
+
+7. **P3 — Review ID collision** — Phase 4 labels “review F3” = DRY parser; Post-review “F3” = analyzer CI. Rename Phase 4 inline refs to “DRY parser” / “all-zero guard” to avoid confusion with `0066_REVIEW.md` finding numbers.
+
+8. **P3 — `test_preflight_fail_open_when_no_balance_data`** — With live `wallet_provider`, fail-open requires provider returning `available_balance <= 0` or `wallet_provider=None`; add one line in Phase 4 tests or Phase 2 note so implementers do not break fail-open when wiring provider in production.
+
+### Phase 4 test matrix
+
+The updated regression list is **sufficient**: parser parity, WS populate, thread safety, fresh vs stale WS, REST fallback, provider-at-preflight, orchestrator wiring, kill-switch off.
+
+### Sequencing
+
+Unchanged and correct: Phases 1→2→3→4; Phase 4 required before production `chase_close_enabled`. Phase 4 may ship immediately after Phase 2 for F1 without waiting for Phase 3 if desired (plan allows; sequencing does not forbid).
+
+### Implementation review note
+
+The **code review above** (Phases 1–3) predates this plan revision. After Phase 4 is implemented, re-run implementation review against the full plan including `wallet_provider` and WS wallet paths.

--- a/docs/features/0066_REVIEW_02.md
+++ b/docs/features/0066_REVIEW_02.md
@@ -1,0 +1,176 @@
+# 0066 Code Review — 110007 Low-Balance Storm Fix (issue #159)
+
+**Review round:** 3 (post-fix re-verification)  
+**Date:** 2026-06-05
+
+## Summary
+
+Feature 0066 is fully implemented across all four plan phases. All blocking review findings (F1–F3) are **resolved and re-verified**. The primary storm-stopper — Phase 2 open-order preflight + 110007 no-enqueue guard — is correct and comprehensively tested. Phase 4 WS wallet feed + non-blocking `peek_wallet_snapshot` bounds preflight staleness to `wallet_ws_max_age_seconds`. Phase 3 chase-close and `moderate_liq_risk` fix are complete; chase remains **default-off** pending live validation.
+
+**Verdict: Ready to merge.**
+
+| Deploy layer | Status |
+|--------------|--------|
+| Phase 1 observability | ✅ Merge |
+| Phase 2 preflight + 110007 guard | ✅ Merge (primary acceptance criterion) |
+| Phase 4 WS wallet feed | ✅ Merge |
+| Phase 3a moderate_liq fix | ✅ Default-on |
+| Phase 3b chase-close | ⏸ Default-off until one live stress event |
+
+**Tests:** 390 passed (CI); 4 passed (0066 analyzer subset); 43 passed (full analyzer suite).
+
+---
+
+## Findings status
+
+| ID | Finding | Severity | Status |
+|----|---------|----------|--------|
+| F1 | `_low_balance` lagged `wallet_provider` | P1 | ✅ Resolved — `_predicate_available_balance()` + 3 tests |
+| F2 | Phase 1e analytics incomplete | P2 | ✅ Resolved — three peaks in Table 8 + 4 analyzer tests |
+| F3 | DEBUG WS-vs-REST source log missing | P2 | ✅ Resolved — `get_wallet_snapshot` return paths + 2 tests |
+| F4 | Analyzer tree gitignored (no CI) | P3 | Accepted — manual pre-live step (see Verification) |
+| F5 | `LowBalanceSkip` at DEBUG not INFO | P3 | Accepted — anti-spam; INFO heartbeat carries `avail=` |
+| F6 | Optional plan items omitted | info | Accepted — 1.5× boost, `low_balance_usdt`, `_chase_entered_ts`, `request_wallet_refresh` |
+| — | Invariant #3 "martingale" comments | P3 | ✅ Resolved — `position.py` uses "risk-mgmt grow short" |
+
+**No open P1/P2 findings.**
+
+---
+
+## Plan compliance
+
+| Phase | Requirement | Status |
+|-------|-------------|--------|
+| **1a** | `WalletSnapshot` + shared cache | ✅ |
+| **1b** | `initial_margin` / `maintenance_margin` on `PositionState` | ✅ |
+| **1c** | Balance kwargs on `on_position_update` | ✅ |
+| **1d** | INFO heartbeat + DEBUG `im_usdt`/`mm_usdt` | ✅ |
+| **1e** | gridbot-health parsers | ✅ (Table 8 peaks; see note below) |
+| **2** | Preflight + 110007 no-enqueue (open only) | ✅ |
+| **3a** | `moderate_liq_risk` balance-aware fix | ✅ |
+| **3b** | Chase stash-and-drain state machine | ✅ (default OFF) |
+| **3b.0** | `post_only` / `timeInForce` | ✅ |
+| **4** | WS wallet + peek + provider preflight | ✅ |
+| **4** | DEBUG WS-vs-REST ops log | ✅ |
+| — | `RULES.md` | ✅ |
+
+**1e note:** Plan text mentions min/avg in the per-window position-metrics table (Table 2). Implementation surfaces `avail` / `total_avail` / `total_mm` as **all-time peaks in Table 8** (`min_available_balance`, `min_total_available_balance`, `max_total_maintenance_margin`) — matching the existing `min_total_margin` peak pattern. Sufficient for incident forensics; Table 2 per-window min/avg rows not added (non-blocking).
+
+---
+
+## Key implementation (verified)
+
+### Predicate ↔ preflight freshness (F1)
+
+```1300:1353:apps/gridbot/src/gridbot/runner.py
+    def _predicate_available_balance(self) -> tuple[Decimal, bool]:
+        ...
+        if self._wallet_provider is not None:
+            ...
+                if age < self._wallet_ws_max_age_seconds:
+                    return Decimal(str(snapshot.available_balance)), True
+        return self._available_balance, False
+
+    def _is_low_balance(self, total_position_value: Decimal) -> bool:
+        avail, authoritative = self._predicate_available_balance()
+        ...
+        if avail <= 0:
+            return authoritative  # fresh 0 = real; latch 0 = no data
+```
+
+Chase (3b) and moderate_liq (3a) share provider freshness with preflight when wired. Stale/None/raising provider falls back to the position-cadence latch (predicate only; preflight fails open).
+
+### Ops DEBUG log (F3)
+
+`get_wallet_snapshot` logs `served from WS (age=…)` or `served from REST cache|fetch` at every return path — use this (not INFO `avail=`) to validate WS freshness in rollout.
+
+### 110007 guard scope
+
+Open-order 110007 failures are dropped from the retry queue; reduce-only keeps the normal retry path (`not intent.reduce_only` gate + `test_reduce_only_110007_still_enqueues`).
+
+---
+
+## Invariants
+
+| # | Invariant | Status |
+|---|-----------|--------|
+| 1 | Per-direction sequential dispatch | ✅ |
+| 2 | Multiplier forward-only; chase cancel-replace scoped | ✅ |
+| 3 | Don't call mult=2.0 "martingale" | ✅ |
+| 4 | Reduce-only guard untouched | ✅ |
+| 5 | Reduce-only bypasses preflight | ✅ |
+| 6 | Additive kill-switches; chase default OFF | ✅ |
+| 7 | No new writers in gridbot | ✅ |
+| 8 | INFO `Position update` heartbeat preserved + extended | ✅ |
+
+---
+
+## Test coverage
+
+### CI — `test_runner_lowbalance_storm.py` (48 tests) + supporting suites
+
+| Area | Tests |
+|------|-------|
+| Storm repro + preflight matrix | `test_110007_storm_blocked_by_preflight`, preflight boundary/killswitch/provider |
+| F1 predicate alignment | `test_low_balance_predicate_uses_fresh_provider`, `…_fresh_zero_is_low_balance`, `…_stale_provider_falls_back_to_latch` |
+| Chase state machine | enter/drain/exit/hysteresis/re-peg/orphan-buffer (15+ tests) |
+| moderate_liq kill-switch | runner + gridcore layers |
+| Phase 4 WS/peek | `test_position_fetcher.py`, `test_orchestrator.py` |
+| F3 DEBUG log | `test_logs_ws_source_with_age_when_fresh`, `test_logs_rest_source_when_ws_stale_or_absent` |
+| 3b.0 post_only | `test_intents.py`, `test_executor.py`, `test_rest_client.py` |
+
+### Analyzer (gitignored)
+
+```bash
+uv run pytest -q .claude/skills/gridbot-health/test_analyze.py \
+  -k "available_balance or total_avail or total_mm"
+# 4 passed
+
+uv run pytest -q .claude/skills/gridbot-health/test_analyze.py
+# 43 passed
+```
+
+---
+
+## Residual edge cases (accepted, documented in RULES.md)
+
+1. **Fail-open when peek stale/missing** — bounded by 110007 no-enqueue guard; possible residual per-tick ERROR spam during the window.
+2. **Chase grow-cancel scope** — tracked grow orders only; untracked exchange orders may 110007 until reconciler catches them.
+3. **Chase buffer timing** — drains on next ticker/execution/order_update tick.
+4. **Predicate vs preflight on stale peek** — predicate falls back to latch; preflight fails open. Tested.
+
+---
+
+## Verification
+
+```bash
+uv run pytest -q \
+  apps/gridbot/tests/test_runner_lowbalance_storm.py \
+  apps/gridbot/tests/test_executor.py \
+  apps/gridbot/tests/test_position_fetcher.py \
+  apps/gridbot/tests/test_orchestrator.py \
+  packages/gridcore/tests/test_intents.py \
+  packages/gridcore/tests/test_position_low_balance.py \
+  packages/bybit_adapter/tests/test_rest_client.py
+```
+
+**Result:** 390 passed in 0.94s.
+
+Pre-live (manual):
+
+```bash
+uv run pytest -q .claude/skills/gridbot-health/test_analyze.py \
+  -k "available_balance or total_avail or total_mm"
+```
+
+**Result:** 4 passed.
+
+---
+
+## Rollout checklist
+
+- [ ] Merge; deploy Phases 1–2 + 4 with defaults
+- [ ] Confirm INFO heartbeat shows `avail=` / `total_avail=` / `total_mm=`
+- [ ] Confirm DEBUG log shows `served from WS (age=…)` during active trading
+- [ ] Run analyzer subset manually (F4)
+- [ ] After one live low-balance event: evaluate promoting `chase_close_enabled`

--- a/docs/features/0066_REVIEW_03.md
+++ b/docs/features/0066_REVIEW_03.md
@@ -1,0 +1,68 @@
+# 0066 Code Review — Follow-up
+
+**Review round:** 4  
+**Date:** 2026-06-05
+
+## Findings
+
+### F1 — Wallet parser ignores `availableBalance` fallback — ✅ RESOLVED (2026-06-05)
+
+**Severity:** P2 — **fixed:** `_snapshot_from_wallet_account_row` now prefers
+`availableToWithdraw`, falls back to the legacy coin-level `availableBalance` when
+v5 is absent/empty (mirrors `recorder.py:404-408`), then to account
+`totalAvailableBalance`. Tests: `test_legacy_available_balance_used_when_v5_field_absent`,
+`…_when_v5_field_empty`, `test_v5_availableToWithdraw_preferred_over_legacy_field`
+(parser) + `test_writes_legacy_available_balance_field` (WS path). RULES.md fallback
+chain updated.
+
+`PositionFetcher._snapshot_from_wallet_account_row()` only reads the USDT coin's
+`availableToWithdraw` key and then falls back to account-level
+`totalAvailableBalance` when that parsed value is `0.0`:
+
+- `apps/gridbot/src/gridbot/position_fetcher.py:395`
+- `apps/gridbot/src/gridbot/position_fetcher.py:401`
+- `apps/gridbot/src/gridbot/position_fetcher.py:404`
+
+The plan explicitly calls out `availableToWithdraw` / `availableBalance`, and the
+repo already has the expected fallback behavior in the recorder:
+
+- `apps/recorder/src/recorder/recorder.py:402`
+- `apps/recorder/src/recorder/recorder.py:407`
+
+That matters because the preflight's authoritativeness depends on the parsed
+`WalletSnapshot.available_balance`. If a live REST/WS wallet row carries coin-level
+free balance as `availableBalance` with no usable `availableToWithdraw` and no
+account-level `totalAvailableBalance`, gridbot will parse free margin as `0.0`.
+With the Phase 4 provider path, a fresh parsed zero blocks all open orders. With
+the no-provider path, the same zero is treated as "no data" and fail-opens. Both
+are wrong for a row that actually contained free margin under `availableBalance`.
+
+Suggested fix: mirror the recorder logic in `_snapshot_from_wallet_account_row()`:
+prefer `availableToWithdraw`; when it is missing or empty, fall back to
+`availableBalance`; only then fall back to `totalAvailableBalance` for UTA
+cross-margin. Add tests for both REST and WS/parser paths where the USDT coin has
+`availableBalance` only.
+
+## Coverage Notes
+
+The current tests are strong for the implemented `availableToWithdraw` +
+`totalAvailableBalance` path, fresh/stale provider behavior, 110007 no-enqueue,
+post-only threading, orchestrator wallet wiring, and chase state transitions.
+The `availableBalance` legacy fallback is **now covered** (F1 fix) on both the REST
+parser and WS paths — see the four new tests listed under F1.
+
+## Verification
+
+Ran the focused 0066 suites and orchestrator coverage:
+
+```bash
+uv run pytest -q apps/gridbot/tests/test_position_fetcher.py apps/gridbot/tests/test_runner_lowbalance_storm.py apps/gridbot/tests/test_executor.py packages/gridcore/tests/test_intents.py packages/gridcore/tests/test_position_low_balance.py packages/bybit_adapter/tests/test_rest_client.py
+# 246 passed (was 242; +4 availableBalance fallback tests from the F1 fix)
+
+uv run pytest -q apps/gridbot/tests/test_orchestrator.py
+# 148 passed
+
+uv run pytest -q .claude/skills/gridbot-health/test_analyze.py -k "available_balance or total_avail or total_mm"
+# 4 passed, 39 deselected
+```
+

--- a/packages/bybit_adapter/src/bybit_adapter/error_codes.py
+++ b/packages/bybit_adapter/src/bybit_adapter/error_codes.py
@@ -14,3 +14,9 @@ https://bybit-exchange.github.io/docs/v5/error
 # order is rejected. Surfaces during local-mirror divergence (feature 0064,
 # issue #149).
 ORDER_QTY_TRUNCATED_TO_ZERO = 110017
+
+# ErrCode 110007 "available balance not enough for new order": the account's
+# free margin cannot cover an OPEN (non-reduce-only) order. Reduce-only orders
+# are exempt (they free margin). Drives the low-balance preflight + retry-queue
+# no-enqueue guard (feature 0066, issue #159).
+INSUFFICIENT_BALANCE = 110007

--- a/packages/bybit_adapter/src/bybit_adapter/rest_client.py
+++ b/packages/bybit_adapter/src/bybit_adapter/rest_client.py
@@ -469,6 +469,7 @@ class BybitRestClient:
         reduce_only: bool = False,
         position_idx: int = 0,
         order_link_id: Optional[str] = None,
+        time_in_force: str = "GTC",
     ) -> dict:
         """Place a new order.
 
@@ -481,6 +482,8 @@ class BybitRestClient:
             reduce_only: Whether this is a reduce-only order
             position_idx: Position index for hedge mode (0=one-way, 1=buy-side, 2=sell-side)
             order_link_id: Custom order ID for tracking (client_order_id)
+            time_in_force: Bybit timeInForce ("GTC" default == today's implicit
+                behavior; "PostOnly" for maker-only chase orders, feature 0066).
 
         Returns:
             Order response dict with keys: orderId, orderLinkId, etc.
@@ -505,6 +508,7 @@ class BybitRestClient:
             "qty": qty,
             "reduceOnly": reduce_only,
             "positionIdx": position_idx,
+            "timeInForce": time_in_force,
         }
         if price is not None:
             params["price"] = price

--- a/packages/bybit_adapter/tests/test_rest_client.py
+++ b/packages/bybit_adapter/tests/test_rest_client.py
@@ -391,6 +391,23 @@ class TestPlaceOrder:
         call_kwargs = mock_session.place_order.call_args[1]
         assert call_kwargs["reduceOnly"] is True
 
+    def test_time_in_force_defaults_to_gtc(self, client, mock_session):
+        """Feature 0066: omitted time_in_force → GTC (today's implicit behavior)."""
+        mock_session.place_order.return_value = _ok_response({"orderId": "o1"})
+        client.place_order(
+            symbol="BTCUSDT", side="Buy", order_type="Limit", qty="0.1", price="100000",
+        )
+        assert mock_session.place_order.call_args[1]["timeInForce"] == "GTC"
+
+    def test_time_in_force_postonly_threads_through(self, client, mock_session):
+        """Feature 0066: time_in_force='PostOnly' reaches params['timeInForce']."""
+        mock_session.place_order.return_value = _ok_response({"orderId": "o1"})
+        client.place_order(
+            symbol="BTCUSDT", side="Sell", order_type="Limit", qty="0.1",
+            price="100000", time_in_force="PostOnly",
+        )
+        assert mock_session.place_order.call_args[1]["timeInForce"] == "PostOnly"
+
     def test_api_error_raises(self, client, mock_session):
         mock_session.place_order.return_value = _error_response(110001, "Insufficient balance")
 

--- a/packages/gridcore/src/gridcore/intents.py
+++ b/packages/gridcore/src/gridcore/intents.py
@@ -62,6 +62,11 @@ class PlaceLimitIntent:
     grid_level: int       # Grid level index for comparison reports
     direction: str        # 'long' or 'short'
     order_link_id: str | None = field(default=None, compare=False)
+    # Feature 0066 (issue #159): post-only (maker) flag for chase-close orders.
+    # Excluded from identity (compare=False, not in _IDENTITY_PARAMS) so the
+    # deterministic client_order_id and dedup are unaffected; defaults False so
+    # every existing emit-site is byte-for-byte unchanged.
+    post_only: bool = field(default=False, compare=False)
 
     # Parameters that determine order identity for deduplication
     # Excludes: qty (execution layer determines), reduce_only (order flag), grid_level (tracking only)
@@ -78,6 +83,7 @@ class PlaceLimitIntent:
         grid_level: int,
         direction: str,
         reduce_only: bool = False,
+        post_only: bool = False,
     ) -> "PlaceLimitIntent":
         """
         Factory method to create a PlaceLimitIntent with deterministic client_order_id.
@@ -103,6 +109,8 @@ class PlaceLimitIntent:
             grid_level: Grid level index (for tracking/reporting, NOT part of identity hash)
             direction: 'long' or 'short'
             reduce_only: Whether this is a reduce-only order (NOT part of identity hash)
+            post_only: Whether this is a post-only (maker-only) order for
+                chase-close (NOT part of identity hash; feature 0066)
 
         Returns:
             PlaceLimitIntent with deterministic client_order_id
@@ -123,6 +131,7 @@ class PlaceLimitIntent:
             client_order_id=deterministic_id,
             grid_level=grid_level,
             direction=direction,
+            post_only=post_only,
         )
 
 

--- a/packages/gridcore/src/gridcore/position.py
+++ b/packages/gridcore/src/gridcore/position.py
@@ -45,6 +45,12 @@ class PositionState:
     liquidation_price: Decimal = Decimal('0')
     leverage: int = 1
     position_value: Decimal = Decimal('0')
+    # Bybit positionIM / positionMM: per-position Initial / Maintenance Margin
+    # in USDT (dollar amounts) — feature 0066 / issue #159. NOT the same as
+    # `margin` above (a positionValue/walletBalance ratio); kept separate so the
+    # ratio-based risk thresholds are never confused with dollar margin.
+    initial_margin: Decimal = Decimal('0')
+    maintenance_margin: Decimal = Decimal('0')
     # Bybit cumRealisedPnl: lifetime cumulative realised PnL; does NOT reset
     # per cycle (~80x the Web UI "Realized" value).
     cum_realized_pnl: Decimal = Decimal('0')
@@ -170,7 +176,8 @@ class Position:
         self,
         position: PositionState,
         opposite_position: PositionState,
-        last_close: float
+        last_close: float,
+        low_balance: bool = False
     ) -> dict[str, float]:
         """
         Calculate order size multipliers based on position state.
@@ -196,6 +203,11 @@ class Position:
             position: Current position state
             opposite_position: Opposite direction position state
             last_close: Current market price
+            low_balance: When True (account free margin exhausted), the
+                moderate_liq_risk arm skips its 0.5 close-throttle so
+                margin-freeing closes are not slowed (feature 0066 / issue #159).
+                Defaults False — backtest and pre-0066 callers keep the original
+                hedge-throttle behavior (and backtest parity).
 
         Returns:
             Dictionary with 'Buy' and 'Sell' multipliers for this position
@@ -263,20 +275,23 @@ class Position:
                 liq_ratio,
                 is_position_equal,
                 total_margin,
-                unrealized_pnl_pct
+                unrealized_pnl_pct,
+                low_balance
             )
         else:  # short
             self._apply_short_position_rules(
                 liq_ratio,
                 is_position_equal,
                 total_margin,
-                unrealized_pnl_pct
+                unrealized_pnl_pct,
+                low_balance
             )
 
         # Log position state (matches reference position.py:24-31)
         logger.debug(
             '%s margin=%.2f liq_ratio=%.2f unrealized_pnl=%.2f%% '
             'upnl_usdt=%.4f realized_usdt=%.4f cum_realized_usdt=%.4f pos_value_usdt=%.2f '
+            'im_usdt=%.4f mm_usdt=%.4f low_balance=%s '
             'multiplier=%s position_ratio=%.2f total_margin=%.2f',
             self.direction,
             float(position.margin),
@@ -286,6 +301,9 @@ class Position:
             float(position.cur_realized_pnl),
             float(position.cum_realized_pnl),
             float(position.position_value),
+            float(position.initial_margin),
+            float(position.maintenance_margin),
+            low_balance,
             self.amount_multiplier,
             self.position_ratio,
             total_margin
@@ -298,7 +316,8 @@ class Position:
         liq_ratio: float,
         is_position_equal: bool,
         total_margin: float,
-        unrealized_pnl_pct: float
+        unrealized_pnl_pct: float,
+        low_balance: bool = False
     ) -> None:
         """
         Apply risk management rules for long positions.
@@ -311,6 +330,9 @@ class Position:
         3. Specific position sizing conditions - strategic adjustments
 
         Capital preservation > strategy optimization.
+
+        ``low_balance`` (feature 0066): when True, the moderate_liq_risk arm
+        skips its 0.5 close-throttle on the opposite side (defaults False).
         """
         # High liquidation risk → decrease long position (HIGHEST PRIORITY)
         if liq_ratio > 1.05 * self.risk_config.min_liq_ratio:
@@ -321,8 +343,17 @@ class Position:
         elif liq_ratio > self.risk_config.min_liq_ratio:
             logger.info('Position adjustment: %s moderate_liq_risk (ratio=%.2f)', self.direction, liq_ratio)
             if self._opposite:
-                # Reduce short's buy orders → allows short to grow as hedge
-                self._opposite.set_amount_multiplier(self.SIDE_BUY, 0.5)
+                if low_balance:
+                    # Feature 0066 (issue #159): under exhausted balance, do NOT
+                    # throttle the opposite short's close (Buy) orders. The 0.5
+                    # hedge-throttle slows the very closes that free margin,
+                    # which deadlocked the bot during the 110007 storm.
+                    logger.info(
+                        'Position adjustment: %s moderate_liq_risk low_balance '
+                        '— skipping close-throttle to free margin', self.direction)
+                else:
+                    # Reduce short's buy orders → allows short to grow as hedge
+                    self._opposite.set_amount_multiplier(self.SIDE_BUY, 0.5)
 
         # Positions equal but low total margin → adjust
         elif is_position_equal and total_margin < self.risk_config.min_total_margin:
@@ -344,7 +375,8 @@ class Position:
         liq_ratio: float,
         is_position_equal: bool,
         total_margin: float,
-        unrealized_pnl_pct: float
+        unrealized_pnl_pct: float,
+        low_balance: bool = False
     ) -> None:
         """
         Apply risk management rules for short positions.
@@ -355,12 +387,15 @@ class Position:
         1. EMERGENCY high liquidation risk → decrease short
         2. Moderate liquidation risk → hedge via opposite (long)
         3. Equal positions with low total margin → adjust
-        4. Small short losing (shared ratio > 2 AND upnl < 0) → martingale short
-        5. Very small short (shared ratio > 5) → martingale short
+        4. Small short losing (shared ratio > 2 AND upnl < 0) → risk-mgmt grow short
+        5. Very small short (shared ratio > 5) → risk-mgmt grow short
 
         Capital preservation > strategy optimization. The if/elif chain means
         only one arm fires per call. position_ratio is the shared
         long.margin / short.margin metric; see calculate_amount_multiplier.
+
+        ``low_balance`` (feature 0066): when True, the moderate_liq_risk arm
+        skips its 0.5 close-throttle on the opposite side (defaults False).
         """
         # 1. High liquidation risk (short) → decrease short position (EMERGENCY)
         # For shorts: liq_ratio = liq_price / last_close, so ratio > 1 always
@@ -375,21 +410,29 @@ class Position:
 
         # 2. Moderate liquidation risk → grow opposite (long) as hedge
         # Reference: bbu_reference/bbu2-master/position.py:81-86. Must be
-        # checked BEFORE the martingale arms (Feature 0027): if the moderate
+        # checked BEFORE the risk-mgmt grow arms (Feature 0027): if the moderate
         # band overlaps with `position_ratio > 2.0 AND upnl < 0`, the safer
-        # action (hedge) wins over the martingale (grow the at-risk side).
+        # action (hedge) wins over the risk-mgmt grow rule (grow the at-risk side).
         elif 0.0 < liq_ratio < self.risk_config.max_liq_ratio:
             logger.info('Position adjustment: %s moderate_liq_risk (ratio=%.2f)', self.direction, liq_ratio)
             if self._opposite:
-                # Reduce long's sell orders → allows long to grow as hedge
-                self._opposite.set_amount_multiplier(self.SIDE_SELL, 0.5)
+                if low_balance:
+                    # Feature 0066 (issue #159): under exhausted balance, do NOT
+                    # throttle the opposite long's close (Sell) orders — the 0.5
+                    # hedge-throttle slows margin-freeing closes (the deadlock).
+                    logger.info(
+                        'Position adjustment: %s moderate_liq_risk low_balance '
+                        '— skipping close-throttle to free margin', self.direction)
+                else:
+                    # Reduce long's sell orders → allows long to grow as hedge
+                    self._opposite.set_amount_multiplier(self.SIDE_SELL, 0.5)
 
         # 3. Positions equal but low total margin → adjust
         elif is_position_equal and total_margin < self.risk_config.min_total_margin:
             logger.info('Position adjustment: %s low_margin (total=%.2f)', self.direction, total_margin)
             self._adjust_position_for_low_margin()
 
-        # 4. Short is the smaller side AND losing → martingale grow short
+        # 4. Short is the smaller side AND losing → risk-mgmt grow short
         # Shared ratio > 2.0 means long.margin > 2 × short.margin, i.e., short
         # is the smaller side. Combined with upnl < 0 the rule averages into
         # the smaller losing side. Matches bbu_reference/bbu2-master/position.py:89-90.
@@ -397,7 +440,7 @@ class Position:
             logger.info('Position adjustment: %s ratio=%.2f increasing sells', self.direction, self.position_ratio)
             self.set_amount_multiplier(self.SIDE_SELL, 2.0)
 
-        # 5. Short extremely small (shared ratio > 5) → martingale grow short
+        # 5. Short extremely small (shared ratio > 5) → risk-mgmt grow short
         # No upnl gate. Matches bbu_reference/bbu2-master/position.py:91-92.
         elif self.position_ratio > 5.0:
             logger.info('Position adjustment: %s ratio=%.2f increasing sells', self.direction, self.position_ratio)

--- a/packages/gridcore/tests/test_intents.py
+++ b/packages/gridcore/tests/test_intents.py
@@ -69,3 +69,21 @@ def test_place_intent_order_link_id_not_in_identity_params():
 
     assert "order_link_id" not in PlaceLimitIntent._IDENTITY_PARAMS
     assert assigned.client_order_id == intent.client_order_id
+
+
+def test_post_only_default_false_preserves_identity():
+    """Feature 0066: post_only is excluded from identity (id + ==/hash)."""
+    plain = PlaceLimitIntent.create(
+        symbol="BTCUSDT", side="Buy", price=Decimal("100"), qty=Decimal("0.1"),
+        grid_level=3, direction="long",
+    )
+    maker = PlaceLimitIntent.create(
+        symbol="BTCUSDT", side="Buy", price=Decimal("100"), qty=Decimal("0.1"),
+        grid_level=3, direction="long", post_only=True,
+    )
+    assert plain.post_only is False
+    assert maker.post_only is True
+    assert maker.client_order_id == plain.client_order_id  # id unaffected
+    assert maker == plain                                   # compare=False
+    assert hash(maker) == hash(plain)
+    assert "post_only" not in PlaceLimitIntent._IDENTITY_PARAMS

--- a/packages/gridcore/tests/test_position_low_balance.py
+++ b/packages/gridcore/tests/test_position_low_balance.py
@@ -1,0 +1,57 @@
+"""Feature 0066 (issue #159) — moderate_liq_risk low-balance bug-fix.
+
+Under exhausted balance the moderate_liq_risk arm must NOT throttle the
+opposite side's close orders (the 0.5 hedge-throttle), because those closes
+free the margin that re-enables opens — the throttle caused the storm deadlock.
+When low_balance is False (the default, and the killswitch-off path) behavior
+is byte-for-byte the pre-0066 hedge-throttle.
+"""
+
+from gridcore.position import Position, RiskConfig
+
+
+def _pair():
+    rc = RiskConfig(
+        min_liq_ratio=0.8, max_liq_ratio=1.2, max_margin=8.0, min_total_margin=0.15,
+    )
+    long_p, short_p = Position.create_linked_pair(rc)
+    long_p.reset_amount_multiplier()
+    short_p.reset_amount_multiplier()
+    return long_p, short_p
+
+
+# Long-branch moderate_liq_risk fires for min_liq_ratio < liq_ratio <= 1.05*min.
+# (0.8, 0.84] → use 0.82. It throttles the opposite SHORT's Buy (close-short).
+
+def test_long_moderate_liq_throttles_close_short_normally():
+    long_p, short_p = _pair()
+    long_p._apply_long_position_rules(0.82, False, 1.0, -1.0, low_balance=False)
+    assert short_p.get_amount_multiplier()["Buy"] == 0.5
+
+
+def test_long_moderate_liq_skips_close_throttle_under_low_balance():
+    long_p, short_p = _pair()
+    long_p._apply_long_position_rules(0.82, False, 1.0, -1.0, low_balance=True)
+    assert short_p.get_amount_multiplier()["Buy"] == 1.0  # NOT throttled
+
+
+# Short-branch moderate_liq_risk fires for 0.95*max <= liq_ratio < max.
+# [1.14, 1.2) → use 1.15. It throttles the opposite LONG's Sell (close-long).
+
+def test_short_moderate_liq_throttles_close_long_normally():
+    long_p, short_p = _pair()
+    short_p._apply_short_position_rules(1.15, False, 1.0, -1.0, low_balance=False)
+    assert long_p.get_amount_multiplier()["Sell"] == 0.5
+
+
+def test_short_moderate_liq_skips_close_throttle_under_low_balance():
+    long_p, short_p = _pair()
+    short_p._apply_short_position_rules(1.15, False, 1.0, -1.0, low_balance=True)
+    assert long_p.get_amount_multiplier()["Sell"] == 1.0  # NOT throttled
+
+
+def test_low_balance_default_is_false_preserves_behavior():
+    """Omitting low_balance (old callers / backtest) keeps the throttle."""
+    long_p, short_p = _pair()
+    long_p._apply_long_position_rules(0.82, False, 1.0, -1.0)
+    assert short_p.get_amount_multiplier()["Buy"] == 0.5


### PR DESCRIPTION
## Summary

Multi-layer, additive fix for the **110007 "available balance not enough"** retry storm under a low-balance + long-heavy state (issue #159). On 2026-06-03 the live bot emitted 3547 ERRORs (~85/min) when the risk-mgmt grow rule (mult=2.0) grew the losing short beyond available balance → 110007 on every attempt → retry-queue amplification.

## What's in it (by phase, all default-on / kill-switchable)

- **Phase 1 — observability:** `WalletSnapshot` with account-level free margin + per-position `positionIM`/`positionMM`; `Position update` heartbeat extended with `avail=` / `total_avail=` / `total_mm=`; gridbot-health all-time peaks.
- **Phase 2 — storm-stopper:** open-order preflight in `_is_good_to_place` (leverage-adjusted `est_cost` + buffer; reduce-only bypasses; fail-open on no data) + retry-queue 110007 no-enqueue guard (open-only). *Primary acceptance criterion.*
- **Phase 3a:** `moderate_liq_risk` balance-aware fix (skip the 0.5 close-throttle under low balance). **3b:** chase-close reduce-only post-only state machine (**default OFF**, stash-and-drain) + `post_only`/`timeInForce` order-path support.
- **Phase 4 — real-time wallet:** WS `wallet` topic feed (`on_wallet_message`, `_wallet_ws_data`, shared parser, `peek_wallet_snapshot` newest-by-timestamp). Provider-fed preflight is **age-bounded then fails open**; the low-balance predicate shares the same provider freshness (review F1); DEBUG WS-vs-REST source/age log (review F3).
- **Wallet parser:** `availableToWithdraw` → legacy `availableBalance` → `totalAvailableBalance` (mirrors `recorder.py`; review round-4 F1).

## Safety / invariants

- Additive & default-preserving: every new field defaults to current behavior; `chase_close_enabled=False` by default; `GridbotConfig.wallet_ws_enabled` full kill-switch.
- Reduce-only orders always bypass the preflight (they free margin, can't 110007).
- Backtest/replay parity preserved (no provider → legacy `_available_balance` path).
- `Position update` INFO heartbeat preserved + extended; no new writers in gridbot.

## Test plan

```bash
uv run pytest apps/gridbot/tests/ packages/gridcore/tests/ \
  packages/bybit_adapter/tests/ apps/backtest/tests/ apps/replay/tests/
# 1793 passed, 1 skipped

# gitignored analyzer (manual, pre-live):
uv run pytest .claude/skills/gridbot-health/test_analyze.py \
  -k "available_balance or total_avail or total_mm"   # 4 passed
```

## Rollout

Deploy Phases 1–2 + 4 with defaults (storm protection). Keep `chase_close_enabled=False` until one live low-balance stress event confirms the dominant position trims without taker slippage (plan §3; the F1 freshness prerequisite is resolved).

## Notes

- Raw incident dumps under `docs/incidents/*.jsonl` are **intentionally excluded** (large + live mainnet balances/orders).
- Review history in `docs/features/0066_REVIEW_01..03.md`; plan in `0066_PLAN.md`.

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)
