### PR TITLE
feat(0073): add CI workflow (make test + make lint)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: CI
+
+# Source of truth for repo health: every PR and every push to main runs
+# `make test` and `make lint`. Both jobs fail the workflow on non-zero exit.
+#
+# Rollout (see docs/features/0073_PLAN.md, Phase 0): the repo is currently
+# RED (ruff errors tracked in #180, GTC assertion in #177). These jobs run as
+# REAL failing checks but are NOT yet a required status check in branch
+# protection, so they do not block the fix PRs for #177-#180. Once those land
+# and both jobs are green, enable the required check in GitHub branch
+# protection (a repo setting, not a file).
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# Cancel superseded runs on the same ref to save CI minutes during the
+# "make green" loop.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+# Tests are hermetic (no Bybit keys / network); read-only is sufficient.
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run tests
+        run: make test
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run lint
+        run: make lint

--- a/README.md
+++ b/README.md
@@ -191,6 +191,15 @@ Always run tests through `uv run` — bare `python -m pytest` skips the workspac
 make lint   # ruff over the whole workspace
 ```
 
+### Continuous Integration
+
+[`.github/workflows/ci.yml`](.github/workflows/ci.yml) runs `make test` and
+`make lint` (as separate jobs) on every pull request and on every push to
+`main`. **CI green is the source of truth for repo health** — reproduce any
+failure locally with the same `make` target. Both jobs fail on any non-zero
+exit; while the repo is being made green (issues #177–#180) the check is not
+yet required for merge in branch protection.
+
 ### Adding a Dependency
 
 ```bash

--- a/RULES.md
+++ b/RULES.md
@@ -71,6 +71,17 @@ make test-integration
 
 **`make test` note**: Runs pytest separately per package to avoid `conftest` ImportPathMismatchError. Coverage is appended; final run prints `term-missing`. `--cov-fail-under` not applied to merged total (~73%).
 
+## Continuous Integration (`.github/workflows/ci.yml`)
+
+The merge gate (feature 0073, issue #176). Two parallel jobs — `test` (`make test`) and `lint` (`make lint`) — run on every PR and on push to `main`; both fail the workflow on any non-zero exit. **CI green is the source of truth for repo health.**
+
+Phase-0 rollout while the repo is red:
+- **Step A (current)** — real failing jobs, no `continue-on-error`; the check is NOT required in branch protection, so it doesn't block the fix PRs for #177–#180.
+- **Step A′** — advisory green via `continue-on-error: true` on `lint` ONLY (never `test`); opt-in scaffolding, avoid unless explicitly requested.
+- **Step B** — after #177–#180 land and both jobs are green, drop any `continue-on-error` and mark the check required.
+
+**Branch protection (making the check "required") is a GitHub repo setting, not a file** — it cannot be enforced from `ci.yml`; set it manually.
+
 ## Development Workflow
 
 1. Define task clearly


### PR DESCRIPTION
## Summary

Adds `.github/workflows/ci.yml` as the merge gate for repo health (issue #176). Two parallel jobs run on every PR and on push to `main`:
- **test** — `make test` (per-package + integration, `timeout-minutes: 30`)
- **lint** — `make lint` (`ruff check .`)

Both fail the workflow on any non-zero exit. Minimal `contents: read` perms, concurrency-cancel on same ref, setup-uv built-in cache, single Python 3.12 (no matrix).

## Phase-0 rollout — Step A (repo currently red)

`make lint` (184 ruff errors, #180) and `make test` (1 GTC assertion failure, #177) are red today. So the jobs run as **real failing checks** but are **NOT yet marked required** in branch protection — this keeps the fix PRs for #177–#180 unblocked. No `continue-on-error` on either job.

**Manual follow-up:** enable the required status check in GitHub branch protection once #177–#180 land and both jobs are green.

## Docs
- `README.md` — new "Continuous Integration" subsection (CI green = source of truth for repo health)
- `RULES.md` — CI section documenting the two jobs + Step A/A′/B rollout + branch-protection-is-manual note

Plan: `docs/features/0073_PLAN.md` (approved via plan-debate).

## Expected CI result on this PR
Both jobs **red** by design (Step A): lint 184 errors, test 1 GTC fail. Merge stays allowed because the check is not required yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)