### PR TITLE
test(0075): include apps/backtest/tests in make test (#178)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ test:
 	uv run pytest apps/comparator/tests --cov=comparator --cov-append -q
 	uv run pytest apps/recorder/tests --cov=recorder --cov-append -q
 	uv run pytest apps/replay/tests --cov=replay --cov-append -q
+	uv run pytest apps/backtest/tests --cov=backtest --cov-append -q
 	uv run pytest apps/pnl_checker/tests --cov=pnl_checker --cov-append -q
 	uv run pytest tests/integration/ --cov-append --cov-report=term-missing -v
 

--- a/RULES.md
+++ b/RULES.md
@@ -79,7 +79,7 @@ uv run pytest apps/pnl_checker/tests --cov=pnl_checker --cov-report=term-missing
 make test-integration
 ```
 
-**`make test` note**: Runs pytest separately per package to avoid `conftest` ImportPathMismatchError. Coverage is appended; final run prints `term-missing`. `--cov-fail-under` not applied to merged total (~73%).
+**`make test` note**: Runs pytest separately per package to avoid `conftest` ImportPathMismatchError. Coverage is appended; final run prints `term-missing`. `--cov-fail-under` not applied to merged total (~73%). Covers every `pyproject.toml` `testpaths` entry, including `apps/backtest/tests` (added for issue #178 — its prior omission was an oversight with no documented justification).
 
 ## Continuous Integration (`.github/workflows/ci.yml`)
 

--- a/docs/features/0075_PLAN.md
+++ b/docs/features/0075_PLAN.md
@@ -1,0 +1,136 @@
+# 0075 — Include `apps/backtest/tests` in `make test` (issue #178, P0 green)
+
+## Context
+
+`apps/backtest/tests` is listed in `pyproject.toml` `[tool.pytest.ini_options]`
+`testpaths` but is **missing** from the root `Makefile` `test` target. `make test`
+runs each testpath as a separate `uv run pytest <dir>` invocation (per-directory to
+avoid `conftest` `ImportPathMismatchError`), so the backtest suite is silently
+skipped — 16 test files / 507 tests never run under `make test` (CI gate). This is a
+P0 "make repository green" item: the suite must run **and pass** once wired in.
+
+Verified facts (this repo, 2026-06-17):
+- `Makefile` `test` target runs, in order: `packages/gridcore/tests`,
+  `packages/bybit_adapter/tests`, `shared/db/tests`, `apps/event_saver/tests`,
+  `apps/gridbot/tests`, `apps/comparator/tests`, `apps/recorder/tests`,
+  `apps/replay/tests`, `apps/pnl_checker/tests`, `tests/integration/`. **No
+  `apps/backtest/tests` line.**
+- `pyproject.toml` `testpaths` **includes** `apps/backtest/tests`; `pythonpath`
+  **includes** `apps/backtest/src`; `addopts = ["--import-mode=importlib"]`;
+  `asyncio_mode = "auto"`. There is **no `[tool.coverage.*]` section** — coverage is
+  driven entirely by CLI flags (`--cov`, `--cov-append`, `--cov-report`).
+- `apps/backtest/tests/` contains 16 `test_*.py` files (`conftest.py` present):
+  `test_cache_lock`, `test_check_tier_drift`, `test_config`, `test_data_provider`,
+  `test_engine`, `test_executor`, `test_fill_simulator_event_follower`,
+  `test_fill_simulator`, `test_instrument_info`, `test_order_manager`,
+  `test_position_tracker`, `test_reporter`, `test_risk_limit_info`,
+  `test_risk_limit_integration`, `test_runner`, `test_session`.
+- `apps/backtest/src/backtest/` is the importable package (`--cov=backtest`
+  resolves).
+- **The suite currently passes**: `uv run pytest apps/backtest/tests -q` → **507
+  passed in ~1.0s**. `uv run pytest apps/backtest/tests --cov=backtest --cov-append
+  -q` → **507 passed**, append into `.coverage` works.
+- `RULES.md` has **no documented reason** for the prior exclusion (it even
+  references `uv run pytest apps/backtest/tests -v` at line 74 and documents the
+  backtest engine at lines 915+). The omission is an oversight.
+
+Because the suite already passes, the triage step is expected to be a no-op
+verification rather than a fix; the plan still mandates it (P0 requires proof, not
+assumption) and specifies failure handling if reality differs at implementation time.
+
+## Files to change
+
+1. `Makefile` — `test` target (lines 8–19). Add one line wiring the backtest suite
+   into the per-directory pytest sequence with coverage append.
+2. `RULES.md` — Testing section. Add a one-line note that `make test` runs all
+   `testpaths` including `apps/backtest/tests`, and that there was **no** prior
+   reason for the exclusion (per acceptance criteria).
+
+No source/code changes are anticipated (suite is green).
+
+## Implementation
+
+### Phase 1 — Triage gate (run before editing)
+
+1. Run `uv run pytest apps/backtest/tests -q`. Expected: 507 passed.
+2. Run `uv run pytest apps/backtest/tests --cov=backtest --cov-append -q`. Expected:
+   507 passed, append succeeds.
+
+**Failure handling (if Phase 1 does NOT show all-pass at implementation time):**
+- Capture failing test ids + tracebacks.
+- Classify each failure:
+  - **Test/fixture bug** (e.g. stale fixture, missing `qty_calculator` on a
+    `BacktestExecutor` per RULES.md line 946) → fix the test surgically; in scope
+    for this P0 item (goal is green repo).
+  - **Real product bug surfaced by a previously-unrun test** → STOP, report to the
+    user with the failing assertion and proposed fix before changing product code
+    (out of scope for a Makefile wiring change; needs explicit approval).
+  - **Flaky/order-dependent** → confirm by re-running in isolation; document in
+    RULES.md if a per-directory invocation is required (it already is).
+- Do not edit the `Makefile` to include the line until Phase 1 is green.
+
+### Phase 2 — Wire into Makefile
+
+In the `test` target, insert the backtest line into the existing per-directory
+sequence. Place it adjacent to `apps/replay/tests` (line 17), keeping the same
+`uv run pytest <dir> --cov=<pkg> --cov-append -q` form used by every line except the
+first (no `--cov-append`) and the last (`tests/integration/`, which adds
+`--cov-report=term-missing -v`). Use `--cov=backtest --cov-append -q`, matching the
+exact flag string from the acceptance criteria:
+
+```
+uv run pytest apps/backtest/tests --cov=backtest --cov-append -q
+```
+
+Constraints:
+- Use a leading TAB (Makefile recipe), not spaces.
+- Keep it before the final `tests/integration/` line so `--cov-report=term-missing`
+  stays last and the TOTAL reflects the appended backtest coverage.
+- Do not reorder or alter any other line (surgical change).
+
+### Phase 3 — Verify full target
+
+1. Run `make test`. Confirm the output shows an `apps/backtest/tests` collection
+   block, all packages pass, and the final TOTAL coverage line includes
+   `apps/backtest/src/backtest/*` rows.
+2. Confirm no new failures were introduced in any other suite (per-directory
+   isolation should make this independent, but verify).
+3. Confirm `.coverage` is removed at start (`rm -f .coverage` already in target) and
+   the merged report at the end now spans the backtest package.
+
+### Phase 4 — Document in RULES.md
+
+Add a short note in the Testing section (near line 74 where the backtest pytest
+command already appears) stating: `make test` runs every `testpaths` entry from
+`pyproject.toml`, including `apps/backtest/tests`, each as a separate per-directory
+`uv run pytest` invocation with `--cov-append`; the prior omission of the backtest
+line was an oversight with no documented justification. Keep it to 1–2 lines per the
+"don't over-complicate RULES.md" guideline.
+
+## Acceptance criteria (from issue #178)
+
+- `make test` executes `apps/backtest/tests`.
+- Coverage append includes the `backtest` package (rows appear in the final TOTAL
+  report).
+- RULES.md documents that there was no prior reason for the exclusion.
+- **The backtest suite passes when included** (507/507 today; Phase 1 gate enforces
+  this before wiring).
+
+## Risks / what could break
+
+- **Coverage TOTAL changes**: adding ~507 tests' coverage shifts the merged TOTAL
+  (currently ~92% on the appended run; Makefile comment cites ~73% on the full
+  merged run). `--cov-fail-under` is **not** set on the merged run, so no gate
+  breaks — but the reported number will move. Acceptable / expected.
+- **Runtime**: +~1–2s; negligible.
+- **TAB vs spaces** in the Makefile recipe — a spaces-indented line silently breaks
+  `make`. Verify with `make test` (Phase 3).
+- **Order dependence across suites** — none expected (each dir is an isolated pytest
+  process by design); Phase 3 verifies.
+
+## Out of scope
+
+- No changes to backtest source code unless Phase 1 surfaces a real failure (then
+  STOP and get approval).
+- No changes to `pyproject.toml` (testpaths/pythonpath already correct).
+- No `--cov-fail-under` enforcement changes (separate concern; tracked elsewhere).

--- a/docs/features/0075_REVIEW.md
+++ b/docs/features/0075_REVIEW.md
@@ -1,0 +1,83 @@
+# 0075 — Code Review: Include `apps/backtest/tests` in `make test` (issue #178)
+
+Reviewed change: `Makefile` (+1 line) and `RULES.md` (note extended). Branch
+`worktree-feature+0075-backtest-make-test`. Reviewed against `0075_PLAN.md` and
+the 6-point review rubric.
+
+## Verdict
+
+**APPROVE.** Plan correctly and fully implemented. No bugs, no scope creep. `make
+test` is green (exit 0, all suites incl. backtest 507 passed). No code review
+findings block merge.
+
+## 1. Plan correctly implemented?
+
+Yes — all 4 phases done:
+
+| Phase | Plan requirement | Status |
+|-------|------------------|--------|
+| 1 — Triage gate | Run `apps/backtest/tests`, expect 507 passed | ✅ 507 passed; no source fixes needed |
+| 2 — Wire Makefile | Insert `uv run pytest apps/backtest/tests --cov=backtest --cov-append -q`, TAB-indented, before `tests/integration` | ✅ line 18, TAB confirmed, before integration |
+| 3 — Verify full target | `make test` green, backtest collected, coverage rows in TOTAL | ✅ exit 0; TOTAL 8593→10851 after backtest run |
+| 4 — RULES.md note | 1–2 line note: covers all testpaths incl. backtest, prior omission unjustified | ✅ extended existing `make test` note |
+
+Flag string matches acceptance criteria verbatim (`--cov=backtest --cov-append -q`).
+
+## 2. Obvious bugs / issues
+
+None.
+- TAB indentation verified (`grep -P '^\t'`) — the Makefile spaces-vs-tabs pitfall
+  called out in the plan is avoided.
+- Placement is after `apps/replay/tests`, before `apps/pnl_checker/tests` and the
+  final `tests/integration/` line — so `--cov-report=term-missing` stays last and
+  the merged TOTAL includes backtest. Empirically confirmed (backtest rows appear
+  in final coverage report).
+- `--cov=backtest` resolves: `apps/backtest/src` is on `pythonpath` and
+  `apps/backtest/src/backtest/` is the package. No `ModuleNotFound`.
+
+## 3. Data alignment issues
+
+N/A — change is a Makefile recipe line + a markdown note. No serialization,
+casing, or nesting surface.
+
+## 4. Over-engineering / file size
+
+None. Minimal 2-line surgical change. New backtest line mirrors the exact
+`uv run pytest <dir> --cov=<pkg> --cov-append -q` form of the 8 sibling lines.
+
+## 5. Weird syntax / style mismatch
+
+None. New Makefile line is byte-for-byte consistent with the surrounding recipe
+lines (same flags, same order of `--cov`/`--cov-append`/`-q`). RULES.md note
+appended to the existing `make test` note rather than creating a new section —
+consistent with the "don't over-complicate RULES.md" guideline.
+
+## 6. Unit tests
+
+No new application code was added, so no new unit tests are required. The change
+*is* test wiring: it causes 16 backtest test files / 507 existing tests to run
+under the CI gate that previously skipped them. Those tests already exist, follow
+project conventions (`test_*.py`, per-package `tests/`, `conftest.py` present),
+and pass (507/507) under both standalone and full `make test` runs.
+
+- Acceptance criteria are verified by executing `make test`, not by a new
+  meta-test. A test asserting "the Makefile contains the backtest line" would be
+  over-engineering (no precedent for testing the Makefile in this repo) — correctly
+  omitted.
+
+## Observations (non-blocking, no action required)
+
+- **O-1 (info).** `make lint` reports 99 pre-existing errors (tracked separately as
+  issue #180; was 184). This change touches zero `.py` files, so it adds none. The
+  `test` CI job (this fix's target) is independent of the `lint` job. Out of scope
+  for #178.
+- **O-2 (info).** Adding backtest coverage moves the merged TOTAL (now ~92% on the
+  appended run vs the ~73% cited in the Makefile comment). No `--cov-fail-under` on
+  the merged run, so nothing breaks — expected per plan §Risks. The stale ~73%
+  figure in the Makefile/RULES.md comment was not updated; left untouched as a
+  surgical-change discipline (pre-existing, not introduced here).
+
+## Conclusion
+
+Implementation matches the plan exactly, satisfies all four issue #178 acceptance
+criteria, and leaves `make test` green. Ready to commit.


### PR DESCRIPTION
## Summary

Fixes #178 (P0 — make repository green). `apps/backtest/tests` was listed in
`pyproject.toml` `testpaths` but missing from the root `Makefile` `test` target,
so `make test` (the CI gate) silently skipped **16 files / 507 tests**.

## Changes

- **`Makefile`**: add `uv run pytest apps/backtest/tests --cov=backtest --cov-append -q`
  to the `test` target, after `apps/replay/tests` and before `tests/integration/`
  (verbatim flag string from the issue acceptance criteria; TAB-indented).
- **`RULES.md`**: extend the `make test` note — it now covers every `testpaths`
  entry including `apps/backtest/tests`; the prior omission was an oversight with
  no documented justification.
- **`docs/features/0075_PLAN.md`**, **`0075_REVIEW.md`**: feature plan + code review.

## Verification

- Triage gate: `uv run pytest apps/backtest/tests` → **507 passed** (no source fixes needed).
- Full `make test` → **exit 0**; backtest suite runs, coverage rows merge into TOTAL
  (8593→10851 statements after the backtest line), all suites pass.

## Acceptance criteria (#178)

- [x] `make test` executes `apps/backtest/tests`
- [x] Coverage append includes the `backtest` package
- [x] RULES.md documents there was no prior reason for the exclusion
- [x] Backtest suite passes when included (507/507)

## Notes

- `make lint` is red (99 errors) — **pre-existing**, tracked separately as #180.
  This PR touches zero `.py` files, so it adds none; the `test` and `lint` CI jobs
  are independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)