### PR TITLE
test(0076): stabilize flaky cache-permission test (#179)

### DIFF
--- a/apps/backtest/tests/test_risk_limit_info.py
+++ b/apps/backtest/tests/test_risk_limit_info.py
@@ -426,7 +426,7 @@ class TestRiskLimitProvider:
         assert any("exceeds" in r.message and "byte limit" in r.message for r in caplog.records)
 
     def test_save_to_cache_write_permission_error(self, tmp_path, caplog):
-        """save_to_cache logs warning and doesn't crash on write failure."""
+        """save_to_cache logs warning and doesn't crash on temp file write permission error."""
         cache_file = tmp_path / "cache.json"
         provider = RiskLimitProvider(cache_path=cache_file, allowed_cache_root=None)
 
@@ -434,12 +434,12 @@ class TestRiskLimitProvider:
         # it with a path-discriminating mock: only the temp cache write (path
         # ends ".tmp") fails; the lock-file open and cache read delegate to the
         # real os.open. This is deterministic and OS-independent (no chmod).
-        real_open = os.open
+        original_os_open = os.open
 
         def fail_only_temp(path, *args, **kwargs):
             if str(path).endswith(".tmp"):
                 raise PermissionError("simulated read-only filesystem")
-            return real_open(path, *args, **kwargs)
+            return original_os_open(path, *args, **kwargs)
 
         with caplog.at_level(logging.WARNING):
             with patch("backtest.risk_limit_info.os.open", side_effect=fail_only_temp):

--- a/apps/backtest/tests/test_risk_limit_info.py
+++ b/apps/backtest/tests/test_risk_limit_info.py
@@ -3,6 +3,7 @@
 import gc
 import json
 import logging
+import os
 import threading
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
@@ -425,24 +426,32 @@ class TestRiskLimitProvider:
         assert any("exceeds" in r.message and "byte limit" in r.message for r in caplog.records)
 
     def test_save_to_cache_write_permission_error(self, tmp_path, caplog):
-        """save_to_cache logs warning and doesn't crash on read-only directory."""
-        read_only_dir = tmp_path / "readonly"
-        read_only_dir.mkdir()
-        cache_file = read_only_dir / "cache.json"
-        read_only_dir.chmod(0o444)
-
+        """save_to_cache logs warning and doesn't crash on write failure."""
+        cache_file = tmp_path / "cache.json"
         provider = RiskLimitProvider(cache_path=cache_file, allowed_cache_root=None)
 
+        # The real write uses os.open (not Path.write_text/open), so intercept
+        # it with a path-discriminating mock: only the temp cache write (path
+        # ends ".tmp") fails; the lock-file open and cache read delegate to the
+        # real os.open. This is deterministic and OS-independent (no chmod).
+        real_open = os.open
+
+        def fail_only_temp(path, *args, **kwargs):
+            if str(path).endswith(".tmp"):
+                raise PermissionError("simulated read-only filesystem")
+            return real_open(path, *args, **kwargs)
+
         with caplog.at_level(logging.WARNING):
-            # Should not raise — permission error is caught and logged
-            provider.save_to_cache("BTCUSDT", SAMPLE_TIERS)
+            with patch("backtest.risk_limit_info.os.open", side_effect=fail_only_temp):
+                # Should not raise — permission error is caught and logged
+                provider.save_to_cache("BTCUSDT", SAMPLE_TIERS)
 
         # Verify warning was logged
         assert any("Failed to write cache file" in r.message for r in caplog.records)
 
-        # Restore permissions for cleanup, then verify no file was created
-        read_only_dir.chmod(0o755)
+        # os.open(temp_path) raised before any bytes were written, so no file remains
         assert not cache_file.exists()
+        assert not cache_file.with_suffix(".tmp").exists()
 
     def test_load_from_cache_rejects_symlink_path(self, tmp_path, caplog):
         """Cache reads are rejected when cache_path is a symlink."""

--- a/docs/features/0076_PLAN.md
+++ b/docs/features/0076_PLAN.md
@@ -1,0 +1,161 @@
+# 0076 — Stabilize flaky backtest cache-permission test (Issue #179, P0)
+
+## Context
+
+`apps/backtest/tests/test_risk_limit_info.py::TestRiskLimitProvider::test_save_to_cache_write_permission_error`
+(~line 427) simulates a read-only cache directory with `read_only_dir.chmod(0o444)`
+to assert that `RiskLimitProvider.save_to_cache` logs a warning and does **not**
+raise on a write failure. Directory-`chmod` behaves differently across OS /
+filesystems (macOS APFS vs Linux, tmpfs, CI runners), so the test is fragile for
+CI. Replace the `chmod`-based approach with a deterministic mock that forces the
+write path to raise `PermissionError`, keeping the same observable assertions
+(warning logged, no exception, no file created). This is item 4 of the
+"make repository green" P0 work.
+
+## How the production write path actually fails
+
+Tracing `save_to_cache` (`apps/backtest/src/backtest/risk_limit_info.py`):
+
+1. `save_to_cache(symbol, tiers)` (line 350) wraps `_save_to_cache_impl` in a
+   `try/except (PermissionError, OSError, ValueError)` and logs
+   `f"Failed to write cache file {self.cache_path}: {e}"` (line 364). This is the
+   exact branch under test.
+2. `_save_to_cache_impl` (line 482) opens `self._locked_cache()` then calls
+   `self._write_cache_file(cache)` (line 511).
+3. `_write_cache_file` (line 419) performs the real disk write via
+   **`os.open(temp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)`**
+   (line 429), then `os.fdopen` + `json.dump`, then `temp_path.replace(...)`.
+
+Key fact: the write does **not** go through `Path.write_text` or the builtin
+`open`. It uses `os.open`. A mock targeting `Path.write_text`/`open` (as the
+issue/spec loosely suggests) would NOT intercept the real write and the test
+would not exercise the intended branch. The correct, minimal interception point
+is `os.open` raising `PermissionError`.
+
+Caveat — `_locked_cache` (line 443) also touches the filesystem before the
+write: `self.cache_path.parent.mkdir(parents=True, exist_ok=True)` (line 464),
+then `open_lock_file(lock_path)` (line 471), and `acquire_file_lock`. Crucially,
+`open_lock_file` lives in **`backtest.cache_lock`** and opens the lock file via
+its own `os.open` (cache_lock.py:80), and `_load_existing_cache` →
+`validate_and_open_cache_file` opens the cache for reading via
+**`backtest.cache_validation`**'s `os.open` (cache_validation.py:72). On the
+write path, `open_lock_file(lock_path)` is reached at line 471 **before**
+`_write_cache_file` is ever called at line 511.
+
+Implication for mocking: `patch("backtest.risk_limit_info.os.open", ...)`
+rebinds the `os.open` attribute on the **shared `os` module object** (all three
+modules do `import os`, so they reference the same object). A *blanket*
+`side_effect=PermissionError` therefore fires at the FIRST `os.open` in the
+write path — which is the lock-file open at cache_lock.py:80 (and, if the cache
+file already exists, the cache-read `os.open` at cache_validation.py:72 even
+earlier) — **not** the temp-file write at risk_limit_info.py:429. The
+PermissionError raised by `open_lock_file` would still propagate up to
+`save_to_cache`'s `except` and log "Failed to write cache file", so the string
+assertion would *coincidentally* pass, but the test would exercise the lock-file
+open path, not the production cache-write branch the issue is about.
+
+Fix: make the patch **path-discriminating** so only the temp cache write fails
+and every other `os.open` (lock file, cache read, mkdir machinery) delegates to
+the real implementation. This keeps the failure localized to the actual cache
+write — matching the production "read-only filesystem" write-failure scenario.
+
+## Change
+
+Single file: `apps/backtest/tests/test_risk_limit_info.py`, function
+`test_save_to_cache_write_permission_error` (lines 427–445).
+
+### New approach
+
+- Use a normal writable `tmp_path` cache directory and file (no `chmod`).
+- Build the provider exactly as today:
+  `RiskLimitProvider(cache_path=cache_file, allowed_cache_root=None)`.
+- Patch `os.open` **as seen by the module under test** with a
+  **path-discriminating** `side_effect`, so only the temp cache write fails and
+  the lock-file open / cache-read / mkdir all use the real `os.open`:
+
+  ```python
+  import os
+  from unittest.mock import patch
+
+  _real_open = os.open  # capture before patching
+
+  def _fail_only_temp(path, *args, **kwargs):
+      if str(path).endswith(".tmp"):
+          raise PermissionError("simulated read-only filesystem")
+      return _real_open(path, *args, **kwargs)
+
+  with patch("backtest.risk_limit_info.os.open", side_effect=_fail_only_temp):
+      provider.save_to_cache("BTCUSDT", tiers)  # must not raise
+  ```
+
+  Rationale: `_write_cache_file` writes to `self.cache_path.with_suffix(".tmp")`
+  (risk_limit_info.py:427), so the only `os.open` whose path ends in `.tmp` is
+  the production cache write at line 429 — that's the one we force to raise. Every
+  other `os.open` on the write path (`open_lock_file` at cache_lock.py:80,
+  `validate_and_open_cache_file` at cache_validation.py:72) delegates to
+  `_real_open` and succeeds. Patching the `backtest.risk_limit_info.os` reference
+  (a real `os` module object shared across modules) means the rebind is visible
+  to those callers too — hence the delegate-to-real branch is mandatory, not
+  optional.
+- Wrap the `save_to_cache` call in `caplog.at_level(logging.WARNING)` (unchanged).
+- Assertions (preserve current observable behavior):
+  - No exception raised (the call returns normally — the `with patch(...)`
+    block simply not raising is the implicit assertion; keep the existing
+    "Should not raise" comment).
+  - `assert any("Failed to write cache file" in r.message for r in caplog.records)`
+    (unchanged — confirms the warning at `risk_limit_info.py:364`).
+  - Replace the cleanup lines (`read_only_dir.chmod(0o755)` then
+    `assert not cache_file.exists()`). With the discriminating mock,
+    `os.open(temp_path, ...)` raises `PermissionError` **before any bytes are
+    written**, so the temp file is never created; `_write_cache_file`'s
+    `except` block then runs `temp_path.unlink(missing_ok=True)` (a no-op) and
+    re-raises. No final cache file is produced. Keep
+    `assert not cache_file.exists()` (no chmod needed) and add
+    `assert not cache_file.with_suffix(".tmp").exists()` for parity with the
+    existing `TestAtomicCacheWrite` tests — both confirm the failed write left
+    no file behind.
+
+### What to remove
+
+- `read_only_dir = tmp_path / "readonly"`, `read_only_dir.mkdir()`,
+  `read_only_dir.chmod(0o444)`, and the trailing `read_only_dir.chmod(0o755)`
+  restore line. The `cache_file` can be a direct child of `tmp_path` (writable),
+  e.g. `cache_file = tmp_path / "cache.json"`.
+
+### Mock target rationale (verbatim from issue/spec, reconciled)
+
+The issue says "mock `Path.write_text` / `open`". The actual write uses
+`os.open`, so the faithful, deterministic interception is
+`backtest.risk_limit_info.os.open`. Document this in the test (one-line
+comment) so a future reader knows why `os.open` and not `Path.write_text`.
+
+## Testing conventions (from RULES.md / `.claude/rules/code-style.md`)
+
+- Hermetic: no real filesystem permission games, no network, no DB — the mock
+  fully determines the failure. Satisfies "mock all network/DB" and removes the
+  OS-dependent `chmod`.
+- Run with `uv run pytest apps/backtest/tests/test_risk_limit_info.py -q`
+  (never bare `pytest`). Confirm the single test passes and the rest of the
+  file is unaffected.
+- Keep the one-line docstring on the test
+  (`"""save_to_cache logs warning and doesn't crash on read-only directory."""`),
+  optionally tightening wording to "on write failure" since it's no longer a
+  read-only directory.
+
+## What could break / verify
+
+- A **blanket** `side_effect=PermissionError` (no path discrimination) would
+  fire at the FIRST `os.open` on the write path — the lock-file open at
+  cache_lock.py:80 (or the cache-read at cache_validation.py:72 if the file
+  exists), NOT the temp write at risk_limit_info.py:429 — because all three
+  modules share the same `os` object that `patch("backtest.risk_limit_info.os.open")`
+  rebinds. The string assertion would still pass by coincidence, but the wrong
+  branch would be tested. The discriminating `side_effect` (above) is required to
+  hit the real cache-write branch.
+- Verify the test actually drives the write branch: the temp-file `os.open`
+  (path ending `.tmp`) must be the one that raises, while `open_lock_file` and
+  the cache read succeed via `_real_open`. The logged message should be the
+  "Failed to write cache file" warning originating from the `_write_cache_file`
+  temp `os.open` — not a lock-file open error.
+- Confirm cross-platform: the test now has zero OS/filesystem permission
+  dependence, so it must pass identically on Linux CI and macOS dev.


### PR DESCRIPTION
## Summary

Fixes #179 (P0 — make repository green). Stabilizes the flaky/platform-dependent test `test_save_to_cache_write_permission_error` in `apps/backtest/tests/test_risk_limit_info.py`.

The old test used `read_only_dir.chmod(0o444)` to force a write failure. Directory `chmod` behaves differently across OS/filesystems (macOS APFS vs Linux, tmpfs) and is a **silent no-op when tests run as root** in CI containers — so the test was fragile and could spuriously fail or not exercise the intended branch.

## Change

Single test file. Replace `chmod` with a deterministic, OS-independent mock:

- Patch `backtest.risk_limit_info.os.open` with a path-discriminating `side_effect` (`fail_only_temp`) that raises `PermissionError` only for the `.tmp` temp-cache write (`_write_cache_file`, `risk_limit_info.py:429`) and delegates every other `os.open` to the captured real implementation.
- Because `import os` shares one module object across `risk_limit_info` / `cache_lock` / `cache_validation` (verified empirically: `r.os is cl.os is cv.os`), the patch also covers the lock-file open and cache read. The delegate-to-real branch is **mandatory** — a blanket `PermissionError` would fire at the lock-file open (`cache_lock.py:80`), not the cache-write branch the issue targets.

## Acceptance criteria

- [x] Test passes reliably on Linux CI and macOS dev (no filesystem/permission dependence)
- [x] Still verifies `save_to_cache` logs "Failed to write cache file" warning and does not raise
- [x] No reliance on directory `chmod(0o444)`
- [x] Added `.tmp`-existence assertion for parity with `TestAtomicCacheWrite`

## Verification

- target test: 5/5 runs pass
- full file: 94 passed
- ruff: clean

Plan produced via plan-debate: `docs/features/0076_PLAN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)