### PR TITLE
fix(0069): keep retry-budget edge on suppressed reconcile

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -395,7 +395,11 @@ same `Orchestrator._force_reconcile_strat` the 0064 breaker uses.
 - **Signal 2 — retry-budget edge.** In `_health_check_once`, fire once per NEW
   edge when `truncate_breaker_reconcile_count >= divergence_retry_budget` (5) AND
   the count differs from `_divergence_budget_last_fired[strat]`. Backstop for when
-  the breaker counts but does not auto-reconcile.
+  the breaker counts but does not auto-reconcile. **Pitfall:** only bump
+  `_divergence_budget_last_fired` when `_trigger_divergence_reconcile` returns
+  `True` (reconcile actually ran). Consuming the edge before a suppressed reconcile
+  (breaker cooldown / detector throttle) leaves the bot stuck with a parked count
+  and no further signal-2 retries until trips advances again.
 - **Signal 3 — REST-vs-local size delta.** `_divergence_size_check_once` (gated by
   `_next_divergence_size_check`, primed half an interval ahead of `_next_order_sync`
   so the two REST sweeps don't co-fire) compares `runner.rest_position_size(dir)`

--- a/apps/gridbot/src/gridbot/orchestrator.py
+++ b/apps/gridbot/src/gridbot/orchestrator.py
@@ -1117,10 +1117,12 @@ class Orchestrator:
                             runner.strat_id, -1
                         )
                     ):
-                        self._divergence_budget_last_fired[runner.strat_id] = trips
-                        self._trigger_divergence_reconcile(
+                        if self._trigger_divergence_reconcile(
                             runner.strat_id, "retry_budget", trips,
-                        )
+                        ):
+                            self._divergence_budget_last_fired[
+                                runner.strat_id
+                            ] = trips
 
             for account_name in list(self._public_ws.keys()):
                 # Check public WS
@@ -1420,11 +1422,13 @@ class Orchestrator:
         signal: str,
         evidence: object,
         direction: Optional[str] = None,
-    ) -> None:
+    ) -> bool:
         """Thin divergence wrapper around ``_force_reconcile_strat`` (issue #151).
 
-        All four detector signals funnel here. Fire-and-forget (returns None — no
-        caller, including signal 4's drain, inspects a return value). Order:
+        All four detector signals funnel here. Returns ``True`` only when a forced
+        reconcile was actually attempted (not kill-switched, detector-throttled,
+        or breaker-cooldown-suppressed). Signal 2 uses this to avoid consuming a
+        retry-budget edge when the reconcile was suppressed. Order:
 
         1. Master kill-switch (BEFORE the throttle): if the per-strat
            ``divergence_detector_enabled`` is False, RETURN immediately (no
@@ -1450,7 +1454,7 @@ class Orchestrator:
             (c for c in self._config.strategies if c.strat_id == strat_id), None
         )
         if cfg is None or not cfg.divergence_detector_enabled:
-            return
+            return False
 
         now = time.monotonic()
         last = self._divergence_last_fire_at.get(strat_id, 0.0)
@@ -1461,7 +1465,7 @@ class Orchestrator:
                 "— skipping",
                 strat_id, signal, now - last, min_interval,
             )
-            return
+            return False
 
         ran = self._force_reconcile_strat(strat_id, None, emit_breaker_warning=False)
         if not ran:
@@ -1470,7 +1474,7 @@ class Orchestrator:
                 "breaker cooldown",
                 strat_id, signal,
             )
-            return
+            return False
 
         logger.warning(
             "%s: state-divergence detected (signal=%s, evidence=%s), "
@@ -1487,6 +1491,7 @@ class Orchestrator:
                     error_key=f"divergence_dedup_clear_{strat_id}",
                 )
         self._divergence_last_fire_at[strat_id] = now
+        return True
 
     def _enqueue_post_recovery_reconcile(self, account_name: str) -> None:
         """Signal 4 — fan out an account-level WS recovery to its strats.

--- a/apps/gridbot/src/gridbot/runner.py
+++ b/apps/gridbot/src/gridbot/runner.py
@@ -195,7 +195,7 @@ class StrategyRunner:
         rest_client: Optional["BybitRestClient"] = None,
         truncate_breaker: Optional[TruncateBreaker] = None,
         on_truncate_breaker_tripped: Optional[Callable[[str, str], None]] = None,
-        on_divergence_failure_mix: Optional[Callable[[str, str, int], None]] = None,
+        on_divergence_failure_mix: Optional[Callable[[str, str, int], bool]] = None,
         clock: Optional[Callable[[], float]] = None,
         wallet_provider: Optional["WalletProvider"] = None,
         wallet_ws_max_age_seconds: float = 45.0,

--- a/apps/gridbot/tests/test_orchestrator_divergence.py
+++ b/apps/gridbot/tests/test_orchestrator_divergence.py
@@ -147,14 +147,15 @@ def test_detector_fire_suppresses_breaker_warning(fixed_clock, caplog):
 
 def test_wrapper_detector_throttle(fixed_clock):
     orch, runner, reconciler = _wire(_gridbot_config())
-    orch._trigger_divergence_reconcile("btcusdt_test", "rest_failure_mix", 10)
+    assert orch._trigger_divergence_reconcile("btcusdt_test", "rest_failure_mix", 10) is True
     assert reconciler.reconcile_reconnect.call_count == 1
-    # Second within the 300s detector throttle → suppressed.
-    orch._trigger_divergence_reconcile("btcusdt_test", "rest_failure_mix", 11)
+    # Second within the 300s detector throttle → suppressed (False = edge not
+    # consumable by signal 2).
+    assert orch._trigger_divergence_reconcile("btcusdt_test", "rest_failure_mix", 11) is False
     assert reconciler.reconcile_reconnect.call_count == 1
     # After the detector throttle (and past the 60s breaker cooldown) → fires.
     fixed_clock["now"] = 1000.0 + 301.0
-    orch._trigger_divergence_reconcile("btcusdt_test", "rest_failure_mix", 12)
+    assert orch._trigger_divergence_reconcile("btcusdt_test", "rest_failure_mix", 12) is True
     assert reconciler.reconcile_reconnect.call_count == 2
 
 
@@ -162,7 +163,7 @@ def test_wrapper_kill_switch(fixed_clock):
     orch, runner, reconciler = _wire(
         _gridbot_config(_strategy_config(divergence_detector_enabled=False))
     )
-    orch._trigger_divergence_reconcile("btcusdt_test", "rest_failure_mix", 10)
+    assert orch._trigger_divergence_reconcile("btcusdt_test", "rest_failure_mix", 10) is False
     reconciler.reconcile_reconnect.assert_not_called()
 
 
@@ -177,7 +178,9 @@ def test_wrapper_suppressed_by_breaker_cooldown_no_misleading_warning(
     orch._force_reconcile_last_at["btcusdt_test"] = 1000.0
 
     with caplog.at_level("WARNING", logger="gridbot.orchestrator"):
-        orch._trigger_divergence_reconcile("btcusdt_test", "rest_failure_mix", 10)
+        assert orch._trigger_divergence_reconcile(
+            "btcusdt_test", "rest_failure_mix", 10
+        ) is False
     msgs = [r.getMessage() for r in caplog.records]
     assert not any("state-divergence detected" in m for m in msgs)
     reconciler.reconcile_reconnect.assert_not_called()
@@ -187,7 +190,9 @@ def test_wrapper_suppressed_by_breaker_cooldown_no_misleading_warning(
     # After the 60s breaker cooldown → fires fully.
     fixed_clock["now"] = 1000.0 + 61.0
     with caplog.at_level("WARNING", logger="gridbot.orchestrator"):
-        orch._trigger_divergence_reconcile("btcusdt_test", "rest_failure_mix", 10)
+        assert orch._trigger_divergence_reconcile(
+            "btcusdt_test", "rest_failure_mix", 10
+        ) is True
     msgs = [r.getMessage() for r in caplog.records]
     assert any("state-divergence detected" in m for m in msgs)
     runner.clear_dedup_cache.assert_called_once()
@@ -239,6 +244,58 @@ def test_signal2_disabled_does_not_fire():
     orch._trigger_divergence_reconcile = Mock()
     orch._health_check_once()
     orch._trigger_divergence_reconcile.assert_not_called()
+
+
+def test_signal2_retries_after_breaker_cooldown_suppresses_reconcile(fixed_clock):
+    """Budget edge must not be consumed when reconcile is rate-limited.
+
+    Otherwise a parked truncate_breaker_reconcile_count (no new 110017s while
+    placements are blocked) never gets the both-direction backstop reconcile.
+    """
+    orch, runner, reconciler = _wire(
+        _gridbot_config(_strategy_config(
+            divergence_retry_budget=5,
+            truncate_breaker_cooldown_seconds=60.0,
+        ))
+    )
+    runner.dirty_rest_refresh_failure_count = 0
+    runner.truncate_breaker_reconcile_count = 5
+    orch._force_reconcile_last_at["btcusdt_test"] = 1000.0
+    fixed_clock["now"] = 1030.0  # 30s later — still inside 60s cooldown
+
+    orch._health_check_once()
+    assert "btcusdt_test" not in orch._divergence_budget_last_fired
+    reconciler.reconcile_reconnect.assert_not_called()
+
+    fixed_clock["now"] = 1070.0  # cooldown expired — same edge should retry
+    orch._health_check_once()
+    assert orch._divergence_budget_last_fired["btcusdt_test"] == 5
+    reconciler.reconcile_reconnect.assert_called_once_with(runner)
+
+
+def test_signal2_retries_after_detector_throttle_suppresses_reconcile(fixed_clock):
+    """Edge-preservation must also hold for the 300s detector-throttle path.
+
+    The 110017 burst that exhausts divergence_retry_budget typically fires
+    signal 1 first, so the throttle (not the breaker cooldown) is the likely
+    suppressor when the health check observes the budget edge.
+    """
+    orch, runner, reconciler = _wire(
+        _gridbot_config(_strategy_config(divergence_retry_budget=5))
+    )
+    runner.dirty_rest_refresh_failure_count = 0
+    runner.truncate_breaker_reconcile_count = 5
+    orch._divergence_last_fire_at["btcusdt_test"] = 1000.0  # signal 1 just fired
+    fixed_clock["now"] = 1030.0  # 30s later — inside the 300s detector throttle
+
+    orch._health_check_once()
+    assert "btcusdt_test" not in orch._divergence_budget_last_fired
+    reconciler.reconcile_reconnect.assert_not_called()
+
+    fixed_clock["now"] = 1000.0 + 301.0  # throttle expired — same edge retries
+    orch._health_check_once()
+    assert orch._divergence_budget_last_fired["btcusdt_test"] == 5
+    reconciler.reconcile_reconnect.assert_called_once_with(runner)
 
 
 # ==========================================================================


### PR DESCRIPTION
## Bug and impact

**Signal 2 retry-budget backstop silently failed when reconcile was suppressed.**

When `truncate_breaker_reconcile_count` crossed `divergence_retry_budget`, the orchestrator recorded `_divergence_budget_last_fired` *before* calling `_trigger_divergence_reconcile`. If the reconcile was then suppressed (breaker cooldown or detector throttle), the edge was consumed without a both-direction resync.

**Concrete trigger:** after repeated 110017 breaker trips, the count reaches the budget (e.g. 5) on the same tick as a breaker-driven reconcile. `_force_reconcile_strat` is rate-limited by the shared cooldown, so signal 2's full reconcile is suppressed — but the edge is marked fired. If placements are now blocked by stale state and no new 110017s arrive, the count stays parked at 5 and signal 2 never retries. The bot can remain stuck until signal 3 (up to 5 min) or manual intervention.

## Fix

- `_trigger_divergence_reconcile` returns `bool` (`True` only when a reconcile was actually attempted — not kill-switched, detector-throttled, or breaker-cooldown-suppressed).
- Signal 2 bumps `_divergence_budget_last_fired` only on `True`.
- `runner.py`: `on_divergence_failure_mix` hint updated `-> None` to `-> bool` (return still intentionally ignored by the runner).

## Tests

- `test_signal2_retries_after_breaker_cooldown_suppresses_reconcile` — breaker-cooldown suppression path (from #169).
- `test_signal2_retries_after_detector_throttle_suppresses_reconcile` — new: detector-throttle suppression path; mutation-tested (flipping the throttle exit to `return True` fails this test and `test_wrapper_detector_throttle`).
- Wrapper suppression tests now assert the return value on all three exits (`is False`) and on fire (`is True`).
- Full gridbot suite: 716 passed.

Supersedes #169 — that branch (`cursor/*`) gets no repo secrets, so the required `claude-review` check dies in 12s with an empty `ANTHROPIC_API_KEY` and the PR can never go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)