### PR TITLE
fix(0077): resolve real Ruff errors in apps/packages/shared (#180)

### DIFF
--- a/apps/backtest/src/backtest/engine.py
+++ b/apps/backtest/src/backtest/engine.py
@@ -7,13 +7,13 @@ import logging
 import uuid
 from datetime import datetime, timedelta
 from decimal import Decimal
-from typing import Iterator, Optional
+from typing import Optional
 
 from grid_db import DatabaseFactory
 from gridcore import DirectionType, SideType, create_qty_calculator
 
 from backtest.config import BacktestConfig, BacktestStrategyConfig, WindDownMode
-from backtest.data_provider import HistoricalDataProvider, InMemoryDataProvider, DataRangeInfo
+from backtest.data_provider import HistoricalDataProvider, InMemoryDataProvider
 from backtest.fill_simulator import TradeThroughFillSimulator
 from backtest.instrument_info import InstrumentInfoProvider, InstrumentInfo
 from backtest.order_manager import BacktestOrderManager
@@ -21,7 +21,7 @@ from backtest.executor import BacktestExecutor
 from backtest.position_tracker import BacktestPositionTracker
 from backtest.risk_limit_info import RiskLimitProvider
 from backtest.runner import BacktestRunner
-from backtest.session import BacktestSession, BacktestMetrics, BacktestTrade
+from backtest.session import BacktestSession, BacktestTrade
 
 
 logger = logging.getLogger(__name__)

--- a/apps/backtest/src/backtest/executor.py
+++ b/apps/backtest/src/backtest/executor.py
@@ -10,7 +10,7 @@ from typing import Callable, Optional
 
 from gridcore import PlaceLimitIntent, CancelIntent
 
-from backtest.order_manager import BacktestOrderManager, SimulatedOrder
+from backtest.order_manager import BacktestOrderManager
 
 
 @dataclass

--- a/apps/backtest/src/backtest/reporter.py
+++ b/apps/backtest/src/backtest/reporter.py
@@ -4,12 +4,10 @@ Supports CSV export for trades, equity curve, and metrics summary.
 """
 
 import csv
-from datetime import datetime
-from decimal import Decimal
 from pathlib import Path
 from typing import Union
 
-from backtest.session import BacktestSession, BacktestMetrics, BacktestTrade
+from backtest.session import BacktestSession, BacktestMetrics
 
 
 class BacktestReporter:

--- a/apps/backtest/tests/test_cache_lock.py
+++ b/apps/backtest/tests/test_cache_lock.py
@@ -6,16 +6,14 @@ requiring an actual Windows environment, enabling cross-platform CI.
 
 import os
 import threading
-from io import BytesIO
 from pathlib import Path
-from unittest.mock import patch, MagicMock, call
+from unittest.mock import patch, MagicMock
 
 import pytest
 
 from backtest.cache_lock import (
     _LOCK_REGION_BYTES,
     _IN_PROCESS_LOCKS,
-    _IN_PROCESS_LOCKS_GUARD,
     acquire_in_process_lock,
     release_in_process_lock,
     acquire_file_lock,

--- a/apps/backtest/tests/test_data_provider.py
+++ b/apps/backtest/tests/test_data_provider.py
@@ -3,12 +3,11 @@
 from datetime import datetime, timedelta
 from decimal import Decimal
 
-import pytest
 
 from gridcore import EventType
 from grid_db import TickerSnapshot, PublicTrade
 
-from backtest.data_provider import HistoricalDataProvider, DataRangeInfo
+from backtest.data_provider import HistoricalDataProvider
 
 
 # ---------------------------------------------------------------------------

--- a/apps/backtest/tests/test_engine.py
+++ b/apps/backtest/tests/test_engine.py
@@ -1,6 +1,6 @@
 """Tests for backtest engine."""
 
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta
 from decimal import Decimal
 
 import pytest
@@ -8,7 +8,7 @@ import pytest
 from gridcore import TickerEvent, EventType
 
 from backtest.engine import BacktestEngine, FundingSimulator
-from backtest.config import BacktestConfig, BacktestStrategyConfig, WindDownMode
+from backtest.config import BacktestConfig, WindDownMode
 from backtest.data_provider import InMemoryDataProvider
 
 

--- a/apps/backtest/tests/test_executor.py
+++ b/apps/backtest/tests/test_executor.py
@@ -1,15 +1,12 @@
 """Tests for backtest executor."""
 
-from datetime import datetime, timezone
 from decimal import Decimal
 
 import pytest
 
 from gridcore import PlaceLimitIntent, CancelIntent
 
-from backtest.executor import BacktestExecutor, OrderResult, CancelResult
-from backtest.fill_simulator import TradeThroughFillSimulator
-from backtest.order_manager import BacktestOrderManager
+from backtest.executor import BacktestExecutor
 
 
 class TestBacktestExecutor:

--- a/apps/backtest/tests/test_instrument_info.py
+++ b/apps/backtest/tests/test_instrument_info.py
@@ -3,7 +3,6 @@
 import json
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
-from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -404,7 +403,7 @@ class TestInstrumentInfoProvider:
         cache_path.write_text(json.dumps({"BTCUSDT": sample_info.to_dict()}))
 
         with patch.object(provider, "fetch_from_bybit", return_value=sample_info) as mock_fetch:
-            result = provider.get("BTCUSDT")
+            provider.get("BTCUSDT")
 
         # Should try API because no cached_at means stale
         mock_fetch.assert_called_once_with("BTCUSDT")

--- a/apps/backtest/tests/test_reporter.py
+++ b/apps/backtest/tests/test_reporter.py
@@ -3,7 +3,6 @@
 import csv
 from datetime import datetime
 from decimal import Decimal
-from pathlib import Path
 
 import pytest
 

--- a/apps/backtest/tests/test_risk_limit_integration.py
+++ b/apps/backtest/tests/test_risk_limit_integration.py
@@ -143,11 +143,6 @@ class TestCacheTTL:
             },
         }))
 
-        fresh_tiers: MMTiers = [
-            (Decimal("300000"), Decimal("0.008"), Decimal("0"), Decimal("0.015")),
-            (Decimal("Infinity"), Decimal("0.015"), Decimal("2100"), Decimal("0.03")),
-        ]
-
         client = MagicMock()
         client.get_risk_limit.return_value = [
             {

--- a/apps/gridbot/src/gridbot/runner.py
+++ b/apps/gridbot/src/gridbot/runner.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 # peek_wallet_snapshot reader injected for the Phase-4 preflight (feature 0066).
 WalletProvider = Callable[[], "Optional[tuple[WalletSnapshot, float]]"]
 
-from gridcore import (
+from gridcore import (  # noqa: E402
     GridEngine,
     GridConfig,
     InstrumentInfo,
@@ -49,17 +49,17 @@ from gridcore import (
     apply_early_imbalance,
 )
 
-from gridbot.config import StrategyConfig
-from gridbot.executor import (
+from gridbot.config import StrategyConfig  # noqa: E402
+from gridbot.executor import (  # noqa: E402
     IntentExecutor,
     is_duplicate_link_error,
     is_insufficient_balance,
     is_network_error,
     is_truncate_error,
 )
-from gridbot.notifier import Notifier
-from gridbot.order_link_id import make_order_link_id
-from gridbot.truncate_breaker import TruncateBreaker
+from gridbot.notifier import Notifier  # noqa: E402
+from gridbot.order_link_id import make_order_link_id  # noqa: E402
+from gridbot.truncate_breaker import TruncateBreaker  # noqa: E402
 
 
 logger = logging.getLogger(__name__)

--- a/apps/gridbot/tests/test_runner_lowbalance_storm.py
+++ b/apps/gridbot/tests/test_runner_lowbalance_storm.py
@@ -612,7 +612,8 @@ def test_preflight_uses_fresh_provider_value(
     strategy_config, mock_executor, instrument_info
 ):
     """A fresh LOW provider balance blocks even when _available_balance is stale-high."""
-    provider = lambda: (WalletSnapshot(available_balance=5.0), 1.0)  # fresh, age 1s
+    def provider():  # fresh, age 1s
+        return (WalletSnapshot(available_balance=5.0), 1.0)
     r = _runner_with_provider(strategy_config, mock_executor, instrument_info, provider)
     r._available_balance = Decimal("100000")  # stale-high — must be ignored
     # est_cost = 100 ≫ fresh 5 → blocked via the provider value, not the latch.
@@ -627,7 +628,8 @@ def test_preflight_blocks_on_fresh_zero_provider(
     The fresh zero means 'no free margin', NOT 'no data'; it must block every
     open and must NOT be replaced by a stale-high _available_balance.
     """
-    provider = lambda: (WalletSnapshot(available_balance=0.0), 1.0)  # fresh zero
+    def provider():  # fresh zero
+        return (WalletSnapshot(available_balance=0.0), 1.0)
     r = _runner_with_provider(strategy_config, mock_executor, instrument_info, provider)
     r._available_balance = Decimal("100000")  # stale-high — must not mask the zero
     assert r._is_good_to_place(_open_short("100.0", "1.0"), EMPTY_LIMITS) is False
@@ -642,7 +644,8 @@ def test_preflight_fails_open_when_peek_stale(
     Both the stale-peek value and _available_balance are set LOW (would block if
     used); the open still passes, proving the check was skipped entirely.
     """
-    provider = lambda: (WalletSnapshot(available_balance=5.0), 100.0)  # stale (>=45)
+    def provider():  # stale (>=45)
+        return (WalletSnapshot(available_balance=5.0), 100.0)
     r = _runner_with_provider(strategy_config, mock_executor, instrument_info, provider)
     r._available_balance = Decimal("5")  # also low — must NOT be used as fallback
     assert r._is_good_to_place(_open_short("100.0", "1.0"), EMPTY_LIMITS) is True
@@ -652,7 +655,8 @@ def test_preflight_fails_open_when_peek_none(
     strategy_config, mock_executor, instrument_info
 ):
     """peek None (no WS, no REST cache) in the provider path → fail-open, no fallback."""
-    provider = lambda: None
+    def provider():
+        return None
     r = _runner_with_provider(strategy_config, mock_executor, instrument_info, provider)
     r._available_balance = Decimal("5")  # low — must NOT be used as fallback
     assert r._is_good_to_place(_open_short("100.0", "1.0"), EMPTY_LIMITS) is True
@@ -673,7 +677,8 @@ def test_preflight_fresh_provider_allows_affordable_open(
     strategy_config, mock_executor, instrument_info
 ):
     """A fresh ample provider balance allows the open."""
-    provider = lambda: (WalletSnapshot(available_balance=200.0), 1.0)
+    def provider():
+        return (WalletSnapshot(available_balance=200.0), 1.0)
     r = _runner_with_provider(strategy_config, mock_executor, instrument_info, provider)
     r._available_balance = Decimal("0")
     assert r._is_good_to_place(_open_short("100.0", "1.0"), EMPTY_LIMITS) is True
@@ -697,7 +702,8 @@ def test_storm_blocked_end_to_end_via_provider(
     that ships with ``wallet_ws_enabled=True``), not only the legacy
     ``_available_balance`` latch (covered by test_110007_storm_blocked_by_preflight).
     """
-    provider = lambda: (WalletSnapshot(available_balance=5.0), 1.0)  # fresh, low
+    def provider():  # fresh, low
+        return (WalletSnapshot(available_balance=5.0), 1.0)
     r = _runner_with_provider(strategy_config, mock_executor, instrument_info, provider)
     enqueued = []
     r._on_intent_failed = lambda intent, error: enqueued.append((intent, error))
@@ -721,7 +727,8 @@ def test_low_balance_predicate_uses_fresh_provider(
     strategy_config, mock_executor, instrument_info
 ):
     """A FRESH provider value drives the predicate even when the latch is stale-high."""
-    provider = lambda: (WalletSnapshot(available_balance=5.0), 1.0)  # fresh, low
+    def provider():  # fresh, low
+        return (WalletSnapshot(available_balance=5.0), 1.0)
     r = _runner_with_provider(strategy_config, mock_executor, instrument_info, provider)
     r._available_balance = Decimal("100000")  # stale-high latch must be ignored
     assert r._is_low_balance(Decimal("100")) is True  # 5 < 100*0.10
@@ -732,7 +739,8 @@ def test_low_balance_predicate_fresh_zero_is_low_balance(
 ):
     """A FRESH provider zero = genuinely no free margin = the MOST extreme
     low-balance state → True (NOT treated as 'no data' like a latch 0)."""
-    provider = lambda: (WalletSnapshot(available_balance=0.0), 1.0)  # fresh zero
+    def provider():  # fresh zero
+        return (WalletSnapshot(available_balance=0.0), 1.0)
     r = _runner_with_provider(strategy_config, mock_executor, instrument_info, provider)
     r._available_balance = Decimal("100000")  # stale-high latch must not mask it
     assert r._is_low_balance(Decimal("100")) is True
@@ -743,7 +751,8 @@ def test_low_balance_predicate_stale_provider_falls_back_to_latch(
 ):
     """A stale/None/raising provider falls back to the position-cadence latch
     (best-available), unlike the preflight which fails open."""
-    stale = lambda: (WalletSnapshot(available_balance=1.0), 100.0)  # stale (>=45)
+    def stale():  # stale (>=45)
+        return (WalletSnapshot(available_balance=1.0), 100.0)
     r = _runner_with_provider(strategy_config, mock_executor, instrument_info, stale)
     r._available_balance = Decimal("50")  # latch ample → not low (50 >= 10)
     assert r._is_low_balance(Decimal("100")) is False

--- a/apps/gridbot/tests/test_runner_truncate_storm.py
+++ b/apps/gridbot/tests/test_runner_truncate_storm.py
@@ -22,7 +22,6 @@ from gridcore.position import DirectionType
 from gridbot.config import StrategyConfig
 from gridbot.executor import IntentExecutor, OrderResult
 from gridbot.runner import StrategyRunner
-from gridbot.truncate_breaker import TruncateBreaker
 
 EMPTY_LIMITS: dict[str, list[dict]] = {"long": [], "short": []}
 

--- a/apps/recorder/tests/test_start_recorder_check.py
+++ b/apps/recorder/tests/test_start_recorder_check.py
@@ -338,8 +338,8 @@ class TestStartRecorderLauncherIntegration:
         launcher = REPO_ROOT / "scripts" / "phase4" / "start_recorder.sh"
         content = launcher.read_text()
         assert "lib/recorder_stop.sh" in content, (
-            f"start_recorder.sh must source lib/recorder_stop.sh; not found"
+            "start_recorder.sh must source lib/recorder_stop.sh; not found"
         )
         assert "_stop_recorder_pattern" in content, (
-            f"start_recorder.sh must call _stop_recorder_pattern"
+            "start_recorder.sh must call _stop_recorder_pattern"
         )

--- a/apps/replay/src/replay/snapshot_loader.py
+++ b/apps/replay/src/replay/snapshot_loader.py
@@ -53,6 +53,7 @@ from grid_db import (
     OrderRepository,
     PositionSnapshotRepository,
     TickerSnapshotRepository,
+    WalletSnapshot,
     WalletSnapshotRepository,
 )
 

--- a/apps/replay/tests/test_engine_collateral_integration.py
+++ b/apps/replay/tests/test_engine_collateral_integration.py
@@ -40,7 +40,6 @@ from gridcore.persistence import GridStateStore
 
 from replay.config import ReplayConfig, ReplayStrategyConfig, SeedConfig
 from replay.engine import ReplayEngine
-from replay.snapshot_loader import load_wallet_seed_full
 
 
 SYMBOL = "BTCUSDT"

--- a/docs/features/0077_PLAN.md
+++ b/docs/features/0077_PLAN.md
@@ -1,0 +1,166 @@
+# 0077 — Fix real Ruff errors (GitHub issue #180, P0)
+
+## Context
+
+CI (feature 0073) runs `make lint` (`uv run ruff check .`) and is red. Issue
+#180 is the P0 slice: fix the **confirmed production bug** plus the remaining
+**real** ruff errors in production and test code under `apps/`, `packages/`,
+`shared/`.
+
+The headline bug is **F821 Undefined name `WalletSnapshot`** at
+`apps/replay/src/replay/snapshot_loader.py:740`
+(`rows_by_coin: dict[str, WalletSnapshot] = {}`). The function uses
+`WalletSnapshotRepository` (already imported) and annotates a dict with the ORM
+row type `WalletSnapshot`, which is **not** imported. `WalletSnapshot` is a
+valid public export of `grid_db` (`shared/db/src/grid_db/__init__.py:21` and
+`__all__` at line 68; class defined at `shared/db/src/grid_db/models.py:472`).
+
+There is **no `[tool.ruff]` config** anywhere in the repo (only `ruff>=0.1.0`
+in root `pyproject.toml` deps). Ruff therefore runs with defaults; ruff version
+is `0.14.10`.
+
+### Out of scope (do NOT touch — separate issue #177)
+- `apps/backtest/debug_walkthrough.py` (30 errors: E402 + F541) — debug tree.
+- `bbu_reference/` (2 errors) — vendored reference.
+- Any `[tool.ruff]` config / per-tree excludes (config-level exclusion of the
+  debug & reference trees is #177's job). Do **not** add excludes here. Do
+  **not** mass `--fix` the whole repo.
+
+### Scope (real errors to fix)
+`uv run ruff check apps/ packages/ shared/` reports **92** errors; **30** of
+those are in the out-of-scope `debug_walkthrough.py`. The **62 in-scope
+errors** are:
+
+| Rule | Count | Auto-fixable | Where |
+|------|-------|--------------|-------|
+| F821 undefined-name | 1 | no | `apps/replay/src/replay/snapshot_loader.py:740` |
+| F401 unused-import | 26 | yes (`--fix`) | 7 in `*/src/*`, 19 in tests |
+| F841 unused-variable | 17 | unsafe-fix only | all in tests |
+| E731 lambda-assignment | 9 | no | `apps/gridbot/tests/test_runner_lowbalance_storm.py` |
+| E402 import-not-at-top | 7 | no | 6 in `apps/gridbot/src/gridbot/runner.py`, 1 in `packages/gridcore/tests/test_comparison.py` |
+| F541 f-string-no-placeholder | 2 | yes | `apps/recorder/tests/test_start_recorder_check.py:341,344` |
+
+Production (`/src/`) errors = 14 (1 F821 + 7 F401 + 6 E402). Test errors = 48.
+
+## Files to change
+
+### Phase 1 — the production bug (F821) + replay verification
+- `apps/replay/src/replay/snapshot_loader.py` — add `WalletSnapshot` to the
+  existing `from grid_db import (...)` block (lines 50–57), next to
+  `WalletSnapshotRepository`. This resolves the `dict[str, WalletSnapshot]`
+  annotation at line 740.
+- Verify: `uv run ruff check apps/replay/src/replay/snapshot_loader.py` (clean)
+  and `uv run pytest apps/replay/tests/test_snapshot_loader.py -q` (passes).
+
+### Phase 2 — production unused imports (F401, 7 in src)
+- `apps/backtest/src/backtest/engine.py` (lines 10:20, 16:82, 24:47)
+- `apps/backtest/src/backtest/executor.py` (line 13:58)
+- `apps/backtest/src/backtest/reporter.py` (lines 7:22, 8:21, 12:64)
+
+For each, remove only the unused symbol from its import. If a removed symbol is
+the sole member of an import, remove the whole line. If an import is a
+re-export shim (symbol intended for downstream import even if unused locally),
+keep it and add `# noqa: F401` — decide per-symbol by grepping usage in the
+package; default action is removal.
+
+### Phase 3 — production E402 in runner.py (6 errors, noqa not reorder)
+- `apps/gridbot/src/gridbot/runner.py` lines 31, 52, 53, 60, 61, 62.
+  These imports follow the module-level statement `WalletProvider = Callable[...]`
+  at line 29, which **must** sit after the `TYPE_CHECKING` block (lines 20–25)
+  because it references the annotation-only `WalletSnapshot` import (inline
+  comment at lines 23–24 documents the circular-import avoidance). Reordering
+  would break the type alias.
+  - Fix: append `# noqa: E402` to each of the 6 flagged import statements
+    (the `from gridcore import (...)` block at line 31 takes the noqa on its
+    first physical line; the five `from gridbot...` imports at 52, 53, 60, 61,
+    62 each take their own). This is the documented-intentional `noqa` path the
+    acceptance criteria explicitly allow.
+
+### Phase 4 — test F401 unused-imports (19 errors)
+Files: `shared/db/tests/test_init_db.py` (2),
+`apps/replay/tests/test_engine_collateral_integration.py` (1),
+`apps/gridbot/tests/test_runner_truncate_storm.py` (1),
+`apps/backtest/tests/test_reporter.py` (1),
+`apps/backtest/tests/test_instrument_info.py` (1),
+`apps/backtest/tests/test_executor.py` (6),
+`apps/backtest/tests/test_engine.py` (2),
+`apps/backtest/tests/test_data_provider.py` (2),
+`apps/backtest/tests/test_cache_lock.py` (3).
+- Safe to auto-fix. Run scoped, rule-limited `--fix` for F401 only on these
+  test files, then eyeball the diff (see Algorithm step 3).
+
+### Phase 5 — test F841 unused-variables (17 errors)
+Files: `packages/gridcore/tests/test_comparison.py` (12),
+`packages/gridcore/tests/test_grid.py` (4),
+`apps/backtest/tests/test_risk_limit_integration.py` (1),
+`apps/backtest/tests/test_instrument_info.py` (1).
+- F841 is **not** safe-auto-fixable (unsafe-fix only). Fix by hand: most are
+  "before/after" measurement pairs in grid-rebalance tests where one half is
+  computed but never asserted (e.g. `test_comparison.py` 1016/1017/1023/1024,
+  `test_grid.py` 319/361 `min/max_price_before`, 346/387 `imbalance_after`).
+  Per-site: prefer **deleting the dead assignment** (surgical, no behavior
+  change) over inventing an assertion. Do not "improve" the tests.
+
+### Phase 6 — test E731 lambda-assignment (9 errors) + F541 (2 errors)
+- `apps/gridbot/tests/test_runner_lowbalance_storm.py` lines 615, 630, 645,
+  655, 676, 700, 724, 735, 746: each is
+  `provider = lambda: (WalletSnapshot(...), <age>)`. Convert each to a nested
+  `def` returning the same tuple. Keep the trailing intent comments
+  (`# fresh, age 1s`, `# stale (>=45)`).
+- `apps/recorder/tests/test_start_recorder_check.py` lines 341, 344: F541
+  f-strings with no placeholder — drop the `f` prefix (auto-fixable).
+- Note: one E402 also exists at `packages/gridcore/tests/test_comparison.py:47`
+  (import after a non-import statement). Inspect that site; if the preceding
+  statement is load-bearing (e.g. `sys.path` shim), append `# noqa: E402`,
+  otherwise reorder the import above it.
+
+## Algorithm (execution order)
+
+1. **Phase 1 first, in isolation.** Edit the `grid_db` import in
+   `snapshot_loader.py`. Run
+   `uv run ruff check apps/replay/src/replay/snapshot_loader.py` →
+   expect "All checks passed". Run
+   `uv run pytest apps/replay/tests/test_snapshot_loader.py -q` → expect pass.
+   This satisfies the headline acceptance criterion before touching anything
+   else.
+2. **Phases 2–3 (production).** Hand-edit. Re-run
+   `uv run ruff check apps/gridbot/src/ apps/backtest/src/ apps/replay/src/`
+   → expect clean. Confirm no production behavior change (imports/noqa only).
+3. **Phase 4 (test F401).** Run a scoped, rule-limited auto-fix, NOT a
+   repo-wide one: `uv run ruff check --select F401 --fix <test files>`. Never
+   run bare `ruff check . --fix` (would rewrite out-of-scope debug file).
+   Inspect `git diff` to confirm only import lines changed.
+4. **Phases 5–6 (test F841 / E731 / F541 / test E402).** Hand-edit F841, E731,
+   and the test_comparison E402. Auto-fix the 2 F541 (`--select F541 --fix`).
+5. **Gate.** Run `uv run ruff check apps/ packages/ shared/`. Expect only the
+   30 `debug_walkthrough.py` errors to remain (those are #177). To prove the
+   in-scope set is clean, run
+   `uv run ruff check apps/ packages/ shared/ --exclude debug_walkthrough.py`
+   → expect "All checks passed". The `--exclude` here is a *verification-only*
+   flag, not a committed config — do not add it to `make lint` or pyproject;
+   that belongs to #177.
+6. **Regression.** Run the affected suites (replay snapshot loader; the
+   backtest test files; gridcore test_comparison/test_grid; gridbot
+   lowbalance/truncate storm; recorder start-check; shared db init) via
+   `uv run pytest <paths> -q` to confirm no test broke from the edits.
+
+## Verification (acceptance)
+- `uv run ruff check apps/replay/src/replay/snapshot_loader.py` → clean.
+- `uv run pytest apps/replay/tests/test_snapshot_loader.py -q` → pass.
+- `uv run ruff check apps/ packages/ shared/ --exclude debug_walkthrough.py` →
+  "All checks passed" (or only the documented intentional `# noqa` — the 6
+  runner.py E402 noqas, and possibly 1 test_comparison E402 noqa).
+- `git diff` stays focused: import edits, the noqa comments, lambda→def
+  rewrites, dead-assignment deletions, f-prefix drops. No `bbu_reference/` or
+  `debug_walkthrough.py` changes; no `[tool.ruff]` config added.
+
+## Notes / pitfalls
+- `make lint` is `uv run ruff check .` (whole repo) so CI stays red from
+  `debug_walkthrough.py` + `bbu_reference/` until #177 lands a config exclude.
+  That is expected and by-design (red CI on main until #177–#180). This issue's
+  gate is the `apps/ packages/ shared/` (minus debug) scope, not bare
+  `make lint`.
+- Do not `--fix` F841/E731 (unsafe or unsupported) and do not run repo-wide
+  `--fix` — it would rewrite the out-of-scope debug file.
+- runner.py: noqa, never reorder — the `WalletProvider` alias placement is
+  load-bearing for circular-import avoidance.

--- a/packages/gridcore/tests/test_comparison.py
+++ b/packages/gridcore/tests/test_comparison.py
@@ -44,7 +44,7 @@ if 'pybit.unified_trading' not in sys.modules:
 if 'pybit.exceptions' not in sys.modules:
     sys.modules['pybit.exceptions'] = MockPybit.exceptions
 
-from gridcore.grid import Grid, GridSideType
+from gridcore.grid import Grid, GridSideType  # noqa: E402
 
 
 def normalize_side(side: str) -> str:
@@ -615,7 +615,7 @@ class TestEngineStrat50Behavior:
             last_price=Decimal('100000.0')
         )
 
-        intents = engine.on_event(event, {'long': [], 'short': []})
+        engine.on_event(event, {'long': [], 'short': []})
 
         # Grid should now be built
         assert len(engine.grid.grid) > 1, "Grid should be built after ticker event"
@@ -784,8 +784,6 @@ class TestEngineStrat50Behavior:
         )
         engine.on_event(ticker_event, {'long': [], 'short': []})
 
-        # Record grid state before execution
-        grid_before = [{'side': g['side'], 'price': g['price']} for g in engine.grid.grid]
 
         # Simulate execution at 99800
         execution_event = ExecutionEvent(
@@ -973,9 +971,6 @@ class TestGridEdgeCaseBehavior:
         grid.build_grid(100000.0)
         initial_grid_prices = [g['price'] for g in grid.grid]
 
-        # Get grid bounds
-        min_price = min(initial_grid_prices)
-        max_price = max(initial_grid_prices)
 
         # Update with price way outside bounds
         grid.update_grid(99800.0, 120000.0)  # Way above max_price
@@ -1012,16 +1007,10 @@ class TestGridEdgeCaseBehavior:
             if g['side'] == 'Sell' and g['price'] > 100500:
                 g['side'] = 'Wait'
 
-        # Count before rebalancing
-        buy_count_before = sum(1 for g in grid.grid if g['side'] == 'Buy')
-        sell_count_before = sum(1 for g in grid.grid if g['side'] == 'Sell')
 
         # Trigger update which should call __center_grid
         grid.update_grid(99000.0, 100000.0)
 
-        # Count after rebalancing
-        buy_count_after = sum(1 for g in grid.grid if g['side'] == 'Buy')
-        sell_count_after = sum(1 for g in grid.grid if g['side'] == 'Sell')
 
         # Should have shifted grid upward (removed bottom buy, added top sell)
         # Note: exact counts depend on how many were marked WAIT, but grid should be more balanced
@@ -1073,12 +1062,6 @@ class TestGridEdgeCaseBehavior:
         wait_items = [g for g in grid.grid if g['side'] == 'Wait']
         assert len(wait_items) > 0, "Should have WAIT items near filled price"
 
-        # Verify wait items are close to filled price
-        for wait_item in wait_items:
-            # Should be within grid_step/4 = 0.05% of filled price
-            diff_pct = abs(wait_item['price'] - 99800.0) / 99800.0 * 100
-            # If marked as WAIT, should be close enough OR was already WAIT
-            # The middle line is always WAIT initially
 
     def test_side_assignment_based_on_current_price(self):
         """
@@ -1567,9 +1550,7 @@ class TestGridComparisonExtended:
 
         # Get grid boundaries
         orig_min = min(g['price'] for g in original_greed.greed)
-        orig_max = max(g['price'] for g in original_greed.greed)
         new_min = min(g['price'] for g in new_grid.grid)
-        new_max = max(g['price'] for g in new_grid.grid)
 
         # Test 1: Price at boundary (should NOT rebuild)
         original_greed.update_greed(99800.0, orig_min + 100)  # Just inside

--- a/packages/gridcore/tests/test_grid.py
+++ b/packages/gridcore/tests/test_grid.py
@@ -316,7 +316,6 @@ class TestGridRebalancing:
         assert grid.is_grid_correct() is True
 
         # Record original grid bounds
-        min_price_before = grid.grid[0]['price']
         max_price_before = grid.grid[-1]['price']
         grid_length_before = len(grid.grid)
 
@@ -343,7 +342,6 @@ class TestGridRebalancing:
         sell_after = sum(1 for g in grid.grid if g['side'] == GridSideType.SELL)
         total_after = buy_after + sell_after
         if total_after > 0:
-            imbalance_after = abs(buy_after - sell_after) / total_after
             # Rebalancing shifts one level at a time, so imbalance may still be above threshold
             # but should be improving (one more sell, one fewer buy than before rebalancing)
             assert sell_after > 0, "Should have at least one sell after rebalancing"
@@ -358,7 +356,6 @@ class TestGridRebalancing:
 
         # Record original grid bounds
         min_price_before = grid.grid[0]['price']
-        max_price_before = grid.grid[-1]['price']
         grid_length_before = len(grid.grid)
 
         # Create sell-heavy imbalance by setting last_close near the bottom of the grid
@@ -384,7 +381,6 @@ class TestGridRebalancing:
         sell_after = sum(1 for g in grid.grid if g['side'] == GridSideType.SELL)
         total_after = buy_after + sell_after
         if total_after > 0:
-            imbalance_after = abs(sell_after - buy_after) / total_after
             # Rebalancing shifts one level at a time, so imbalance may still be above threshold
             # but should be improving (one more buy, one fewer sell than before rebalancing)
             assert buy_after > 0, "Should have at least one buy after rebalancing"

--- a/shared/db/tests/test_init_db.py
+++ b/shared/db/tests/test_init_db.py
@@ -1,10 +1,9 @@
 """Tests for database initialization script."""
 
 import sys
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 from grid_db.init_db import main, initialize_database
-from grid_db.settings import DatabaseSettings
 
 
 class TestInitDb:


### PR DESCRIPTION
## Summary
Fixes the P0 in-scope slice of #180 — the confirmed production bug plus the remaining real ruff errors under `apps/`, `packages/`, `shared/`.

- **F821** (production bug): import `WalletSnapshot` from `grid_db` in `apps/replay/src/replay/snapshot_loader.py` (fixes `dict[str, WalletSnapshot]` annotation at line 740).
- **F401** ×26: removed unused imports (scoped `--select F401 --fix`).
- **E402** ×6 in `gridbot/runner.py`: `# noqa: E402` — the `WalletProvider` type alias must sit below the `TYPE_CHECKING` block for circular-import avoidance; reordering would break it.
- **F841** ×17: deleted dead test variables (side-effecting calls preserved; one dead loop removed).
- **E731** ×9: lambda→def in `test_runner_lowbalance_storm.py`.
- **F541** ×2: dropped f-prefix on placeholder-free f-strings.
- **E402** ×1 in `test_comparison.py`: `# noqa` (load-bearing `sys.modules` mock shim).

Plan: `docs/features/0077_PLAN.md` (planned via adversarial plan-debate, approved iter 1).

## Verification
- `uv run ruff check apps/replay/src/replay/snapshot_loader.py` → clean
- `uv run ruff check apps/ packages/ shared/ --exclude debug_walkthrough.py` → **All checks passed**
- Affected suites green: gridcore 105/1skip, backtest 108, gridbot 102, recorder 13, shared/db 3, replay 55.

## Out of scope (#177)
`apps/backtest/debug_walkthrough.py`, `bbu_reference/`, and any `[tool.ruff]` config/excludes. Bare `make lint` (whole repo) stays red until #177 lands a config exclude — by design.

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)