### PR TITLE
feat(0069): auto state-divergence detector + on-demand forced reconcile

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -343,6 +343,95 @@ Pitfalls / invariants (all enforced + tested):
   `test_truncate_breaker.py`, `test_runner_truncate_storm.py`,
   `TestForcedReconcile` in `test_orchestrator.py`.
 
+### Auto state-divergence detector (feature 0069, issue #151)
+
+Closes the gap the 2026-05-30 incident exposed: after ~5h of WS instability the
+local mirror diverged far enough that the bot could not self-recover until a
+manual restart re-ran the cold-start reconciler. WS reconnects fired but did NOT
+force a full position+order re-sync. This detector watches FOUR observable signals
+and, on any fire, triggers a **forced full reconcile WITHOUT restarting** — the
+same `Orchestrator._force_reconcile_strat` the 0064 breaker uses.
+
+- **Reuses `_force_reconcile_strat`**, now `(strat_id, direction: str|None,
+  emit_breaker_warning=True) -> bool`. `direction=None` (every detector signal)
+  does ONE rate-limit check, ONE `reconcile_reconnect`, then refreshes BOTH LONG
+  and SHORT mirrors — handled INTERNALLY so the per-strat rate-limit timestamp is
+  set once (two back-to-back calls would rate-limit the second side and leave a
+  hedge-mode mirror half stale). Returns True only when a reconcile actually ran
+  (False = rate-limited / no runner). The breaker-trip caller still passes a
+  specific direction + the default `emit_breaker_warning=True` → byte-for-byte
+  unchanged.
+- **Two SEPARATE throttles.** The detector throttle
+  (`_divergence_last_fire_at`, `divergence_reconcile_min_interval_seconds`,
+  default **300s**) is distinct from the breaker cooldown
+  (`_force_reconcile_last_at`, `truncate_breaker_cooldown_seconds`, default 60s).
+  The wrapper `_trigger_divergence_reconcile` checks its own throttle, then calls
+  `_force_reconcile_strat(direction=None, emit_breaker_warning=False)` and branches
+  on the bool: only on True does it emit the single
+  `state-divergence detected (signal=…, evidence=…), forcing full reconcile`
+  WARNING, clear the runner dedup cache (`clear_dedup_cache()`), and bump the
+  detector throttle. On False (suppressed by the breaker cooldown) it emits a
+  DEBUG line and does NONE of those — so the analyzer's `force_reconcile_fired`
+  never overstates real reconciles and the dedup cache is never evicted without a
+  resync. Passing `emit_breaker_warning=False` suppresses the breaker line (and
+  its `'None'` direction text) on the detector path, so each reconcile matches
+  EXACTLY ONE analyzer pattern (no double-count).
+- **Master kill-switch `divergence_detector_enabled`** (default True) is enforced
+  BOTH at the wrapper entry (catch-all) AND at each signal's upstream work, so the
+  detector is fully inert (no signal, no extra REST) when off.
+- **Signal 1 — placement-failure UNION.** `runner._record_placement_failure(error)`
+  (called from BOTH `_execute_place_intent` failure exits) appends to a rolling
+  `_placement_failure_window` (deque, stamped/evicted via the injectable
+  `self._clock()`) when the error is in the UNION {110017, 110072, network};
+  **110007 is EXCLUDED** (intentional low-balance drop). At
+  `divergence_failure_mix_threshold` (10) within
+  `divergence_failure_mix_window_seconds` (60) it CLEARS the window and fires the
+  `on_divergence_failure_mix` callback — "a fire" = threshold-reached, regardless
+  of whether the downstream reconcile is then suppressed (so a cooldown-suppressed
+  fire does not leave the window full and re-trigger on every later failure). Two
+  new classifiers in `executor.py`: `is_network_error` (narrow lowercased tokens:
+  `timeout`/`connection`/`temporarily unavailable`/`readtimeout`) and
+  `is_duplicate_link_error` (110072 / "OrderLinkedID is duplicate").
+- **Signal 2 — retry-budget edge.** In `_health_check_once`, fire once per NEW
+  edge when `truncate_breaker_reconcile_count >= divergence_retry_budget` (5) AND
+  the count differs from `_divergence_budget_last_fired[strat]`. Backstop for when
+  the breaker counts but does not auto-reconcile.
+- **Signal 3 — REST-vs-local size delta.** `_divergence_size_check_once` (gated by
+  `_next_divergence_size_check`, primed half an interval ahead of `_next_order_sync`
+  so the two REST sweeps don't co-fire) compares `runner.rest_position_size(dir)`
+  (a NEW **pure** REST read — no mirror mutation, no throttle write, no failure-
+  counter bump, unlike `_refresh_position_size_from_rest`) to the local mirror.
+  Evaluates BOTH directions, fires ONCE with `direction=None` if EITHER exceeds
+  `qty_step * divergence_size_delta_qty_step_multiplier` (5). A `None` REST read
+  skips that direction (no fire). `divergence_size_check_interval_seconds` carries
+  `gt=0` (cannot be disabled) so position size ALWAYS has a periodic backstop.
+- **Signal 4 — post-WS-recovery.** A PRIVATE-channel gap/reset (heartbeat
+  `_on_ws_disconnect kind=="private"`, or the private reconnect branches of
+  `_health_check_once` / `_ws_health_check_once`) fans out account→strats via
+  `_account_to_runners` into `_pending_post_recovery_reconcile` (a `set[str]`
+  guarded by `_pending_post_recovery_lock` — `_on_ws_disconnect` runs on the WS
+  heartbeat thread). Public-only gaps do NOT enqueue. The set is drained
+  swap-and-clear ONCE per `_tick` at a PINNED point: after the per-tick WS event
+  drains (so no concurrent reader of a half-cleared dedup cache) and IMMEDIATELY
+  before the order-sync gate (sharing the tick's `now`). A throttle/cooldown-
+  suppressed strat is DROPPED, not retried (no 10Hz busy-loop); when it would be
+  throttle-suppressed AND `order_sync_interval > 0`, the drain peeks the throttle
+  and sets `_next_order_sync = 0.0` so the order-sync gate runs THIS tick
+  (fast-track), shrinking the order-level backstop from up to `order_sync_interval`
+  to the same tick.
+- Config (all on `StrategyConfig`, default-on): `divergence_detector_enabled`,
+  `divergence_failure_mix_threshold` (ge=1), `divergence_failure_mix_window_seconds`
+  (gt=0), `divergence_retry_budget` (ge=1), `divergence_size_check_interval_seconds`
+  (gt=0), `divergence_size_delta_qty_step_multiplier` (gt=0),
+  `divergence_reconcile_min_interval_seconds` (gt=0). Constant
+  `bybit_adapter.error_codes.ORDER_LINK_ID_DUPLICATE = 110072`.
+- **Analyzer**: `force_reconcile_fired` is a SINGLE merged `event_coverage` key
+  covering BOTH origins (detector WARNING + 0064 breaker line) — do NOT split.
+- Files touched: `runner.py`, `orchestrator.py`, `executor.py`, `config.py`,
+  `error_codes.py`, `.claude/skills/gridbot-health/analyze.py`. Tests:
+  `test_runner_divergence.py`, `test_orchestrator_divergence.py`,
+  classifier tests in `test_executor.py`, config tests in `test_config.py`.
+
 ### 110007 low-balance preflight + chase-close (feature 0066, issue #159)
 
 Defends against the **110007 "available balance not enough"** retry storm that

--- a/apps/gridbot/src/gridbot/config.py
+++ b/apps/gridbot/src/gridbot/config.py
@@ -232,6 +232,75 @@ class StrategyConfig(BaseModel):
         description="Window length (seconds) for the periodic LowBalanceSkip summary.",
     )
 
+    # Feature 0069 — auto state-divergence detector + on-demand forced reconcile
+    # (issue #151). Four signals (placement-failure union / retry-budget /
+    # REST-vs-local size delta / post-WS-recovery) converge on one forced
+    # reconcile, throttled SEPARATELY from the 0064 breaker cooldown. All
+    # default-on so existing conf/*.yaml keep working unchanged.
+    divergence_detector_enabled: bool = Field(
+        default=True,
+        description=(
+            "Master kill-switch for the state-divergence detector. When False "
+            "the detector is fully inert: no signal records, no extra REST, no "
+            "forced reconcile, no WARNING. The 0064 breaker is unaffected."
+        ),
+    )
+    divergence_failure_mix_threshold: int = Field(
+        default=10,
+        ge=1,
+        description=(
+            "Signal 1: fire when this many placement failures whose error is in "
+            "the UNION of {110017, 110072, network} occur within "
+            "divergence_failure_mix_window_seconds on one strat (110007 is "
+            "EXCLUDED — it is an intentional low-balance drop, not divergence)."
+        ),
+    )
+    divergence_failure_mix_window_seconds: float = Field(
+        default=60.0,
+        gt=0,
+        description="Signal 1: rolling window (seconds) for the placement-failure UNION count.",
+    )
+    divergence_retry_budget: int = Field(
+        default=5,
+        ge=1,
+        description=(
+            "Signal 2: fire once per new edge when truncate_breaker_reconcile_count "
+            "reaches this many breaker-driven reconciles (backstop for the cases "
+            "the breaker counts but does not auto-reconcile)."
+        ),
+    )
+    divergence_size_check_interval_seconds: float = Field(
+        default=300.0,
+        gt=0,
+        description=(
+            "Signal 3: cadence (seconds) of the read-only REST-vs-local "
+            "position-size delta sweep. gt=0 (cannot be disabled): position size "
+            "always has a periodic backstop, which is why a throttle-suppressed "
+            "signal-4 reconcile can be safely dropped. NOTE: a single "
+            "orchestrator-level gate drives the sweep for ALL strats at the "
+            "MINIMUM interval across enabled strats — a strat configured with a "
+            "longer interval is swept more often (harmless: the per-runner read "
+            "is cheap and idempotent)."
+        ),
+    )
+    divergence_size_delta_qty_step_multiplier: float = Field(
+        default=5.0,
+        gt=0,
+        description=(
+            "Signal 3: fire when abs(rest_size - local_size) exceeds "
+            "qty_step * this multiplier for either direction."
+        ),
+    )
+    divergence_reconcile_min_interval_seconds: float = Field(
+        default=300.0,
+        gt=0,
+        description=(
+            "Detector throttle: minimum seconds between forced reconciles per "
+            "strat triggered by ANY divergence signal. SEPARATE from the 0064 "
+            "breaker cooldown (truncate_breaker_cooldown_seconds)."
+        ),
+    )
+
     # Mode
     shadow_mode: bool = Field(default=False, description="Log intents without executing")
 

--- a/apps/gridbot/src/gridbot/executor.py
+++ b/apps/gridbot/src/gridbot/executor.py
@@ -13,6 +13,7 @@ from typing import Callable, Optional
 from bybit_adapter.rest_client import BybitRestClient
 from bybit_adapter.error_codes import (
     INSUFFICIENT_BALANCE,
+    ORDER_LINK_ID_DUPLICATE,
     ORDER_QTY_TRUNCATED_TO_ZERO,
 )
 from gridcore.intents import PlaceLimitIntent, CancelIntent
@@ -62,6 +63,55 @@ def is_insufficient_balance(error: Optional[str]) -> bool:
     if match:
         code = int(match.group(1) or match.group(2))
         return code == INSUFFICIENT_BALANCE
+    return False
+
+
+# Feature 0069 (issue #151) — narrow lowercased-token test for transient
+# network/transport failures surfaced as the str(exception) from execute_place.
+# NARROW on purpose: must NOT match a bare "error" or a digit, so it never
+# swallows a real ErrCode classification. "connection" covers ConnectionError;
+# "readtimeout"/"timeout" cover pybit's ReadTimeout.
+_NETWORK_ERROR_TOKENS = (
+    "timeout",
+    "connection",
+    "temporarily unavailable",
+    "readtimeout",
+)
+
+
+def is_network_error(error: Optional[str]) -> bool:
+    """Return True if an error string looks like a transient network failure.
+
+    Counts toward the state-divergence detector's sustained placement-failure
+    UNION (feature 0069 / issue #151) alongside ``is_truncate_error`` (110017)
+    and ``is_duplicate_link_error`` (110072). Module-level for isolated
+    testability — no inline substring checks at the call site. Deliberately
+    narrow: a bare ``"error"`` or a stray digit must NOT match.
+    """
+    if not error:
+        return False
+    lowered = error.lower()
+    return any(token in lowered for token in _NETWORK_ERROR_TOKENS)
+
+
+def is_duplicate_link_error(error: Optional[str]) -> bool:
+    """Return True if an error string carries Bybit ErrCode 110072.
+
+    110072 ("OrderLinkedID is duplicate") means a re-sent order reused a still-
+    cached orderLinkId, or a REST retry landed an order whose first ack never
+    arrived via WS. Matches the numeric code (via the shared ``_ERR_CODE_RE``
+    for both wire formats) OR the literal wording. Module-level (mirrors
+    ``is_truncate_error``) so the runner branches without a mock executor —
+    feature 0069 / issue #151. Replaces the inline 110072 substring checks.
+    """
+    if not error:
+        return False
+    if "orderlinkedid is duplicate" in error.lower():
+        return True
+    match = _ERR_CODE_RE.search(error)
+    if match:
+        code = int(match.group(1) or match.group(2))
+        return code == ORDER_LINK_ID_DUPLICATE
     return False
 
 

--- a/apps/gridbot/src/gridbot/orchestrator.py
+++ b/apps/gridbot/src/gridbot/orchestrator.py
@@ -13,6 +13,7 @@ import threading
 import time
 from collections import deque
 from datetime import datetime, UTC
+from decimal import Decimal
 from typing import Optional
 from uuid import UUID
 
@@ -23,6 +24,7 @@ from grid_db import DatabaseFactory
 from grid_db import Run, RunRepository, Strategy, BybitAccount, User
 from grid_db.identity import account_id_for, strategy_id_for, user_id_for
 from gridcore import (
+    DirectionType,
     GridStateStore,
     InstrumentInfo,
     TickerEvent,
@@ -129,6 +131,24 @@ class Orchestrator:
         # tripped breaker cannot itself spam REST during an outage. strat_id ->
         # monotonic ts of the last forced reconcile.
         self._force_reconcile_last_at: dict[str, float] = {}
+
+        # Feature 0069 (issue #151) — state-divergence detector. Logic lives on
+        # the orchestrator (no separate class). All four signals converge on
+        # _trigger_divergence_reconcile -> _force_reconcile_strat(direction=None).
+        # Detector throttle (≥5 min default), SEPARATE from the breaker cooldown:
+        # strat_id -> monotonic ts of the last divergence-driven forced reconcile.
+        self._divergence_last_fire_at: dict[str, float] = {}
+        # Signal 2 edge-tracking: strat_id -> the breaker reconcile-count value
+        # we last fired on (fire once per new exhaustion edge, not every tick).
+        self._divergence_budget_last_fired: dict[str, int] = {}
+        # Signal 4 — strats pending a post-WS-recovery forced reconcile. Mutated
+        # from the WS heartbeat thread (_on_ws_disconnect) AND the main loop, so
+        # guarded by a dedicated lock; drained (swap-and-clear) once per _tick.
+        self._pending_post_recovery_reconcile: set[str] = set()
+        self._pending_post_recovery_lock = threading.Lock()
+        # Signal 3 — next REST-vs-local size-delta sweep (primed with a phase
+        # offset vs _next_order_sync in start() so the two sweeps do not co-fire).
+        self._next_divergence_size_check: float = 0.0
 
         # Run tracking
         self._run_ids: dict[str, UUID] = {}  # strat_id -> run_id
@@ -347,6 +367,12 @@ class Orchestrator:
         self._next_ws_health_check = now + _WS_HEALTH_CHECK_INTERVAL
         self._next_order_sync = now  # order sync runs immediately on first tick
         self._next_retry_tick = now + _RETRY_TICK_INTERVAL
+        # Feature 0069 signal 3 — phase-offset half an interval ahead of
+        # _next_order_sync (which fires this tick) so the two periodic REST sweeps
+        # do not co-fire and produce a synchronized burst.
+        self._next_divergence_size_check = (
+            now + self._divergence_size_check_interval() / 2.0
+        )
 
         self._running = True
         self._started = True
@@ -548,6 +574,35 @@ class Orchestrator:
                     "_ws_health_check_once", e,
                     error_key="periodic_ws_health_check",
                 )
+        # Feature 0069 signal 4 — drain post-WS-recovery forced reconciles.
+        # PINNED here: after the per-tick WS event drains (steps 1/2/2.5) so no
+        # order-update event is adjudicated against a half-cleared dedup cache,
+        # and IMMEDIATELY BEFORE the order-sync gate (sharing this tick's `now`)
+        # so a fast-tracked _next_order_sync is consumed THIS tick. Swap-and-clear
+        # under the lock, then iterate the captured set OUTSIDE the lock. The
+        # drain NEVER re-adds: a strat whose reconcile is suppressed (detector
+        # throttle or breaker cooldown) is DROPPED, not retried (position size is
+        # backstopped by signal 3, order-level by the periodic order-sync).
+        with self._pending_post_recovery_lock:
+            pending_recovery = self._pending_post_recovery_reconcile
+            self._pending_post_recovery_reconcile = set()
+        for strat_id in pending_recovery:
+            cfg = next(
+                (c for c in self._config.strategies if c.strat_id == strat_id),
+                None,
+            )
+            # Fast-track the order-sync (same tick) when the reconcile WOULD be
+            # throttle-suppressed AND order-sync is enabled — shrinking the
+            # order-level backstop from up to order_sync_interval to this tick.
+            # Read-only peek (does NOT bump the throttle); a NON-suppressed strat
+            # reconciles directly below and needs no fast-track.
+            if cfg is not None and self._config.order_sync_interval > 0:
+                last = self._divergence_last_fire_at.get(strat_id, 0.0)
+                if (now - last) < cfg.divergence_reconcile_min_interval_seconds:
+                    self._next_order_sync = 0.0
+            self._trigger_divergence_reconcile(
+                strat_id, "post_ws_recovery", "private_ws_recovery", direction=None,
+            )
         if (
             self._config.order_sync_interval > 0
             and now >= self._next_order_sync
@@ -563,6 +618,22 @@ class Orchestrator:
                 self._notifier.alert_exception(
                     "_order_sync_once", e,
                     error_key="periodic_order_sync",
+                )
+        # Feature 0069 signal 3 — periodic REST-vs-local position-size delta sweep.
+        if now >= self._next_divergence_size_check:
+            self._next_divergence_size_check = (
+                now + self._divergence_size_check_interval()
+            )
+            try:
+                self._divergence_size_check_once()
+            except Exception as e:
+                logger.error(
+                    "Periodic check failed (_divergence_size_check_once): %s",
+                    e, exc_info=True,
+                )
+                self._notifier.alert_exception(
+                    "_divergence_size_check_once", e,
+                    error_key="periodic_divergence_size_check",
                 )
         if now >= self._next_retry_tick:
             for rq in self._retry_queues.values():
@@ -771,6 +842,8 @@ class Orchestrator:
             # Feature 0064 — dirty-mirror REST refresh + breaker forced reconcile.
             rest_client=self._rest_clients[account_name],
             on_truncate_breaker_tripped=self._force_reconcile_strat,
+            # Feature 0069 (issue #151) — signal 1 placement-failure UNION fire.
+            on_divergence_failure_mix=self._trigger_divergence_reconcile,
             # Feature 0066 Phase 4 — real-time wallet preflight source.
             wallet_provider=wallet_provider,
             wallet_ws_max_age_seconds=self._config.wallet_ws_max_age_seconds,
@@ -1029,6 +1102,26 @@ class Orchestrator:
                         runner.strat_id, trips, rest_failures,
                     )
 
+                # Feature 0069 signal 2 — reconciler retry-budget exhaustion.
+                # Fire once per NEW edge (count crosses to a value we have not
+                # yet fired on), not every tick while parked at the same value.
+                cfg = next(
+                    (c for c in self._config.strategies
+                     if c.strat_id == runner.strat_id),
+                    None,
+                )
+                if cfg is not None and cfg.divergence_detector_enabled:
+                    if (
+                        trips >= cfg.divergence_retry_budget
+                        and trips != self._divergence_budget_last_fired.get(
+                            runner.strat_id, -1
+                        )
+                    ):
+                        self._divergence_budget_last_fired[runner.strat_id] = trips
+                        self._trigger_divergence_reconcile(
+                            runner.strat_id, "retry_budget", trips,
+                        )
+
             for account_name in list(self._public_ws.keys()):
                 # Check public WS
                 pub_ws = self._public_ws.get(account_name)
@@ -1081,6 +1174,10 @@ class Orchestrator:
                                 "(threshold=%.1fs) — blocking main polling loop",
                                 account_name, elapsed, _WS_RECONNECT_SLOW_THRESHOLD,
                             )
+                    # Feature 0069 signal 4 — a private socket was found dead and
+                    # reconnected; schedule a forced reconcile (drained next _tick).
+                    # Private-only — the public branch above does NOT enqueue.
+                    self._enqueue_post_recovery_reconcile(account_name)
         except Exception as e:
             self._notifier.alert_exception(
                 "_health_check_once", e, error_key="health_check_loop",
@@ -1124,6 +1221,13 @@ class Orchestrator:
                     "WS socket dead for %s/private; resetting",
                     account_name,
                 )
+                # Feature 0069 signal 4 — a dead PRIVATE socket IS the divergence
+                # event; enqueue on DETECTION (before reset) so a forced reconcile
+                # is scheduled even if reset() raises — the reconcile runs over
+                # REST, independent of the WS socket. Mirrors _health_check_once,
+                # which enqueues after its reconnect try/except regardless of
+                # success. Private-only (public loop above does NOT enqueue).
+                self._enqueue_post_recovery_reconcile(account_name)
                 priv_ws.reset()
             except Exception as e:
                 logger.error(
@@ -1166,6 +1270,14 @@ class Orchestrator:
             account_name, kind,
         )
 
+        # Feature 0069 signal 4 — a PRIVATE-channel gap means order/position acks
+        # may have been missed; schedule a forced reconcile drained next _tick.
+        # Public-only gaps imply stale price ticks, not order/position divergence,
+        # so they do NOT enqueue. Runs on the WS heartbeat thread — the helper
+        # takes _pending_post_recovery_lock.
+        if kind == "private":
+            self._enqueue_post_recovery_reconcile(account_name)
+
         def _do_reset() -> None:
             try:
                 client.reset()
@@ -1206,22 +1318,52 @@ class Orchestrator:
             "%s: Untracked order seen — fast-tracking order sync", strat_id,
         )
 
-    def _force_reconcile_strat(self, strat_id: str, direction: str) -> None:
-        """Breaker-triggered forced position + order reconcile (feature 0064).
+    def _force_reconcile_strat(
+        self,
+        strat_id: str,
+        direction: "str | None",
+        emit_breaker_warning: bool = True,
+    ) -> bool:
+        """Forced position + order reconcile (feature 0064; extended 0069).
 
-        Wired as the runner's ``on_truncate_breaker_tripped`` callback. Resyncs
-        the order book via ``reconcile_reconnect`` (handles untracked-on-exchange
-        / missing-in-memory) AND the position size via
-        ``_refresh_position_size_from_rest(force=True)`` — the piece
-        ``reconcile_reconnect`` does NOT do today — closing the stale-mirror gap
-        that defeated ``_is_good_to_place``. Rate-limited to at most once per
+        Wired as the runner's ``on_truncate_breaker_tripped`` callback AND reused
+        by the state-divergence detector (issue #151). Resyncs the order book via
+        ``reconcile_reconnect`` (handles untracked-on-exchange / missing-in-memory)
+        AND the position size via ``_refresh_position_size_from_rest(force=True)``
+        — the piece ``reconcile_reconnect`` does NOT do — closing the stale-mirror
+        gap that defeated ``_is_good_to_place``. Rate-limited to at most once per
         ``truncate_breaker_cooldown_seconds`` per strat so a tripped breaker
-        cannot itself spam REST during an outage. Designed to be reusable by the
-        broader divergence detector (issue #151).
+        cannot itself spam REST during an outage.
+
+        ``direction``:
+          - a specific side (``DirectionType.LONG``/``SHORT``) — the breaker-trip
+            caller's path: ONE ``reconcile_reconnect`` + ONE position refresh for
+            that side (unchanged behaviour).
+          - ``None`` — every detector signal's path: ONE rate-limit check, ONE
+            ``reconcile_reconnect`` (whole-runner / direction-agnostic), then a
+            position refresh for BOTH LONG and SHORT (each in its own try/except).
+            Handled INTERNALLY so the rate-limit timestamp is set exactly once and
+            the second direction is never silently dropped behind the rate-limit
+            (which two back-to-back calls would do — leaving a hedge-mode mirror
+            half stale behind a WARNING claiming a full reconcile).
+
+        ``emit_breaker_warning``: when True (default — breaker-trip caller) the
+        ``"110017 breaker tripped — forcing ..."`` WARNING is emitted (byte-for-
+        byte unchanged). The detector wrapper passes False so that line — and its
+        ``'None'`` direction text — is suppressed; only the wrapper's single
+        ``state-divergence detected`` WARNING is emitted on a detector fire,
+        keeping the analyzer's merged ``force_reconcile_fired`` count at one per
+        reconcile (each reconcile matches exactly one of the two scanned patterns).
+
+        Returns True when a reconcile was ATTEMPTED (not rate-limited / no runner),
+        False on every no-op exit. True does NOT guarantee full success — the two
+        REST steps run in independent try/excepts and a partial failure is alerted
+        via ``_notifier.alert_exception`` but still returns True (the WARNING is
+        about the action taken, not a success guarantee).
         """
         runner = self._runners.get(strat_id)
         if runner is None:
-            return
+            return False
         account_name = self._get_account_for_strategy(strat_id)
         reconciler = self._reconcilers.get(account_name) if account_name else None
 
@@ -1237,13 +1379,14 @@ class Orchestrator:
                 "%s: forced reconcile rate-limited (%.1fs since last < %.1fs)",
                 strat_id, now - last, cooldown,
             )
-            return
+            return False
         self._force_reconcile_last_at[strat_id] = now
 
-        logger.warning(
-            "%s: 110017 breaker tripped — forcing %s position + order reconcile",
-            strat_id, direction,
-        )
+        if emit_breaker_warning:
+            logger.warning(
+                "%s: 110017 breaker tripped — forcing %s position + order reconcile",
+                strat_id, direction,
+            )
         if reconciler is not None:
             try:
                 reconciler.reconcile_reconnect(runner)
@@ -1253,15 +1396,185 @@ class Orchestrator:
                     error_key=f"force_reconcile_orders_{strat_id}",
                 )
         # Position-size resync is the #149-critical healing step — it closes the
-        # stale-mirror gap that defeats _is_good_to_place. Run it in its OWN
-        # try/except so an order-reconcile failure above never skips it (P2).
-        try:
-            runner._refresh_position_size_from_rest(direction, force=True)
-        except Exception as e:
-            self._notifier.alert_exception(
-                f"forced reconcile position {strat_id}", e,
-                error_key=f"force_reconcile_pos_{strat_id}",
+        # stale-mirror gap that defeats _is_good_to_place. Run each direction in
+        # its OWN try/except so an order-reconcile failure above never skips it
+        # (P2) and one direction's failure never skips the other (B-1).
+        directions = (
+            (DirectionType.LONG, DirectionType.SHORT)
+            if direction is None
+            else (direction,)
+        )
+        for d in directions:
+            try:
+                runner._refresh_position_size_from_rest(d, force=True)
+            except Exception as e:
+                self._notifier.alert_exception(
+                    f"forced reconcile position {strat_id}", e,
+                    error_key=f"force_reconcile_pos_{strat_id}",
+                )
+        return True
+
+    def _trigger_divergence_reconcile(
+        self,
+        strat_id: str,
+        signal: str,
+        evidence: object,
+        direction: "str | None" = None,
+    ) -> None:
+        """Thin divergence wrapper around ``_force_reconcile_strat`` (issue #151).
+
+        All four detector signals funnel here. Fire-and-forget (returns None — no
+        caller, including signal 4's drain, inspects a return value). Order:
+
+        1. Master kill-switch (BEFORE the throttle): if the per-strat
+           ``divergence_detector_enabled`` is False, RETURN immediately (no
+           reconcile, no WARNING, no throttle bump). This is the catch-all the
+           kill-switch test asserts.
+        2. Detector throttle (SEPARATE from the breaker cooldown): if within
+           ``divergence_reconcile_min_interval_seconds`` of the last divergence
+           fire, emit DEBUG and RETURN — without calling ``_force_reconcile_strat``
+           and without bumping the throttle.
+        3. Call ``_force_reconcile_strat`` exactly ONCE — ALWAYS ``direction=None``
+           (the internal both-directions handling does the work) and ALWAYS
+           ``emit_breaker_warning=False`` (suppress the breaker line on this path).
+           Branch on the returned bool so side-effects ONLY land on a real
+           reconcile:
+             - False (rate-limited by the breaker cooldown / no runner): single
+               DEBUG "suppressed" line; NO WARNING, NO dedup-clear, NO throttle
+               bump. A suppressed fire never evicts adjudication state without a
+               resync, and the analyzer counter never overstates real reconciles.
+             - True: the single ``state-divergence detected`` WARNING, clear the
+               runner's dedup cache, and bump the detector throttle.
+        """
+        cfg = next(
+            (c for c in self._config.strategies if c.strat_id == strat_id), None
+        )
+        if cfg is None or not cfg.divergence_detector_enabled:
+            return
+
+        now = time.monotonic()
+        last = self._divergence_last_fire_at.get(strat_id, 0.0)
+        min_interval = cfg.divergence_reconcile_min_interval_seconds
+        if (now - last) < min_interval:
+            logger.debug(
+                "%s: divergence signal=%s within throttle (%.1fs since last < %.1fs) "
+                "— skipping",
+                strat_id, signal, now - last, min_interval,
             )
+            return
+
+        ran = self._force_reconcile_strat(strat_id, None, emit_breaker_warning=False)
+        if not ran:
+            logger.debug(
+                "%s: divergence signal=%s suppressed — forced reconcile within "
+                "breaker cooldown",
+                strat_id, signal,
+            )
+            return
+
+        logger.warning(
+            "%s: state-divergence detected (signal=%s, evidence=%s), "
+            "forcing full reconcile",
+            strat_id, signal, evidence,
+        )
+        runner = self._runners.get(strat_id)
+        if runner is not None:
+            try:
+                runner.clear_dedup_cache()
+            except Exception as e:
+                self._notifier.alert_exception(
+                    f"divergence dedup clear {strat_id}", e,
+                    error_key=f"divergence_dedup_clear_{strat_id}",
+                )
+        self._divergence_last_fire_at[strat_id] = now
+
+    def _enqueue_post_recovery_reconcile(self, account_name: str) -> None:
+        """Signal 4 — fan out an account-level WS recovery to its strats.
+
+        The three trigger sources (``_on_ws_disconnect`` heartbeat gap,
+        ``_health_check_once`` private reconnect, ``_ws_health_check_once`` private
+        reset) identify the socket by ``account_name``; the pending set is keyed by
+        ``strat_id``, so fan out via ``_account_to_runners`` here. Skips per-strat
+        when the detector is disabled. Takes ``_pending_post_recovery_lock`` because
+        ``_on_ws_disconnect`` runs on the WS heartbeat thread. The set dedups the
+        public+private double-fire for the same account naturally.
+        """
+        runners = self._account_to_runners.get(account_name, [])
+        with self._pending_post_recovery_lock:
+            for runner in runners:
+                cfg = next(
+                    (c for c in self._config.strategies
+                     if c.strat_id == runner.strat_id),
+                    None,
+                )
+                if cfg is None or not cfg.divergence_detector_enabled:
+                    continue
+                self._pending_post_recovery_reconcile.add(runner.strat_id)
+
+    def _divergence_size_check_interval(self) -> float:
+        """Cadence for the signal-3 size-delta sweep (orchestrator-level gate).
+
+        The per-strat ``divergence_size_check_interval_seconds`` is honoured by
+        taking the MIN across enabled strats so the most-frequent strat's cadence
+        is respected; the sweep itself is per-runner and cheap, so over-checking a
+        slower strat is harmless. Falls back to 300s when no strat is enabled.
+        """
+        intervals = [
+            c.divergence_size_check_interval_seconds
+            for c in self._config.strategies
+            if c.divergence_detector_enabled
+        ]
+        return min(intervals) if intervals else 300.0
+
+    def _divergence_size_check_once(self) -> None:
+        """Signal 3 — read-only REST-vs-local position-size delta sweep.
+
+        For each runner: skip when the detector is disabled, when
+        ``_instrument_info`` is None (no-rounding mode), or when ``qty_step`` is not
+        a positive ``Decimal``. Evaluate BOTH directions via the pure
+        ``rest_position_size`` read (no mirror mutation); a ``None`` REST read skips
+        that direction (no fire). If EITHER direction's ``abs(rest - local)`` exceeds
+        ``qty_step * multiplier``, fire ONCE with ``direction=None`` (full reconcile
+        refreshes both mirrors — never targets one side, avoiding the same-sweep
+        throttle trap).
+        """
+        for runner in self._runners.values():
+            cfg = next(
+                (c for c in self._config.strategies
+                 if c.strat_id == runner.strat_id),
+                None,
+            )
+            if cfg is None or not cfg.divergence_detector_enabled:
+                continue
+            info = getattr(runner, "_instrument_info", None)
+            if info is None:
+                continue
+            qty_step = getattr(info, "qty_step", None)
+            if not isinstance(qty_step, Decimal) or qty_step <= 0:
+                continue
+            threshold = qty_step * Decimal(
+                str(cfg.divergence_size_delta_qty_step_multiplier)
+            )
+            deltas: list[tuple[str, Decimal]] = []
+            for direction, local_size in (
+                (DirectionType.LONG, runner._long_position.size),
+                (DirectionType.SHORT, runner._short_position.size),
+            ):
+                rest_size = runner.rest_position_size(direction)
+                if rest_size is None:
+                    logger.debug(
+                        "%s: divergence size-check REST read failed for %s — "
+                        "skipping that direction",
+                        runner.strat_id, direction,
+                    )
+                    continue
+                deltas.append((direction, abs(rest_size - local_size)))
+            diverged = [(d, delta) for d, delta in deltas if delta > threshold]
+            if diverged:
+                evidence = "+".join(f"{d} Δ{delta}" for d, delta in deltas)
+                self._trigger_divergence_reconcile(
+                    runner.strat_id, "rest_size_delta", evidence, direction=None,
+                )
 
     def _order_sync_once(self) -> None:
         """Single-shot order reconciliation sweep.

--- a/apps/gridbot/src/gridbot/orchestrator.py
+++ b/apps/gridbot/src/gridbot/orchestrator.py
@@ -1321,7 +1321,7 @@ class Orchestrator:
     def _force_reconcile_strat(
         self,
         strat_id: str,
-        direction: "str | None",
+        direction: Optional[str],
         emit_breaker_warning: bool = True,
     ) -> bool:
         """Forced position + order reconcile (feature 0064; extended 0069).
@@ -1419,7 +1419,7 @@ class Orchestrator:
         strat_id: str,
         signal: str,
         evidence: object,
-        direction: "str | None" = None,
+        direction: Optional[str] = None,
     ) -> None:
         """Thin divergence wrapper around ``_force_reconcile_strat`` (issue #151).
 

--- a/apps/gridbot/src/gridbot/orchestrator.py
+++ b/apps/gridbot/src/gridbot/orchestrator.py
@@ -1410,7 +1410,7 @@ class Orchestrator:
             except Exception as e:
                 self._notifier.alert_exception(
                     f"forced reconcile position {strat_id}", e,
-                    error_key=f"force_reconcile_pos_{strat_id}",
+                    error_key=f"force_reconcile_pos_{strat_id}_{d}",
                 )
         return True
 

--- a/apps/gridbot/src/gridbot/runner.py
+++ b/apps/gridbot/src/gridbot/runner.py
@@ -52,7 +52,9 @@ from gridcore import (
 from gridbot.config import StrategyConfig
 from gridbot.executor import (
     IntentExecutor,
+    is_duplicate_link_error,
     is_insufficient_balance,
+    is_network_error,
     is_truncate_error,
 )
 from gridbot.notifier import Notifier
@@ -193,6 +195,7 @@ class StrategyRunner:
         rest_client: Optional["BybitRestClient"] = None,
         truncate_breaker: Optional[TruncateBreaker] = None,
         on_truncate_breaker_tripped: Optional[Callable[[str, str], None]] = None,
+        on_divergence_failure_mix: Optional[Callable[[str, str, int], None]] = None,
         clock: Optional[Callable[[], float]] = None,
         wallet_provider: Optional["WalletProvider"] = None,
         wallet_ws_max_age_seconds: float = 45.0,
@@ -269,6 +272,9 @@ class StrategyRunner:
         self._rest_client = rest_client
         self._clock = clock or time.monotonic
         self._on_truncate_breaker_tripped = on_truncate_breaker_tripped
+        # Feature 0069 (issue #151) signal 1 — callback invoked when the rolling
+        # placement-failure UNION window crosses its threshold.
+        self._on_divergence_failure_mix = on_divergence_failure_mix
         self._truncate_breaker = truncate_breaker or TruncateBreaker(
             max_consecutive=strategy_config.truncate_breaker_max_consecutive,
             window_seconds=strategy_config.truncate_breaker_window_seconds,
@@ -307,6 +313,12 @@ class StrategyRunner:
             DirectionType.LONG: 0,
             DirectionType.SHORT: 0,
         }
+        # Feature 0069 (issue #151) signal 1 — rolling window of monotonic
+        # timestamps of placement failures in the UNION {110017, 110072,
+        # network}. Stamped/evicted via self._clock() (injectable) so tests
+        # drive the window deterministically; cleared the instant the threshold
+        # fires (see _record_placement_failure).
+        self._placement_failure_window: deque[float] = deque()
 
         # Qty computation
         self._instrument_info = instrument_info
@@ -1322,6 +1334,106 @@ class StrategyRunner:
             # Establish the REST baseline the WS gate consults for THIS episode.
             self._last_rest_position_size[direction] = new_size
 
+    def rest_position_size(self, direction: str) -> Optional[Decimal]:
+        """PURE REST read of one direction's position size (feature 0069 sig 3).
+
+        Factors ONLY the ``positionIdx``/``get_positions`` read out of
+        ``_refresh_position_size_from_rest`` WITHOUT any side effects: it does
+        NOT write ``_last_dirty_rest_at``, does NOT bump
+        ``_dirty_rest_refresh_failure_count``, and does NOT mutate the
+        ``_long_position``/``_short_position`` mirrors. Used by the divergence
+        size-delta sweep, which must not perturb the dirty-refresh throttle or
+        the failure-counter observability that signal 2 reads.
+
+        Returns the parsed exchange size as ``Decimal`` (``Decimal("0")`` when no
+        entry for the direction), or ``None`` on ``rest_client is None`` or any
+        ``get_positions``/parse error — the caller SKIPS the comparison for that
+        direction (no fire) rather than counting a phantom delta. A ``None``
+        return is logged at DEBUG so REST flakiness stays observable.
+        """
+        if self._rest_client is None:
+            logger.debug(
+                "%s: rest_position_size for %s skipped — no rest_client",
+                self.strat_id, direction,
+            )
+            return None
+        position_idx = 1 if direction == DirectionType.LONG else 2
+        try:
+            positions = self._rest_client.get_positions(self._config.symbol)
+        except Exception as e:
+            logger.debug(
+                "%s: rest_position_size get_positions failed for %s: %s: %s",
+                self.strat_id, direction, type(e).__name__, e,
+            )
+            return None
+
+        def _matches(p: dict) -> bool:
+            try:
+                return int(p.get("positionIdx", -1)) == position_idx
+            except (TypeError, ValueError):
+                return False
+
+        entry = next((p for p in positions if _matches(p)), None)
+        if entry is None:
+            return Decimal("0")
+        try:
+            return Decimal(str(entry.get("size", 0) or 0))
+        except (ArithmeticError, ValueError, TypeError):
+            logger.debug(
+                "%s: rest_position_size unparseable size %r for %s",
+                self.strat_id, entry.get("size"), direction,
+            )
+            return None
+
+    def clear_dedup_cache(self) -> None:
+        """Clear the verdict-aware SAME ORDER dedup cache (feature 0069).
+
+        Called by the orchestrator's divergence wrapper AFTER a real forced
+        reconcile so stale orderLinkId adjudication state cannot suppress fresh
+        retriggers against the now-resynced grid. Runs synchronously on the main
+        tick thread (signals 1/2/3 fire there; signal 4 drains there), so there
+        is no concurrent reader of a half-cleared cache. The cache re-populates
+        naturally as new SAME ORDER pairs are adjudicated on later ticks.
+        """
+        self._same_order_dedup_cache.clear()
+
+    def _record_placement_failure(self, error: Optional[str]) -> None:
+        """Feed one placement failure into the divergence UNION window (sig 1).
+
+        Invoked from BOTH ``_execute_place_intent`` failure exits (110017 branch
+        and the non-110017 early-return that carries 110072/network). Applies the
+        UNION-membership test itself ({110017, 110072, network}; 110007 is
+        excluded) so both call sites pass the raw ``result.error``. Stamps/evicts
+        with ``self._clock()`` (injectable) so the window is deterministic under
+        a fake clock. When the count reaches the threshold the window is CLEARED
+        immediately and the ``on_divergence_failure_mix`` callback is invoked —
+        "a fire" means threshold-reached, regardless of whether the downstream
+        wrapper then reconciles or suppresses (so a cooldown-suppressed fire does
+        not leave the window full and re-trigger on every subsequent failure).
+        Inert when the detector is disabled.
+        """
+        if not self._config.divergence_detector_enabled:
+            return
+        if not (
+            is_truncate_error(error)
+            or is_duplicate_link_error(error)
+            or is_network_error(error)
+        ):
+            return
+        now = self._clock()
+        window = self._placement_failure_window
+        window.append(now)
+        cutoff = now - self._config.divergence_failure_mix_window_seconds
+        while window and window[0] < cutoff:
+            window.popleft()
+        if len(window) >= self._config.divergence_failure_mix_threshold:
+            count = len(window)
+            window.clear()
+            if self._on_divergence_failure_mix is not None:
+                self._on_divergence_failure_mix(
+                    self.strat_id, "rest_failure_mix", count
+                )
+
     def _predicate_available_balance(self) -> tuple[Decimal, bool]:
         """Free margin for the low-balance PREDICATE (3a moderate_liq + 3b chase).
 
@@ -2038,11 +2150,17 @@ class StrategyRunner:
         if not is_truncate_error(result.error):
             # Non-110017 failure → existing retry-queue behaviour (feature 0032
             # wire-id reuse preserved via the failed-tracked-order path above).
+            # Feature 0069 — 110072/network leave via THIS branch, so record
+            # here too (the helper applies the UNION test and ignores the rest).
+            self._record_placement_failure(result.error)
             if self._on_intent_failed:
                 self._on_intent_failed(assigned, result.error)
             return
 
         # --- 110017 (orderQty truncated to zero) handling ---
+        # Feature 0069 signal 1 — 110017 feeds the placement-failure UNION too
+        # (the helper short-circuits when the detector is disabled).
+        self._record_placement_failure(result.error)
         # Mark the direction dirty so the NEXT placement REST-refreshes the
         # mirror before the guard (self-heal), even before the breaker trips.
         self._position_dirty[intent.direction] = True

--- a/apps/gridbot/tests/test_config.py
+++ b/apps/gridbot/tests/test_config.py
@@ -112,6 +112,40 @@ class TestStrategyConfig:
         with pytest.raises(ValidationError):
             StrategyConfig(**base, dirty_rest_refresh_min_interval_seconds=0)  # gt=0
 
+    def test_divergence_detector_defaults(self):
+        """Feature 0069 — defaults ship on and load cleanly (issue #151)."""
+        strategy = StrategyConfig(
+            strat_id="btc_main", account="main", symbol="BTCUSDT",
+            tick_size=Decimal("0.1"),
+        )
+        assert strategy.divergence_detector_enabled is True
+        assert strategy.divergence_failure_mix_threshold == 10
+        assert strategy.divergence_failure_mix_window_seconds == 60.0
+        assert strategy.divergence_retry_budget == 5
+        assert strategy.divergence_size_check_interval_seconds == 300.0
+        assert strategy.divergence_size_delta_qty_step_multiplier == 5.0
+        assert strategy.divergence_reconcile_min_interval_seconds == 300.0
+
+    def test_divergence_detector_invalid_values_rejected(self):
+        """Feature 0069 — counts/budgets use ge=1; intervals/windows/multiplier
+        use gt=0; degenerate YAML is rejected at load."""
+        base = dict(
+            strat_id="btc_main", account="main", symbol="BTCUSDT",
+            tick_size=Decimal("0.1"),
+        )
+        with pytest.raises(ValidationError):
+            StrategyConfig(**base, divergence_failure_mix_threshold=0)  # ge=1
+        with pytest.raises(ValidationError):
+            StrategyConfig(**base, divergence_retry_budget=0)  # ge=1
+        with pytest.raises(ValidationError):
+            StrategyConfig(**base, divergence_failure_mix_window_seconds=0)  # gt=0
+        with pytest.raises(ValidationError):
+            StrategyConfig(**base, divergence_size_check_interval_seconds=0)  # gt=0
+        with pytest.raises(ValidationError):
+            StrategyConfig(**base, divergence_reconcile_min_interval_seconds=0)  # gt=0
+        with pytest.raises(ValidationError):
+            StrategyConfig(**base, divergence_size_delta_qty_step_multiplier=0)  # gt=0
+
     def test_increase_same_position_on_low_margin_defaults_false(self):
         """Test low-margin equal-position boost flag defaults off."""
         strategy = StrategyConfig(

--- a/apps/gridbot/tests/test_executor.py
+++ b/apps/gridbot/tests/test_executor.py
@@ -14,8 +14,14 @@ from gridbot.executor import (
     AUTH_ERROR_CODES,
     is_truncate_error,
     is_insufficient_balance,
+    is_network_error,
+    is_duplicate_link_error,
 )
-from bybit_adapter.error_codes import ORDER_QTY_TRUNCATED_TO_ZERO, INSUFFICIENT_BALANCE
+from bybit_adapter.error_codes import (
+    ORDER_QTY_TRUNCATED_TO_ZERO,
+    INSUFFICIENT_BALANCE,
+    ORDER_LINK_ID_DUPLICATE,
+)
 
 
 class TestIsTruncateError:
@@ -73,6 +79,62 @@ class TestIsInsufficientBalance:
     def test_none_and_empty_are_not_insufficient_balance(self):
         assert is_insufficient_balance(None) is False
         assert is_insufficient_balance("") is False
+
+
+class TestIsNetworkError:
+    """Feature 0069 — narrow transient-network classifier for the divergence
+    placement-failure UNION (issue #151)."""
+
+    def test_matches_timeout(self):
+        assert is_network_error("Connection timeout") is True
+        assert is_network_error("Read timed out... ReadTimeout") is True
+
+    def test_matches_connection_and_readtimeout(self):
+        assert is_network_error("requests.exceptions.ConnectionError: boom") is True
+        assert is_network_error("pybit raised ReadTimeout after 10s") is True
+
+    def test_matches_temporarily_unavailable(self):
+        assert is_network_error("503 Service Temporarily Unavailable") is True
+
+    def test_does_not_match_generic_error_or_digits(self):
+        # NARROW: a bare "error" or a stray digit must NOT classify as network.
+        assert is_network_error("some weird error") is False
+        assert is_network_error("12345") is False
+
+    def test_does_not_match_errcodes(self):
+        assert is_network_error("Bybit API error: [110017] truncated") is False
+        assert is_network_error("Bybit API error: [110007] balance") is False
+
+    def test_none_and_empty_are_not_network(self):
+        assert is_network_error(None) is False
+        assert is_network_error("") is False
+
+
+class TestIsDuplicateLinkError:
+    """Feature 0069 — classify ErrCode 110072 ('OrderLinkedID is duplicate')."""
+
+    def test_constant_is_110072(self):
+        assert ORDER_LINK_ID_DUPLICATE == 110072
+
+    def test_detects_check_response_format(self):
+        err = "Bybit API error in place_order: [110072] OrderLinkedID is duplicate"
+        assert is_duplicate_link_error(err) is True
+
+    def test_detects_pybit_native_format(self):
+        err = "place_order failed (ErrCode: 110072) duplicate"
+        assert is_duplicate_link_error(err) is True
+
+    def test_detects_wording_case_insensitive(self):
+        assert is_duplicate_link_error("orderlinkedid is DUPLICATE") is True
+
+    def test_other_error_code_is_not_duplicate(self):
+        assert is_duplicate_link_error("Bybit API error: [110017] truncated") is False
+        assert is_duplicate_link_error("Bybit API error: [110007] balance") is False
+        assert is_duplicate_link_error("Connection timeout") is False
+
+    def test_none_and_empty_are_not_duplicate(self):
+        assert is_duplicate_link_error(None) is False
+        assert is_duplicate_link_error("") is False
 
 
 @pytest.fixture

--- a/apps/gridbot/tests/test_orchestrator_divergence.py
+++ b/apps/gridbot/tests/test_orchestrator_divergence.py
@@ -1,0 +1,545 @@
+"""Feature 0069 — orchestrator-side state-divergence detector (issue #151).
+
+Covers the _force_reconcile_strat refactor (B-1 single-call both-directions +
+breaker-WARNING gating), the _trigger_divergence_reconcile wrapper (throttle,
+kill-switch, breaker-cooldown suppression), and the four signals (placement-
+failure union wiring, retry-budget edge, REST-size delta sweep, post-WS-recovery
+enqueue/drain/fast-track).
+
+    uv run pytest apps/gridbot/tests/test_orchestrator_divergence.py
+"""
+
+from datetime import datetime, UTC
+from decimal import Decimal
+from unittest.mock import Mock, MagicMock
+
+import pytest
+
+from gridcore.position import DirectionType
+
+from gridbot.config import GridbotConfig, AccountConfig, StrategyConfig
+from gridbot.orchestrator import Orchestrator
+from gridbot.reconciler import ReconciliationResult
+
+
+# --------------------------------------------------------------------------
+# Fixtures / helpers
+# --------------------------------------------------------------------------
+
+def _strategy_config(**overrides) -> StrategyConfig:
+    base = dict(
+        strat_id="btcusdt_test",
+        account="test_account",
+        symbol="BTCUSDT",
+        tick_size=Decimal("0.1"),
+        grid_count=20,
+        grid_step=0.2,
+    )
+    base.update(overrides)
+    return StrategyConfig(**base)
+
+
+def _gridbot_config(strategy_config=None, **grid_overrides) -> GridbotConfig:
+    cfg = dict(
+        accounts=[AccountConfig(
+            name="test_account", api_key="k", api_secret="s", testnet=True,
+        )],
+        strategies=[strategy_config or _strategy_config()],
+        database_url="sqlite:///:memory:",
+        position_check_interval=60.0,
+    )
+    cfg.update(grid_overrides)
+    return GridbotConfig(**cfg)
+
+
+def _wire(gridbot_config, *, instrument_info=None):
+    """Orchestrator + one Mock runner + Mock reconciler + routing map."""
+    orch = Orchestrator(gridbot_config)
+    orch._notifier = Mock()  # avoid real Telegram side effects in alert paths
+    runner = Mock()
+    runner.strat_id = "btcusdt_test"
+    runner.symbol = "BTCUSDT"
+    # Ints so the signal-2 block in _health_check_once does not raise on Mock
+    # comparisons (which would abort the method before the WS reconnect loop).
+    runner.truncate_breaker_reconcile_count = 0
+    runner.dirty_rest_refresh_failure_count = 0
+    if instrument_info is not None:
+        runner._instrument_info = instrument_info
+    reconciler = Mock()
+    reconciler.reconcile_reconnect = MagicMock(return_value=ReconciliationResult())
+    orch._runners["btcusdt_test"] = runner
+    orch._reconcilers["test_account"] = reconciler
+    orch._account_to_runners["test_account"] = [runner]
+    return orch, runner, reconciler
+
+
+@pytest.fixture
+def fixed_clock(monkeypatch):
+    clock = {"now": 1000.0}
+    monkeypatch.setattr("gridbot.orchestrator.time.monotonic", lambda: clock["now"])
+    return clock
+
+
+# ==========================================================================
+# B-1 — _force_reconcile_strat single-call both-directions
+# ==========================================================================
+
+def test_force_reconcile_direction_none_refreshes_both(fixed_clock):
+    orch, runner, reconciler = _wire(_gridbot_config())
+    ran = orch._force_reconcile_strat("btcusdt_test", None)
+    assert ran is True
+    reconciler.reconcile_reconnect.assert_called_once_with(runner)
+    assert runner._refresh_position_size_from_rest.call_count == 2
+    runner._refresh_position_size_from_rest.assert_any_call(DirectionType.LONG, force=True)
+    runner._refresh_position_size_from_rest.assert_any_call(DirectionType.SHORT, force=True)
+
+
+def test_force_reconcile_second_call_within_cooldown_returns_false(fixed_clock):
+    """Single-call model: a second back-to-back direction=None call within the
+    cooldown returns False and does NO reconcile/refresh (the rate-limit ts is
+    set once per call; the second direction is never silently dropped)."""
+    orch, runner, reconciler = _wire(_gridbot_config())
+    assert orch._force_reconcile_strat("btcusdt_test", None) is True
+    reconciler.reconcile_reconnect.reset_mock()
+    runner._refresh_position_size_from_rest.reset_mock()
+    assert orch._force_reconcile_strat("btcusdt_test", None) is False
+    reconciler.reconcile_reconnect.assert_not_called()
+    runner._refresh_position_size_from_rest.assert_not_called()
+
+
+def test_force_reconcile_specific_direction_unchanged(fixed_clock):
+    """Breaker-trip caller path: one reconcile + one refresh for the side."""
+    orch, runner, reconciler = _wire(_gridbot_config())
+    assert orch._force_reconcile_strat("btcusdt_test", "long") is True
+    reconciler.reconcile_reconnect.assert_called_once_with(runner)
+    runner._refresh_position_size_from_rest.assert_called_once_with("long", force=True)
+
+
+def test_force_reconcile_missing_runner_returns_false(fixed_clock):
+    orch = Orchestrator(_gridbot_config())
+    assert orch._force_reconcile_strat("nope", None) is False
+
+
+# B-1 breaker-WARNING gating ------------------------------------------------
+
+def test_breaker_warning_emitted_by_default(fixed_clock, caplog):
+    orch, runner, reconciler = _wire(_gridbot_config())
+    with caplog.at_level("WARNING", logger="gridbot.orchestrator"):
+        orch._force_reconcile_strat("btcusdt_test", "long")  # default True
+    msgs = [r.getMessage() for r in caplog.records]
+    assert any("110017 breaker tripped — forcing long" in m for m in msgs)
+
+
+def test_detector_fire_suppresses_breaker_warning(fixed_clock, caplog):
+    orch, runner, reconciler = _wire(_gridbot_config())
+    with caplog.at_level("WARNING", logger="gridbot.orchestrator"):
+        orch._trigger_divergence_reconcile("btcusdt_test", "rest_failure_mix", 10)
+    msgs = [r.getMessage() for r in caplog.records]
+    # Exactly ONE detector WARNING, NO breaker line (and no 'None' direction).
+    assert sum("state-divergence detected" in m for m in msgs) == 1
+    assert not any("110017 breaker tripped — forcing" in m for m in msgs)
+    assert not any("None position + order reconcile" in m for m in msgs)
+
+
+# ==========================================================================
+# Wrapper — throttle, kill-switch, breaker-cooldown suppression
+# ==========================================================================
+
+def test_wrapper_detector_throttle(fixed_clock):
+    orch, runner, reconciler = _wire(_gridbot_config())
+    orch._trigger_divergence_reconcile("btcusdt_test", "rest_failure_mix", 10)
+    assert reconciler.reconcile_reconnect.call_count == 1
+    # Second within the 300s detector throttle → suppressed.
+    orch._trigger_divergence_reconcile("btcusdt_test", "rest_failure_mix", 11)
+    assert reconciler.reconcile_reconnect.call_count == 1
+    # After the detector throttle (and past the 60s breaker cooldown) → fires.
+    fixed_clock["now"] = 1000.0 + 301.0
+    orch._trigger_divergence_reconcile("btcusdt_test", "rest_failure_mix", 12)
+    assert reconciler.reconcile_reconnect.call_count == 2
+
+
+def test_wrapper_kill_switch(fixed_clock):
+    orch, runner, reconciler = _wire(
+        _gridbot_config(_strategy_config(divergence_detector_enabled=False))
+    )
+    orch._trigger_divergence_reconcile("btcusdt_test", "rest_failure_mix", 10)
+    reconciler.reconcile_reconnect.assert_not_called()
+
+
+def test_wrapper_suppressed_by_breaker_cooldown_no_misleading_warning(
+    fixed_clock, caplog
+):
+    """F-1-6: a forced reconcile within the breaker's 60s cooldown returns False;
+    the wrapper must NOT emit the WARNING, NOT clear the dedup cache, NOT bump the
+    detector throttle. After the cooldown elapses the same signal fires fully."""
+    orch, runner, reconciler = _wire(_gridbot_config())
+    # Simulate a breaker trip that just set the internal cooldown.
+    orch._force_reconcile_last_at["btcusdt_test"] = 1000.0
+
+    with caplog.at_level("WARNING", logger="gridbot.orchestrator"):
+        orch._trigger_divergence_reconcile("btcusdt_test", "rest_failure_mix", 10)
+    msgs = [r.getMessage() for r in caplog.records]
+    assert not any("state-divergence detected" in m for m in msgs)
+    reconciler.reconcile_reconnect.assert_not_called()
+    runner.clear_dedup_cache.assert_not_called()
+    assert "btcusdt_test" not in orch._divergence_last_fire_at
+
+    # After the 60s breaker cooldown → fires fully.
+    fixed_clock["now"] = 1000.0 + 61.0
+    with caplog.at_level("WARNING", logger="gridbot.orchestrator"):
+        orch._trigger_divergence_reconcile("btcusdt_test", "rest_failure_mix", 10)
+    msgs = [r.getMessage() for r in caplog.records]
+    assert any("state-divergence detected" in m for m in msgs)
+    runner.clear_dedup_cache.assert_called_once()
+    assert orch._divergence_last_fire_at["btcusdt_test"] == 1061.0
+
+
+# ==========================================================================
+# Signal 2 — retry-budget exhaustion edge
+# ==========================================================================
+
+def _wire_for_signal2(budget=5):
+    orch, runner, reconciler = _wire(
+        _gridbot_config(_strategy_config(divergence_retry_budget=budget))
+    )
+    runner.dirty_rest_refresh_failure_count = 0
+    orch._trigger_divergence_reconcile = Mock()  # isolate edge logic from throttle
+    return orch, runner
+
+
+def test_signal2_fires_on_edge_then_not_while_parked_then_on_next_edge():
+    orch, runner = _wire_for_signal2(budget=5)
+    runner.truncate_breaker_reconcile_count = 5
+    orch._health_check_once()  # edge: 5 >= 5, never fired
+    assert orch._trigger_divergence_reconcile.call_count == 1
+    orch._trigger_divergence_reconcile.assert_called_with("btcusdt_test", "retry_budget", 5)
+    orch._health_check_once()  # parked at 5 → no re-fire
+    assert orch._trigger_divergence_reconcile.call_count == 1
+    runner.truncate_breaker_reconcile_count = 6  # advances to a new edge
+    orch._health_check_once()
+    assert orch._trigger_divergence_reconcile.call_count == 2
+    orch._trigger_divergence_reconcile.assert_called_with("btcusdt_test", "retry_budget", 6)
+
+
+def test_signal2_below_budget_does_not_fire():
+    orch, runner = _wire_for_signal2(budget=5)
+    runner.truncate_breaker_reconcile_count = 4
+    orch._health_check_once()
+    orch._trigger_divergence_reconcile.assert_not_called()
+
+
+def test_signal2_disabled_does_not_fire():
+    orch, runner, reconciler = _wire(
+        _gridbot_config(_strategy_config(
+            divergence_detector_enabled=False, divergence_retry_budget=5,
+        ))
+    )
+    runner.dirty_rest_refresh_failure_count = 0
+    runner.truncate_breaker_reconcile_count = 9
+    orch._trigger_divergence_reconcile = Mock()
+    orch._health_check_once()
+    orch._trigger_divergence_reconcile.assert_not_called()
+
+
+# ==========================================================================
+# Signal 3 — REST-vs-local position-size delta sweep
+# ==========================================================================
+
+def _wire_for_signal3(*, long_rest, short_rest, long_local, short_local,
+                      qty_step=Decimal("0.1"), multiplier=5.0,
+                      instrument_info="real", enabled=True):
+    cfg = _strategy_config(
+        divergence_detector_enabled=enabled,
+        divergence_size_delta_qty_step_multiplier=multiplier,
+    )
+    orch, runner, reconciler = _wire(_gridbot_config(cfg))
+    if instrument_info == "real":
+        runner._instrument_info = Mock(qty_step=qty_step)
+    else:
+        runner._instrument_info = instrument_info
+    runner._long_position = Mock(size=long_local)
+    runner._short_position = Mock(size=short_local)
+
+    def _rest(direction):
+        return long_rest if direction == DirectionType.LONG else short_rest
+    runner.rest_position_size = MagicMock(side_effect=_rest)
+    return orch, runner, reconciler
+
+
+def test_signal3_only_long_diverges_fires_once_direction_none(fixed_clock):
+    # qty_step 0.1 * 5 = 0.5 threshold. LONG Δ=1.0 (>0.5), SHORT Δ=0.0.
+    orch, runner, reconciler = _wire_for_signal3(
+        long_rest=Decimal("1.0"), short_rest=Decimal("0.0"),
+        long_local=Decimal("0.0"), short_local=Decimal("0.0"),
+    )
+    orch._trigger_divergence_reconcile = Mock()
+    orch._divergence_size_check_once()
+    assert orch._trigger_divergence_reconcile.call_count == 1
+    args, kwargs = orch._trigger_divergence_reconcile.call_args
+    assert args[0] == "btcusdt_test"
+    assert args[1] == "rest_size_delta"
+    assert "long" in args[2]  # evidence names the diverging side
+    assert kwargs.get("direction") is None
+
+
+def test_signal3_neither_diverges_no_fire_and_no_mutation(fixed_clock):
+    orch, runner, reconciler = _wire_for_signal3(
+        long_rest=Decimal("0.2"), short_rest=Decimal("0.2"),
+        long_local=Decimal("0.2"), short_local=Decimal("0.2"),
+    )
+    orch._trigger_divergence_reconcile = Mock()
+    orch._divergence_size_check_once()
+    orch._trigger_divergence_reconcile.assert_not_called()
+    # The read-only sweep must not mutate the mirror.
+    assert runner._long_position.size == Decimal("0.2")
+    assert runner._short_position.size == Decimal("0.2")
+
+
+def test_signal3_both_diverge_single_full_reconcile_throttle_bumped_once(fixed_clock):
+    """P1-a: both sides diverge in one sweep → EXACTLY ONE _force_reconcile_strat
+    (direction=None), both mirrors refreshed, throttle bumped once — no second
+    per-side call that would be throttle-suppressed."""
+    orch, runner, reconciler = _wire_for_signal3(
+        long_rest=Decimal("1.0"), short_rest=Decimal("2.0"),
+        long_local=Decimal("0.0"), short_local=Decimal("0.0"),
+    )
+    orch._divergence_size_check_once()  # real wrapper
+    reconciler.reconcile_reconnect.assert_called_once_with(runner)
+    assert runner._refresh_position_size_from_rest.call_count == 2
+    assert list(orch._divergence_last_fire_at.keys()) == ["btcusdt_test"]
+
+
+def test_signal3_skips_when_instrument_info_none(fixed_clock):
+    orch, runner, reconciler = _wire_for_signal3(
+        long_rest=Decimal("1.0"), short_rest=Decimal("0.0"),
+        long_local=Decimal("0.0"), short_local=Decimal("0.0"),
+        instrument_info=None,
+    )
+    orch._trigger_divergence_reconcile = Mock()
+    orch._divergence_size_check_once()
+    orch._trigger_divergence_reconcile.assert_not_called()
+
+
+def test_signal3_skips_when_qty_step_not_positive(fixed_clock):
+    orch, runner, reconciler = _wire_for_signal3(
+        long_rest=Decimal("1.0"), short_rest=Decimal("0.0"),
+        long_local=Decimal("0.0"), short_local=Decimal("0.0"),
+        qty_step=Decimal("0"),
+    )
+    orch._trigger_divergence_reconcile = Mock()
+    orch._divergence_size_check_once()
+    orch._trigger_divergence_reconcile.assert_not_called()
+
+
+def test_signal3_none_rest_read_skips_direction(fixed_clock):
+    # LONG REST read fails (None) → skipped; SHORT in-sync → no fire.
+    orch, runner, reconciler = _wire_for_signal3(
+        long_rest=None, short_rest=Decimal("0.0"),
+        long_local=Decimal("9.0"), short_local=Decimal("0.0"),
+    )
+    orch._trigger_divergence_reconcile = Mock()
+    orch._divergence_size_check_once()
+    orch._trigger_divergence_reconcile.assert_not_called()
+
+
+def test_signal3_disabled_does_not_read_rest(fixed_clock):
+    orch, runner, reconciler = _wire_for_signal3(
+        long_rest=Decimal("1.0"), short_rest=Decimal("0.0"),
+        long_local=Decimal("0.0"), short_local=Decimal("0.0"),
+        enabled=False,
+    )
+    orch._divergence_size_check_once()
+    runner.rest_position_size.assert_not_called()
+
+
+# ==========================================================================
+# Signal 4 — post-WS-recovery enqueue / drain / fast-track
+# ==========================================================================
+
+def test_signal4_private_disconnect_enqueues_account_strats(fixed_clock):
+    orch, runner, reconciler = _wire(_gridbot_config())
+    orch._private_ws["test_account"] = Mock()
+    orch._on_ws_disconnect("test_account", "private", datetime.now(UTC))
+    assert orch._pending_post_recovery_reconcile == {"btcusdt_test"}
+
+
+def test_signal4_public_disconnect_does_not_enqueue(fixed_clock):
+    orch, runner, reconciler = _wire(_gridbot_config())
+    orch._public_ws["test_account"] = Mock()
+    orch._on_ws_disconnect("test_account", "public", datetime.now(UTC))
+    assert orch._pending_post_recovery_reconcile == set()
+
+
+def test_signal4_fanout_and_dedup(fixed_clock):
+    cfg2 = _strategy_config(strat_id="ethusdt_test", symbol="ETHUSDT")
+    gc = _gridbot_config(_strategy_config())
+    gc.strategies.append(cfg2)
+    orch = Orchestrator(gc)
+    r1, r2 = Mock(), Mock()
+    r1.strat_id, r2.strat_id = "btcusdt_test", "ethusdt_test"
+    orch._account_to_runners["test_account"] = [r1, r2]
+    orch._enqueue_post_recovery_reconcile("test_account")
+    orch._enqueue_post_recovery_reconcile("test_account")  # dedup
+    assert orch._pending_post_recovery_reconcile == {"btcusdt_test", "ethusdt_test"}
+
+
+def test_signal4_enqueue_skipped_when_disabled(fixed_clock):
+    orch, runner, reconciler = _wire(
+        _gridbot_config(_strategy_config(divergence_detector_enabled=False))
+    )
+    orch._enqueue_post_recovery_reconcile("test_account")
+    assert orch._pending_post_recovery_reconcile == set()
+
+
+def _make_tick_safe(orch, clock_now):
+    """Neutralise the other periodic checks so _tick exercises only the signal-4
+    drain + the order-sync gate."""
+    far = clock_now + 1e9
+    orch._next_position_check = far
+    orch._next_health_check = far
+    orch._next_ws_health_check = far
+    orch._next_retry_tick = far
+    orch._next_divergence_size_check = far
+    orch._position_fetcher = Mock()
+    orch._order_sync_once = Mock()
+
+
+def test_signal4_drain_fires_once_per_strat_and_empties(fixed_clock):
+    orch, runner, reconciler = _wire(_gridbot_config())
+    _make_tick_safe(orch, fixed_clock["now"])
+    orch._pending_post_recovery_reconcile = {"btcusdt_test"}
+    orch._tick()
+    reconciler.reconcile_reconnect.assert_called_once_with(runner)
+    assert orch._pending_post_recovery_reconcile == set()
+
+
+def test_signal4_throttle_suppressed_is_dropped(fixed_clock):
+    orch, runner, reconciler = _wire(_gridbot_config())
+    _make_tick_safe(orch, fixed_clock["now"])
+    # Detector throttle ACTIVE (a recent unrelated fire).
+    orch._divergence_last_fire_at["btcusdt_test"] = fixed_clock["now"]
+    orch._pending_post_recovery_reconcile = {"btcusdt_test"}
+    orch._tick()
+    reconciler.reconcile_reconnect.assert_not_called()  # suppressed
+    assert orch._pending_post_recovery_reconcile == set()  # dropped, not retried
+    # A later tick with nothing pending does not resurrect it.
+    fixed_clock["now"] += 10_000.0
+    _make_tick_safe(orch, fixed_clock["now"])
+    orch._tick()
+    reconciler.reconcile_reconnect.assert_not_called()
+
+
+def test_signal4_dropped_reconcile_fast_tracks_order_sync(fixed_clock):
+    orch, runner, reconciler = _wire(_gridbot_config())  # order_sync_interval default 61
+    _make_tick_safe(orch, fixed_clock["now"])
+    orch._next_order_sync = fixed_clock["now"] + 1e9  # far future
+    orch._divergence_last_fire_at["btcusdt_test"] = fixed_clock["now"]  # throttle active
+    orch._pending_post_recovery_reconcile = {"btcusdt_test"}
+    orch._tick()
+    # Fast-track zeroed _next_order_sync and the gate consumed it THIS tick.
+    orch._order_sync_once.assert_called_once()
+    # Still dropped via the wrapper; not retried.
+    reconciler.reconcile_reconnect.assert_not_called()
+    assert orch._pending_post_recovery_reconcile == set()
+    # The gate reset _next_order_sync (does not stay 0.0).
+    assert orch._next_order_sync != 0.0
+
+
+def test_signal4_no_fast_track_when_order_sync_disabled(fixed_clock):
+    orch, runner, reconciler = _wire(_gridbot_config(order_sync_interval=0.0))
+    _make_tick_safe(orch, fixed_clock["now"])
+    orch._next_order_sync = fixed_clock["now"] + 1e9
+    orch._divergence_last_fire_at["btcusdt_test"] = fixed_clock["now"]  # throttle active
+    orch._pending_post_recovery_reconcile = {"btcusdt_test"}
+    orch._tick()
+    orch._order_sync_once.assert_not_called()  # gate requires interval > 0
+    assert orch._pending_post_recovery_reconcile == set()  # still dropped
+
+
+# Signal 4 — the production trigger-path enqueue wirings -----------------------
+
+def test_signal4_health_check_private_reconnect_enqueues(fixed_clock):
+    orch, runner, reconciler = _wire(_gridbot_config())
+    priv = Mock()
+    priv.is_connected.return_value = False
+    pub = Mock()
+    pub.is_connected.return_value = True  # public stays up → skipped
+    orch._private_ws["test_account"] = priv
+    orch._public_ws["test_account"] = pub
+    orch._health_check_once()
+    assert orch._pending_post_recovery_reconcile == {"btcusdt_test"}
+
+
+def test_signal4_health_check_public_reconnect_does_not_enqueue(fixed_clock):
+    orch, runner, reconciler = _wire(_gridbot_config())
+    pub = Mock()
+    pub.is_connected.return_value = False
+    orch._public_ws["test_account"] = pub
+    orch._health_check_once()
+    assert orch._pending_post_recovery_reconcile == set()
+
+
+def test_signal4_health_check_enqueues_even_when_reconnect_raises(fixed_clock):
+    orch, runner, reconciler = _wire(_gridbot_config())
+    # _health_check_once iterates self._public_ws.keys(), so the account must be
+    # present there for the per-account loop to run (production always has both).
+    pub = Mock()
+    pub.is_connected.return_value = True
+    orch._public_ws["test_account"] = pub
+    priv = Mock()
+    priv.is_connected.return_value = False
+    priv.connect.side_effect = Exception("boom")  # reconnect fails
+    orch._private_ws["test_account"] = priv
+    orch._health_check_once()  # must not raise
+    # The dead socket is the divergence event — enqueue regardless of reconnect.
+    assert orch._pending_post_recovery_reconcile == {"btcusdt_test"}
+
+
+def test_signal4_ws_health_check_private_reset_enqueues(fixed_clock):
+    orch, runner, reconciler = _wire(_gridbot_config())
+    priv = Mock()
+    priv.is_socket_alive.return_value = False
+    orch._private_ws["test_account"] = priv
+    orch._ws_health_check_once()
+    assert orch._pending_post_recovery_reconcile == {"btcusdt_test"}
+    priv.reset.assert_called_once()
+
+
+def test_signal4_ws_health_check_public_reset_does_not_enqueue(fixed_clock):
+    orch, runner, reconciler = _wire(_gridbot_config())
+    pub = Mock()
+    pub.is_socket_alive.return_value = False
+    orch._public_ws["test_account"] = pub
+    orch._ws_health_check_once()
+    assert orch._pending_post_recovery_reconcile == set()
+
+
+def test_signal4_ws_health_check_enqueues_even_when_reset_raises(fixed_clock):
+    """The enqueue happens on DETECTION (before reset), so a failing reset() does
+    not skip scheduling the REST-based forced reconcile."""
+    orch, runner, reconciler = _wire(_gridbot_config())
+    priv = Mock()
+    priv.is_socket_alive.return_value = False
+    priv.reset.side_effect = Exception("boom")
+    orch._private_ws["test_account"] = priv
+    orch._ws_health_check_once()  # must not raise
+    assert orch._pending_post_recovery_reconcile == {"btcusdt_test"}
+
+
+def test_signal4_fresh_disconnect_after_throttle_reconciles(fixed_clock):
+    """The pending set is per-event, not a deferral queue: a suppressed strat is
+    dropped, but a FRESH disconnect after the throttle window reconciles normally."""
+    orch, runner, reconciler = _wire(_gridbot_config())
+    _make_tick_safe(orch, fixed_clock["now"])
+    orch._divergence_last_fire_at["btcusdt_test"] = fixed_clock["now"]  # throttle active
+    orch._pending_post_recovery_reconcile = {"btcusdt_test"}
+    orch._tick()  # suppressed → dropped
+    reconciler.reconcile_reconnect.assert_not_called()
+    assert orch._pending_post_recovery_reconcile == set()
+    # Advance past the 300s detector throttle; a fresh disconnect re-enqueues.
+    fixed_clock["now"] += 301.0
+    _make_tick_safe(orch, fixed_clock["now"])
+    orch._pending_post_recovery_reconcile = {"btcusdt_test"}
+    orch._tick()
+    reconciler.reconcile_reconnect.assert_called_once_with(runner)
+    assert orch._pending_post_recovery_reconcile == set()

--- a/apps/gridbot/tests/test_runner_divergence.py
+++ b/apps/gridbot/tests/test_runner_divergence.py
@@ -1,0 +1,308 @@
+"""Feature 0069 — runner-side pieces of the state-divergence detector (#151).
+
+Covers signal 1's rolling placement-failure UNION recorder, the post-reconcile
+``clear_dedup_cache``, and the read-only ``rest_position_size`` REST helper.
+
+    uv run pytest apps/gridbot/tests/test_runner_divergence.py
+"""
+
+from decimal import Decimal
+from itertools import cycle
+from unittest.mock import Mock, MagicMock
+
+import pytest
+
+from gridcore import InstrumentInfo
+from gridcore.intents import PlaceLimitIntent
+from gridcore.position import DirectionType
+
+from gridbot.config import StrategyConfig
+from gridbot.executor import IntentExecutor, OrderResult
+from gridbot.runner import StrategyRunner
+
+EMPTY_LIMITS: dict[str, list[dict]] = {"long": [], "short": []}
+
+TRUNCATE_ERROR = "Bybit API error in place_order: [110017] orderQty will be truncated to zero"
+DUP_LINK_ERROR = "Bybit API error in place_order: [110072] OrderLinkedID is duplicate"
+NETWORK_ERROR = "requests.exceptions.ConnectionError: Connection timeout"
+LOW_BAL_ERROR = "Bybit API error: [110007] available balance not enough for new order"
+
+
+def _positions(size, position_idx=1):
+    return [
+        {
+            "symbol": "SOLUSDT",
+            "positionIdx": position_idx,
+            "side": "Buy" if position_idx == 1 else "Sell",
+            "size": str(size),
+            "avgPrice": "84.0",
+        }
+    ]
+
+
+def _reduce_only_sell(price="84.51", qty="0.1"):
+    return PlaceLimitIntent.create(
+        symbol="SOLUSDT",
+        side="Sell",
+        price=Decimal(price),
+        qty=Decimal(qty),
+        grid_level=3,
+        direction="long",
+        reduce_only=True,
+    )
+
+
+@pytest.fixture
+def clock():
+    return {"now": 0.0}
+
+
+@pytest.fixture
+def instrument_info():
+    return InstrumentInfo(
+        symbol="SOLUSDT",
+        qty_step=Decimal("0.01"),
+        tick_size=Decimal("0.01"),
+        min_qty=Decimal("0.01"),
+        max_qty=Decimal("10000"),
+    )
+
+
+@pytest.fixture
+def mock_executor():
+    executor = Mock(spec=IntentExecutor)
+    executor.shadow_mode = False
+    executor.auth_cooldown = False
+    executor.execute_place = MagicMock(
+        return_value=OrderResult(success=True, order_id="order_1")
+    )
+    return executor
+
+
+@pytest.fixture
+def mock_rest_client():
+    client = Mock()
+    client.get_positions = MagicMock(return_value=_positions("0.05"))
+    return client
+
+
+@pytest.fixture
+def runner_factory(mock_executor, instrument_info, mock_rest_client, clock):
+    """Build a runner with overridable divergence config + signal-1 callback."""
+    def _make(
+        *,
+        on_divergence_failure_mix=None,
+        threshold=10,
+        window=60.0,
+        enabled=True,
+    ):
+        config = StrategyConfig(
+            strat_id="solusdt_test",
+            account="test_account",
+            symbol="SOLUSDT",
+            tick_size=Decimal("0.01"),
+            grid_count=30,
+            grid_step=0.3,
+            divergence_detector_enabled=enabled,
+            divergence_failure_mix_threshold=threshold,
+            divergence_failure_mix_window_seconds=window,
+        )
+        r = StrategyRunner(
+            strategy_config=config,
+            executor=mock_executor,
+            instrument_info=instrument_info,
+            rest_client=mock_rest_client,
+            clock=lambda: clock["now"],
+            on_divergence_failure_mix=on_divergence_failure_mix,
+        )
+        r._wallet_balance = Decimal("10000")
+        return r
+    return _make
+
+
+# --------------------------------------------------------------------------
+# Signal 1 — rolling placement-failure UNION recorder
+# --------------------------------------------------------------------------
+
+def test_signal1_fires_once_at_threshold_then_window_resets(runner_factory):
+    calls = []
+    r = runner_factory(
+        on_divergence_failure_mix=lambda *a: calls.append(a),
+        threshold=10, window=60.0,
+    )
+    errors = cycle([TRUNCATE_ERROR, DUP_LINK_ERROR, NETWORK_ERROR])
+    for _ in range(9):
+        r._record_placement_failure(next(errors))
+    assert calls == []  # below threshold
+    r._record_placement_failure(next(errors))  # 10th → fire
+    assert calls == [("solusdt_test", "rest_failure_mix", 10)]
+    # The window clears at the moment of fire, so the very next failure starts
+    # fresh and does NOT immediately re-fire.
+    assert len(r._placement_failure_window) == 0
+    r._record_placement_failure(next(errors))
+    assert len(calls) == 1
+    assert len(r._placement_failure_window) == 1
+
+
+def test_signal1_eviction_past_window_prevents_fire(runner_factory, clock):
+    """Advancing the clock past the window before the 10th failure evicts the
+    earlier entries, so the threshold is NOT reached — proves eviction reads the
+    injectable clock."""
+    calls = []
+    r = runner_factory(
+        on_divergence_failure_mix=lambda *a: calls.append(a),
+        threshold=10, window=60.0,
+    )
+    clock["now"] = 0.0
+    for _ in range(9):
+        r._record_placement_failure(TRUNCATE_ERROR)
+    clock["now"] = 61.0  # all nine are now older than the 60s window
+    r._record_placement_failure(TRUNCATE_ERROR)  # 10th, but 9 evicted → len == 1
+    assert calls == []
+    assert len(r._placement_failure_window) == 1
+
+
+def test_signal1_excludes_110007(runner_factory):
+    """110007 (low-balance, feature 0066) is an intentional drop, NOT divergence
+    — it must not even enter the window."""
+    calls = []
+    r = runner_factory(
+        on_divergence_failure_mix=lambda *a: calls.append(a), threshold=1,
+    )
+    r._record_placement_failure(LOW_BAL_ERROR)
+    assert calls == []
+    assert len(r._placement_failure_window) == 0
+
+
+def test_signal1_ignores_unrelated_errors(runner_factory):
+    calls = []
+    r = runner_factory(
+        on_divergence_failure_mix=lambda *a: calls.append(a), threshold=1,
+    )
+    r._record_placement_failure("some weird non-classified error")
+    assert calls == []
+    assert len(r._placement_failure_window) == 0
+
+
+def test_signal1_inert_when_detector_disabled(runner_factory):
+    calls = []
+    r = runner_factory(
+        on_divergence_failure_mix=lambda *a: calls.append(a),
+        threshold=1, enabled=False,
+    )
+    r._record_placement_failure(TRUNCATE_ERROR)
+    assert calls == []
+    assert len(r._placement_failure_window) == 0
+
+
+def test_signal1_records_via_non_110017_branch(runner_factory, mock_executor):
+    """Integration: a 110072 failure leaves _execute_place_intent via the
+    non-110017 early-return branch and MUST feed the recorder (threshold=1)."""
+    calls = []
+    r = runner_factory(
+        on_divergence_failure_mix=lambda *a: calls.append(a), threshold=1,
+    )
+    r._long_position.size = Decimal("0.2")  # stale-high so the guard passes
+    mock_executor.execute_place.return_value = OrderResult(
+        success=False, error=DUP_LINK_ERROR
+    )
+    r._execute_place_intent(_reduce_only_sell(qty="0.1"), EMPTY_LIMITS)
+    assert calls == [("solusdt_test", "rest_failure_mix", 1)]
+
+
+def test_signal1_records_via_110017_branch(runner_factory, mock_executor):
+    """Integration: a 110017 failure leaves via the truncate branch and MUST
+    feed the recorder too (threshold=1)."""
+    calls = []
+    r = runner_factory(
+        on_divergence_failure_mix=lambda *a: calls.append(a), threshold=1,
+    )
+    r._long_position.size = Decimal("0.2")
+    mock_executor.execute_place.return_value = OrderResult(
+        success=False, error=TRUNCATE_ERROR
+    )
+    r._execute_place_intent(_reduce_only_sell(qty="0.1"), EMPTY_LIMITS)
+    assert calls == [("solusdt_test", "rest_failure_mix", 1)]
+
+
+# --------------------------------------------------------------------------
+# clear_dedup_cache
+# --------------------------------------------------------------------------
+
+def test_clear_dedup_cache_empties_cache(runner_factory):
+    r = runner_factory()
+    r._same_order_dedup_cache[frozenset({"a", "b"})] = object()
+    r._same_order_dedup_cache[frozenset({"c", "d"})] = object()
+    assert len(r._same_order_dedup_cache) == 2
+    r.clear_dedup_cache()
+    assert r._same_order_dedup_cache == {}
+
+
+# --------------------------------------------------------------------------
+# rest_position_size — PURE read, no side effects
+# --------------------------------------------------------------------------
+
+def test_rest_position_size_returns_parsed_size(runner_factory, mock_rest_client):
+    r = runner_factory()
+    mock_rest_client.get_positions.return_value = _positions("0.37", position_idx=1)
+    assert r.rest_position_size(DirectionType.LONG) == Decimal("0.37")
+
+
+def test_rest_position_size_no_entry_returns_zero(runner_factory, mock_rest_client):
+    r = runner_factory()
+    mock_rest_client.get_positions.return_value = _positions("0.5", position_idx=1)
+    # Asking for SHORT (idx 2) when only a LONG entry exists → flat (0).
+    assert r.rest_position_size(DirectionType.SHORT) == Decimal("0")
+
+
+def test_rest_position_size_none_when_no_rest_client(
+    mock_executor, instrument_info, clock
+):
+    config = StrategyConfig(
+        strat_id="solusdt_test", account="test_account", symbol="SOLUSDT",
+        tick_size=Decimal("0.01"), grid_count=30, grid_step=0.3,
+    )
+    r = StrategyRunner(
+        strategy_config=config, executor=mock_executor,
+        instrument_info=instrument_info, rest_client=None,
+        clock=lambda: clock["now"],
+    )
+    assert r.rest_position_size(DirectionType.LONG) is None
+
+
+def test_rest_position_size_none_on_exception(runner_factory, mock_rest_client):
+    r = runner_factory()
+    mock_rest_client.get_positions.side_effect = Exception("boom")
+    assert r.rest_position_size(DirectionType.LONG) is None
+
+
+def test_rest_position_size_none_on_unparseable(runner_factory, mock_rest_client):
+    r = runner_factory()
+    mock_rest_client.get_positions.return_value = _positions("not-a-number")
+    assert r.rest_position_size(DirectionType.LONG) is None
+
+
+def test_rest_position_size_does_not_mutate_state(runner_factory, mock_rest_client):
+    """PURE read: no mirror mutation, no throttle write, no failure-count bump."""
+    r = runner_factory()
+    r._long_position.size = Decimal("0.2")
+    before_throttle = dict(r._last_dirty_rest_at)
+    before_fail = r._dirty_rest_refresh_failure_count
+    mock_rest_client.get_positions.return_value = _positions("0.99")
+    out = r.rest_position_size(DirectionType.LONG)
+    assert out == Decimal("0.99")
+    assert r._long_position.size == Decimal("0.2")  # mirror untouched
+    assert r._last_dirty_rest_at == before_throttle  # throttle untouched
+    assert r._dirty_rest_refresh_failure_count == before_fail  # counter untouched
+
+
+def test_rest_position_size_exception_does_not_bump_failure_counter(
+    runner_factory, mock_rest_client
+):
+    r = runner_factory()
+    before = r._dirty_rest_refresh_failure_count
+    mock_rest_client.get_positions.side_effect = Exception("boom")
+    assert r.rest_position_size(DirectionType.LONG) is None
+    # Unlike _refresh_position_size_from_rest, the pure read must NOT increment
+    # the dirty-refresh failure counter (signal 2 reads it).
+    assert r._dirty_rest_refresh_failure_count == before

--- a/docs/features/0069_PLAN.md
+++ b/docs/features/0069_PLAN.md
@@ -1,0 +1,806 @@
+# Feature 0069 — Auto state-divergence detector + on-demand forced reconcile (issue #151)
+
+## Context
+
+The 2026-05-30 mainnet_live incident: after ~5h of intermittent WS instability
+(15+ disconnects), local state diverged from the exchange far enough that the bot
+could not self-recover in real time. Symptoms: 535× `110017 orderQty will be
+truncated to zero` on SOLUSDT (bot resubmitting reduce-only orders against a
+stale local long size — filed as #149); 5× `110072 OrderLinkedID is duplicate`
+(REST-retrying orders that had already landed but whose acks never arrived via
+WS); LTC open-order count dropped 40→36 and stayed reduced. Cleared only after a
+manual operator restart, which ran the normal cold-start reconciler. WS reconnects
+fired during the incident but reconnecting did NOT force a full position + order
+re-sync, so accumulated divergence persisted until intervention.
+
+GOAL: detect local-vs-exchange state divergence via observable signals and trigger
+a **forced full reconcile** (the same code path the bot runs on demand today —
+`Orchestrator._force_reconcile_strat`, which is itself the reusable extract of the
+cold-start `reconcile_startup` steps) **without restarting the process**. Emit one
+clear WARNING line per fire. Throttle re-fires.
+
+### What already exists (verified — issue #149 has SHIPPED, commit `7d013ae`)
+
+The issue's "ships first" dependency (#149) is in `main`. Reusing its machinery
+heavily; the function names below are the REAL ones (issue estimates differ where
+noted):
+
+- **`Orchestrator._force_reconcile_strat(strat_id, direction)`** —
+  `apps/gridbot/src/gridbot/orchestrator.py:1209`. Feature 0064's breaker-triggered
+  forced reconcile. Already: looks up runner + reconciler; rate-limits per-strat via
+  `self._force_reconcile_last_at` (orchestrator.py:131) using
+  `truncate_breaker_cooldown_seconds`; emits an UNCONDITIONAL breaker WARNING
+  (`"%s: 110017 breaker tripped — forcing %s position + order reconcile"`,
+  orchestrator.py:1243-1246) after the rate-limit check passes and BEFORE any
+  reconcile work; calls
+  `reconciler.reconcile_reconnect(runner)` (full open-orders REST fetch + grid
+  reconcile) in its own try/except; then `runner._refresh_position_size_from_rest(direction, force=True)`
+  (runner.py:1242) in a SEPARATE try/except so a position-size resync always runs.
+  This IS the "force_reconcile()" the issue asks for. The issue's estimate of a
+  separate `reconcile_startup()`-extraction is unnecessary — this function already
+  is the reusable, cold-start-independent callable. The detector should call THIS.
+  (The signature above documents the CURRENT pre-feature state; this feature refactors it
+  to `direction: str | None -> bool` — see Files to change / the two-throttle contract for
+  the authoritative target signature.)
+- **`Reconciler.reconcile_startup(runner)`** — `reconciler.py:68`; cold-start path,
+  called from `Orchestrator.start()` at orchestrator.py:294. `reconcile_reconnect`
+  (reconciler.py:148) is the in-flight equivalent. Both fetch open orders via REST
+  and inject/reconcile against the local grid.
+- **Per-runner dedup cache** — real attribute is **`StrategyRunner._same_order_dedup_cache`**
+  (runner.py:437), a `dict[frozenset[str], _SameOrderDedupEntry]`. Issue's name is
+  correct. No public clear method exists yet.
+- **110017/110072/network surfacing** — `Executor.execute_place`
+  (`apps/gridbot/src/gridbot/executor.py:188`) catches all `place_order` exceptions
+  and returns `OrderResult(success=False, error=str(e))` (executor.py:251-258). The
+  runner classifies via `is_truncate_error` (110017) and `is_insufficient_balance`
+  (110007); 110072 and network errors fall through to the retry-queue path
+  (`_on_intent_failed`, runner.py:2038-2043). **There is NO rolling per-strat
+  placement-failure counter today** — signal (1) must add one.
+- **WS health / silence** — `BybitWebSocketClient` heartbeat watchdog
+  (`packages/bybit_adapter/src/bybit_adapter/ws_client.py:283`) fires
+  `on_disconnect(disconnect_ts)` after `DEFAULT_DISCONNECT_THRESHOLD = 30.0s` of no
+  messages (ws_client.py:30 — note: **30s, not the 60s the issue assumes**; logs
+  "Detected disconnection: no messages for {gap}s"). The orchestrator wires this to
+  `_on_ws_disconnect(account_name, kind, disconnected_at)` (orchestrator.py:1138),
+  which dispatches `client.reset()` on a worker thread and logs "WS message gap
+  detected". Separately `_health_check_once` (orchestrator.py:1010) and
+  `_ws_health_check_once` (orchestrator.py:1089) reconnect dead sockets. None of
+  these force a full position+order reconcile after reconnect — exactly the gap
+  signal (4) closes.
+- **Main loop / tick** — `Orchestrator.run()` (orchestrator.py:355) → `_tick()`
+  (orchestrator.py:388) every `_CHECK_INTERVAL = 0.1s`. Periodic work is
+  timestamp-gated (`_next_order_sync` orchestrator.py:240, `_next_retry_tick`).
+  The per-tick "Position update" INFO heartbeat is the analyzer's cadence anchor —
+  do NOT touch it.
+- **Config** — `StrategyConfig` (`apps/gridbot/src/gridbot/config.py:26`) already
+  carries `truncate_breaker_max_consecutive/window_seconds/cooldown_seconds/reconcile`
+  (config.py:83-101). New thresholds go here (per-strat) following the same
+  `Field(default=..., description=...)` pattern. `conf/gridbot_test.yaml` does not
+  set the breaker fields, so they rely on defaults — new fields likewise ship as
+  default-on/with documented defaults and need no YAML edit to work.
+- **gridbot-health analyzer** — `.claude/skills/gridbot-health/analyze.py` (gitignored
+  skill tree). `event_coverage` is a closed key set `_EVENT_COVERAGE_KEYS`
+  (analyze.py:393) with labels `_EVENT_COVERAGE_LABELS` (analyze.py:413), rendered in
+  Table 13 and seeded by `_default_event_coverage` (analyze.py:433). Window events are
+  collected by a per-line message scan in `_build_event_coverage_window`
+  (analyze.py:837-903) and additively merged by `merge_event_coverage` (analyze.py:906).
+  Adding `force_reconcile_fired` = new key + label + a line scan on the detector's
+  WARNING text.
+
+## Detection signals (any fires; per-strat; thresholds configurable, default-on, ship incrementally)
+
+A new `StateDivergenceDetector` orchestration (signals 1–3; logic lives on the
+`Orchestrator` as instance attributes/methods — NOT a separate class or module) plus a
+post-recovery scheduling hook (signal 4). All four converge on calling
+`_force_reconcile_strat(strat_id, direction)` through a thin wrapper
+`_trigger_divergence_reconcile(strat_id, signal, evidence, direction=None)`.
+
+**Master kill-switch enforcement (`divergence_detector_enabled`, config line 446).**
+Following the Feature 0066/0067 enable-flag pattern (each defense guards at the entry of
+its method with `if not cfg.<flag>: return` — e.g. `low_balance_skip_summary_enabled` at
+runner.py:1617, `low_balance_skip_transition_logs_enabled` at runner.py:1487/1521), the
+detector enforces its flag in TWO complementary places so it is fully inert (no signal,
+no wasted REST) when `divergence_detector_enabled=False`:
+  - **At `_trigger_divergence_reconcile` ENTRY (catch-all):** resolve the per-strat `cfg`
+    and `if not cfg.divergence_detector_enabled: return` BEFORE the throttle check — this
+    covers all four signals' reconcile path (the kill-switch test asserts against this).
+  - **Skip the upstream per-signal work** so the detector does no wasted REST or callback
+    bookkeeping when disabled: do not register/honor the signal-1
+    `on_divergence_failure_mix` callback (skip recording in `_record_placement_failure`
+    when disabled); skip the signal-2 cap check in `_health_check_once`; skip the signal-3
+    `_next_divergence_size_check` sweep (the `rest_position_size` REST read); and skip the
+    signal-4 enqueue at all three sources. Each per-signal skip uses the same
+    `if not cfg.divergence_detector_enabled` guard.
+
+**Wrapper algorithm (entry-to-exit order):**
+  1. **Master kill-switch (BEFORE the throttle):** if `not cfg.divergence_detector_enabled`
+     → RETURN immediately (no reconcile, no WARNING, no throttle bump).
+  2. **Entry throttle check:** if
+     `now - _divergence_last_fire_at.get(strat_id, 0.0) <
+     divergence_reconcile_min_interval_seconds` → emit a DEBUG line and RETURN immediately,
+     WITHOUT calling `_force_reconcile_strat` and WITHOUT bumping the throttle. (This is the
+     detector throttle the throttle test asserts; the breaker-cooldown branch below is a
+     SEPARATE, second gate.)
+  3. Call `_force_reconcile_strat` exactly once — ALWAYS `direction=None` for every detector
+     signal (1/2/3/4); see the two-throttle contract below — and branch on the returned bool.
+
+**Two throttles, and the wrapper must not emit a misleading WARNING when the reconcile
+is suppressed.** There are two independent rate-limits: the detector throttle
+(`_divergence_last_fire_at`, default ≥5 min) and `_force_reconcile_strat`'s OWN internal
+per-strat rate-limit (`_force_reconcile_last_at`, gated by
+`truncate_breaker_cooldown_seconds`, default 60s — orchestrator.py:1234-1240). Today
+`_force_reconcile_strat` silently `return`s (logging only DEBUG "rate-limited") when its
+internal cooldown is active. A breaker trip calls `_force_reconcile_strat` DIRECTLY
+(bypassing the wrapper, so it does NOT bump `_divergence_last_fire_at`) and sets
+`_force_reconcile_last_at`. If a detector signal then fires within 60s and the wrapper
+naively emitted its WARNING + cleared the dedup cache + bumped the detector throttle, the
+operator would see "state-divergence detected … forcing full reconcile" with NO reconcile
+actually performed, and the analyzer's `force_reconcile_fired` count would overstate real
+reconciles.
+
+**Double-WARNING / double-count on detector fires — the internal breaker WARNING must be
+gated.** `_force_reconcile_strat` UNCONDITIONALLY emits its OWN breaker-style WARNING
+(`"%s: 110017 breaker tripped — forcing %s position + order reconcile"`,
+orchestrator.py:1243-1246) once the rate-limit check passes, BEFORE the reconcile work.
+On the detector path this line is wrong/misleading and double-fires: ALL detector signals
+(1/2/3/4) call with `direction=None`, so it prints the literal string `'None'` as the
+direction AND emits a breaker line for what is a divergence (not a breaker) trip — and in
+EVERY detector case the wrapper ALSO emits its own `"state-divergence detected … forcing full
+reconcile"` WARNING, so each detector fire produces TWO WARNINGs. WORSE: the merged `force_reconcile_fired` analyzer
+counter (the N-7/P3-5b decision) scans for BOTH `"state-divergence detected"` AND
+`"110017 breaker tripped — forcing"`, so a single detector reconcile matches both patterns
+and increments the counter TWICE — a metric double-count. FIX: add an
+`emit_breaker_warning: bool = True` parameter to `_force_reconcile_strat`; the internal
+breaker WARNING (orchestrator.py:1243-1246) emits ONLY when `emit_breaker_warning` is True.
+The breaker-trip caller (`on_truncate_breaker_tripped`) uses the default (True), so its line
+and analyzer counter are EXACTLY unchanged. The detector wrapper passes
+`emit_breaker_warning=False`, so on the detector path the breaker line (and its `'None'`
+text) is suppressed and ONLY the wrapper's single `state-divergence detected …` WARNING is
+emitted. This RESTORES merged-counter correctness: each reconcile emits exactly ONE of the
+two scanned patterns (breaker fires → breaker line; detector fires → detector line), so
+`force_reconcile_fired` counts each reconcile once, not twice.
+
+To prevent this, refactor
+`_force_reconcile_strat(strat_id, direction: str | None, emit_breaker_warning: bool = True) -> bool`
+to (a) RETURN whether it actually ran (True) or was rate-limited / had no runner (False),
+(b) handle the BOTH-directions case INTERNALLY so the rate-limit timestamp is set
+exactly once per call, and (c) emit the internal breaker WARNING
+(orchestrator.py:1243-1246) ONLY when `emit_breaker_warning` is True (default True =
+unchanged breaker-trip behavior; the detector wrapper passes False). **Why internal, not two wrapper calls:** the per-strat rate-limit
+(`_force_reconcile_last_at`, orchestrator.py:1234) is set BEFORE any reconcile work
+(orchestrator.py:1241), so two back-to-back calls would always rate-limit the second one —
+leaving the second direction's position mirror never resynced (in hedge mode both long and
+short can be nonzero, so half the state would stay stale behind a WARNING claiming a full
+reconcile). New contract:
+  - **`direction is None`** (full reconcile, ALL detector signals 1/2/3/4): do the rate-limit
+    check ONCE, set `_force_reconcile_last_at[strat_id]` ONCE, run `reconcile_reconnect(runner)`
+    ONCE (it is whole-runner / direction-agnostic), then call
+    `_refresh_position_size_from_rest(direction, force=True)` for BOTH `DirectionType.LONG`
+    and `DirectionType.SHORT` (each in its own try/except, as today). Returns True.
+  - **`direction` is a specific side** (existing breaker-trip caller ONLY): unchanged
+    single-direction behavior — one rate-limit check, one `reconcile_reconnect`, one
+    `_refresh_position_size_from_rest(direction, force=True)`. Returns True. (No detector
+    signal uses the targeted side any more — signal 3 now fires `direction=None` like 1/2/4;
+    see signal 3.)
+  - **No-op paths return False:** the DEBUG-"rate-limited" `return` (orchestrator.py:1240)
+    and the `runner is None` early `return` (orchestrator.py:1224) — see Files-to-change for
+    the full enumeration.
+
+The breaker-trip caller (orchestrator.py wiring of `on_truncate_breaker_tripped`) still
+passes a SPECIFIC direction and uses the `emit_breaker_warning` default (True) and ignores
+the return value (behavior unchanged — same breaker WARNING, same analyzer line). The wrapper
+`_trigger_divergence_reconcile` calls `_force_reconcile_strat` EXACTLY ONCE — ALWAYS with
+`direction=None` for every detector signal (1/2/3/4); the internal both-directions handling
+does the work — and ALWAYS passing `emit_breaker_warning=False` so the internal breaker
+WARNING (and its `'None'` direction text) is suppressed on the detector path — and branches
+on the single returned bool so
+side-effects ONLY land when a reconcile actually runs:
+  - if the call returned False (rate-limited by the breaker cooldown / no runner): emit a single
+    DEBUG line (e.g. "%s: divergence signal=%s suppressed — forced reconcile within breaker
+    cooldown") and RETURN WITHOUT emitting the WARNING, WITHOUT clearing the dedup cache, and
+    WITHOUT bumping `_divergence_last_fire_at`;
+  - if the call returned True: emit the single WARNING line (format below), clear the
+    per-runner `_same_order_dedup_cache` for the strat (new
+    `StrategyRunner.clear_dedup_cache()` method — issue's "Clear orderLinkId dedup
+    caches"), bump `_divergence_last_fire_at`, and RETURN.
+  The wrapper returns `None` for all four signals — it is fire-and-forget; no caller (including
+  signal 4's drain) inspects a return value. A reconcile suppressed by the detector throttle
+  (step 2) or the breaker cooldown is simply NOT acted on further; for signal 4 the pending
+  strat is dropped (see signal 4).
+  Note clearing the dedup cache only AFTER a real reconcile means a suppressed fire never
+  evicts adjudication state without a resync.
+
+The detector throttle stays SEPARATE from the breaker's `_force_reconcile_last_at` (a
+breaker trip and a detector fire do not cross-suppress each other's bookkeeping); the
+wrapper additionally honors `_force_reconcile_strat`'s internal rate-limit via its return
+value as described above.
+
+WARNING line (verbatim format from issue):
+`state-divergence detected (signal=<which>, evidence=<count/delta>), forcing full reconcile`
+where `<which>` ∈ {`rest_failure_mix`, `retry_budget`, `rest_size_delta`,
+`post_ws_recovery`}. `<evidence>` is the per-signal value: a count (signals 1/2), a delta
+string (signal 3), or — for signal 4 — the FIXED string `private_ws_recovery` (no per-event
+gap value is carried into the drain; the exact gap seconds remain in the upstream
+`_on_ws_disconnect` / "WS message gap detected" line).
+
+### (1) Sustained REST placement-failure UNION
+≥10 failed placements whose error is in the UNION of {110017, 110072, network} within
+60s on a single strat → fire. (Renamed from "mix" — the algorithm counts the union of
+the three classes, NOT a requirement of ≥1 of each.) Defaults: count=10, window=60s.
+- Add TWO named, unit-testable classifiers in `executor.py` ALONGSIDE the existing
+  `is_truncate_error` (executor.py:32) and `is_insufficient_balance` (executor.py:50), for
+  symmetry and isolated testability (no inline substring checks at the call site):
+  - `is_network_error(error: Optional[str]) -> bool` — NARROW lowercased-token test on the
+    error string (which is `str(exception)` from `execute_place`, executor.py:251-258),
+    matching any of: `timeout`, `connection`, `temporarily unavailable`, plus pybit's
+    transient exception class names surfaced into the string (`ReadTimeout`,
+    `ConnectionError`/`Connection`). It must NOT match generic substrings like "error" or a
+    bare digit.
+  - `is_duplicate_link_error(error: Optional[str]) -> bool` — narrow case-insensitive match
+    on `110072` (via the shared `_ERR_CODE_RE`, ErrCode 110072) OR the substring
+    `"OrderLinkedID is duplicate"`. Replaces the inline 110072 substring checks.
+  There are NO network/duplicate classifiers today (only the two ErrCode classifiers
+  exist), so both are net-new and must be functions, not inline substrings, so they can be
+  tested in isolation.
+- Record on every `execute_place` failure in `_execute_place_intent` (runner.py:~2017+)
+  when the error matches 110017 (`is_truncate_error`), 110072
+  (`is_duplicate_link_error`), OR `is_network_error`. 110007 (low-balance, Feature 0066) is
+  EXCLUDED — it is an intentional drop, not divergence.
+- **Two failure exit paths must both feed the recorder.** 110072 and network errors leave
+  `_execute_place_intent` via the NON-110017 early-return branch
+  (runner.py:2038-2043: `if not is_truncate_error(result.error): ... self._on_intent_failed(...);
+  return`), AFTER the 110007 low-balance exclusion at runner.py:2030-2036; 110017 is handled
+  separately at runner.py:2045+. A single-branch recorder would miss 110072/network.
+  Mandate a shared recorder helper `_record_placement_failure(error)` invoked from BOTH:
+  the non-110017 early-return branch (for 110072/network, after the 110007 exclusion) and
+  the 110017 branch (for truncate errors). The helper itself applies the
+  union-membership test (110017/110072/network) and ignores anything else, so both call
+  sites can pass the raw `result.error`. Both feed the one rolling window /
+  `on_divergence_failure_mix` callback.
+- **110072 alone counts toward the union.** Rationale: although a lone 110072
+  (already-acked-but-no-WS-ack) is individually benign and the existing retry queue
+  handles it, a SUSTAINED run of ≥10 such failures inside 60s on one strat is itself
+  evidence the WS ack path is degraded and the local mirror may be drifting — which is
+  exactly the divergence this signal exists to catch. The threshold (10-in-60s), not the
+  per-error severity, is what makes it actionable; a steady-state trickle of occasional
+  110072s evicts out of the window and never fires.
+- Add a small rolling-window failure recorder to `StrategyRunner` (new
+  `_placement_failure_window: deque[float]` keyed by the runner's injectable monotonic clock).
+  **`_record_placement_failure` AND the window eviction read `self._clock()`** (the runner's
+  injectable monotonic clock, runner.py:196 — already used as `self._clock()` for testable
+  timing elsewhere), NOT bare `time.monotonic()`, so the signal-1 fake-clock test can drive
+  the 60s window deterministically.
+- Algorithm per record: append `now = self._clock()`; evict entries older than `window`
+  (compared against `self._clock()`); if
+  `len(window) >= threshold` → invoke the detector callback `(strat_id, "rest_failure_mix",
+  count)`. **The window clears at the MOMENT the threshold is hit and the
+  `on_divergence_failure_mix` callback is invoked** (in the runner, at this recording site),
+  REGARDLESS of the downstream wrapper outcome — i.e. whether the orchestrator's
+  `_trigger_divergence_reconcile` then actually reconciles or suppresses the reconcile via
+  the breaker cooldown. "A fire" means threshold-reached / callback-invoked, NOT
+  reconcile-succeeded. This prevents repeated callbacks on every subsequent failure while
+  the breaker cooldown is suppressing the reconcile (if the window only cleared on a
+  successful reconcile, a cooldown-suppressed fire would leave the window full and re-trigger
+  the callback on each new failure during the cooldown). The cleared window re-arms cleanly.
+- 110017's existing `TruncateBreaker` is scope-keyed `(side, price)`; this signal is
+  the broader cross-error/cross-scope aggregate the breaker does not catch.
+
+### (2) Reconciler retry-budget exhausted
+The existing per-strat counter is `StrategyRunner.truncate_breaker_reconcile_count`
+(runner.py:455 property; field runner.py:299). When it crosses a new hard cap
+(`divergence_retry_budget`, default e.g. 5 breaker-driven reconciles) the detector
+fires `(strat_id, "retry_budget", count)`. Poll this in the existing
+`_health_check_once` sweep (orchestrator.py:1023-1030 already reads
+`truncate_breaker_reconcile_count` and `dirty_rest_refresh_failure_count` per runner)
+— add the cap check there.
+- **Edge rule (concrete).** Track a per-strat `_divergence_budget_last_fired[strat_id]`
+  (the count value at which we last fired). On each health tick, fire WHEN
+  `count >= divergence_retry_budget` AND `count != _divergence_budget_last_fired.get(strat_id, -1)`,
+  then store `_divergence_budget_last_fired[strat_id] = count`. This fires once per new
+  exhaustion edge (each time the count crosses to a value we have not yet fired on), NOT
+  every health tick while the count stays parked at the same value.
+- **Backstop role.** Because the breaker itself increments
+  `truncate_breaker_reconcile_count` when it calls `_force_reconcile_strat` on a trip with
+  `truncate_breaker_reconcile=True`, signal 2 can poll the same tick a breaker reconcile
+  ran. Signal 2 is primarily a backstop for when `truncate_breaker_reconcile=False` (the
+  breaker counts but does not auto-reconcile) or the breaker-driven reconcile was suppressed
+  by the cooldown. When it overlaps a real breaker reconcile, the `_force_reconcile_strat`
+  rate-limit returns False so the wrapper emits no misleading WARNING — harmless redundancy.
+
+### (3) REST-vs-local position-size delta
+Every Nth tick (default 5 min, gated like `_next_order_sync`) fetch position size via
+REST for each (strat, direction) and compare to the local mirror.
+
+**Read-only helper — explicit side-effect contract.** Add
+`StrategyRunner.rest_position_size(direction) -> Decimal|None`. It factors ONLY the REST
+read out of `_refresh_position_size_from_rest` (runner.py:1242-1281): compute
+`position_idx = 1 if direction == DirectionType.LONG else 2`, call
+`self._rest_client.get_positions(self._config.symbol)`, apply the same `positionIdx`
+filter, and return the entry's parsed `size` as `Decimal` (or `Decimal("0")` when no
+entry, mirroring the existing logic). It is a PURE read: it must NOT write
+`self._last_dirty_rest_at` (runner.py:1260), must NOT increment
+`self._dirty_rest_refresh_failure_count` (runner.py:1274,1297), and must NOT touch
+`self._long_position.size` / `self._short_position.size` or any other mirror field — all
+of which `_refresh_position_size_from_rest` DOES mutate. On `rest_client is None` or any
+`get_positions`/parse exception it returns `None`, and the detector caller SKIPS the
+comparison for that direction (no fire) rather than counting it as a delta. A `None` return
+(REST error) is intentionally treated as "skip, no fire" but MUST be logged at DEBUG so REST
+flakiness during the detection window stays observable. This keeps signal-3 polling from
+perturbing the dirty-refresh throttle and the failure-counter observability that signal 2
+reads.
+
+**`qty_step` lookup.** Compare the REST size to the local mirror
+(`runner._long_position.size` / `_short_position.size`). The threshold scale is
+`runner._instrument_info.qty_step` — the per-runner `InstrumentInfo` already injected at
+construction (runner.py:312; class imported at runner.py:34 via `from gridcore import
+InstrumentInfo`; `qty_step` is a `Decimal` attribute set at
+`packages/gridcore/src/gridcore/instrument_info.py:30`). The detector reads it off the runner directly
+(`runner._instrument_info.qty_step`); there is no orchestrator-level symbol→qty_step map
+and none is needed. **Skip signal 3 for the strat (no fire, no exception) when
+`runner._instrument_info is None` (no-rounding mode) OR `qty_step` is not a positive
+`Decimal`** — `InstrumentInfo` validates `qty_step > 0` at construction
+(`instrument_info.py:25`), but the detector still guards defensively so a malformed/zero
+step never makes the `> qty_step * multiplier` comparison mis-behave. **Evaluate BOTH
+directions first, then fire EXACTLY ONCE.** Compute `abs(rest - local)` for LONG and SHORT
+in the same sweep; if EITHER direction exceeds `qty_step * multiplier`, fire ONCE with
+`(strat_id, "rest_size_delta", max_delta, direction=None)` — reusing the B-1 `direction=None`
+path (one detector-throttle check, one `reconcile_reconnect`, refresh BOTH LONG and SHORT
+mirrors). Do NOT fire per-direction with a targeted side. **Why `direction=None`, not
+per-side:** firing the FIRST diverging side targeted would bump `_divergence_last_fire_at`,
+so a SECOND same-sweep diverging side would be throttle-suppressed and its mirror never
+refreshed — in hedge mode (both sides nonzero) that recreates the exact "half stale behind a
+full-sounding reconcile" risk the B-1 fix eliminated for signals 1/2/4. Refreshing the
+in-sync side too is cheap and idempotent. The `evidence` names which side(s) diverged and
+the max delta (e.g. `long Δ0.7+short Δ0.0`). Defaults: interval=300s, multiplier=5. Schedule
+via a new `_next_divergence_size_check` timestamp gate in `_tick`/`run`. **Prime `_next_divergence_size_check` with a phase offset relative to
+`_next_order_sync`** (e.g. seed it half an interval ahead at startup) so the two periodic
+sweeps do not co-fire on the same tick and produce a synchronized REST burst; REST volume is
+otherwise negligible.
+
+### (4) Post-recovery enforcement (cheapest; most directly motivated)
+After a private-WS recovery, schedule a forced reconcile on the SAME tick the drain runs
+— EVEN IF WS resumes normally. Two trigger scopes funnel here: (a) SILENCE-GATED — the 30s heartbeat
+watchdog firing `_on_ws_disconnect` after `disconnect_threshold` of no messages; and
+(b) ANY-DEAD-SOCKET — the health-check reconnect paths (`_health_check_once`,
+`_ws_health_check_once`), which reconnect a dead socket regardless of sustained silence.
+Both scopes enqueue into the same pending set, drained and force-reconciled on the SAME tick
+(at the pinned drain point, immediately before the order-sync gate), subject to the same detector
+throttle. Treat sustained silence (and any private-socket reset) as a divergence event in
+itself.
+
+**Account→strat fan-out (the three trigger sources are keyed by `account_name`, NOT
+`strat_id`).** All three sources — `_on_ws_disconnect(account_name, kind,
+disconnected_at)` (orchestrator.py:1138), the WS-reconnect block inside
+`_health_check_once` (orchestrator.py:1035-1083), and `_ws_health_check_once`
+(orchestrator.py:1101-1136) — identify the affected socket by `account_name` (+ `kind`
+∈ {public, private}). `_pending_post_recovery_reconcile` is keyed by `strat_id`, so each
+source MUST fan out account→strats before enqueueing: look up
+`runners = self._account_to_runners.get(account_name, [])` (the existing map,
+orchestrator.py:158, already iterated this way in `_order_sync_once` at
+orchestrator.py:1275) and add each `runner.strat_id` to the pending set. Because
+`_pending_post_recovery_reconcile` is a `set[str]`, the public+private double-fires for
+the same account (both `kind`s land on the same strats) dedup naturally — no extra guard
+needed.
+
+**Only PRIVATE-WS gaps enqueue.** Position/order acks ride the PRIVATE channel; a
+public-ticker-only gap implies stale price ticks, not order/position divergence, and
+forcing a REST reconcile on every routine public-feed blip would be exactly the
+false-positive churn this feature avoids. Therefore: in `_on_ws_disconnect` enqueue only
+when `kind == "private"`; in `_health_check_once` enqueue only from the private-WS
+reconnect branch (orchestrator.py:1059-1083), not the public branch (1032-1057); in
+`_ws_health_check_once` enqueue only from the private loop (orchestrator.py:1119-1136),
+not the public loop (1101-1118). (The disconnect threshold of 30s — ws_client.py:30 —
+already qualifies as "sustained"; the issue's >60s is satisfied by the existing 30s
+gate. Document the actual 30s value as the trigger.)
+
+- In `_tick`, drain `_pending_post_recovery_reconcile` ONCE per tick (swap-and-clear, see the
+  cross-thread note). **PINNED INSERTION POINT (same-tick):** the drain goes INSIDE the
+  step-4 periodic-checks block, AFTER `now = time.monotonic()` (orchestrator.py:511) and
+  IMMEDIATELY BEFORE the order-sync gate (orchestrator.py:551-555). This placement is still
+  AFTER the per-tick WS event drains (steps 1, 2, 2.5 — done by orchestrator.py:480), so it
+  satisfies the dedup-cache safety invariant (no concurrent reader of a half-cleared cache),
+  AND it sits one statement before the order-sync gate so a fast-tracked `_next_order_sync =
+  0.0` (see the fast-track decision below) is consumed by the gate the SAME tick. For each
+  captured strat call
+  `_trigger_divergence_reconcile(strat_id, "post_ws_recovery", "private_ws_recovery",
+  direction=None)` fire-and-forget. The drain does NOT re-add any strat — a strat whose
+  reconcile is suppressed (detector throttle OR breaker cooldown) is simply DROPPED, not
+  retried. This is a single-pass drain: each enqueued strat gets exactly one reconcile
+  ATTEMPT per disconnect event, and the swap-and-clear empties the pending set every tick.
+  **Fixed evidence value (no per-event gap carried):** signal 4 passes the literal string
+  `private_ws_recovery` as `evidence`, so `_pending_post_recovery_reconcile: set[str]` need
+  carry nothing beyond the strat_id from the enqueue site to the drain. The exact gap seconds
+  remain visible to operators in the upstream `_on_ws_disconnect` / "WS message gap detected"
+  log line, so no information is lost. `_trigger_divergence_reconcile` is fire-and-forget for
+  every signal (1/2/3/4) — no caller inspects a return value.
+- **Decision: a throttle-suppressed post_ws_recovery reconcile is DROPPED, not deferred —
+  but the order-sync backstop is fast-tracked to run the SAME tick.**
+  post_ws_recovery stays UNDER the detector throttle (it honors the same ≥5-min throttle so a
+  disconnect storm does not loop) AND under the breaker's 60s cooldown via
+  `_force_reconcile_strat`'s internal rate-limit. When EITHER suppresses the reconcile, the
+  pending strat is DROPPED — NOT re-enqueued, NOT retried. Rationale: post_ws_recovery is a
+  prompt-reconcile OPTIMIZATION, not the only safety net. When the detector throttle is active,
+  an actual full reconcile already ran within the last interval (≤5 min ago), and any residual
+  gap-induced divergence is backstopped on two distinct axes:
+  - **Position-size drift is ALWAYS backstopped** by signal 3 — the REST-vs-local
+    position-size delta sweep, now `direction=None`, on a ≤5-min cadence. Its interval field
+    `divergence_size_check_interval_seconds` carries `gt=0` (config.py section below), so it
+    CANNOT be disabled: position size always has a periodic backstop.
+  - **Order-level drift is backstopped by the periodic order-sync WHEN ENABLED.** The periodic
+    order-sync sweep (`_next_order_sync` / `reconcile_reconnect`) reconciles the order book, but
+    it is OPTIONAL: `order_sync_interval` (config.py:304, default 61.0) explicitly supports `0`
+    to DISABLE the sweep — it has NO `gt=0` bound, and the gate at orchestrator.py:551-553 runs
+    `_order_sync_once` only when `order_sync_interval > 0`. So when order-sync is enabled
+    (the default), order-level drift is reconciled on its periodic cadence; if an operator sets
+    `order_sync_interval=0` they have disabled order reconciliation WHOLESALE (cold-start aside),
+    and forgoing the post-WS-recovery order backstop is their explicit, documented tradeoff —
+    NOT a regression introduced by this drop decision.
+  - **FAST-TRACK the order-sync on a dropped signal-4 (when enabled) — SAME TICK.** To shrink the
+    order-level backstop latency from up-to-`order_sync_interval`s (≤61s default) to the SAME
+    tick, the signal-4 drain peeks the detector-throttle eligibility for each pending strat
+    (`now - _divergence_last_fire_at.get(strat_id, 0.0) < divergence_reconcile_min_interval_seconds`)
+    and, when the reconcile WOULD be throttle-suppressed AND `self._config.order_sync_interval > 0`,
+    sets `self._next_order_sync = 0.0` — reusing the idiomatic fast-track pattern at
+    orchestrator.py:1204 ("Untracked order seen — fast-tracking order sync"). Because the drain is
+    PINNED immediately before the order-sync gate (orchestrator.py:551-555) inside the SAME step-4
+    block — after the shared `now = time.monotonic()` (orchestrator.py:511) — the gate's very next
+    evaluation (`order_sync_interval > 0 and now >= _next_order_sync`) sees the zeroed
+    `_next_order_sync` and runs `_order_sync_once()` THIS tick, then resets
+    `_next_order_sync = now + order_sync_interval`. So the order-level reconcile runs this tick, not
+    up to `order_sync_interval` seconds later, and `_next_order_sync` does NOT remain `0.0` after the
+    tick (the gate consumes and resets it). This is automatically a NO-OP when
+    `order_sync_interval = 0` (the gate at orchestrator.py:551-553 requires `> 0`, so zeroing
+    `_next_order_sync` never schedules a sweep). The peek is read-only and does NOT change the drop
+    decision: the strat is still DROPPED from `_pending_post_recovery_reconcile` (no re-enqueue /
+    retry / status-enum), the wrapper is still fire-and-forget with no return value, and the
+    fast-track sets one orchestrator-level timestamp immediately before the order-sync gate.
+    (`_next_order_sync` is account/orchestrator-scoped, not per-strat — orchestrator.py:240 — so a
+    single fast-track covers all strats' orders this tick.)
+  So dropping a throttle-suppressed prompt reconcile is safe: position size is always backstopped
+  by signal 3, and order-level drift is backstopped by the periodic order-sync when enabled —
+  now fast-tracked to run the same tick rather than up to a full interval later. This eliminates the
+  10Hz busy-loop a re-enqueue would create (`_tick` runs every 0.1s, so a re-added strat would
+  re-drain ~10×/s for the whole ~5-min window → ~3,000 wrapper calls + DEBUG lines per pending
+  strat). The detector throttle here is observability-churn control plus REST-spam control; the
+  breaker's 60s cooldown bounds REST and the single-pass drain means no retention at all.
+
+**Cross-thread access to `_pending_post_recovery_reconcile` (signal 4 ONLY).**
+`_on_ws_disconnect` runs on the WS client's heartbeat thread (orchestrator.py:1141-1156
+docstring; ws_client invokes the callback from its watchdog loop), so it mutates the set
+from a DIFFERENT thread than `_tick` (main thread), which iterates and clears it. The
+`_health_check_once`/`_ws_health_check_once` reconnect paths run on the main loop, but
+the `_on_ws_disconnect` add does not — a plain `set` add concurrent with the main-thread
+iterate/clear can raise `RuntimeError: set changed size during iteration` or drop an add.
+Guard the set with a dedicated `threading.Lock` (`_pending_post_recovery_lock`,
+init alongside the set near orchestrator.py:131): every `.add(strat_id)` (all three
+sources) takes the lock; the `_tick` drain takes the same lock to swap-and-clear
+atomically — `with self._pending_post_recovery_lock: pending = self._pending_post_recovery_reconcile;
+self._pending_post_recovery_reconcile = set()` — then releases the lock and iterates the
+captured `pending` set OUTSIDE the lock (so the forced reconcile / REST calls do not hold
+it). The drain ONLY clears; it NEVER re-adds. The heartbeat thread (and the main-loop
+reconnect paths) ONLY add. There is no re-add path, so the two threads never contend over a
+re-enqueue: a suppressed strat is dropped, and the next disconnect event re-adds it fresh.
+Signals 1/2/3 are all main-thread-only and need no locking; this is the sole cross-thread
+signal.
+
+## Action when fired (`_trigger_divergence_reconcile` → `_force_reconcile_strat`)
+
+Reuses the existing 0064 path, which already does everything the issue lists:
+1. Fetch full position state both directions — the wrapper calls `_force_reconcile_strat`
+   ONCE with `direction=None` for EVERY detector signal (1/2/3/4), and that single call
+   internally runs `_refresh_position_size_from_rest(direction, force=True)` for BOTH LONG and
+   SHORT after one `reconcile_reconnect`. (Signal 3 evaluates both directions to decide
+   whether to fire, but the reconcile itself is always full / `direction=None` — it never
+   targets a single side, avoiding the same-sweep throttle trap.) See the two-throttle
+   contract in Detection signals.
+2. Fetch open-orders list + reconcile with local grid — `reconcile_reconnect(runner)` (run
+   ONCE per `_force_reconcile_strat` call, direction-agnostic).
+3. Clear `_same_order_dedup_cache` — via new `StrategyRunner.clear_dedup_cache()`,
+   called by the wrapper AFTER `_force_reconcile_strat` returns True (a real reconcile
+   ran) — NOT before, and NOT when the call was rate-limited (issue requirement;
+   not in the 0064 path today). Clearing only after a real resync means a suppressed fire
+   never evicts adjudication state without a resync. Safe-to-clear invariant:
+   `clear_dedup_cache()` and the forced reconcile both run synchronously on the MAIN tick
+   thread — signals 1/2/3 fire on the main thread, and signal 4 drains on the main thread
+   (see signal-4 cross-thread note; the heartbeat thread only ADDS to the pending set, it
+   never clears the cache). The signal-4 drain is PINNED inside the step-4 periodic-checks
+   block, after `now = time.monotonic()` (orchestrator.py:511) and immediately before the
+   order-sync gate (orchestrator.py:551-555) — which is AFTER the per-tick WS event drains
+   (steps 1, 2, 2.5 — done by orchestrator.py:480), so no order-update event referencing a
+   now-evicted pair_key is being adjudicated concurrently and there is no concurrent reader
+   of a half-cleared cache. The cache re-populates naturally as new SAME-ORDER pairs are
+   adjudicated on subsequent ticks. Do NOT place the signal-4 drain at the top of `_tick`
+   (before the event-processing steps 1/2/2.5) or after the order-sync gate; the pinned
+   point — after the event drains, immediately before the gate — is what satisfies BOTH the
+   dedup-cache safety invariant AND the same-tick fast-track of `_next_order_sync` (signal 4).
+4. Missing close-side orders are re-emitted by the engine on the next ticker against
+   the now-fresh position size (the #149 dirty-mirror/cap path prevents re-triggering
+   110017). No extra resubmit logic needed here.
+5. Emit EXACTLY ONE WARNING line per detector fire — but ONLY when `_force_reconcile_strat`
+   actually ran (returned True). Because the wrapper passes `emit_breaker_warning=False`, the
+   internal breaker WARNING (orchestrator.py:1243-1246, which would otherwise print the
+   `'None'` direction and a misleading breaker line for every detector signal 1/2/3/4) is
+   SUPPRESSED, so the only line emitted on a detector fire is the wrapper's single
+   `state-divergence detected …` WARNING. When the call was rate-limited by the breaker
+   cooldown (or had no runner), the wrapper emits a DEBUG-level "suppressed" line instead and
+   skips the WARNING / dedup-clear / throttle bump (see the two-throttle note in Detection
+   signals). This keeps the analyzer's `force_reconcile_fired` count equal to real reconciles:
+   each reconcile emits exactly one of the two scanned patterns, never both.
+   **What True means:** the bool reports that a reconcile was ATTEMPTED (not rate-limited),
+   NOT that it fully succeeded. `reconcile_reconnect` and `_refresh_position_size_from_rest`
+   each run in independent try/excepts (orchestrator.py:1247-1264) and the reconcile is
+   non-atomic (mark-cancelled loop then inject loop, no rollback — pre-existing 0064
+   behavior, not changed here), so a partially-failed reconcile still returns True and the
+   WARNING still fires. A partial failure is surfaced via the existing
+   `_notifier.alert_exception` path; the WARNING wording ("forcing full reconcile") is
+   intentionally about the action taken, not a success guarantee. No new atomicity work is
+   in scope.
+6. Throttle ≥5 min per strat (`_divergence_last_fire_at`, new config
+   `divergence_reconcile_min_interval_seconds`, default 300) — bumped only on a fire that
+   actually reconciled (step 5).
+
+## Files to change
+
+- **`apps/gridbot/src/gridbot/runner.py`**
+  - New rolling placement-failure window (signal 1): field in `__init__`
+    (near runner.py:299 observability fields), recording in `_execute_place_intent`
+    failure branches (runner.py:2017-2073) via the shared `_record_placement_failure(error)`
+    helper, which timestamps appends and evicts using `self._clock()` (the injectable
+    monotonic clock, runner.py:196) — NOT `time.monotonic()` — so tests drive the window
+    deterministically. Wired with a `Callable` callback hook (`on_divergence_failure_mix`)
+    from the orchestrator like the existing `on_truncate_breaker_tripped`.
+  - New `clear_dedup_cache()` clearing `_same_order_dedup_cache` (runner.py:437).
+  - New read-only `rest_position_size(direction)` helper (signal 3), factoring the
+    `positionIdx`/`get_positions` read out of `_refresh_position_size_from_rest`
+    (runner.py:1242-1281) WITHOUT mirror mutation.
+- **`apps/gridbot/src/gridbot/executor.py`**
+  - Two new module-level classifiers (signal 1) alongside the existing
+    `is_truncate_error`/`is_insufficient_balance`, giving all four:
+    `is_network_error(error: Optional[str]) -> bool` — narrow lowercased-token test
+    (`timeout`, `connection`, `temporarily unavailable`, `readtimeout`); and
+    `is_duplicate_link_error(error: Optional[str]) -> bool` — ErrCode 110072 (via
+    `_ERR_CODE_RE`) / `"OrderLinkedID is duplicate"`.
+- **`apps/gridbot/src/gridbot/orchestrator.py`**
+  - New `StateDivergenceDetector` orchestration state (all initialized in `__init__` near
+    orchestrator.py:131): `_divergence_last_fire_at: dict[str,float]` and
+    `_divergence_budget_last_fired: dict[str,int]` — both initialized to EMPTY dicts and
+    read via `.get(strat_id, default)` (`0.0` and `-1` respectively) to avoid KeyError on
+    first fire; `_pending_post_recovery_reconcile: set[str]` (empty) plus a
+    `_pending_post_recovery_lock: threading.Lock` guarding it (signal 4 cross-thread);
+    `_next_divergence_size_check: float` (primed with a phase offset vs `_next_order_sync` —
+    see signal 3).
+  - Refactor `_force_reconcile_strat(strat_id, direction: str | None, emit_breaker_warning: bool = True)`
+    (orchestrator.py:1209) to RETURN `bool` and handle `direction is None` INTERNALLY. Every
+    no-op exit returns False: the `runner is None` early `return` (orchestrator.py:1224) and
+    the rate-limited `return` (orchestrator.py:1240). The path that actually reconciles
+    returns True (the `reconciler is None` case is NOT an early exit — it falls through to the
+    position refresh and still reconciles, so it returns True). When `direction is None`:
+    one rate-limit check, set `_force_reconcile_last_at` once, one `reconcile_reconnect`,
+    then `_refresh_position_size_from_rest(force=True)` for BOTH LONG and SHORT (each in its
+    own try/except). When `direction` is a specific side: unchanged single-direction
+    behavior. **Gate the internal breaker WARNING (orchestrator.py:1243-1246) on
+    `emit_breaker_warning`** — emit it ONLY when True, so the breaker-trip caller (which uses
+    the default True) is byte-for-byte unchanged, while the detector wrapper (which passes
+    False) suppresses the breaker line and its `'None'`-direction text. Existing breaker-trip
+    caller passes a specific direction, uses the `emit_breaker_warning` default, and ignores
+    the return.
+  - `_trigger_divergence_reconcile(strat_id, signal, evidence, direction=None)` —
+    FIRST guards the master kill-switch (resolve per-strat `cfg`;
+    `if not cfg.divergence_detector_enabled: return` — this is the catch-all the kill-switch
+    test asserts), THEN checks the detector throttle (`_divergence_last_fire_at`, DEBUG +
+    return if within interval), then calls `_force_reconcile_strat` ONCE — ALWAYS
+    `direction=None` for every detector signal (1/2/3/4), ALWAYS `emit_breaker_warning=False`
+    so the internal breaker WARNING is suppressed on the detector path — and branches on the
+    single bool: on True (actual reconcile) → the SINGLE `state-divergence detected …` WARNING
+    line + dedup-cache clear + throttle bump; on False (rate-limited by the breaker cooldown /
+    no runner) → DEBUG "suppressed" line, no WARNING/clear/bump. **Returns `None`** — the
+    wrapper is fire-and-forget for all four signals; no caller (including signal 4's drain)
+    inspects a return value. A reconcile suppressed by the detector throttle or the breaker
+    cooldown is simply not acted on further (for signal 4 the pending strat is dropped).
+  - Signal (1) callback wiring (mirror `on_truncate_breaker_tripped` wiring at
+    orchestrator.py:773 / `_init_strategy`). The shared recorder `_record_placement_failure`
+    skips recording when `not cfg.divergence_detector_enabled` (no callback fired when
+    disabled).
+  - Signal (2): retry-budget cap check inside `_health_check_once`
+    (orchestrator.py:1023-1030); skip the cap check when `not cfg.divergence_detector_enabled`.
+  - Signal (3): `_next_divergence_size_check` gate + sweep in `_tick`/`run`
+    (orchestrator.py:355-388), primed at the SAME init site as `_next_order_sync`
+    (orchestrator.py:348) but with a deliberately DIFFERENT value — a half-interval PHASE
+    OFFSET relative to `_next_order_sync` (see signal 3) so the two periodic sweeps do not
+    co-fire on the same tick. Same code location, intentionally offset value (not the same
+    value). Skip the sweep (no `rest_position_size` REST read) when
+    `not cfg.divergence_detector_enabled`.
+  - Signal (4): skip the enqueue at all three sources when
+    `not cfg.divergence_detector_enabled`; otherwise enqueue into
+    `_pending_post_recovery_reconcile` (under `_pending_post_recovery_lock`) from the
+    PRIVATE-only branches of `_on_ws_disconnect`
+    (orchestrator.py:1138, `kind == "private"`), `_health_check_once`
+    (orchestrator.py:1059-1083), and `_ws_health_check_once` (orchestrator.py:1119-1136),
+    fanning out account→strats via `_account_to_runners.get(account_name, [])`; drain
+    under the same lock (swap-and-clear) in `_tick` at the PINNED point — inside the step-4
+    periodic-checks block, after `now = time.monotonic()` (orchestrator.py:511) and IMMEDIATELY
+    BEFORE the order-sync gate (orchestrator.py:551-555), which is after the per-tick WS event
+    drains (steps 1/2/2.5, done by orchestrator.py:480) — then
+    iterate the captured set OUTSIDE the lock and call
+    `_trigger_divergence_reconcile(strat_id, "post_ws_recovery", "private_ws_recovery",
+    direction=None)` per strat, fire-and-forget. The drain NEVER re-adds: a strat whose
+    reconcile is suppressed (detector throttle or breaker cooldown) is DROPPED. Backstop:
+    position size is ALWAYS covered by signal 3 (`divergence_size_check_interval_seconds`
+    carries `gt=0`, cannot be disabled); order-level drift is covered by the periodic
+    order-sync WHEN ENABLED (`order_sync_interval > 0`, default 61). **Fast-track on a dropped
+    signal-4:** in the drain, for each pending strat, PEEK the detector-throttle eligibility
+    (`now - _divergence_last_fire_at.get(strat_id, 0.0) < divergence_reconcile_min_interval_seconds`,
+    read-only — does NOT bump the throttle); when the reconcile WOULD be throttle-suppressed
+    AND `self._config.order_sync_interval > 0`, set `self._next_order_sync = 0.0` (the
+    orchestrator-level fast-track idiom from orchestrator.py:1204). Because the drain is pinned
+    immediately before the order-sync gate (orchestrator.py:551-555) sharing the same `now`
+    (orchestrator.py:511), the gate consumes the zeroed `_next_order_sync` and runs
+    `_order_sync_once()` the SAME tick, then resets `_next_order_sync = now + order_sync_interval`
+    — so the order-level reconcile runs this tick (not up to `order_sync_interval`s later) and
+    `_next_order_sync` does NOT stay `0.0` after the tick. Automatically a no-op
+    when `order_sync_interval = 0` (the gate at orchestrator.py:551-553 requires `> 0`). The
+    fast-track does NOT reintroduce deferral/retry/status-enum and does NOT add a return value
+    to the wrapper — it sets one orchestrator-level timestamp before/around the fire-and-forget
+    call. Single-pass drain, no retention, no 10Hz busy-loop.
+- **`apps/gridbot/src/gridbot/config.py`** — new `StrategyConfig` fields with defaults,
+  descriptions, AND explicit Pydantic `Field` constraints matching the breaker convention
+  (config.py:83-96: `truncate_breaker_max_consecutive` uses `ge=1`,
+  `*_window_seconds`/`*_cooldown_seconds` use `gt=0`) so degenerate YAML is rejected at load:
+  `divergence_detector_enabled` (bool, default True — master kill-switch),
+  `divergence_failure_mix_threshold` (int, default 10, `ge=1`),
+  `divergence_failure_mix_window_seconds` (float, default 60.0, `gt=0`),
+  `divergence_retry_budget` (int, default 5, `ge=1`),
+  `divergence_size_check_interval_seconds` (float, default 300.0, `gt=0`),
+  `divergence_size_delta_qty_step_multiplier` (float, default 5.0, `gt=0`),
+  `divergence_reconcile_min_interval_seconds` (float, default 300.0, `gt=0`).
+  Counts/budgets use `ge=1` (a 0 threshold would fire constantly); time
+  intervals/windows and the qty-step multiplier use `gt=0` (a 0 interval/window would
+  hot-loop or divide oddly, a 0 multiplier would make every delta exceed the threshold).
+  - **Known characteristic (accepted, no jitter):** on a shared network flare hitting
+    multiple strats at once, all per-strat `_divergence_last_fire_at` timers expire together,
+    so a synchronized re-fire burst can occur after the throttle window (the throttle has no
+    per-strat jitter). This is ACCEPTED: the breaker's 60s cooldown plus the per-strat
+    pending-set dedup bound the burst, and no account-level rate-limiter is in scope. (An
+    optional small per-strat jitter on the throttle window could de-correlate re-fires, but
+    is not adopted here.)
+- **`.claude/skills/gridbot-health/analyze.py`** — add `"force_reconcile_fired"` to
+  `_EVENT_COVERAGE_KEYS` (analyze.py:393) + a `_EVENT_COVERAGE_LABELS` entry
+  (analyze.py:413); add a line scan in `_build_event_coverage_window`
+  (analyze.py:863-878) matching `"state-divergence detected"`. The scan ALSO matches the
+  existing 0064 `"110017 breaker tripped — forcing"` line, so the SINGLE merged
+  `force_reconcile_fired` counter covers BOTH forced-reconcile origins (detector + breaker)
+  — do NOT split into two keys. **No double-count:** because the detector wrapper passes
+  `emit_breaker_warning=False`, a detector fire suppresses the breaker line and emits ONLY the
+  `state-divergence detected` line, while a breaker trip emits ONLY the breaker line — so each
+  reconcile matches EXACTLY ONE of the two scanned patterns and the merged counter increments
+  once per reconcile (never twice). Updates Table 13 automatically via the closed-key plumbing.
+  Note in `.claude/skills/gridbot-health/SKILL.md` and `README` that `force_reconcile_fired`
+  aggregates both the divergence-detector and the 0064 breaker-origin reconciles into one
+  counter.
+
+## Documentation
+
+- `StrategyConfig` field descriptions document each threshold (acceptance: "Configurable
+  thresholds in YAML; defaults shipped; document each in SKILL/README").
+- Add a short `RULES.md` note under the existing "110017 retry-storm self-heal +
+  circuit-breaker (feature 0064, issue #149)" section: the divergence detector reuses
+  `_force_reconcile_strat`, the four signals, their defaults, and the SEPARATE 5-min
+  detector throttle vs. the breaker cooldown.
+
+## Tests
+
+- **B-1 regression (`_force_reconcile_strat` single-call both-directions):** with a fresh
+  rate-limit window (no recent `_force_reconcile_last_at`), `_force_reconcile_strat(strat_id,
+  direction=None)` performs ONE rate-limit check, calls `reconcile_reconnect` exactly ONCE,
+  and calls `_refresh_position_size_from_rest(force=True)` for BOTH `DirectionType.LONG` and
+  `DirectionType.SHORT` (assert both directions' mirrors refreshed) after that single
+  rate-limit check; returns True.
+- **B-1 companion (single-call model, old two-call bug cannot recur):** a second
+  back-to-back `direction=None` call within the cooldown returns False and performs NO
+  `reconcile_reconnect` and NO `_refresh_position_size_from_rest` (proves the rate-limit
+  timestamp is set once per call and the second direction is never silently dropped behind a
+  rate-limit).
+- **B-1 breaker-WARNING gating (no double-WARNING / no double-count on detector fires):**
+  (a) with a fresh rate-limit window, a breaker-origin call `_force_reconcile_strat(strat_id,
+  direction="long")` (default `emit_breaker_warning=True`) emits the
+  `"110017 breaker tripped — forcing long position + order reconcile"` WARNING (unchanged).
+  (b) A detector fire — `direction=None` for every detector signal (1/2/3/4) — going through
+  `_trigger_divergence_reconcile` (which passes `emit_breaker_warning=False`) emits EXACTLY
+  ONE WARNING matching `state-divergence detected` and NO `"110017 breaker tripped — forcing"`
+  line (in particular, no `'None'`-direction breaker line). (c) A single detector reconcile
+  increments
+  `force_reconcile_fired` EXACTLY ONCE (not twice) when its captured WARNING text is fed
+  through the analyzer scan.
+- **Signal 1 (acceptance scenario):** inject 10 successive `execute_place`
+  failures (mix of 110017/110072/network) within 60s on a single strat, driving the runner's
+  injected fake `clock` (which `_record_placement_failure` reads via `self._clock()`) →
+  assert detector fires once, `_trigger_divergence_reconcile` invoked, dedup cache
+  cleared, `_force_reconcile_strat` called, window self-resets. Also assert that advancing the
+  fake clock past the 60s window before the 10th failure EVICTS earlier entries so the
+  threshold is NOT reached (no fire) — proving eviction reads the injectable clock. Then a
+  fresh ticker recovers (mirror resynced).
+- **Signal 2:** drive `truncate_breaker_reconcile_count` past `divergence_retry_budget`
+  → fires once on the edge; assert NO re-fire while the count stays parked at the same value
+  across multiple health ticks; assert it DOES re-fire when the count advances to the next
+  edge (count != last-fired count).
+- **Signal 3:** only-LONG-diverges (delta > `qty_step*5` on LONG, ≤ on SHORT) → ONE fire with
+  `direction=None`, and BOTH LONG and SHORT mirrors refreshed (full reconcile); neither
+  diverges → no fire; mirror NOT mutated by the read-only check; and signal 3 is SKIPPED (no
+  fire, no exception) when `_instrument_info is None` (and, defensively, when `qty_step` is
+  not a positive Decimal). Also assert a `None` return from `rest_position_size` (REST error)
+  skips the comparison for that direction (no fire).
+- **Signal 3 both-directions regression (P1-a — single fire, no throttle trap):** BOTH LONG
+  and SHORT diverge in the SAME size-delta sweep → EXACTLY ONE `_force_reconcile_strat` call
+  (`direction=None`), both mirrors refreshed, and the throttle is bumped ONCE — assert there
+  is NO second (per-side) call that would be throttle-suppressed and leave one side's mirror
+  stale. Evidence names both diverging sides + the max delta.
+- **Signal 4:** a PRIVATE `_on_ws_disconnect` enqueues every strat on the account (via
+  `_account_to_runners` fan-out); next `_tick` drains and fires once per strat. A PUBLIC-kind
+  disconnect does NOT enqueue. A public+private double-fire for the same account enqueues each
+  strat once (set dedup). The enqueue takes `_pending_post_recovery_lock`; the drain
+  swap-and-clears under the same lock and the pending set is EMPTY after the drain (single-pass,
+  no retention).
+- **Signal 4 throttle-suppressed reconcile is DROPPED (not retained, not retried):** prime
+  `_divergence_last_fire_at[strat]` so the detector throttle is ACTIVE (simulate an earlier
+  unrelated fire), enqueue a `post_ws_recovery` for that strat, then drain `_tick`: assert the
+  strat does NOT reconcile this tick (`_force_reconcile_strat` not called for it), and that
+  `_pending_post_recovery_reconcile` is EMPTY afterward — the suppressed strat is DROPPED, NOT
+  re-added/retained/retried. (Residual divergence is backstopped by signal 3 for position size
+  and the periodic order-sync for orders; this test asserts the drop, not the backstop.) Then
+  advance the fake clock past `divergence_reconcile_min_interval_seconds` and drain again with
+  the set still empty: assert NO reconcile runs (nothing pending — confirming the dropped strat
+  is not resurrected on a later tick). A FRESH disconnect after the throttle window enqueues
+  again and reconciles normally — the throttle is per-event, not a deferral queue.
+- **Signal 4 dropped-reconcile fast-tracks the order-sync (when enabled) — assert the EFFECT,
+  not the sentinel:** prime `_divergence_last_fire_at[strat]` so the detector throttle is ACTIVE
+  (the reconcile will be dropped), enqueue a `post_ws_recovery` for that strat. With
+  `order_sync_interval > 0` (default 61) and a `_next_order_sync` far in the future: drive one
+  full `_tick` (the pinned drain sits immediately before the order-sync gate, sharing the same
+  `now`) and assert `_order_sync_once` IS invoked exactly ONCE within that SAME `_tick`
+  (spy/mock on `_order_sync_once` or `reconcile_reconnect`) — proving the fast-track zeroed
+  `_next_order_sync` and the very next gate consumed it the same tick. Do NOT assert
+  `_next_order_sync == 0.0` after the tick — the gate resets it to `now + order_sync_interval`,
+  so the sentinel does NOT persist. Also assert the strat still does NOT reconcile via the
+  divergence wrapper this tick AND `_pending_post_recovery_reconcile` is EMPTY (still dropped,
+  not retried). With `order_sync_interval = 0`: the SAME dropped-reconcile `_tick` does NOT
+  invoke `_order_sync_once` (the gate at orchestrator.py:551-553 keeps the sweep off even with
+  `_next_order_sync` zeroed), and the strat is still dropped — documenting the accepted tradeoff
+  that disabling order reconciliation wholesale forgoes the post-WS-recovery order backstop.
+  (Optional companion: a NON-suppressed drain — throttle clear — reconciles directly via the
+  wrapper and does NOT need to fast-track the order-sync, since the full reconcile already runs
+  `reconcile_reconnect`.)
+- **Signal 4 suppressed-no-misleading-WARNING (F-1-6):** prime
+  `_force_reconcile_last_at[strat]` (simulate a breaker trip) within the 60s cooldown,
+  then fire a detector signal → assert NO "state-divergence detected … forcing full
+  reconcile" WARNING is emitted, `_same_order_dedup_cache` is NOT cleared,
+  `_divergence_last_fire_at` is NOT bumped, and `force_reconcile_fired` does not increment;
+  after the cooldown elapses, the same signal DOES emit the WARNING and reconcile.
+- **Classifiers (`test_executor.py`):** `is_network_error` MATCHES timeout / connection /
+  temporarily-unavailable / `ReadTimeout` / `ConnectionError` strings (lowercased-token) and
+  does NOT match generic `"error"`, a bare digit, `110017`, or `110007`;
+  `is_duplicate_link_error` MATCHES `"110072"` and `"OrderLinkedID is duplicate"`
+  (case-insensitive) and does NOT match other ErrCodes.
+- **Throttle:** two signals within `divergence_reconcile_min_interval_seconds` → second
+  suppressed; after the interval → fires again.
+- **Kill-switch:** `divergence_detector_enabled=False` → no signal fires.
+- **Config validation:** a `StrategyConfig` with `divergence_failure_mix_threshold=0` (or
+  `divergence_retry_budget=0`) is REJECTED by Pydantic at load (violates `ge=1`); a config
+  with `divergence_failure_mix_window_seconds=0` / `divergence_size_check_interval_seconds=0`
+  / `divergence_reconcile_min_interval_seconds=0` / `divergence_size_delta_qty_step_multiplier=0`
+  is REJECTED (violates `gt=0`). Valid defaults load cleanly.
+- **Analyzer:** a window containing the detector WARNING line (`"state-divergence detected"`)
+  increments `event_coverage["force_reconcile_fired"]` and renders in Table 13. ALSO assert
+  that a window line matching the 0064 breaker text (`"110017 breaker tripped — forcing"`)
+  ALSO increments `event_coverage["force_reconcile_fired"]`, covering the merged-counter
+  behavior (BOTH origins feed the one counter), not just the detector WARNING. **No
+  double-count:** a window representing a SINGLE detector reconcile (only the
+  `state-divergence detected` line, breaker line suppressed via `emit_breaker_warning=False`)
+  increments the counter by EXACTLY ONE — assert it does not also count a breaker line, since
+  the wrapper never emits one on a detector fire.
+
+## Out of scope
+
+- #149's pre-send qty cap / per-intent circuit-breaker (already shipped).
+- Underlying network instability (host/ISP) — infra-side.
+- Replacing the WS health detector — kept; only the post-recovery forced-reconcile
+  enforcement is added.

--- a/docs/features/0069_REVIEW.md
+++ b/docs/features/0069_REVIEW.md
@@ -1,0 +1,38 @@
+# 0069 Code Review — Auto state-divergence detector + forced reconcile
+
+Plan reviewed: `docs/features/0069_PLAN.md`
+
+## Findings
+
+No open implementation findings after follow-up fixes.
+
+## Notes
+
+- The analyzer changes live under `.claude/skills/gridbot-health/`, which is gitignored by repository convention (`.gitignore:42`; see `docs/features/0063_PLAN.md` and `docs/features/0068_PLAN.md`). They are intentionally local/operator-skill changes, not normal tracked source changes. If this feature is later published as a branch artifact that must include the skill tree, it will need an explicit force-add or a tracked skill-source location.
+- Follow-up lint cleanup was applied in the new divergence tests: semicolon-separated mock setup was split onto separate lines, and the unused `replace` import was removed.
+
+## Positive Review Notes
+
+- The two-throttle contract is implemented correctly: `_trigger_divergence_reconcile` checks the detector throttle first, calls `_force_reconcile_strat(..., direction=None, emit_breaker_warning=False)` exactly once, and only emits the detector WARNING / clears dedup / bumps `_divergence_last_fire_at` when `_force_reconcile_strat` returns `True`.
+- `_force_reconcile_strat(direction=None)` handles both LONG and SHORT internally under one cooldown timestamp and suppresses the breaker WARNING on detector calls, preventing the analyzer double-count described in the plan.
+- Kill-switch coverage is present at the wrapper and upstream signal work: signal 1 recording, signal 2 health check edge, signal 3 REST read, and signal 4 enqueue all skip when `divergence_detector_enabled=False`.
+- Signal 1 records the intended union `{110017, 110072, network}` from both failure exits and excludes 110007.
+- Signal 3 uses a read-only `rest_position_size` helper and fires one full reconcile with `direction=None` when either side exceeds the configured qty-step threshold.
+- Signal 4 correctly limits enqueueing to private WS paths, drains via a locked pending set in `_tick`, drops suppressed pending entries, and fast-tracks order sync when detector-throttle suppression would otherwise leave order state waiting for the normal interval.
+- Analyzer logic locally includes the merged `force_reconcile_fired` key, label, detector/breaker scan, no-double-count tests, and additive merge test.
+
+## Verification
+
+- `uv run pytest -q apps/gridbot/tests/test_orchestrator_divergence.py apps/gridbot/tests/test_runner_divergence.py apps/gridbot/tests/test_executor.py apps/gridbot/tests/test_config.py`  
+  Result: `143 passed in 0.25s`
+- `uv run pytest -q .claude/skills/gridbot-health/test_analyze.py`  
+  Result: `55 passed in 0.03s`
+- `uv run ruff check`  
+  Result: failed on pre-existing full-repo lint issues outside this feature's tracked changes.
+- Scoped ruff on feature files fails only on pre-existing analyzer/runner lint baseline (`.claude/skills/gridbot-health/analyze.py` ambiguous `l` variables and `runner.py` import-order baseline).
+
+## Test Coverage Assessment
+
+Coverage is strong for the new behavior: happy paths, throttle/cooldown suppression, kill-switch inertness, both-direction reconcile, signal edge behavior, REST read failure paths, dedup clearing, analyzer registration/counting/merge, and production WS trigger paths are all covered with fast isolated mocks.
+
+Remaining risk is mostly operational rather than logic-level: the analyzer update lives in ignored local skill files by repository convention, and full-repo lint remains red because of the existing lint baseline.

--- a/packages/bybit_adapter/src/bybit_adapter/error_codes.py
+++ b/packages/bybit_adapter/src/bybit_adapter/error_codes.py
@@ -20,3 +20,11 @@ ORDER_QTY_TRUNCATED_TO_ZERO = 110017
 # are exempt (they free margin). Drives the low-balance preflight + retry-queue
 # no-enqueue guard (feature 0066, issue #159).
 INSUFFICIENT_BALANCE = 110007
+
+# ErrCode 110072 "OrderLinkedID is duplicate": a re-submitted order reuses an
+# orderLinkId Bybit still caches (it survives ~1-2h past the order lifetime), or
+# a REST retry lands an order whose first ack never arrived via WS. Individually
+# benign (the retry queue handles it), but a SUSTAINED run is evidence the WS ack
+# path is degraded and the local mirror may be drifting — counted by the
+# state-divergence detector (feature 0069, issue #151).
+ORDER_LINK_ID_DUPLICATE = 110072

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,45 +1,25 @@
-# 0065 — Backtest wallet seed: re-mark non-USDT collateral (totalEquity / liq_price parity)
+# 0069 — Auto state-divergence detector + on-demand forced reconcile (issue #151)
 
-Plan: docs/features/0065_PLAN.md  |  Branch: feature/0065-collateral-remark. TDD throughout (RED → GREEN per phase).
+Plan: docs/features/0069_PLAN.md  |  Branch: feature/0069-divergence-detector
 
-## Grounding (resolved from real DB `recorder_ltcusdt_phase4.db`)
-- [x] SOL per-coin `raw_json`: `walletBalance`, `usdValue`, `collateralSwitch`(bool), `marginCollateral`(bool) confirmed
-- [x] SOL only 3 rows (quiet-coin staleness real → ticker fallback needed)
-- [x] Fixture: run_id `1aff13af-…`, account `9bdb9748-…`, SOLUSDT ticker present, traded sym LTCUSDT
+## Status: implementation + tests + docs COMPLETE (adversarial review running)
 
-## Phase 1 — Data layer
-- [x] 1B repos: `WalletSnapshotRepository.get_all_coins_latest_before` (+2 tests)
-- [x] 1B repos: `TickerSnapshotRepository.get_mark_at_or_before` (+2 tests)
-- [x] 1B `WalletSeed`: +6 fields (`field(default_factory=...)`, frozen-safe)
-- [x] 1B `load_collateral_seed(...)` loader (fresh `usdValue/bal` vs ticker fallback, `_strip_tz`) (+9 tests)
-- [x] 1B `engine._load_seed` merge via `dataclasses.replace`; raise `SeedDataQualityError` (+2 tests)
-- [x] 1C `SeedConfig`: 4 collateral fields (+3 tests)
-- [x] 1A recorder: `RecorderConfig.collateral_symbols` + merged public sub set (+3 tests)
+- [x] error_codes.py — `ORDER_LINK_ID_DUPLICATE = 110072`
+- [x] executor.py — `is_network_error`, `is_duplicate_link_error` classifiers
+- [x] config.py — 7 new `divergence_*` StrategyConfig fields (ge=1 / gt=0 constraints)
+- [x] runner.py — `_record_placement_failure` (signal 1), `clear_dedup_cache`,
+      `rest_position_size` (pure read), `on_divergence_failure_mix` ctor param,
+      `_placement_failure_window`, two `_execute_place_intent` call sites
+- [x] orchestrator.py — `_force_reconcile_strat` refactor (`direction:str|None`,
+      `emit_breaker_warning`, `-> bool`, both-directions internal), wrapper
+      `_trigger_divergence_reconcile`, `_enqueue_post_recovery_reconcile`,
+      `_divergence_size_check_once`/`_interval`, signal-1 wiring, signal-2 edge in
+      `_health_check_once`, signal-3 gate+priming, signal-4 enqueues (3 private
+      sources) + pinned `_tick` drain + order-sync fast-track, new __init__ state
+- [x] analyze.py — merged `force_reconcile_fired` event_coverage key + label + scan
+- [x] Tests: test_runner_divergence.py, test_orchestrator_divergence.py,
+      test_executor.py classifiers, test_config.py, test_analyze.py
+- [x] Docs: RULES.md 0069 section, SKILL.md Table 13 note
+- [x] Full suite green: 1258 passed, 1 skipped (apps/gridbot + packages)
 
-## Phase 2 — Backtest equity re-marking
-- [x] 2A `BacktestSession`: collateral kwargs, `seed_contrib`, `collateral_marks`, `update_collateral_mark`, `collateral_drift_total`, `collateral_drift_by_coin` (+7 tests)
-- [x] 2A re-mark DELTA in BOTH `update_equity` AND `refresh_balances`; `current_balance`/`equity_curve`/`final_balance` unchanged
-- [x] 2B `CollateralMarkFeed` (per-coin ticker stream, `mark_at(coin, ts)`) (+4 tests)
-- [x] 2B engine: build session w/ collateral kwargs; `update_collateral_mark` at TOP of tick loop (before `process_fills`)
-- [x] 2B wind-down: `leave_open` default for #3a (documented; close_all out of scope)
-
-## Phase 3 — Comparator attribution
-- [x] 3 `ValidationMetrics`: `non_usdt_collateral_drift_total`, `collateral_drift_by_coin`, 3 list fields
-- [x] 3 engine: plumb session drift + seed lists into metrics after finalize
-- [x] 3 `reporter.export_metrics` rows + `print_summary` line (+3 tests)
-
-## Verification
-- [x] All new unit tests pass (loader, repos, session, recorder config, reporter, engine_seed)
-- [x] Engine integration: SOL fixture, #3a (<$1), #3b, #4 USDT-only no-op (+3 tests)
-- [x] Full repo suite green — 2439 passed, 3 skipped (+38 new)
-- [x] `scripts/verify_0065_collateral.py` runs on real DB (SOL drift attribution)
-- [x] Operator YAML examples (replay + recorder) documented
-- [x] RULES.md entry 25 added
-- [x] Adversarial review pass — 4-lens + verify (P0s = positive confirmations; applied 8 P1–P3 fixes: feed monotonicity guard, deterministic tie-break, _strip_tz DRY, close_all/#3a doc, collateral_coins validator, never-marked WARN, InvalidOperation log, session contract assert)
-- [ ] User sign-off + commit (awaiting explicit instruction)
-
-## What could break (revisit)
-- Frozen dataclass mutable default → `field(default_factory=...)` ✓
-- Static seed balances vs live balance drift (SOL doubled mid-window) — #3a WARN documented
-- `_strip_tz` tz mismatch (naive SQLite ts vs aware config at_ts) — handled + tested
-- Perp mark vs Bybit `usdValue` basis divergence on tight #3a — documented limitation
+## Not committed — awaiting user review/approval before any commit.


### PR DESCRIPTION
## Summary

- **4 independent signals** detect local↔exchange divergence without process restart: rolling placement-failure UNION window (signal 1), retry-budget edge rule (signal 2), periodic REST position-size delta sweep (signal 3), private-WS-recovery enqueue with order-sync fast-track (signal 4)
- **`_force_reconcile_strat` refactored** to `(strat_id, direction: str|None, emit_breaker_warning: bool=True) -> bool`: `direction=None` handles both LONG+SHORT under one cooldown timestamp; `emit_breaker_warning=False` suppresses the internal WARNING on detector paths to prevent analyzer double-count
- **`_trigger_divergence_reconcile` wrapper** enforces kill-switch → 300s detector throttle → forced reconcile → side-effects only on `True` return; breaker path (0064) retains its own 60s cooldown independently
- **Analyzer**: merged `force_reconcile_fired` key covers both detector + 0064 breaker origins with no double-count by design
- **7 new `StrategyConfig` fields** with Pydantic constraints (`divergence_detector_enabled`, `divergence_failure_mix_threshold`, `divergence_failure_mix_window_seconds`, `divergence_retry_budget`, `divergence_size_check_interval_seconds`, `divergence_size_delta_qty_step_multiplier`, `divergence_reconcile_min_interval_seconds`)
- Closes issue #151; addresses the 2026-05-30 mainnet incident (15+ WS disconnects → accumulated divergence → required manual restart)

## Test plan

- [x] `uv run pytest -q apps/gridbot/tests/test_orchestrator_divergence.py apps/gridbot/tests/test_runner_divergence.py apps/gridbot/tests/test_executor.py apps/gridbot/tests/test_config.py` — **143 passed**
- [x] `uv run pytest -q apps/gridbot/` — **714 passed**
- [x] `uv run pytest -q .claude/skills/gridbot-health/test_analyze.py` — **55 passed** (6 new `force_reconcile_fired` tests)
- [x] Code review (`docs/features/0069_REVIEW.md`): no open findings after fix cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)