### PR TITLE
feat(0078): add root Ruff config excluding archived/debug/reference (#181)

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -92,6 +92,15 @@ Phase-0 rollout while the repo is red:
 
 **Branch protection (making the check "required") is a GitHub repo setting, not a file** — it cannot be enforced from `ci.yml`; set it manually.
 
+### Lint / Ruff (Feature 0078, issue #181)
+
+`make lint` = `uv run ruff check .`. Root config lives in `pyproject.toml` `[tool.ruff]` (ruff defaults; only an additive `exclude` list). Excluded trees, each with a rationale comment in the config:
+- `apps/backtest/debug_walkthrough.py` — interactive debug walkthrough; not app code.
+- `bbu_reference` — vendored bbu2 reference; not maintained, has its own nested `ruff.toml` (line-length 140).
+- `scripts` — one-off research/migration tooling; disposable, not imported by apps.
+
+Maintained code is NOT excluded. When a maintained file has an intentional lint error, prefer a targeted `# noqa: <code>` over excluding it — e.g. `tests/integration/conftest.py:16` carries `# noqa: E402` on the `gridcore.config` import that must follow the `sys.path.insert` block.
+
 ## Development Workflow
 
 1. Define task clearly

--- a/docs/features/0078_PLAN.md
+++ b/docs/features/0078_PLAN.md
@@ -1,0 +1,107 @@
+# 0078 — Add Ruff config (exclude archived/debug/reference only)
+
+GitHub issue #181 (P1). Pairs with #180 (already merged).
+
+## Context
+
+`make lint` runs `uv run ruff check .` (see `Makefile`, `lint:` target). The root
+`pyproject.toml` currently has NO `[tool.ruff]` section, so ruff lints the entire
+tree — including intentionally-unmaintained code — and reports **37 errors**.
+
+Goal: add a root `[tool.ruff]` config with an explicit `exclude` list (brief
+comment per path) so `make lint` checks ALL maintained application code but skips
+the debug/reference/one-off trees, AND fix the one error that lives in maintained
+code. End state: `uv run ruff check .` → `All checks passed!` and `make lint` green.
+
+### Ground truth — current 37 errors (`uv run ruff check .`)
+
+| Count | Location | Code(s) | Disposition |
+|------:|----------|---------|-------------|
+| 30 | `apps/backtest/debug_walkthrough.py` | E402 (×~28), F401 (`backtest.engine.FundingSimulator`), F841 (`check_config`) | EXCLUDE (debug script; contents OUT OF SCOPE — do not edit) |
+| 2 | `bbu_reference/bbu2-master/{settings.py,bybit_api_usdt.py}` | E402 | EXCLUDE (vendored reference; OUT OF SCOPE) |
+| 3 | `scripts/research_0045_im_mm_distribution.py` | F541 (×3, f-string w/o placeholders) | EXCLUDE via `scripts/` |
+| 1 | `scripts/verify_0065_collateral.py` | F401 (`decimal.Decimal` unused) | EXCLUDE via `scripts/` |
+| 1 | `tests/integration/conftest.py:16` | E402 | **FIX with `# noqa: E402`** (MAINTAINED test code — do NOT exclude) |
+
+## Decisions
+
+- **Exclude `scripts/` wholesale.** `scripts/` is one-off research/migration tooling
+  (`research_0045_*`, `verify_0065_*`, `migrate_0034/0042/0056/0059_*`,
+  `_phase2_formula_check.py`, `check_tier_drift.py`, `plot_pnl_correlation.py`,
+  `phase4/`). Not application code, not imported by apps. Excluding the dir (rather
+  than fixing 4 nits) matches the issue's "skip intentionally-unmaintained trees"
+  intent and avoids churn on disposable scripts.
+- **Fix, do not exclude, `tests/integration/conftest.py`.** This is maintained test
+  code. The E402 at line 16 (`from gridcore.config import GridConfig`) is intentional:
+  it sits after a deliberate `sys.path.insert(...)` block (lines 9–14) so
+  `import integration_helpers` resolves under per-app pytest runs. Correct fix is a
+  trailing `# noqa: E402` on that import line — NOT moving the import (which would
+  break the sys.path setup) and NOT excluding the file.
+- **`bbu_reference/` has its own nested ruff configs** (e.g.
+  `bbu_reference/backtest_reference/bbu_backtest-main/ruff.toml`, `line-length = 140`).
+  Adding `bbu_reference` to the root `exclude` makes our root ruff skip that whole
+  tree, so the nested 140-col config is irrelevant to `make lint`. (No `ruff.toml`
+  exists directly at `bbu_reference/ruff.toml`; nested ones live deeper.)
+
+## Files to change
+
+1. `pyproject.toml` — add `[tool.ruff]` section (new; after the existing
+   `[tool.pytest.ini_options]` block, lines 25–29).
+2. `tests/integration/conftest.py` — line 16: append `  # noqa: E402`.
+3. `RULES.md` — add a short "Lint / Ruff" subsection documenting excluded paths + why.
+
+OUT OF SCOPE (do NOT edit contents): `apps/backtest/debug_walkthrough.py`,
+`bbu_reference/`. Do NOT exclude active packages: `apps/backtest/src`,
+`apps/replay`, `packages/`, `shared/`, `apps/gridbot`.
+
+## Step-by-step
+
+### Step 1 — Root `[tool.ruff]` in `pyproject.toml`
+
+Append a new `[tool.ruff]` table after line 29. It needs only an `exclude` list
+(no rule-set changes — keep ruff defaults so maintained code is checked exactly as
+#180 left it). Each excluded path gets a one-line `#` comment stating why.
+
+Exclude entries (each with brief comment):
+
+- `apps/backtest/debug_walkthrough.py` — interactive debug walkthrough; not app code.
+- `bbu_reference` — vendored bbu2 reference; not maintained, has its own ruff config.
+- `scripts` — one-off research/migration scripts; disposable, not imported by apps.
+
+Notes:
+- Ruff's built-in default excludes (`.venv`, `__pycache__`, `.git`, build dirs, etc.)
+  still apply; the root `exclude` list is additive to those defaults, so listing
+  these three is sufficient. (`scripts/__pycache__` and `scripts/phase4` fall under
+  the `scripts` dir exclusion.)
+- Use repo-root-relative paths (ruff matches `exclude` entries against paths
+  relative to the config file, which is repo root).
+
+### Step 2 — Fix the maintained-code error
+
+`tests/integration/conftest.py` line 16:
+
+`from gridcore.config import GridConfig` → append `  # noqa: E402`
+
+This is the only error in maintained code; without it `ruff check .` stays red even
+after the excludes. Do not reorder imports — the `sys.path.insert` block above must
+run first.
+
+### Step 3 — Document in `RULES.md`
+
+Add a concise subsection (e.g. "### Lint / Ruff (Feature 0078)") near the existing
+legacy-carve-out notes. Content:
+- `make lint` = `uv run ruff check .`; root config in `pyproject.toml` `[tool.ruff]`.
+- Excluded paths and rationale: `apps/backtest/debug_walkthrough.py` (debug),
+  `bbu_reference` (vendored reference, own ruff.toml at 140 cols), `scripts`
+  (one-off research/migration tooling).
+- Maintained test code is NOT excluded — `tests/integration/conftest.py` carries a
+  `# noqa: E402` on the post-`sys.path.insert` `gridcore.config` import; prefer
+  `# noqa` over excluding when fixing maintained-code lint errors.
+
+## Verify
+
+- `uv run ruff check .` → `All checks passed!`
+- `make lint` → exit 0 (green).
+- Sanity that excludes are scoped, not blanket: confirm maintained trees are still
+  linted, e.g. `uv run ruff check apps/replay packages shared apps/gridbot apps/backtest/src`
+  runs without error and is NOT skipped (ruff reports it checked files, not "0 files").

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,3 +27,12 @@ pythonpath = ["packages/gridcore/src", "packages/bybit_adapter/src", "shared/db/
 testpaths = ["packages/gridcore/tests", "packages/bybit_adapter/tests", "shared/db/tests", "apps/event_saver/tests", "apps/gridbot/tests", "apps/backtest/tests", "apps/comparator/tests", "apps/recorder/tests", "apps/replay/tests", "apps/pnl_checker/tests", "tests/integration"]
 asyncio_mode = "auto"
 addopts = ["--import-mode=importlib"]
+
+[tool.ruff]
+# Lint all maintained code; skip intentionally-unmaintained trees (issue #181).
+# Additive to ruff's built-in defaults (.venv, __pycache__, .git, build dirs, etc.).
+exclude = [
+    "apps/backtest/debug_walkthrough.py",  # interactive debug walkthrough; not app code
+    "bbu_reference",                        # vendored bbu2 reference; not maintained, has its own ruff config
+    "scripts",                              # one-off research/migration scripts; disposable, not imported by apps
+]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -13,7 +13,7 @@ _INTEGRATION_DIR = str(Path(__file__).resolve().parent)
 if _INTEGRATION_DIR not in sys.path:
     sys.path.insert(0, _INTEGRATION_DIR)
 
-from gridcore.config import GridConfig
+from gridcore.config import GridConfig  # noqa: E402
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
Adds a root `[tool.ruff]` config so whole-repo `make lint` (`uv run ruff check .`) lints all maintained code but skips intentionally-unmaintained trees. With #180 (real fixes) merged, `make lint` is now **green repo-wide**.

- **`pyproject.toml`** — new `[tool.ruff]` with `exclude` (rationale comment per path):
  - `apps/backtest/debug_walkthrough.py` — interactive debug walkthrough; not app code
  - `bbu_reference` — vendored bbu2 reference; not maintained, has its own ruff config
  - `scripts` — one-off research/migration tooling; disposable, not imported by apps
- **`tests/integration/conftest.py:16`** — `# noqa: E402` on the `gridcore.config` import that must follow the `sys.path.insert` block. Maintained code → fixed, **not** excluded.
- **`RULES.md`** — `### Lint / Ruff (Feature 0078)` documenting excluded paths + the noqa-over-exclude rule.

Plan: `docs/features/0078_PLAN.md` (adversarial plan-debate, approved iter 1).

## Verification
- `uv run ruff check .` → **All checks passed!**
- `make lint` → exit 0 (green)
- Excludes scoped, not blanket — no active tree skipped (grep: nothing imports `scripts/`/`bbu_reference/`/`debug_walkthrough.py`); integration suite 53 passed.

## Out of scope
Did not modify `bbu_reference/` or `debug_walkthrough.py` contents; did not exclude any active package.

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)