### PR TITLE
fix(0066): drop buffered grow-side cancels on chase-close exit

### DIFF
--- a/apps/gridbot/src/gridbot/runner.py
+++ b/apps/gridbot/src/gridbot/runner.py
@@ -1943,6 +1943,13 @@ class StrategyRunner:
 
     def _exit_chase(self) -> None:
         self._retire_live_chase_order("chase_exit")
+        # Drop buffered grow-side cancel intents queued on _enter_chase. They are
+        # only valid while CHASING; if exit happens before the next drain, leaving
+        # them would cancel resting grid opens after chase mode has ended.
+        self._pending_chase_intents = [
+            i for i in self._pending_chase_intents
+            if not (isinstance(i, CancelIntent) and i.reason == "chase_close")
+        ]
         logger.info("%s: chase-close EXIT %s", self.strat_id, self._chase_direction)
         self._chase_state = "IDLE"
         self._chase_direction = None

--- a/apps/gridbot/tests/test_runner_lowbalance_storm.py
+++ b/apps/gridbot/tests/test_runner_lowbalance_storm.py
@@ -456,6 +456,28 @@ def test_chase_exit_before_drain_does_not_orphan_buffered_place(chase_runner):
     assert chase_runner._chase_state == "IDLE"
 
 
+def test_chase_exit_before_drain_drops_buffered_grow_side_cancels(chase_runner):
+    """Exit before drain must not leave buffered grow-side cancels that would
+    fire on the next dispatch tick after chase mode has ended."""
+    grow_buy = PlaceLimitIntent.create(
+        symbol="SOLUSDT", side="Buy", price=Decimal("95"), qty=Decimal("1"),
+        grid_level=1, direction="long", reduce_only=False,
+    )
+    chase_runner._tracked_orders[grow_buy.client_order_id] = TrackedOrder(
+        client_order_id=grow_buy.client_order_id, intent=grow_buy,
+        status="placed", order_id="grow-1",
+    )
+    chase_runner._low_balance = True
+    chase_runner._long_position.size = Decimal("10")
+    chase_runner._evaluate_chase(100.0, 8.0)  # enter → grow cancel + chase buffered
+    assert any(c.order_id == "grow-1" for c in _cancels(chase_runner._pending_chase_intents))
+    chase_runner._low_balance = False         # balance recovers before drain
+    chase_runner._evaluate_chase(100.0, 8.0)  # exit
+    assert _cancels(chase_runner._pending_chase_intents) == []
+    assert _places(chase_runner._pending_chase_intents) == []
+    assert chase_runner._chase_state == "IDLE"
+
+
 def test_chase_repeg_before_drain_replaces_not_accumulates(chase_runner):
     """Re-peg before drain replaces the still-buffered place (no accumulation)."""
     chase_runner._low_balance = True


### PR DESCRIPTION
## Bug and impact

With `chase_close_enabled=True`, chase-close could cancel resting grid grow-side orders **after** chase mode had already exited.

**Trigger:** low balance + extreme position ratio enters chase (`_enter_chase` buffers `CancelIntent(reason="chase_close")` for grow-side opens). Balance or ratio recovers before the next dispatch drain (`_drain_pending_chase_intents`). `_exit_chase` retired only the buffered chase place; grow-side cancel intents remained and fired on the next tick.

**Impact:** unintended cancellation of live grid orders when chase-close is enabled (default off).

## Root cause

`_exit_chase` called `_retire_live_chase_order` (chase place only) but did not clear buffered grow-side cancel intents queued on entry.

## Fix

Filter `reason=="chase_close"` cancel intents out of `_pending_chase_intents` in `_exit_chase`, after `_retire_live_chase_order("chase_exit")` so chase_exit/chase_replace cancels are preserved.

## Validation

- TDD: regression test `test_chase_exit_before_drain_drops_buffered_grow_side_cancels` added first, confirmed failing on main (`CancelIntent(order_id='grow-1', reason='chase_close')` survived exit), passes with fix
- `uv run pytest apps/gridbot/tests/test_runner_lowbalance_storm.py` — 68 passed
- `uv run pytest apps/gridbot/tests/` — 715 passed
- cavecrew-reviewer pass: 0 bugs, 0 risks

Replicates #171 (bot PR, not mergeable per policy). Closes #171 supersedes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)