### PR TITLE
feat(0067): suppress LowBalanceSkip log spam with edges and 60s summary

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -488,6 +488,54 @@ short with mult=2.0; the grown open exceeded free margin → 110007 every attemp
   Promote `chase_close_enabled` to on only after one live low-balance stress
   event confirms the dominant side decreases without market-order slippage.
 
+#### LowBalanceSkip log-spam suppression (feature 0067, issue #164)
+
+- The per-intent `LowBalanceSkip` DEBUG (one line per blocked open per tick →
+  ~2.1M/day under a sustained storm) is **suppressed by default** and replaced
+  by ENTER/EXIT INFO edges per `(direction, side)` + a 60s INFO summary. Both
+  default-on and kill-switchable; with **both flags False** the preflight emits
+  the per-intent DEBUG line exactly as before (byte-for-byte). The accept/reject
+  DECISION is never changed — only what is logged.
+- **Edges resolve at the SAMPLE boundary, never inline per intent.**
+  `_preflight_blocks_open` (Part A) only records per-sample scratch
+  (`_skip_tick_seen`, keyed by `(direction, side)`); `_reconcile_skip_edges`
+  (Part B) emits ENTER/EXIT. Part B runs as the **first statement of
+  `_drain_pending_chase_intents`, BEFORE its `if not self._pending_chase_intents:
+  return` guard** (the guard returns on the common chase-disabled path, so a call
+  after it would never fire during a storm). So the reconcile of dispatch N's
+  scratch happens at the top of dispatch N+1 (one evaluated-sample latency).
+  Pitfall: a test that calls `_preflight_blocks_open` alone sees NO edge — drive
+  `preflight → _reconcile_skip_edges()` per sample, and ≥1 test must drive the
+  real `on_ticker`/`on_order_update` handlers (cross-dispatch timing).
+- **Scratch semantics (load-bearing):** absence of a key from `_skip_tick_seen`
+  means "no fresh evidence this sample", NOT "affordable". A fail-open
+  (`_preflight_available_balance` → None) is evidence-neutral: no scratch write,
+  no window increment, no state mutation — so a stale-WS blip mid-storm produces
+  no churn and doesn't discard a sibling key's genuine skip. EXIT requires the key
+  to be present with `blocked=False` (evaluated-fresh-and-affordable). `blocked`
+  is sticky-True within a sample → no intra-tick EXIT/ENTER flutter.
+- **Scratch write is gated on `transition_logs_enabled`; the scratch clear (Part
+  B step 3) is UNCONDITIONAL** — a `True→False→True` runtime flag flip must not
+  strand stale evidence and replay it on re-enable. The `_skip_window` summary
+  counter is incremented unconditionally on every genuine skip (independent of
+  the transition flag) so the summary works even with edge logging off.
+- **Idle-timeout sweep** (`low_balance_skip_exit_idle_seconds`, default 60s, 0
+  disables): EXITs an `active` key that was removed from the grid mid-storm with
+  no recovery EXIT. Sweeps ALL active keys, not just scratch keys; safe because a
+  live storm re-blocks every ~100ms so `last_blocked_clock` refreshes and it never
+  fires mid-storm — only after a sustained block-absence. A re-block then re-ENTERs
+  fresh (count reset).
+- Config (`StrategyConfig`, all default-on / preserve behavior):
+  `low_balance_skip_transition_logs_enabled` (True),
+  `low_balance_skip_exit_idle_seconds` (60, `ge=0`),
+  `low_balance_skip_summary_enabled` (True),
+  `low_balance_skip_summary_interval_sec` (60, `gt=0`).
+- Files touched: `runner.py` (state in `__init__`, Part A in
+  `_preflight_blocks_open`, `_reconcile_skip_edges` + `_emit_skip_summary`, drain
+  hook), `config.py`. Tests: `test_runner_lowbalance_storm.py` (17 new, keyed
+  `test_low_balance_skip_*`). Record floats (`avail_min/max`,
+  `first_blocked_price`) are `float`; affordability comparison stays `Decimal`.
+
 ### SAME ORDER detection
 
 - `StrategyRunner._check_same_orders_side()` compares tracked orders by `TrackedOrder.placed_ts` when both fills map to tracked orders; use fill `exchange_ts` only as a fallback for untracked/legacy events. Duplicate same-price orders can rest concurrently and fill more than 5s apart in thin markets, so fill-time-only windows silently miss the critical duplicate-placement bug.

--- a/apps/gridbot/src/gridbot/config.py
+++ b/apps/gridbot/src/gridbot/config.py
@@ -191,6 +191,47 @@ class StrategyConfig(BaseModel):
         ),
     )
 
+    # Feature 0067 — suppress LowBalanceSkip log spam (issue #164). Both
+    # default-on and kill-switchable; with BOTH False the preflight emits the
+    # per-intent DEBUG line exactly as today (byte-for-byte current behavior).
+    low_balance_skip_transition_logs_enabled: bool = Field(
+        default=True,
+        description=(
+            "Master kill-switch for LowBalanceSkip state-transition logging. "
+            "When True, the per-intent DEBUG line is suppressed and the "
+            "sustained-skip regime is logged only at its edges (ENTER/EXIT INFO) "
+            "per (direction, side). When False, the per-intent DEBUG fires on "
+            "every rejection (current behavior). The accept/reject decision is "
+            "never changed — only what is logged."
+        ),
+    )
+    low_balance_skip_exit_idle_seconds: int = Field(
+        default=60,
+        ge=0,
+        description=(
+            "Idle-timeout for the reconcile sweep that EXITs an active "
+            "LowBalanceSkip key after this many seconds with no fresh blocks "
+            "(resolves a key removed from the grid mid-storm without a recovery "
+            "EXIT). 0 disables the sweep (pure event-driven EXIT). Far longer "
+            "than the ~100ms inter-block gap during a live storm, so it never "
+            "false-fires mid-storm."
+        ),
+    )
+    low_balance_skip_summary_enabled: bool = Field(
+        default=True,
+        description=(
+            "Kill-switch for the periodic INFO summary of LowBalanceSkip "
+            "activity. Flushes on the dispatch cadence (no asyncio task); "
+            "increments independently of the transition flag so the summary "
+            "works even when transition logging is off."
+        ),
+    )
+    low_balance_skip_summary_interval_sec: int = Field(
+        default=60,
+        gt=0,
+        description="Window length (seconds) for the periodic LowBalanceSkip summary.",
+    )
+
     # Mode
     shadow_mode: bool = Field(default=False, description="Log intents without executing")
 

--- a/apps/gridbot/src/gridbot/runner.py
+++ b/apps/gridbot/src/gridbot/runner.py
@@ -352,6 +352,27 @@ class StrategyRunner:
         # persistently-raising provider can't flood the log on the hot path).
         self._last_wallet_provider_error_log: float = 0.0
 
+        # Feature 0067 (issue #164) — suppress LowBalanceSkip log spam. Under a
+        # sustained low-balance regime the stateless preflight re-rejects the
+        # same N grid levels every tick (~10/s), so the per-intent DEBUG line
+        # floods the log (~2.1M/day). Instead we log only the ENTER/EXIT edges
+        # of the regime (per (direction, side)) at INFO and a periodic summary.
+        # Plain dict ops on the single-threaded dispatch path: no Bybit calls,
+        # no asyncio task (the summary + edge reconcile flush on the existing
+        # dispatch cadence via _drain_pending_chase_intents using self._clock()).
+        # `_skip_state`: per-key sustained-regime record (survives across ticks).
+        # `_skip_tick_seen`: per-sample scratch (keys evaluated with FRESH
+        #   balance this dispatch; written only when transition logging is on,
+        #   cleared unconditionally each reconcile).
+        # `_skip_window` (+ avail band): per-summary-window skip counts,
+        #   incremented unconditionally on every genuine skip.
+        self._skip_state: dict[tuple[str, str], dict] = {}
+        self._skip_tick_seen: dict[tuple[str, str], dict] = {}
+        self._skip_window: dict[tuple[str, str], int] = {}
+        self._skip_window_avail_min: Optional[float] = None
+        self._skip_window_avail_max: Optional[float] = None
+        self._skip_summary_last_emit: float = 0.0
+
         # Restore full grid if available and config matches
         restored_grid = self._load_grid_state()
 
@@ -1421,8 +1442,21 @@ class StrategyRunner:
         test (``est_cost = qty*price/leverage``; over-conservative leverage only
         ever over-rejects, never lets an unaffordable open through).
         """
+        # Feature 0067 — the affordability DECISION below is unchanged; this
+        # method now also records per-(direction, side) skip evidence so the
+        # sustained-skip regime can be logged at its edges (ENTER/EXIT) instead
+        # of one DEBUG line per blocked grid level per tick. THREE return points,
+        # all preserved:
         avail = self._preflight_available_balance(intent)
         if avail is None:
+            # (0) Fail-open: no fresh balance data (no provider + non-positive
+            # latch, provider raised, or a stale WS peek). The order is allowed
+            # through, so this is NOT a skip: state-neutral AND evidence-neutral
+            # — no _skip_state mutation, no _skip_window increment, and no
+            # _skip_tick_seen write (a fail-open carries no affordability verdict,
+            # so it must neither create nor satisfy an EXIT for the key). Leaving
+            # the key absent from the scratch is what preserves a sibling key's
+            # genuine fresh skip recorded in the same sample (Medium-3).
             logger.debug(
                 "%s: preflight skipped (no fresh balance data) for %s %s",
                 self.strat_id, intent.direction, intent.side,
@@ -1431,25 +1465,177 @@ class StrategyRunner:
         leverage = max(self._effective_leverage(intent.direction), Decimal("1"))
         est_cost = (intent.qty * intent.price) / leverage
         buffer = Decimal(str(self._config.preflight_balance_buffer))
+        key = (intent.direction, intent.side)
         if avail < est_cost * (Decimal("1") + buffer):
-            # DEBUG, not INFO: this fires once per blocked open intent on the hot
-            # dispatch path, and by design fires for every unaffordable grid level
-            # on every ticker tick for the whole duration of the low-balance state
-            # (a blocked open never rests, so it is re-emitted next tick). INFO
-            # here would be sustained log spam precisely during the storm. Matches
-            # every sibling per-intent drop (qty<=0 / 110017 breaker / the generic
-            # `_is_good_to_place` rejection), all DEBUG. The low-balance state stays
-            # observable at INFO via the per-tick `Position update` heartbeat
-            # (avail= / total_avail=).
-            logger.debug(
-                "%s: LowBalanceSkip %s %s qty=%s price=%s "
-                "est_cost=%.4f avail=%.4f buffer=%s",
-                self.strat_id, intent.direction, intent.side,
-                intent.qty, intent.price, float(est_cost),
-                float(avail), buffer,
-            )
+            # (1) Unaffordable → a genuine fresh skip; block (return True).
+            avail_f = float(avail)
+            # Phase-2 window counter: incremented unconditionally on every
+            # genuine skip, INDEPENDENT of the transition flag, so the periodic
+            # summary works even when transition logging is off (M1). Reset only
+            # by the summary flush itself.
+            self._skip_window[key] = self._skip_window.get(key, 0) + 1
+            self._skip_window_avail_min = (
+                avail_f if self._skip_window_avail_min is None
+                else min(self._skip_window_avail_min, avail_f))
+            self._skip_window_avail_max = (
+                avail_f if self._skip_window_avail_max is None
+                else max(self._skip_window_avail_max, avail_f))
+            if self._config.low_balance_skip_transition_logs_enabled:
+                # Per-sample scratch upsert (written ONLY while transition logging
+                # is on → no count accrual / False→True poisoning when off). The
+                # ENTER/EXIT edges + the 60s summary carry the signal, so the
+                # per-intent DEBUG line is suppressed here.
+                s = self._skip_tick_seen.get(key)
+                if s is None:
+                    s = {"blocked": False, "count": 0, "avail_min": avail_f,
+                         "avail_max": avail_f, "first_blocked_price": 0.0}
+                    self._skip_tick_seen[key] = s
+                if not s["blocked"]:
+                    # first BLOCKED level for this key this sample (sticky-True).
+                    s["blocked"] = True
+                    s["first_blocked_price"] = float(intent.price)
+                s["count"] += 1
+                s["avail_min"] = min(s["avail_min"], avail_f)
+                s["avail_max"] = max(s["avail_max"], avail_f)
+            else:
+                # Transition logging OFF → emit the per-intent DEBUG line exactly
+                # as before (byte-for-byte current behavior). DEBUG, not INFO:
+                # one line per blocked open on the hot path; the low-balance
+                # state also stays observable at INFO via the per-tick
+                # `Position update` heartbeat (avail= / total_avail=).
+                logger.debug(
+                    "%s: LowBalanceSkip %s %s qty=%s price=%s "
+                    "est_cost=%.4f avail=%.4f buffer=%s",
+                    self.strat_id, intent.direction, intent.side,
+                    intent.qty, intent.price, float(est_cost),
+                    avail_f, buffer,
+                )
             return True
+        # (2) Genuinely affordable → allow (return False). Mark the key
+        # evaluated-fresh-affordable for this sample so Part B can drive an EXIT;
+        # a sibling level already recorded as blocked stays blocked (sticky).
+        if self._config.low_balance_skip_transition_logs_enabled:
+            if key not in self._skip_tick_seen:
+                self._skip_tick_seen[key] = {
+                    "blocked": False, "count": 0, "avail_min": float(avail),
+                    "avail_max": float(avail), "first_blocked_price": 0.0}
         return False
+
+    # ---- Feature 0067 (issue #164) — LowBalanceSkip edge logging + summary ----
+
+    def _reconcile_skip_edges(self) -> None:
+        """Resolve LowBalanceSkip ENTER/EXIT edges at the SAMPLE boundary (once
+        per dispatch, via _drain_pending_chase_intents). Edges are decided on the
+        WHOLE sample's view of a key — never inline per intent — so a cheap
+        affordable level and a pricier blocked level of the same key in one tick
+        resolve to a single "blocked" verdict instead of EXIT/ENTER flutter.
+
+        Reconciles ONLY keys present in `_skip_tick_seen` (the keys actually
+        evaluated with FRESH balance in the just-finished sample). A key absent
+        from the scratch (no open intents for it, or only fail-open reads) carries
+        no evidence and is left untouched by steps 1-2 — this is what prevents an
+        interleaved `on_order_update` (which evaluates zero open preflights) from
+        manufacturing a spurious EXIT then re-ENTER on the next `on_ticker`.
+
+        Edge LOGGING (steps 1-2) is gated on the transition kill-switch; the
+        scratch CLEAR (step 3) is UNCONDITIONAL so a True→False→True runtime flag
+        flip cannot strand scratch written in the last enabled dispatch and replay
+        it as stale evidence on re-enable.
+        """
+        cfg = self._config
+        if cfg.low_balance_skip_transition_logs_enabled:
+            now = self._clock()
+            # Step 1 — per-key edges for keys evaluated fresh this sample.
+            for key, s in self._skip_tick_seen.items():
+                direction, side = key
+                st = self._skip_state.get(key)
+                if s["blocked"]:
+                    if st is None or not st["active"]:
+                        # ENTER — start (or restart) the sustained-skip regime.
+                        self._skip_state[key] = {
+                            "active": True, "count": s["count"],
+                            "avail_min": s["avail_min"], "avail_max": s["avail_max"],
+                            "first_blocked_price": s["first_blocked_price"],
+                            "last_blocked_clock": now,
+                        }
+                        logger.info(
+                            "%s: LowBalanceSkip ENTER direction=%s side=%s "
+                            "first_blocked_price=%.4f avail_min=%.4f avail_max=%.4f",
+                            self.strat_id, direction, side,
+                            s["first_blocked_price"], s["avail_min"], s["avail_max"],
+                        )
+                    else:
+                        # Sustained — accumulate, widen band, refresh idle clock.
+                        st["count"] += s["count"]
+                        st["avail_min"] = min(st["avail_min"], s["avail_min"])
+                        st["avail_max"] = max(st["avail_max"], s["avail_max"])
+                        st["last_blocked_clock"] = now
+                else:
+                    # Evaluated fresh and zero blocked levels for this key.
+                    if st is not None and st["active"]:
+                        # EXIT — the recovery edge.
+                        logger.info(
+                            "%s: LowBalanceSkip EXIT direction=%s side=%s after "
+                            "%d skips, avail_min=%.4f avail_max=%.4f",
+                            self.strat_id, direction, side, st["count"],
+                            st["avail_min"], st["avail_max"],
+                        )
+                        st["active"] = False
+                        st["count"] = 0
+                    # else: affordable and already idle → no-op.
+            # Step 2 — idle-timeout sweep over ALL active keys (not just scratch
+            # keys) to EXIT a key removed from the grid mid-storm with no recovery
+            # EXIT. During a live storm the key is re-blocked every tick (~10/s)
+            # so last_blocked_clock refreshes and the timeout never fires — it
+            # only fires after a SUSTAINED absence of blocks (a genuinely ended
+            # episode), so it does not reintroduce a single-event false EXIT.
+            idle = cfg.low_balance_skip_exit_idle_seconds
+            if idle > 0:
+                for key, st in self._skip_state.items():
+                    if st["active"] and now - st["last_blocked_clock"] >= idle:
+                        direction, side = key
+                        logger.info(
+                            "%s: LowBalanceSkip EXIT direction=%s side=%s after %d "
+                            "skips (idle %ss, no affordable confirmation)",
+                            self.strat_id, direction, side, st["count"], idle,
+                        )
+                        st["active"] = False
+                        st["count"] = 0
+        # Step 3 — UNCONDITIONAL scratch clear for the next sample.
+        self._skip_tick_seen = {}
+
+    def _emit_skip_summary(self) -> None:
+        """Periodic INFO summary of LowBalanceSkip activity, flushed on the
+        dispatch cadence (no asyncio task) using the injectable self._clock().
+        Per-runner (per-strat); the window counter accumulates independently of
+        the transition flag, so the summary works even with edge logging off."""
+        cfg = self._config
+        if not cfg.low_balance_skip_summary_enabled:
+            return
+        now = self._clock()
+        if now - self._skip_summary_last_emit < cfg.low_balance_skip_summary_interval_sec:
+            return
+        total = sum(self._skip_window.values())
+        if total == 0:
+            # No activity this window — advance the clock, emit nothing (no
+            # empty-window spam).
+            self._skip_summary_last_emit = now
+            return
+        parts = " ".join(
+            f"{direction}.{side}={n}"
+            for (direction, side), n in self._skip_window.items()
+        )
+        logger.info(
+            "%s: LowBalanceSkip %ss window: %s(%s) total=%d avail_min=%.4f avail_max=%.4f",
+            self.strat_id, cfg.low_balance_skip_summary_interval_sec,
+            self.strat_id, parts, total,
+            self._skip_window_avail_min if self._skip_window_avail_min is not None else 0.0,
+            self._skip_window_avail_max if self._skip_window_avail_max is not None else 0.0,
+        )
+        self._skip_window = {}
+        self._skip_window_avail_min = None
+        self._skip_window_avail_max = None
+        self._skip_summary_last_emit = now
 
     # ---- Feature 0066 (issue #159) — chase-close active defense (default OFF) ----
 
@@ -1461,6 +1647,16 @@ class StrategyRunner:
         buffer is reused through the existing dispatch path (cancel-before-place,
         per-place limits refresh, reduce-only guard) with zero new dispatch code.
         """
+        # Feature 0067 — flush the LowBalanceSkip edge reconcile + periodic
+        # summary on the existing dispatch cadence. These MUST run BEFORE the
+        # early-return guard below: the guard returns on the common path
+        # (chase_close_enabled=False default → empty chase buffer almost always),
+        # so a call placed after it would never fire during a low-balance storm.
+        # The reconcile observes the scratch written by the PREVIOUS dispatch's
+        # _execute_intents (one evaluated-sample latency, harmless for logging).
+        self._reconcile_skip_edges()
+        self._emit_skip_summary()
+
         if not self._pending_chase_intents:
             return
         buffered = self._pending_chase_intents

--- a/apps/gridbot/src/gridbot/runner.py
+++ b/apps/gridbot/src/gridbot/runner.py
@@ -371,7 +371,11 @@ class StrategyRunner:
         self._skip_window: dict[tuple[str, str], int] = {}
         self._skip_window_avail_min: Optional[float] = None
         self._skip_window_avail_max: Optional[float] = None
-        self._skip_summary_last_emit: float = 0.0
+        # Baseline the first summary window to construction time, NOT 0.0:
+        # production self._clock is time.monotonic (a large value), so a 0.0
+        # baseline would make `now - last_emit >= interval` true on the very
+        # first skip and flush a mislabeled "<interval>s window" after one tick.
+        self._skip_summary_last_emit: float = self._clock()
 
         # Restore full grid if available and config matches
         restored_grid = self._load_grid_state()

--- a/apps/gridbot/tests/test_runner_lowbalance_storm.py
+++ b/apps/gridbot/tests/test_runner_lowbalance_storm.py
@@ -1125,6 +1125,27 @@ def test_low_balance_skip_summary_emits_via_drain_hook(lb_runner, lb_clock, capl
     assert "total=1" in summ[0].getMessage()
 
 
+def test_low_balance_skip_summary_baseline_is_construction_clock(
+    strategy_config, mock_executor, instrument_info, caplog
+):
+    """Regression (review P2): _skip_summary_last_emit baselines to the clock AT
+    CONSTRUCTION, not 0.0. Production self._clock is time.monotonic (a large
+    value); a 0.0 baseline is only saved from an immediate first-skip flush by the
+    first drain's empty-window advance — fragile. This locks the explicit baseline:
+    construct at a high clock, record a skip, then emit DIRECTLY (no intervening
+    empty-window drain) → no flush until a full interval has actually elapsed."""
+    clk = _FakeClock(1000.0)
+    r = _make_runner(strategy_config, mock_executor, instrument_info, clk)
+    assert r._skip_summary_last_emit == 1000.0  # baselined to construction, not 0.0
+    with caplog.at_level("INFO"):
+        r._preflight_blocks_open(_open_short("100.0", "1.0"))  # window has 1 skip
+        r._emit_skip_summary()                                  # 1000-1000=0 < 60 → no flush
+        assert _info_lines(caplog, "window:") == []
+        clk.t = 1061.0
+        r._emit_skip_summary()                                  # full interval → flush
+    assert len(_info_lines(caplog, "window:")) == 1
+
+
 # ---- Acceptance criterion — both kill-switches off restore current behavior ----
 
 def test_low_balance_skip_killswitches_off_preserve_debug(

--- a/apps/gridbot/tests/test_runner_lowbalance_storm.py
+++ b/apps/gridbot/tests/test_runner_lowbalance_storm.py
@@ -731,3 +731,415 @@ def test_low_balance_predicate_stale_provider_falls_back_to_latch(
     r2 = _runner_with_provider(strategy_config, mock_executor, instrument_info, _raise)
     r2._available_balance = Decimal("5")  # latch low → low (5 < 10), no raise escapes
     assert r2._is_low_balance(Decimal("100")) is True
+
+
+# --------------------------------------------------------------------------
+# Feature 0067 — suppress LowBalanceSkip log spam (issue #164)
+#
+# Two complementary, default-on, kill-switchable changes: (1) state-transition
+# (ENTER/EXIT) INFO logging that suppresses the per-intent DEBUG spam while the
+# sustained-skip regime is active for a (direction, side) key; (2) a periodic
+# 60s INFO summary. Edges resolve at the SAMPLE boundary (Part B
+# `_reconcile_skip_edges`), not inline per intent — so the unit shape is
+# "preflight per intent, then reconcile", and ≥1 integration test drives the
+# real dispatch handlers (reconcile runs at the top of the NEXT dispatch).
+# --------------------------------------------------------------------------
+
+class _FakeClock:
+    """Mutable monotonic float-seconds clock for the 60s-window / idle-timeout
+    tests (injected as ``clock=`` like the existing timing tests)."""
+
+    def __init__(self, t: float = 0.0):
+        self.t = t
+
+    def __call__(self) -> float:
+        return self.t
+
+
+def _open_long(price="100.0", qty="1.0"):
+    """A grow-side open-long Buy (reduce_only=False) → key ('long', 'Buy')."""
+    return PlaceLimitIntent.create(
+        symbol="SOLUSDT", side="Buy", price=Decimal(price), qty=Decimal(qty),
+        grid_level=3, direction="long", reduce_only=False,
+    )
+
+
+def _skip_debug_lines(caplog):
+    """The per-intent ``LowBalanceSkip`` DEBUG lines only (NOT the 'preflight
+    skipped (no fresh balance data)' fail-open DEBUG, NOT INFO edges/summary)."""
+    return [r for r in caplog.records
+            if r.levelname == "DEBUG" and "LowBalanceSkip" in r.getMessage()]
+
+
+def _info_lines(caplog, token):
+    return [r for r in caplog.records
+            if r.levelname == "INFO" and token in r.getMessage()]
+
+
+@pytest.fixture
+def lb_clock():
+    return _FakeClock()
+
+
+@pytest.fixture
+def lb_runner(strategy_config, mock_executor, instrument_info, lb_clock):
+    """Runner on a mutable clock, low (blocking) available balance, no provider
+    → open preflights reach the LowBalanceSkip site. Feature 0067 transition +
+    summary default-on. (Sets ``_available_balance`` — NOT ``_wallet_balance``,
+    which is unrelated to the preflight; runner.py:1409.)"""
+    r = StrategyRunner(
+        strategy_config=strategy_config, executor=mock_executor,
+        instrument_info=instrument_info, rest_client=None, clock=lb_clock,
+    )
+    r._available_balance = Decimal("5")  # est_cost 100 ≫ 5 → blocked (no provider)
+    return r
+
+
+def _make_runner(strategy_config, mock_executor, instrument_info, clock, **cfg_update):
+    cfg = strategy_config.model_copy(update=cfg_update) if cfg_update else strategy_config
+    r = StrategyRunner(
+        strategy_config=cfg, executor=mock_executor,
+        instrument_info=instrument_info, rest_client=None, clock=clock,
+    )
+    r._available_balance = Decimal("5")
+    return r
+
+
+# ---- Phase 1 — state-transition (ENTER/EXIT) logging ----
+
+def test_low_balance_skip_logs_only_on_transition(lb_runner, caplog):
+    """Same unaffordable key over two samples → exactly 1 ENTER, 0 EXIT, and
+    ZERO per-intent DEBUG (the edge carries the signal). Block decision still True."""
+    with caplog.at_level("DEBUG"):
+        assert lb_runner._preflight_blocks_open(_open_short("100.0", "1.0")) is True
+        lb_runner._reconcile_skip_edges()
+        assert lb_runner._preflight_blocks_open(_open_short("100.0", "1.0")) is True
+        lb_runner._reconcile_skip_edges()
+    enter = _info_lines(caplog, "LowBalanceSkip ENTER")
+    assert len(enter) == 1
+    # Guard the ENTER operator payload shape (a dropped/mis-formatted token would
+    # otherwise pass every other test, which only checks the "ENTER" substring).
+    enter_msg = enter[0].getMessage()
+    assert "direction=short side=Sell" in enter_msg
+    assert "first_blocked_price=" in enter_msg
+    assert "avail_min=" in enter_msg and "avail_max=" in enter_msg
+    assert len(_info_lines(caplog, "LowBalanceSkip EXIT")) == 0
+    assert _skip_debug_lines(caplog) == []
+
+
+def test_low_balance_skip_exit_after_balance_restored(lb_runner, caplog):
+    """Sample 1 blocked (ENTER); sample 2 same key affordable (EXIT carrying count)."""
+    with caplog.at_level("DEBUG"):
+        lb_runner._available_balance = Decimal("5")
+        lb_runner._preflight_blocks_open(_open_short("100.0", "1.0"))
+        lb_runner._reconcile_skip_edges()  # ENTER
+        lb_runner._available_balance = Decimal("200")  # affordable now
+        assert lb_runner._preflight_blocks_open(_open_short("100.0", "1.0")) is False
+        lb_runner._reconcile_skip_edges()  # EXIT
+    assert len(_info_lines(caplog, "LowBalanceSkip ENTER")) == 1
+    exits = _info_lines(caplog, "LowBalanceSkip EXIT")
+    assert len(exits) == 1
+    assert "after 1 skips" in exits[0].getMessage()
+    assert lb_runner._skip_state[("short", "Sell")]["active"] is False
+
+
+@pytest.mark.parametrize("affordable_first", [True, False])
+def test_low_balance_skip_no_intratick_flutter(lb_runner, caplog, affordable_first):
+    """One sample, same key: a cheap AFFORDABLE level + a pricier BLOCKED level
+    (either order) → exactly 1 ENTER, 0 EXIT (no intra-tick EXIT/ENTER flutter)."""
+    lb_runner._available_balance = Decimal("50")  # cheap (est 10) ok, pricey (est 100) blocked
+    with caplog.at_level("DEBUG"):
+        if affordable_first:
+            assert lb_runner._preflight_blocks_open(_open_short("10.0", "1.0")) is False
+            assert lb_runner._preflight_blocks_open(_open_short("100.0", "1.0")) is True
+        else:
+            assert lb_runner._preflight_blocks_open(_open_short("100.0", "1.0")) is True
+            assert lb_runner._preflight_blocks_open(_open_short("10.0", "1.0")) is False
+        lb_runner._reconcile_skip_edges()
+    assert len(_info_lines(caplog, "LowBalanceSkip ENTER")) == 1
+    assert len(_info_lines(caplog, "LowBalanceSkip EXIT")) == 0
+
+
+def test_low_balance_skip_failopen_does_not_exit(lb_runner, caplog):
+    """A stale-WS-style fail-open sample is evidence-neutral: key stays active,
+    no EXIT, no ENTER, window counter unchanged (M4)."""
+    with caplog.at_level("DEBUG"):
+        lb_runner._available_balance = Decimal("5")
+        lb_runner._preflight_blocks_open(_open_short("100.0", "1.0"))
+        lb_runner._reconcile_skip_edges()  # ENTER, active
+        lb_runner._available_balance = Decimal("0")  # no data → fail-open (None)
+        window_before = dict(lb_runner._skip_window)
+        assert lb_runner._preflight_blocks_open(_open_short("100.0", "1.0")) is False
+        lb_runner._reconcile_skip_edges()
+    assert len(_info_lines(caplog, "LowBalanceSkip ENTER")) == 1
+    assert len(_info_lines(caplog, "LowBalanceSkip EXIT")) == 0
+    assert lb_runner._skip_state[("short", "Sell")]["active"] is True
+    assert lb_runner._skip_window == window_before  # fail-open did not count
+
+
+def test_low_balance_skip_no_false_exit_on_interleaved_event(lb_runner, caplog):
+    """Integration shape (M2/High): on_ticker(blocked) → on_order_update(no opens)
+    → on_ticker(blocked). Reconcile runs at the top of the NEXT dispatch, so the
+    interleaved order-update must NOT manufacture a spurious EXIT: exactly 1
+    ENTER, 0 EXIT across the whole sequence."""
+    from unittest.mock import Mock as _Mock
+    lb_runner._engine = _Mock()
+    lb_runner._resolve_qty = lambda intent: intent  # bypass qty calc; keep qty=1
+    lb_runner._on_unknown_order = None
+    ou = _Mock()
+    ou.status = "New"
+    ou.order_id = "oid"
+    ou.order_link_id = "olid"
+    with caplog.at_level("DEBUG"):
+        lb_runner._engine.on_event = _Mock(return_value=[_open_short("100.0", "1.0")])
+        lb_runner.on_ticker(_Mock())          # blocked grid → scratch written
+        lb_runner._engine.on_event = _Mock(return_value=[])
+        lb_runner.on_order_update(ou)         # reconcile prior sample → ENTER; no opens
+        lb_runner._engine.on_event = _Mock(return_value=[_open_short("100.0", "1.0")])
+        lb_runner.on_ticker(_Mock())          # reconcile empty → no EXIT; blocked again
+    assert len(_info_lines(caplog, "LowBalanceSkip ENTER")) == 1
+    assert len(_info_lines(caplog, "LowBalanceSkip EXIT")) == 0
+
+
+def test_low_balance_skip_partial_failopen_preserves_sibling_skip(
+    strategy_config, mock_executor, instrument_info, caplog
+):
+    """One sample: long.Buy evaluates fresh-unaffordable (genuine skip) while
+    short.Sell fails open (stale peek) → long.Buy ENTERs (its skip is NOT
+    discarded), short.Sell untouched/absent from state (Medium-3). Uses a
+    stateful provider so the two intents get different freshness."""
+    calls = {"n": 0}
+
+    def provider():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return (WalletSnapshot(available_balance=5.0), 1.0)    # fresh → blocked
+        return (WalletSnapshot(available_balance=5.0), 100.0)      # stale → fail-open
+
+    r = StrategyRunner(
+        strategy_config=strategy_config, executor=mock_executor,
+        instrument_info=instrument_info, rest_client=None, clock=lambda: 0.0,
+        wallet_provider=provider, wallet_ws_max_age_seconds=45.0,
+    )
+    with caplog.at_level("DEBUG"):
+        assert r._preflight_blocks_open(_open_long("100.0", "1.0")) is True    # fresh, blocked
+        assert r._preflight_blocks_open(_open_short("100.0", "1.0")) is False  # stale, fail-open
+        r._reconcile_skip_edges()
+    enter = _info_lines(caplog, "LowBalanceSkip ENTER")
+    assert len(enter) == 1
+    assert "direction=long side=Buy" in enter[0].getMessage()
+    assert r._skip_state[("long", "Buy")]["active"] is True
+    assert ("short", "Sell") not in r._skip_state  # sibling untouched (absent from scratch)
+
+
+def test_low_balance_skip_per_key_independent(lb_runner, caplog):
+    """long.Buy + short.Sell both blocked (2 ENTER); next sample short.Sell
+    recovers while long.Buy stays blocked → independent EXIT for short.Sell only."""
+    with caplog.at_level("DEBUG"):
+        lb_runner._available_balance = Decimal("5")
+        lb_runner._preflight_blocks_open(_open_long("100.0", "1.0"))
+        lb_runner._preflight_blocks_open(_open_short("100.0", "1.0"))
+        lb_runner._reconcile_skip_edges()  # 2 ENTER
+        lb_runner._preflight_blocks_open(_open_long("100.0", "1.0"))   # still blocked
+        lb_runner._preflight_blocks_open(_open_short("1.0", "1.0"))    # est 1 → affordable
+        lb_runner._reconcile_skip_edges()
+    assert len(_info_lines(caplog, "LowBalanceSkip ENTER")) == 2
+    exits = _info_lines(caplog, "LowBalanceSkip EXIT")
+    assert len(exits) == 1
+    assert "direction=short side=Sell" in exits[0].getMessage()
+    assert lb_runner._skip_state[("long", "Buy")]["active"] is True
+    assert lb_runner._skip_state[("short", "Sell")]["active"] is False
+
+
+# ---- Phase 1 — idle-timeout sweep (stuck-active removed keys) ----
+
+def test_low_balance_skip_idle_timeout_exits_removed_key(lb_runner, lb_clock, caplog):
+    """A key removed from the intent set mid-storm (no recovery EXIT) is swept to
+    EXIT after `low_balance_skip_exit_idle_seconds`; a later re-block re-ENTERs
+    fresh (count reset), NOT a silent Sustained."""
+    with caplog.at_level("DEBUG"):
+        lb_runner._preflight_blocks_open(_open_short("100.0", "1.0"))
+        lb_runner._reconcile_skip_edges()  # ENTER, last_blocked_clock=0
+        lb_runner._reconcile_skip_edges()  # t=0, empty scratch, no timeout
+        lb_clock.t = 30.0
+        lb_runner._reconcile_skip_edges()  # 30 < 60, no timeout
+        lb_clock.t = 61.0
+        lb_runner._reconcile_skip_edges()  # 61 >= 60 → idle EXIT
+    assert len(_info_lines(caplog, "LowBalanceSkip ENTER")) == 1
+    exits = _info_lines(caplog, "LowBalanceSkip EXIT")
+    assert len(exits) == 1
+    assert "idle 60s" in exits[0].getMessage()
+    assert lb_runner._skip_state[("short", "Sell")]["active"] is False
+    caplog.clear()
+    with caplog.at_level("DEBUG"):
+        lb_runner._preflight_blocks_open(_open_short("100.0", "1.0"))
+        lb_runner._reconcile_skip_edges()
+    assert len(_info_lines(caplog, "LowBalanceSkip ENTER")) == 1  # fresh episode
+
+
+def test_low_balance_skip_idle_timeout_disabled_keeps_active(
+    strategy_config, mock_executor, instrument_info, lb_clock, caplog
+):
+    """`low_balance_skip_exit_idle_seconds=0` disables the sweep → a removed key
+    stays active forever (documents the opt-out)."""
+    r = _make_runner(strategy_config, mock_executor, instrument_info, lb_clock,
+                     low_balance_skip_exit_idle_seconds=0)
+    with caplog.at_level("DEBUG"):
+        r._preflight_blocks_open(_open_short("100.0", "1.0"))
+        r._reconcile_skip_edges()  # ENTER
+        lb_clock.t = 100000.0
+        r._reconcile_skip_edges()  # no sweep (disabled)
+    assert len(_info_lines(caplog, "LowBalanceSkip EXIT")) == 0
+    assert r._skip_state[("short", "Sell")]["active"] is True
+
+
+def test_low_balance_skip_flag_flip_true_false_true_no_stale_replay(lb_runner, caplog):
+    """True (scratch written) → flip False (reconcile clears scratch unconditionally,
+    no edge) → flip True (reconcile, no new intents) → 0 ENTER, 0 EXIT (no stale
+    evidence replayed from the pre-disable sample)."""
+    with caplog.at_level("DEBUG"):
+        lb_runner._preflight_blocks_open(_open_short("100.0", "1.0"))
+        assert ("short", "Sell") in lb_runner._skip_tick_seen  # scratch written while on
+        lb_runner._config = lb_runner._config.model_copy(
+            update={"low_balance_skip_transition_logs_enabled": False})
+        lb_runner._reconcile_skip_edges()  # unconditional clear; flag off → no edge
+        assert lb_runner._skip_tick_seen == {}
+        lb_runner._config = lb_runner._config.model_copy(
+            update={"low_balance_skip_transition_logs_enabled": True})
+        lb_runner._reconcile_skip_edges()  # no new intents → nothing replays
+    assert _info_lines(caplog, "LowBalanceSkip ENTER") == []
+    assert _info_lines(caplog, "LowBalanceSkip EXIT") == []
+    assert ("short", "Sell") not in lb_runner._skip_state
+
+
+def test_low_balance_skip_no_scratch_leak_when_transition_off(
+    strategy_config, mock_executor, instrument_info, caplog
+):
+    """transition off → scratch never written (no unbounded count accrual), but
+    the window counter still accumulates. Flip on → first ENTER count == this
+    sample's skips only (no inflation carried from the off period) (F2)."""
+    r = _make_runner(strategy_config, mock_executor, instrument_info, lambda: 0.0,
+                     low_balance_skip_transition_logs_enabled=False)
+    with caplog.at_level("DEBUG"):
+        for _ in range(3):
+            r._preflight_blocks_open(_open_short("100.0", "1.0"))
+            assert r._skip_tick_seen == {}  # never written while off
+    assert r._skip_window[("short", "Sell")] == 3  # window still accumulates
+    r._config = r._config.model_copy(
+        update={"low_balance_skip_transition_logs_enabled": True})
+    caplog.clear()
+    with caplog.at_level("DEBUG"):
+        r._preflight_blocks_open(_open_short("100.0", "1.0"))
+        r._reconcile_skip_edges()
+    assert len(_info_lines(caplog, "LowBalanceSkip ENTER")) == 1
+    assert r._skip_state[("short", "Sell")]["count"] == 1  # not inflated by off period
+
+
+# ---- Phase 2 — periodic 60s summary ----
+
+def test_low_balance_skip_emit_summary_at_60s(lb_runner, lb_clock, caplog):
+    """Accumulate skips, advance the clock past the interval, flush → exactly 1
+    INFO summary carrying total / per-(direction,side) counts / avail band;
+    window reset; a second flush within the window emits nothing."""
+    with caplog.at_level("INFO"):
+        for _ in range(3):
+            lb_runner._preflight_blocks_open(_open_short("100.0", "1.0"))
+            lb_runner._reconcile_skip_edges()
+        lb_clock.t = 61.0
+        lb_runner._emit_skip_summary()
+    summ = _info_lines(caplog, "window:")
+    assert len(summ) == 1
+    msg = summ[0].getMessage()
+    assert "total=3" in msg
+    assert "short.Sell=3" in msg
+    assert "avail_min=" in msg and "avail_max=" in msg
+    assert lb_runner._skip_window == {}
+    caplog.clear()
+    with caplog.at_level("INFO"):
+        lb_runner._emit_skip_summary()  # within window → nothing
+    assert _info_lines(caplog, "window:") == []
+
+
+def test_low_balance_skip_summary_fires_with_transition_logs_off(
+    strategy_config, mock_executor, instrument_info, lb_clock, caplog
+):
+    """M1 row 3: transition off + summary on → per-intent DEBUG still fires AND
+    the 60s summary still emits (window counter is increment-independent of the
+    transition flag); no ENTER/EXIT."""
+    r = _make_runner(strategy_config, mock_executor, instrument_info, lb_clock,
+                     low_balance_skip_transition_logs_enabled=False,
+                     low_balance_skip_summary_enabled=True)
+    with caplog.at_level("DEBUG"):
+        r._preflight_blocks_open(_open_short("100.0", "1.0"))
+        r._reconcile_skip_edges()
+        lb_clock.t = 61.0
+        r._emit_skip_summary()
+    assert len(_skip_debug_lines(caplog)) == 1
+    assert len(_info_lines(caplog, "window:")) == 1
+    assert _info_lines(caplog, "LowBalanceSkip ENTER") == []
+
+
+def test_low_balance_skip_transition_on_summary_off(
+    strategy_config, mock_executor, instrument_info, lb_clock, caplog
+):
+    """M1 row 2: transition ON + summary OFF → ENTER edges fire and the per-intent
+    DEBUG is suppressed, but NO 60s summary line even when the clock is past the
+    interval (the summary kill-switch is honored independently of the transition
+    flag, and short-circuits before advancing _skip_summary_last_emit)."""
+    r = _make_runner(strategy_config, mock_executor, instrument_info, lb_clock,
+                     low_balance_skip_transition_logs_enabled=True,
+                     low_balance_skip_summary_enabled=False)
+    with caplog.at_level("DEBUG"):
+        r._preflight_blocks_open(_open_short("100.0", "1.0"))
+        r._reconcile_skip_edges()       # ENTER (transition on)
+        lb_clock.t = 61.0
+        r._emit_skip_summary()          # summary off → nothing, even past interval
+    assert len(_info_lines(caplog, "LowBalanceSkip ENTER")) == 1
+    assert _skip_debug_lines(caplog) == []        # per-intent DEBUG suppressed
+    assert _info_lines(caplog, "window:") == []   # summary suppressed
+    assert r._skip_summary_last_emit == 0.0       # guard returns before clock update
+
+
+def test_low_balance_skip_summary_empty_window_no_emit(lb_runner, lb_clock, caplog):
+    """Clock past interval but zero skips → no summary line (and last-emit advances)."""
+    lb_clock.t = 61.0
+    with caplog.at_level("INFO"):
+        lb_runner._emit_skip_summary()
+    assert _info_lines(caplog, "window:") == []
+    assert lb_runner._skip_summary_last_emit == 61.0
+
+
+def test_low_balance_skip_summary_emits_via_drain_hook(lb_runner, lb_clock, caplog):
+    """Summary flushes through _drain_pending_chase_intents (production hook), and a
+    high monotonic baseline does not cause an immediate summary on the first skip."""
+    lb_clock.t = 1000.0
+    with caplog.at_level("INFO"):
+        lb_runner._drain_pending_chase_intents()  # empty window → advance baseline
+        lb_runner._preflight_blocks_open(_open_short("100.0", "1.0"))
+        lb_runner._drain_pending_chase_intents()  # skips present but within interval
+        assert _info_lines(caplog, "window:") == []
+        lb_clock.t = 1061.0
+        lb_runner._drain_pending_chase_intents()  # past interval → summary via drain
+    summ = _info_lines(caplog, "window:")
+    assert len(summ) == 1
+    assert "total=1" in summ[0].getMessage()
+
+
+# ---- Acceptance criterion — both kill-switches off restore current behavior ----
+
+def test_low_balance_skip_killswitches_off_preserve_debug(
+    strategy_config, mock_executor, instrument_info, caplog
+):
+    """Both flags False → byte-for-byte current behavior: per-intent DEBUG on
+    every rejection, NO INFO ENTER/EXIT/summary lines."""
+    r = _make_runner(strategy_config, mock_executor, instrument_info, lambda: 0.0,
+                     low_balance_skip_transition_logs_enabled=False,
+                     low_balance_skip_summary_enabled=False)
+    with caplog.at_level("DEBUG"):
+        assert r._preflight_blocks_open(_open_short("100.0", "1.0")) is True
+        r._reconcile_skip_edges()
+        r._emit_skip_summary()
+    debug = _skip_debug_lines(caplog)
+    assert len(debug) == 1
+    assert "qty=" in debug[0].getMessage() and "est_cost=" in debug[0].getMessage()
+    assert _info_lines(caplog, "LowBalanceSkip") == []

--- a/docs/features/0067_PLAN.md
+++ b/docs/features/0067_PLAN.md
@@ -1,0 +1,552 @@
+# Feature 0067 — Suppress LowBalanceSkip log spam in sustained low-balance state (issue #164)
+
+## Context
+
+Feature 0066 Phase 2's preflight rejects unaffordable OPEN orders locally in
+`_preflight_blocks_open` (`runner.py:1414-1452`), logging a per-intent
+`LowBalanceSkip` line on every rejection. The preflight is **stateless by
+design** — every intent runs the full check independently — and the engine
+re-generates the same intent set every dispatch tick because no fills advance
+state while the bot is balance-constrained. Result: same N unaffordable grid
+levels → same N skips → repeat per tick (~10/s across both strats) → ~1,500
+LowBalanceSkip events/minute ≈ 2.1M/day. Observed live 2026-06-05 23:53→:
+12,905 events in ~3 minutes during a Storm-5 that 0066 successfully
+suppressed.
+
+The skip itself is functionally correct and already DEBUG-level (Bybit
+unaffected, zero requests, nanosecond per-check, not enqueued). The problem is
+purely **operational noise**: DEBUG log volume slows `tail -f` / `grep` /
+`awk` during incident analysis and grows the log file ~3.1MB/day.
+
+This feature is a logging quality-of-life follow-up. Two complementary,
+**default-on, kill-switchable** changes (mirroring the 0066 additive/kill-switch
+pattern): (1) state-transition logging that promotes ENTER/EXIT of the
+sustained-skip regime to INFO while suppressing the per-intent DEBUG spam in
+between, and (2) a periodic 60s INFO summary of skip activity. When both
+kill-switches are off, behavior is byte-for-byte the current per-intent DEBUG.
+
+### Grounding (verified file paths / functions, current code)
+
+- `apps/gridbot/src/gridbot/runner.py`:
+  - `_preflight_blocks_open(self, intent)` — lines 1414-1452. The
+    `LowBalanceSkip` DEBUG log is at **1444-1450**, emitted right before
+    `return True` (1451) when `avail < est_cost * (1 + buffer)`. Returns
+    `False` (1452) on the affordable path. This is the single skip-emit site.
+  - `_preflight_available_balance(self, intent)` — lines ~1380-1412 (called by
+    `_preflight_blocks_open` at 1424; returns `None` on fail-open).
+  - `_is_good_to_place(self, intent, limits)` — lines 1639-1698; calls
+    `_preflight_blocks_open` at 1679-1682 (gated on
+    `not intent.reduce_only and self._config.preflight_balance_check_enabled`).
+  - `_drain_pending_chase_intents(self)` — lines 1456-1468; called at the top
+    of `on_ticker` (634), `on_execution` (686), `on_order_update` (767). These
+    three are the dispatch ticks and the natural hook for a per-tick summary
+    flush (see Phase 2 — no asyncio task needed).
+  - `__init__` — lines 181-353; Feature-0066 runner state initialized at
+    320-353 (`self._available_balance`, `self._low_balance`, chase state). New
+    skip-state dicts initialize here alongside them.
+  - `self._clock` — line 270 (`clock or time.monotonic`, a **float-seconds**
+    monotonic clock; injectable, used by tests). Use `self._clock()` for the
+    60s window timing, NOT `datetime.now()` — matches the 0064 breaker/0066
+    dirty-refresh timing convention (`runner.py:1235`, `1732`).
+  - `strat_id` — instance attr used in every log line.
+  - The per-tick `Position update` INFO heartbeat (940-947) already carries
+    `avail=` / `total_avail=` / `total_mm=` — the low-balance state stays
+    observable there; this feature does NOT touch it (MEMORY: keep the
+    heartbeat). The ENTER/EXIT/summary INFO lines are additive.
+- `apps/gridbot/src/gridbot/config.py`:
+  - `class StrategyConfig(BaseModel)` — line 26. Feature-0066 preflight/chase
+    fields at 105-192 (`preflight_balance_check_enabled`,
+    `preflight_balance_buffer`, `assumed_leverage`, `low_balance_fraction`,
+    `chase_*`). New 0067 fields go in this block, same `Field(...)` style.
+  - `class GridbotConfig(BaseModel)` — line 241 (NOT used here; the new flags
+    are per-strategy like the 0066 preflight flags).
+- `packages/gridcore/src/gridcore/position.py`:
+  - `class DirectionType(StrEnum)` — line 20 (`LONG='long'`, `SHORT='short'`).
+    `intent.direction` is a `DirectionType` value; `intent.side` is the wire
+    string `"Buy"`/`"Sell"`. The skip-state key uses both.
+- `apps/gridbot/tests/test_runner_lowbalance_storm.py` — the Phase-2/3 suite.
+  New tests append here (same fixtures: `strategy_config`, `instrument_info`,
+  `mock_executor`, a runner-building fixture; `_open_short()` helper;
+  `EMPTY_LIMITS`). Tests drive `_is_good_to_place` / `_preflight_blocks_open`
+  directly with `caplog` and an injected `_clock`, like the existing storm
+  tests.
+- `.claude/skills/gridbot-health/analyze.py` — read-only log parser
+  (gitignored tree; edits do NOT need a feature branch). Currently has **no**
+  `LowBalanceSkip` parser (verified absent). Optional Phase 3 surfacing of the
+  new INFO summary tokens; not required by the acceptance criteria.
+
+---
+
+## Project invariants this plan must honor
+
+1. **Keep the per-tick `Position update` INFO heartbeat** (runner.py:940-947)
+   untouched — it is the analyzer's cadence/liveness anchor. The new INFO
+   lines are additive, not a replacement.
+2. **Additive, default-on, kill-switchable** (0066 pattern): each new
+   `StrategyConfig` field has a default that improves behavior, plus a
+   per-feature kill-switch. **When both transition + summary flags are False →
+   byte-for-byte the current per-intent DEBUG behavior** (acceptance
+   criterion). No silent allow-through: the preflight's accept/reject decision
+   is unchanged — this feature only changes *what is logged*, never *whether an
+   order is blocked*.
+3. **No new Bybit calls, no hot-path I/O, no asyncio task.** The summary
+   flushes on the existing dispatch-tick cadence (`_drain_pending_chase_intents`
+   call sites) using the injectable `self._clock()`. State updates are plain
+   dict ops on the runner (single-threaded dispatch path).
+4. **Reduce-only orders never reach the skip site** — they bypass the preflight
+   in `_is_good_to_place` (1679 gate). Skip-state is therefore only ever keyed
+   on open-order rejections. No change there.
+
+---
+
+## Phase 1 — State-transition logging (per (direction, side))
+
+Goal: log only the **edges** of the sustained-skip regime at INFO, and suppress
+the per-intent DEBUG line while the regime is active for that key, so a Storm-5
+emits a handful of INFO transitions instead of ~15,000 DEBUG lines.
+
+### State
+
+Add to `StrategyRunner.__init__` (alongside the 0066 balance fields, ~line 325):
+
+- `self._skip_state: dict[tuple[str, str], dict]` — keyed by
+  **`(direction, side)`** where `direction` is the `DirectionType` value and
+  `side` is `"Buy"`/`"Sell"`. Each value is a small record:
+  `{active: bool, count: int, avail_min: float, avail_max: float,
+  first_blocked_price: float, last_blocked_clock: float}`. `count` = skips since
+  the last transition; `avail_min`/`avail_max` track the available-balance band
+  observed during the active burst; `last_blocked_clock` = `self._clock()` at the
+  most recent blocked observation, used by the Part B idle-timeout sweep. Default
+  missing key = inactive.
+
+**Key-tuple decision (M2 — fixed, no implementer choice):** the canonical key
+is the 2-tuple `(direction, side)` everywhere — `_skip_state` AND the Phase-2
+`_skip_window`. `strat_id` is constant per runner, so it is **not** in the key;
+it is supplied to every log line as `self.strat_id`. Do not use a 3-tuple.
+
+**Numeric-type decision (M6 — fixed):** `avail_min`/`avail_max`/
+`first_blocked_price` in the record are stored as **`float`** (apply `float(...)`
+at write time), matching the existing per-intent DEBUG which already formats
+`float(avail)` / `intent.price` (runner.py:1449). `est_cost`/`buffer`/`avail`
+stay `Decimal` for the affordability *comparison*; only the values stashed into
+the state record (and emitted in logs) are coerced to `float`. Do not mix
+`Decimal` and `float` in the record.
+
+Per-sample scratch (reset every reconcile, see Algorithm Part B):
+
+- `self._skip_tick_seen: dict[tuple[str, str], dict]` — the keys
+  `(direction, side)` that were **evaluated with fresh balance** during the
+  current sample (one dispatch's open-intent batch). A key is present **iff** at
+  least one of its open intents got a fresh (non-fail-open) affordability verdict
+  this sample. Value `{blocked: bool, count: int, avail_min: float,
+  avail_max: float, first_blocked_price: float}` where `blocked` is the OR of
+  "any level unaffordable", `count` = number of unaffordable levels. This is the
+  load-bearing distinction (see EXIT semantics below): **absence of a key from
+  `_skip_tick_seen` means "no fresh evidence about this key this sample", NOT
+  "this key is affordable".** There is **no** tick-wide fail-open flag — a
+  fail-open intent simply contributes nothing to `_skip_tick_seen`.
+
+### Algorithm — edges resolve at the TICK boundary, not per intent
+
+**Why not per-intent edge detection (the "Important" flutter finding):**
+affordability is **per intent** (`est_cost = qty*price/leverage`, runner.py:1432),
+but a single `(direction, side)` key spans **many grid levels at different
+prices** that are all dispatched within one tick. If ENTER/EXIT were driven
+inline per intent, then near the recovery boundary a single tick could process a
+cheap (affordable) level → fire EXIT → then a pricier same-key level still
+unaffordable → fire ENTER, producing EXIT/ENTER flutter **inside one tick**, and
+the `after N skips` EXIT would be misleading while other levels of that key are
+still blocked. No per-intent ordering guarantee can prevent this — the decision
+needs the **whole tick's** view of a key.
+
+**EXIT semantics (explicit — resolves the design ambiguity).** `EXIT` means
+**"we evaluated ≥1 of this key's open intents with fresh balance during a sample
+and found the key affordable (zero blocked levels)"** — NOT "the latest dispatch
+had zero blocked intents". This distinction is load-bearing: dispatch events
+differ in what they evaluate. `on_ticker` (634) regenerates the full grid →
+evaluates every key's open intents. `on_execution` (686) and `on_order_update`
+(767) run the reconcile hook too but often evaluate **zero** open preflights
+(an order-status update generates no grid opens). If EXIT meant "latest dispatch
+had zero blocked intents", an active key would EXIT spuriously the moment an
+`on_order_update` slipped between two `on_ticker`s — then re-ENTER on the next
+`on_ticker` — manufacturing exactly the ENTER/EXIT churn this feature suppresses,
+driven by **event interleaving rather than affordability**. The per-key
+`_skip_tick_seen` model prevents this: a key only EXITs when it was actually
+evaluated-fresh-and-affordable; a sample that did not evaluate the key (no open
+intents for it, or only fail-open reads) leaves the key's state untouched.
+
+So the state machine is split into two parts:
+
+**Part A — per-intent, inside `_preflight_blocks_open` (runner.py:1424-1452).**
+The method has **THREE** return points; preserve all three:
+
+> **Scratch lifecycle (F2 + runtime flag flips):** the per-sample scratch
+> `_skip_tick_seen` is **written** by Part A only when `transition_logs_enabled`
+> is True (no writes when off → no unbounded `count` accumulation, no
+> `False→True` poisoning). It is **cleared** by Part B step 3 **unconditionally,
+> every dispatch, regardless of the flag** — so a `True→False→True` toggle cannot
+> strand scratch written in the last enabled dispatch and replay it as stale
+> evidence when re-enabled. (These are `StrategyConfig` fields and the bot
+> supports runtime config reload, so flag flips are assumed possible.) The
+> Phase-2 **window counter is separate** and stays unconditional (it feeds the
+> summary).
+
+- **(0) Fail-open `None` (1424-1430):** `_preflight_available_balance` returns
+  `None` (no provider + non-positive latch, provider raised, or a **stale** WS
+  peek, 1398-1404 — plausible mid-storm when WS lags). Log the existing
+  `preflight skipped (no fresh balance data)` DEBUG and `return False`. **State-
+  neutral and evidence-neutral:** no `_skip_state` mutation, **no window-counter
+  increment** (a fail-open is not a skip — the order is allowed through), and
+  **no `_skip_tick_seen` write** (a fail-open carries no affordability verdict,
+  so it must neither create nor satisfy an EXIT). Byte-for-byte as today.
+- **(1) Unaffordable → `return True` (1434-1451):** `avail is not None` and
+  `avail < est_cost*(1+buffer)`. A genuine fresh skip. Do three things, then
+  `return True`:
+  - **Only when `transition_logs_enabled` is True**, upsert the key into
+    `_skip_tick_seen[(direction, side)]`: set `blocked=True`, bump `count`, fold
+    `float(avail)` into running `avail_min`/`avail_max`, and set
+    `first_blocked_price = float(intent.price)` if this is the first **blocked**
+    entry for the key this sample. (`blocked` is sticky-True — a later affordable
+    level on the same key this sample must not flip it back to False.)
+  - Increment the Phase-2 window counter **here, unconditionally on a genuine
+    skip — independent of `transition_logs_enabled`** (M1: the summary must work
+    even when transition logging is off). Gated only by the Phase-2 summary
+    flush itself.
+  - **Per-intent DEBUG suppression (purely flag-driven, not state-driven):** if
+    `transition_logs_enabled` is **True** → **suppress** the per-intent DEBUG
+    line entirely (the ENTER/EXIT edges + the 60s summary carry the signal). If
+    **False** → emit the existing per-intent DEBUG line exactly as today
+    (byte-for-byte current behavior). Suppression is independent of the
+    tick-boundary `active` flag, so there is no first-sample DEBUG leak before
+    the first ENTER is computed.
+- **(2) Genuinely affordable → `return False` (1452):** `avail is not None` and
+  `avail >= est_cost*(1+buffer)`. **Only when `transition_logs_enabled` is
+  True**, mark the key evaluated-fresh-affordable: if the key is **absent** from
+  `_skip_tick_seen` this sample, insert `{blocked: False, count: 0, ...}`; if it
+  is already present (a sibling level was blocked) do **not** clear `blocked`.
+  This is what lets a genuinely-affordable sample drive EXIT in Part B. No inline
+  EXIT here. `return False`.
+
+> Rationale: the fail-open branch (0) is *evidence-neutral* — it writes nothing
+> to `_skip_tick_seen`. So a sample in which a key's only open intents fail open
+> leaves that key **absent** from the scratch, and Part B (which acts only on
+> keys present in the scratch) leaves the key's `active` state untouched: no
+> spurious EXIT on a stale-WS blip, and — crucially — no discarding of a sibling
+> key's genuine fresh skip recorded in the same sample (Medium-3). The old
+> tick-wide fail-open short-circuit is **removed**; per-key presence subsumes it.
+
+**Part B — sample-boundary reconciliation (`_reconcile_skip_edges`).** Runs once
+per dispatch, at the **same hook as the Phase-2 summary flush** (top of
+`_drain_pending_chase_intents`, see Phase 2). **The edge *logging* (steps 1 + 2)
+is gated on `transition_logs_enabled`; the scratch *clear* (step 3) is
+UNCONDITIONAL.** It reconciles **only the keys present in `_skip_tick_seen`** (the
+keys actually evaluated with fresh balance in the just-finished sample). Keys NOT
+in the scratch are left **untouched by steps 1–2** — this is the High/Medium-3
+fix: a dispatch that evaluated no open intents for a key (or only fail-open
+reads) carries no evidence and must not move that key's state. The exception is
+the idle-timeout sweep (step 2), which acts on keys regardless of presence.
+
+When `transition_logs_enabled` is True:
+
+1. For each key in `_skip_tick_seen` with record `s` and `st =
+   _skip_state.get(key)`. Let `now = self._clock()`:
+   - **ENTER** (`s.blocked and (st is None or not st.active)`): set
+     `active=True`, `count = s.count`, `last_blocked_clock = now`, copy
+     `avail_min/avail_max/first_blocked_price` from `s`; log **INFO**
+     `LowBalanceSkip ENTER direction=<d> side=<s> first_blocked_price=<p>
+     avail_min=<x> avail_max=<y>`.
+   - **Sustained** (`s.blocked and st.active`): `count += s.count`, widen
+     `avail_min/avail_max`, refresh `last_blocked_clock = now`. No log.
+   - **EXIT** (`not s.blocked and st is not None and st.active`): the key was
+     evaluated fresh this sample and **zero** levels were blocked → log **INFO**
+     `LowBalanceSkip EXIT direction=<d> side=<s> after <count> skips,
+     avail_min=<x> avail_max=<y>`; set `active=False`, `count=0`.
+   - (`not s.blocked and not active`): no-op (affordable and already idle).
+2. **Idle-timeout sweep (resolves stuck-active removed keys).** If
+   `low_balance_skip_exit_idle_seconds > 0`, scan every **active** key in
+   `_skip_state` (not just scratch keys): if
+   `now - st.last_blocked_clock >= low_balance_skip_exit_idle_seconds` → log
+   **INFO** `LowBalanceSkip EXIT direction=<d> side=<s> after <count> skips
+   (idle <secs>s, no affordable confirmation)`; set `active=False`, `count=0`.
+   During a live storm the key is re-blocked every tick (~10/s) so
+   `last_blocked_clock` refreshes continuously and the timeout never fires — it
+   only fires after a *sustained* absence of blocks (a genuinely ended episode),
+   so it does NOT reintroduce the High finding's single-intervening-event false
+   EXIT. A subsequent re-block emits a fresh **ENTER** (new episode, `count`
+   reset) — this is what makes the "resets on the next ENTER" promise in the
+   removed-key note (Part B Notes) actually true.
+
+3. **Unconditionally** (regardless of `transition_logs_enabled`) clear
+   `_skip_tick_seen` for the next sample. This is the True→False→True fix: if the
+   flag is toggled off, scratch written during the last enabled dispatch must not
+   survive the disabled period and get replayed as stale evidence on re-enable.
+
+Two independent correctness properties hold:
+- **No intra-tick flutter** — a key with *any* blocked level this sample has
+  `s.blocked=True` (sticky), so a cheap affordable level and a pricier blocked
+  level in the same `on_ticker` resolve to one "blocked" verdict, not an
+  EXIT-then-ENTER pair.
+- **No inter-event false EXIT** — EXIT requires the key to be *present* in the
+  scratch with `blocked=False`, i.e. actually evaluated-fresh-and-affordable.
+  An interleaved `on_execution`/`on_order_update` that generates no open intents
+  for the key produces no scratch entry for it → no EXIT. Per-key independence is
+  preserved: long.Buy can EXIT while short.Sell stays active.
+
+Notes:
+- **Production timing is one *evaluated sample* of latency, not one dispatch.**
+  The reconcile at the top of dispatch N observes the scratch written during
+  dispatch N-1's `_execute_intents`. Because only open-preflight-evaluating
+  dispatches write the scratch, the effective edge latency is "until the next
+  dispatch runs the drain hook" — harmless for a logging feature. The dispatch
+  handlers (`on_ticker`/`on_execution`/`on_order_update`) always call the drain
+  hook first (634/686/767), so reconcile runs every dispatch regardless of
+  whether the chase buffer is empty; it simply no-ops when the prior sample's
+  scratch is empty.
+- A key removed from the intent set with no successor (grid reshape, side
+  disabled, or a reduce-only flip — the entire side stops emitting opens while
+  still unaffordable, *without* a recovery EXIT) would otherwise keep its last
+  `active` state forever: a later re-block takes the **Sustained** path
+  (`s.blocked and st.active`), so **no new ENTER fires and `count`/avail bleed
+  across separate episodes**. The **idle-timeout sweep (Part B step 2)** resolves
+  this: after `low_balance_skip_exit_idle_seconds` with no blocks the key is
+  EXITed and reset, so a fresh episode re-ENTERs cleanly with `count` reset. Set
+  `low_balance_skip_exit_idle_seconds = 0` to disable the sweep and accept the
+  stuck-active behavior (pure event-driven EXIT only).
+
+### Config (Phase 1) — `StrategyConfig`
+
+Add (0066 `Field(...)` style, in the preflight block ~line 132):
+- `low_balance_skip_transition_logs_enabled: bool = Field(default=True, ...)` —
+  master kill-switch for the ENTER/EXIT INFO + DEBUG suppression. When False →
+  current per-intent DEBUG behavior.
+- `low_balance_skip_exit_idle_seconds: int = Field(default=60, ge=0, ...)` —
+  idle-timeout for the Part B sweep that EXITs an active key after this many
+  seconds with no fresh blocks (resolves stuck-active removed keys). `0` disables
+  the sweep (pure event-driven EXIT). Default 60s is far longer than the
+  ~100ms inter-block gap during a live storm, so it never false-fires mid-storm.
+
+---
+
+## Phase 2 — Periodic 60s summary
+
+Goal: a single INFO line every 60s summarizing skip activity across all keys, so
+the operator sees aggregate pressure without per-intent noise.
+
+### State
+
+Add to `__init__`:
+- `self._skip_summary_last_emit: float = 0.0` (monotonic seconds, via
+  `self._clock()`).
+- `self._skip_window: dict[tuple[str,str], int]` (keyed by `(direction, side)`)
+  plus window-level `avail_min`/`avail_max` floats. **Incremented in Part A's
+  unaffordable branch (`avail is not None` and unaffordable), unconditionally on
+  every genuine skip — independent of `transition_logs_enabled`** (M1: the
+  summary must accumulate even when transition logging is off). The fail-open
+  `avail is None` branch and the affordable branch must NOT increment it. Reset
+  on each summary emit.
+
+### Flush mechanism (no asyncio task)
+
+Both per-tick hooks — Part B's `_reconcile_skip_edges()` and the summary
+`_emit_skip_summary()` — are called as the **first two statements of
+`_drain_pending_chase_intents`, BEFORE its `if not self._pending_chase_intents:
+return` guard** (runner.py:1464). This placement is mandatory and unambiguous:
+the guard returns early on the common path (`chase_close_enabled=False` default →
+empty chase buffer almost always), so a call placed *after* the guard would never
+fire during a storm. Do **not** put either call after the guard, and do not split
+them across the three dispatch entry points — both live at the top of the drain
+method so there is exactly one call site.
+
+`_emit_skip_summary(self) -> None` logic:
+- If `not self._config.low_balance_skip_summary_enabled` → return.
+- `now = self._clock()`; if `now - self._skip_summary_last_emit <
+  low_balance_skip_summary_interval_sec` → return.
+- If no skip activity since last emit (`_skip_window` empty / total 0) → update
+  `_skip_summary_last_emit = now` and return (no empty-window spam).
+- Else log **INFO**:
+  `LowBalanceSkip <interval>s window: <strat>(long.Buy=N short.Sell=M ...)
+  total=<T> avail_min=<x> avail_max=<y>`, then reset `_skip_window` and set
+  `_skip_summary_last_emit = now`.
+
+This piggybacks on the existing tick cadence (~10/s) so the 60s check is cheap
+and needs no background task or orchestrator change. The summary is per-runner
+(per-strat), so each strat emits its own line — matching the issue's
+`ltc(...) sol(...)` example which is two separate strat runners, each logging
+its own `<strat>(...)` group.
+
+### Flag-combination matrix (M1 — all four defined)
+
+| `transition_logs` | `summary` | Behavior |
+|---|---|---|
+| **True** (default) | **True** (default) | Per-intent DEBUG suppressed; ENTER/EXIT INFO at edges; 60s INFO summary. |
+| True | False | Per-intent DEBUG suppressed; ENTER/EXIT INFO at edges; **no** summary line. |
+| False | True | **Per-intent DEBUG every rejection** (current behavior); no ENTER/EXIT; 60s summary still fires (window counter is increment-independent of the transition flag). |
+| False | False | **Byte-for-byte current behavior**: per-intent DEBUG only, no INFO lines (acceptance criterion). |
+
+### Config (Phase 2) — `StrategyConfig`
+
+- `low_balance_skip_summary_enabled: bool = Field(default=True, ...)` —
+  kill-switch for the periodic summary.
+- `low_balance_skip_summary_interval_sec: int = Field(default=60, gt=0, ...)`.
+
+---
+
+## Phase 3 — gridbot-health analyzer (optional, read-only)
+
+`.claude/skills/gridbot-health/analyze.py` has no `LowBalanceSkip` parser
+today. Optional: add a regex for the new INFO `LowBalanceSkip <N>s window:
+... total=<T>` line and surface a per-strat skip-rate / total in the existing
+per-strat metrics table, plus an all-time `max_low_balance_skip_window` peak
+(follow the existing peak-tracking pattern). Not required by the acceptance
+criteria (DEBUG was already filtered by the analyzer); include only if cheap.
+This tree is gitignored — no feature branch needed; run its tests manually
+(`uv run pytest .claude/skills/gridbot-health/test_analyze.py`).
+
+---
+
+## Test strategy
+
+Repo convention (`.claude/rules/code-style.md`): a change starts with a
+reproducing/asserting test. New tests append to
+`apps/gridbot/tests/test_runner_lowbalance_storm.py` (reuse its fixtures; inject
+`clock=` so the 60s window is deterministic — pass a controllable fake clock to
+`StrategyRunner(... clock=fake)` the way the timing tests do). Drive
+`_is_good_to_place` / `_preflight_blocks_open` directly with `caplog`.
+
+**Test driver model (M3 — edges and summary are sample-boundary, not inline).**
+Because Part A only writes per-sample scratch and Part B emits the ENTER/EXIT
+edges, a test that calls `_preflight_blocks_open` alone will see **no**
+ENTER/EXIT line. Two complementary test shapes:
+
+*Unit shape* (fast, for branch logic) — simulate one sample explicitly:
+1. call `_preflight_blocks_open(intent)` (or `_is_good_to_place`) once per
+   intent in the sample, then
+2. call `runner._reconcile_skip_edges()` to flush that sample's edges, and
+3. for summary assertions, advance the fake clock and call
+   `runner._emit_skip_summary()` explicitly.
+A "next sample" is another round of step 1 + step 2.
+
+*Integration shape (M2 — REQUIRED, ≥1 test)* — the unit shape calls preflight
+then reconcile in the same step, but **production reconciles at the top of the
+next dispatch**, before that dispatch's intents are generated (one-evaluated-
+sample latency). A unit-only suite can pass while production has the
+cross-dispatch behavior. So at least one test must drive the real dispatch
+handlers in sequence — `on_ticker` (blocked grid) → `on_order_update` (no open
+intents) → `on_ticker` — feeding a stub engine that returns the low-balance open
+intents on ticker events and nothing on the order-update event, and assert the
+**event interleaving produces exactly 1 ENTER and 0 spurious EXIT** (see
+`test_low_balance_skip_no_false_exit_on_interleaved_event` below). This is the
+test that would fail under the rejected "latest dispatch had zero blocked
+intents" semantics.
+
+**Fixture attribute caveat:** the no-provider preflight reads
+`runner._available_balance` (runner.py:1409), NOT `runner._wallet_balance`. The
+shared `runner` fixture sets `r._wallet_balance = Decimal("10000")` (line 93),
+which is **unrelated** to the preflight and must not be relied on to make an
+intent (un)affordable. New low-balance tests must set
+`runner._available_balance = Decimal("5")` (small positive, no provider →
+`_wallet_provider` stays `None`) to reach the skip site — exactly as the
+reproducer does at line 112. Do not set/inspect `_wallet_balance` for these
+tests.
+
+- `test_low_balance_skip_logs_only_on_transition`: same unaffordable intent over
+  two ticks (preflight + reconcile each tick; low `_available_balance`, no
+  provider) → exactly **1** INFO `LowBalanceSkip ENTER`, **0** per-intent DEBUG
+  `LowBalanceSkip` lines, **0** EXIT. (The accept/reject return is still `True`
+  both times.)
+- `test_low_balance_skip_exit_after_balance_restored`: tick 1 unaffordable intent
+  + reconcile (ENTER); tick 2 affordable same-key intent (raise
+  `_available_balance`) + reconcile → **1** ENTER + **1** EXIT INFO, EXIT carries
+  the skip `count`.
+- `test_low_balance_skip_no_intratick_flutter` (the "Important" finding): in a
+  **single tick**, run a same-key affordable intent (cheap level) AND an
+  unaffordable intent (pricier level) — in either order — then reconcile →
+  exactly **1** ENTER and **0** EXIT (the key is "blocked this tick" because ≥1
+  level blocked; no intra-tick EXIT/ENTER flutter).
+- `test_low_balance_skip_failopen_does_not_exit` (M4 — the evidence-neutral
+  invariant): sample 1 unaffordable + reconcile (ENTER, key active); sample 2 the
+  balance read fails open (`_available_balance = 0` → `_preflight_available_balance`
+  returns `None`, or inject a provider returning stale/None) so the key is
+  **absent** from `_skip_tick_seen` + reconcile → **0** EXIT, **0** ENTER, key
+  stays `active`, window counter unchanged for that sample. Asserts a stale-WS
+  blip mid-storm produces no churn.
+- `test_low_balance_skip_no_false_exit_on_interleaved_event` (M2/High —
+  integration shape): `on_ticker` with a blocked low-balance grid (ENTER) →
+  `on_order_update` that evaluates **no** open intents → `on_ticker` with the grid
+  still blocked. Assert across the whole sequence: exactly **1** ENTER, **0**
+  EXIT. Under the rejected "latest dispatch had zero blocked intents" semantics
+  the interleaved `on_order_update` would force a spurious EXIT (then re-ENTER);
+  the per-key `_skip_tick_seen` model must keep the key continuously active.
+- `test_low_balance_skip_partial_failopen_preserves_sibling_skip` (Medium-3): in
+  **one sample**, key long.Buy evaluates fresh-unaffordable (genuine skip) while
+  key short.Sell fails open → reconcile → **1** ENTER for long.Buy (its skip
+  evidence is NOT discarded), short.Sell untouched (absent from scratch). Guards
+  against tick-wide fail-open invalidating a sibling key's real skip.
+- `test_low_balance_skip_idle_timeout_exits_removed_key` (Medium — stuck-active):
+  sample 1 unaffordable + reconcile (ENTER, active); then the key is **removed**
+  (no further open intents for it) — run several reconciles with empty scratch,
+  advancing the fake clock **past `low_balance_skip_exit_idle_seconds`** → exactly
+  **1** idle EXIT (`(idle <secs>s ...)`), key `active=False`. Then re-block the
+  same key + reconcile → a **fresh ENTER** with `count` reset (new episode), NOT a
+  silent Sustained. Asserts the removed-key "resets on the next ENTER" promise.
+  Companion `..._idle_timeout_disabled_keeps_active` with
+  `low_balance_skip_exit_idle_seconds=0`: same removal → **0** idle EXIT, key
+  stays active (documents the opt-out).
+- `test_low_balance_skip_flag_flip_true_false_true_no_stale_replay` (Low):
+  `transition_logs_enabled=True`, run an unaffordable sample so `_skip_tick_seen`
+  is populated; **flip to False** and run one dispatch's reconcile → `_skip_tick_seen`
+  is cleared (unconditional step 3) and no edge logged; **flip back to True** and
+  reconcile with no new intents → **0** ENTER, **0** EXIT (no stale evidence
+  replayed from the pre-disable sample).
+- `test_low_balance_skip_emit_summary_at_60s` (M3): accumulate skips
+  (preflight + reconcile), advance the fake clock past
+  `low_balance_skip_summary_interval_sec`, **call `_emit_skip_summary()`
+  explicitly** → exactly **1** INFO summary line carrying `total=`,
+  per-(direction,side) counts, and `avail_min`/`avail_max`; `_skip_window` reset
+  afterward; a second explicit `_emit_skip_summary()` within the window emits
+  nothing.
+- `test_low_balance_skip_summary_fires_with_transition_logs_off` (M1 row 3):
+  `transition_logs_enabled=False`, `summary_enabled=True` → per-intent DEBUG
+  still fires per rejection AND the 60s summary still emits (window counter
+  increments independently of the transition flag).
+- `test_low_balance_skip_no_scratch_leak_when_transition_off` (F2): with
+  `transition_logs_enabled=False`, run several unaffordable samples (preflight
+  only; Part B does not run) → `_skip_tick_seen` stays empty after every sample
+  (scratch never written) while `_skip_window` still accumulates. Then flip
+  `transition_logs_enabled=True` and run one unaffordable sample + reconcile →
+  exactly **1** ENTER with `count == this sample's skips` (no inflated count
+  carried over from the off period), proving the flag flip is not poisoned.
+- `test_low_balance_skip_summary_empty_window_no_emit`: clock past interval but
+  zero skips since last emit → no summary line (and `_skip_summary_last_emit`
+  advanced).
+- `test_low_balance_skip_killswitches_off_preserve_debug`: both
+  `low_balance_skip_transition_logs_enabled=False` and
+  `low_balance_skip_summary_enabled=False` → byte-for-byte current behavior: the
+  per-intent DEBUG `LowBalanceSkip` line fires on every rejection, **no** INFO
+  ENTER/EXIT/summary lines (acceptance criterion).
+- `test_low_balance_skip_per_key_independent`: tick 1 long.Buy + short.Sell both
+  unaffordable + reconcile (2 ENTER); tick 2 short.Sell affordable while long.Buy
+  still unaffordable + reconcile → independent EXIT for short.Sell only; long.Buy
+  stays active (no spurious EXIT).
+- Guardrail: existing Phase-2/Phase-4 preflight tests
+  (`test_preflight_blocks_unaffordable_open`, `..._allows_affordable_open`,
+  `..._bypassed_for_reduce_only`, `..._fail_open_*`,
+  `test_preflight_blocks_on_fresh_zero_provider`, etc.) still pass — the
+  block/allow **decision** is unchanged; only the log emission differs. Any
+  existing test asserting on the per-intent DEBUG `LowBalanceSkip` text must be
+  updated to either run with the kill-switch off or assert the new
+  ENTER/summary shape.
+
+### Backtest / replay parity
+
+The new config fields default-on but only affect logging; the preflight
+decision is unchanged. Confirm backtest/replay paths (which don't feed balance,
+so the preflight fails open and never reaches the skip site) are unaffected, and
+that the new fields are optional defaults so existing `StrategyConfig`
+constructions and configs compile unchanged.
+
+After implementation, add a RULES.md note under the 0066 entry: the
+LowBalanceSkip per-intent DEBUG is suppressed under sustained low-balance and
+replaced by ENTER/EXIT INFO transitions + a 60s INFO summary; both gated by
+`low_balance_skip_transition_logs_enabled` / `low_balance_skip_summary_enabled`
+(both default-on); flags-off restores per-intent DEBUG.

--- a/docs/features/0067_REVIEW.md
+++ b/docs/features/0067_REVIEW.md
@@ -1,0 +1,86 @@
+# 0067 Code Review — Suppress LowBalanceSkip Log Spam
+
+**Date:** 2026-06-06  
+**Plan:** `docs/features/0067_PLAN.md`  
+**Scope reviewed:** `apps/gridbot/src/gridbot/config.py`, `apps/gridbot/src/gridbot/runner.py`, `apps/gridbot/tests/test_runner_lowbalance_storm.py`, `RULES.md`
+
+## Findings
+
+No blocking findings.
+
+### P3 — `RULES.md` test count is stale
+
+`RULES.md` says the feature added 16 `test_low_balance_skip_*` tests, but the
+current implementation has 17 test functions in the 0067 section after adding
+`test_low_balance_skip_summary_emits_via_drain_hook`. This is documentation-only
+drift; the behavior and test coverage are fine.
+
+Recommended fix: update the count in `RULES.md` from 16 to 17, or avoid a hard
+count there.
+
+### P3 — `runner.py` continues to absorb feature-specific state machines
+
+Feature 0067 adds roughly 200 lines of state, reconciliation, summary, and tests
+around an already large `runner.py`. The logic is currently understandable and
+well colocated with `_preflight_blocks_open`, but the module is becoming a
+collection point for several independent operational state machines.
+
+This is not a blocker for this logging feature. It is a refactor pressure point:
+future additions of this shape should consider a small helper object for
+stateful log aggregation to keep `StrategyRunner` focused on dispatch behavior.
+
+## Fixed Since Previous Review
+
+- The summary-hook coverage gap is fixed by
+  `test_low_balance_skip_summary_emits_via_drain_hook`, which verifies summary
+  emission through `_drain_pending_chase_intents()`.
+- The startup-summary concern is covered in the same test with a high fake
+  monotonic baseline. The production dispatch order calls
+  `_drain_pending_chase_intents()` before generating/executing a tick's intents,
+  so an empty first drain advances `_skip_summary_last_emit` before the first
+  skip can be recorded.
+- The new E731 lambda assignments in the intra-tick flutter test were removed.
+
+## Plan Compliance
+
+- The preflight accept/reject decision is unchanged.
+- Fail-open remains evidence-neutral: no skip state, no scratch, no summary
+  window increment.
+- Genuine skips increment the summary window independently of transition logging.
+- Per-intent DEBUG is suppressed when transition logging is enabled and restored
+  when it is disabled.
+- ENTER/EXIT edges resolve at sample boundary, not inline per intent.
+- `_skip_tick_seen` is keyed by `(direction, side)` and uses sticky blocked
+  semantics within a sample.
+- Scratch clear is unconditional, including runtime flag flips.
+- Idle-timeout sweep covers active keys outside the scratch set.
+- Summary and edge reconcile are placed before the chase-buffer early return.
+- The `Position update` INFO heartbeat is untouched.
+- Config fields are per-strategy, default-on, and kill-switchable.
+
+## Test Review
+
+The added tests are broad and targeted. They cover transition-only logging,
+recovery EXIT, no intra-tick flutter, fail-open neutrality, interleaved dispatch
+events, sibling fail-open preservation, per-key independence, idle timeout,
+runtime flag flips, summary flag combinations, empty summary windows, summary
+emission via the production drain hook, and both kill-switches off.
+
+The tests use a fake monotonic clock for interval/idle determinism, `caplog` for
+log assertions, and direct preflight/reconcile calls for branch-level behavior
+plus real dispatch handlers where production ordering matters.
+
+## Verification
+
+```bash
+uv run pytest -q apps/gridbot/tests/test_runner_lowbalance_storm.py
+# 66 passed in 0.15s
+```
+
+```bash
+uv run ruff check apps/gridbot/src/gridbot/config.py apps/gridbot/src/gridbot/runner.py apps/gridbot/tests/test_runner_lowbalance_storm.py
+# failed: remaining reported issues are pre-existing E402 import-layout findings
+# in runner.py and pre-existing E731 provider lambdas above the added 0067 test
+# section. The new 0067 intra-tick lambda assignments from the prior review are
+# fixed.
+```


### PR DESCRIPTION
## Summary
- Suppress per-intent `LowBalanceSkip` DEBUG spam during sustained low-balance storms by logging ENTER/EXIT INFO edges per `(direction, side)` and a periodic 60s INFO summary.
- Preflight accept/reject decisions are unchanged; both behaviors are default-on and kill-switchable via new `StrategyConfig` fields.
- Add 17 `test_low_balance_skip_*` tests covering transition logging, fail-open neutrality, interleaved dispatch, idle timeout, summary flag combinations, and drain-hook summary emission.

## Test plan
- [x] `uv run pytest -q apps/gridbot/tests/test_runner_lowbalance_storm.py` (66 passed)
- [ ] Confirm live/staging logs show ENTER/EXIT + 60s summary during a low-balance episode instead of per-intent DEBUG floods
- [ ] Verify both kill-switches off restores per-intent DEBUG behavior

Closes #164


Made with [Cursor](https://cursor.com)