### PR TITLE
test(0074): fix integration test for time_in_force=GTC (#177)

### DIFF
--- a/tests/integration/test_engine_to_executor.py
+++ b/tests/integration/test_engine_to_executor.py
@@ -213,6 +213,7 @@ class TestExecutorRESTPayloadMapping:
             "reduce_only": intent.reduce_only,
             "position_idx": 1 if intent.direction == "long" else 2,
             "order_link_id": result.order_link_id,
+            "time_in_force": "GTC",
         }
         assert result.order_link_id is not None
         prefix, sep, suffix = result.order_link_id.partition("-")


### PR DESCRIPTION
## Summary

P0 fix for issue #177 — red CI on `main`. Feature 0066 (issue #159) added maker-only support: `IntentExecutor.execute_place` now threads `time_in_force` into `BybitRestClient.place_order` (`"PostOnly"` if `post_only` else `"GTC"`). The integration test `TestExecutorRESTPayloadMapping::test_place_intent_maps_to_rest_params` asserts the full `place_order` kwargs with exact dict equality, so the new `"time_in_force": "GTC"` key broke it.

## Change

- `tests/integration/test_engine_to_executor.py`: add `"time_in_force": "GTC"` to the asserted `call_kwargs` dict (1 line).
- Production `executor.py` is correct and **unchanged**.
- Mirrors already-green unit coverage in `apps/gridbot/tests/test_executor.py` (`test_default_intent_passes_gtc_tif` / `test_post_only_intent_passes_postonly_tif`).

## Verification

`uv run pytest tests/integration/test_engine_to_executor.py apps/gridbot/tests/test_executor.py -q` → 73 passed.

Fixes #177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)