### PR TITLE
feat(0079): production safety caps (exposure/order/loss/rate limits)

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -45,7 +45,7 @@ Project-specific "what not to do" — pairs with the universal Constraints in `.
 - **Don't edit `bbu_reference/`** — vendored legacy BBU2 bot our code was ported from (its own `ruff.toml`, line-length 140; outside our lint/test scope). Read it to understand original behavior (see "Legacy bbu2 paths" above), but never modify it.
 - **Don't hand-edit generated/data dirs** — `data/`, `output/`, `results/`, `db/` are gitignored recorder/replay/backtest artifacts and SQLite DBs, not source. `conf/` holds real tracked config (risk-limit tiers, instrument caches) — leave unless asked.
 - **Backward-compat is deliberate, not speculative** — existing compat (`DirectionType`/`SideType` StrEnum aliases, replay `strict_cross` baseline, `extract_client_order_prefix` no-hyphen fallback) is intentional. Don't add new compat shims without a stated reason.
-- **No dead config fields** — don't add YAML fields/flags "for later"; e.g. `max_margin` is declared but never read (the bot has no automatic position cap).
+- **No dead config fields** — don't add YAML fields/flags "for later"; e.g. `max_margin` is declared but never read. (Feature 0079 added a real automatic position cap via the **C1 `safety_caps.max_notional_per_symbol`** notional limit — see "Production safety caps"; `max_margin` itself remains dead/unrevived.)
 - **Don't point tooling at live state without explicit ask** — the account is Bybit **mainnet** (`mainnet_live`); never run against the live gridbot DB or live orders unless told.
 
 ## Package Management with uv
@@ -531,6 +531,68 @@ short with mult=2.0; the grown open exceeded free margin → 110007 every attemp
   hook), `config.py`. Tests: `test_runner_lowbalance_storm.py` (17 new, keyed
   `test_low_balance_skip_*`). Record floats (`avail_min/max`,
   `first_blocked_price`) are `float`; affordability comparison stays `Decimal`.
+
+### Production safety caps (feature 0079, issue #182)
+
+Hard, **last-resort** caps enforced OUTSIDE strategy logic so they cannot be
+overridden by grid-engine decisions (the #159 storm motivated them). They are
+**additive** to `min_liq_ratio` / `max_liq_ratio` / the low-balance preflight —
+they do NOT replace them. All cap state + decision logic lives in ONE place,
+`gridbot/safety_caps.py` (`SafetyCaps` + frozen `CapDecision`); the orchestrator
+builds ONE instance per strat in `_init_strategy` and passes the SAME object
+(and the same monotonic clock) to both the `StrategyRunner` (C1/C2/C3) and the
+`IntentExecutor` (C4) so the C4 window and the loss latch are one source of truth.
+
+- **Four caps** (`StrategyConfig.safety_caps`, a `SafetyCapsConfig`; every
+  per-cap value defaults to `None` = that cap disabled, so an existing YAML with
+  no `safety_caps:` block is byte-for-byte pre-0079 — no order is ever rejected
+  until the operator opts in; `enabled` is the master kill-switch):
+  - **C1 `max_notional_per_symbol`** (USDT) — halt new OPENs when live
+    `long.position_value + short.position_value >= cap`. Reduce-only closes are
+    EXEMPT.
+  - **C2 `max_open_orders`** — pure count limit on tracked `placed` orders;
+    rejects BOTH open and reduce-only at/above the cap.
+  - **C3 `session_loss_limit`** (positive USDT magnitude) + flag
+    `session_loss_auto_reset_utc_midnight`. Evaluated in `on_position_update`
+    (where realized PnL lands) off the per-cycle `cur_realized_pnl` sum (the
+    Bybit UI "Realized", NOT the ~80x lifetime `cumRealisedPnl`). On trip it is a
+    **full circuit breaker**: cancel ALL working orders once (via
+    `_execute_cancel_intent` → honors shadow mode + tracked-order state; uses the
+    wire `orderId`, not `orderLinkId`) then suppress ALL new places (open AND
+    reduce-only) via `loss_tripped()`. Recovery: latch clears on the first
+    position update of the next UTC date (auto-reset True) or only on process
+    restart (False). The UTC reset date is seeded lazily on the first
+    `check_loss_breaker` (the constructor has only a monotonic clock; UTC enters
+    via the `now_utc` arg).
+  - **C4 `max_orders_per_minute`** — trailing-60s rate limit at
+    `IntentExecutor.execute_place` (the single live-submit choke point, so
+    retry-queue re-dispatch is rate-limited too). Returns the non-retryable
+    `error="safety_cap_rate_limit"` sentinel; only real successes consume the
+    window — **shadow placements do not**.
+- **Precedence**: caps run in `_execute_place_intent` as **Step 2.5** — AFTER
+  qty-resolve (Step 1) + the 110017 breaker (Step 2) and BEFORE the dirty refresh
+  / `_is_good_to_place` guard — so a capped intent never reaches the strategy
+  guard or the exchange. When a cap and a strategy guard both want to reject, the
+  cap wins (it runs first / fail-closed). A capped or rate-limited intent is
+  **dropped, NOT enqueued** to the retry queue (mirrors the 110007 / 110017
+  drop): the runner short-circuits any `error.startswith("safety_cap")`.
+- **Live-only → replay/backtest parity preserved by construction**: caps run in
+  `StrategyRunner` / `IntentExecutor` only; `apps/backtest` / `apps/replay` /
+  `apps/comparator` use `BacktestRunner` and import neither, so the cap code
+  never runs there. `max_margin` remains dead/unused — C1 supersedes its original
+  intent with a real notional cap (it does NOT revive `max_margin`).
+- **Shadow mode**: the runner-level C1/C2/C3 run BEFORE the executor, so a
+  tripped cap suppresses even the `[SHADOW] Would place …` log (faithful); C4 is
+  after the executor's shadow early-return, so shadow never consumes its window.
+- Rejection logging is throttled per reason (`_SAFETY_CAP_WARN_THROTTLE_SEC`,
+  runner) and per executor (`_RATE_LIMIT_WARN_THROTTLE_SEC`); Telegram alerts
+  throttle via `error_key=f"safety_cap_{reason}_{strat_id}"`.
+- Files: `config.py` (`SafetyCapsConfig`), `safety_caps.py` (**new**),
+  `runner.py` (Step 2.5, C3 in `on_position_update`, cached per-direction
+  `position_value`, drop-not-enqueue), `executor.py` (C4 + `record_accepted_submission`),
+  `orchestrator.py` (`_init_strategy` builds + shares one instance),
+  `gridbot.yaml.example`. Tests: `test_safety_caps.py` (**new**, unit trip+recovery
+  per cap), `test_runner.py` / `test_executor.py` (integration).
 
 ### SAME ORDER detection
 

--- a/apps/gridbot/conf/gridbot.yaml.example
+++ b/apps/gridbot/conf/gridbot.yaml.example
@@ -22,6 +22,17 @@ strategies:
     min_total_margin: 0.15
     increase_same_position_on_low_margin: false  # true = boost own side x2 on low margin; false = suppress opposite side x0.5
     shadow_mode: false  # Set to true to log without executing
+    # Feature 0079 (issue #182) — production safety caps. Hard, last-resort caps
+    # enforced outside strategy logic; ADDITIVE to min_liq_ratio / low-balance
+    # preflight (they are not replaced). Omitting a field disables that cap, so
+    # an existing config with no safety_caps block keeps the pre-0079 behavior.
+    safety_caps:
+      enabled: true  # master kill-switch; false = every cap inert (pre-0079 path)
+      max_notional_per_symbol: "1000"  # C1: halt new OPENs when long+short notional (USDT) >= this; reduce-only closes always allowed. Omit to disable.
+      max_open_orders: 60  # C2: reject place intents (open AND reduce-only — a count limit) at/above this many tracked orders. Omit to disable.
+      session_loss_limit: "50"  # C3: positive USDT magnitude; when session realized PnL <= -this, cancel working orders once then suppress all new places. Omit to disable.
+      session_loss_auto_reset_utc_midnight: true  # C3 recovery: true = latch clears at the next UTC date; false = stays latched until process restart.
+      max_orders_per_minute: 30  # C4: reject submissions above this many accepted real orders in any trailing 60s (at the executor; shadow placements don't count). Omit to disable.
 
   - strat_id: "ethusdt_main"
     account: "main_account"

--- a/apps/gridbot/src/gridbot/config.py
+++ b/apps/gridbot/src/gridbot/config.py
@@ -23,6 +23,87 @@ class AccountConfig(BaseModel):
     testnet: bool = Field(default=True, description="Use testnet endpoints")
 
 
+class SafetyCapsConfig(BaseModel):
+    """Feature 0079 (issue #182) — production safety caps.
+
+    Hard, last-resort caps enforced OUTSIDE strategy logic (in
+    ``StrategyRunner`` / ``IntentExecutor``), additive to and independent of
+    ``min_liq_ratio`` / ``max_liq_ratio`` / the low-balance preflight. Every
+    per-cap value defaults to ``None`` (that cap disabled), so an existing
+    deployment that has no ``safety_caps:`` block sees NO behavioral change on
+    upgrade — no order is ever rejected until the operator opts a cap in.
+    ``enabled`` is the master kill-switch: when False every cap is inert.
+    """
+
+    enabled: bool = Field(
+        default=True,
+        description=(
+            "Master kill-switch. When False every cap is inert (no state, no "
+            "checks, no logs) — the byte-for-byte pre-0079 path. When True the "
+            "machinery is wired but each still-None cap remains disabled."
+        ),
+    )
+    max_notional_per_symbol: Optional[Decimal] = Field(
+        default=None,
+        gt=0,
+        description=(
+            "C1 — max live total position notional per symbol in USDT "
+            "(long.position_value + short.position_value). When the cap is "
+            "reached the runner suppresses new OPEN place intents; reduce-only "
+            "closes always pass. None disables C1."
+        ),
+    )
+    max_open_orders: Optional[int] = Field(
+        default=None,
+        ge=1,
+        description=(
+            "C2 — max tracked (placed) open orders per strat. A pure count "
+            "limit: rejects BOTH open and reduce-only place intents at/above "
+            "the cap. None disables C2."
+        ),
+    )
+    session_loss_limit: Optional[Decimal] = Field(
+        default=None,
+        gt=0,
+        description=(
+            "C3 — session realized-loss circuit breaker, a POSITIVE USDT "
+            "magnitude (tripped when session realized PnL <= -value). On trip "
+            "the runner cancels working orders once and then suppresses ALL new "
+            "place intents until recovery. None disables C3."
+        ),
+    )
+    session_loss_auto_reset_utc_midnight: bool = Field(
+        default=True,
+        description=(
+            "C3 recovery mode. True = the loss latch auto-clears on the first "
+            "position update of the next UTC calendar date. False = stay "
+            "latched until process restart."
+        ),
+    )
+    max_orders_per_minute: Optional[int] = Field(
+        default=None,
+        ge=1,
+        description=(
+            "C4 — max accepted real order submissions in any trailing 60s, "
+            "enforced at IntentExecutor.execute_place (the single live-submit "
+            "choke point, so retry-queue re-dispatch is rate-limited too). "
+            "Shadow placements do not consume the window. None disables C4."
+        ),
+    )
+
+    @field_validator(
+        "max_notional_per_symbol", "session_loss_limit", mode="before"
+    )
+    @classmethod
+    def _coerce_decimal(cls, v):
+        """Coerce str/int/float money fields to Decimal (mirrors tick_size)."""
+        if v is None:
+            return v
+        if isinstance(v, (str, int, float)):
+            return Decimal(str(v))
+        return v
+
+
 class StrategyConfig(BaseModel):
     """Grid trading strategy configuration."""
 
@@ -300,6 +381,11 @@ class StrategyConfig(BaseModel):
             "breaker cooldown (truncate_breaker_cooldown_seconds)."
         ),
     )
+
+    # Feature 0079 (issue #182) — production safety caps (exposure / order /
+    # loss / rate limits) enforced outside strategy logic. default_factory so
+    # existing YAMLs load unchanged and get the all-disabled SafetyCapsConfig.
+    safety_caps: SafetyCapsConfig = Field(default_factory=SafetyCapsConfig)
 
     # Mode
     shadow_mode: bool = Field(default=False, description="Log intents without executing")

--- a/apps/gridbot/src/gridbot/executor.py
+++ b/apps/gridbot/src/gridbot/executor.py
@@ -6,6 +6,7 @@ and the exchange. It handles the actual order placement and cancellation.
 
 import logging
 import re
+import time
 from dataclasses import dataclass
 from datetime import datetime, UTC
 from typing import Callable, Optional
@@ -19,9 +20,14 @@ from bybit_adapter.error_codes import (
 from gridcore.intents import PlaceLimitIntent, CancelIntent
 from gridcore.position import DirectionType
 from gridbot.order_link_id import make_order_link_id
+from gridbot.safety_caps import SafetyCaps
 
 
 logger = logging.getLogger(__name__)
+
+# Feature 0079 (issue #182) — throttle the C4 rate-limit WARNING so a sustained
+# rate-limit (every queued/re-dispatched intent rejected) does not flood the log.
+_RATE_LIMIT_WARN_THROTTLE_SEC = 60.0
 
 # Bybit error codes that indicate auth/permission problems (not retryable)
 AUTH_ERROR_CODES = {10003, 10004, 10005, 33004}
@@ -168,6 +174,8 @@ class IntentExecutor:
         position_idx_short: int = 2,
         max_auth_failures: int = 5,
         on_cooldown_entered: Optional[Callable[[], None]] = None,
+        safety_caps: Optional[SafetyCaps] = None,
+        clock: Callable[[], float] = time.monotonic,
     ):
         """Initialize executor.
 
@@ -178,6 +186,14 @@ class IntentExecutor:
             position_idx_short: Position index for short direction (hedge mode).
             max_auth_failures: Consecutive auth errors before entering cooldown.
             on_cooldown_entered: Callback fired when auth cooldown activates.
+            safety_caps: Optional shared ``SafetyCaps`` (feature 0079 / issue
+                #182). The orchestrator passes the SAME instance it gives the
+                StrategyRunner so the C4 rate-limit window and the runner's
+                C1/C2/C3 share one source of truth. When None (direct/test
+                callers) C4 is inert.
+            clock: Monotonic clock for the C4 window; MUST be the same callable
+                the shared SafetyCaps uses (the orchestrator passes one value to
+                both). Defaults to ``time.monotonic``; injectable for tests.
         """
         self._client = rest_client
         self._shadow_mode = shadow_mode
@@ -187,6 +203,12 @@ class IntentExecutor:
         self._auth_failure_count = 0
         self._auth_cooldown = False
         self._on_cooldown_entered = on_cooldown_entered
+        # Feature 0079 (issue #182) — C4 max-orders-per-minute rate limit. The
+        # executor is the single live-submit choke point (catches retry-queue
+        # re-dispatch, which bypasses the runner). Inert when safety_caps is None.
+        self._safety_caps = safety_caps
+        self._clock = clock
+        self._rate_limit_warn_last: float = 0.0
 
     @property
     def shadow_mode(self) -> bool:
@@ -261,6 +283,30 @@ class IntentExecutor:
                 order_link_id=unique_link_id,
             )
 
+        # Feature 0079 (issue #182) — C4 rate limit. Checked AFTER the shadow
+        # early-return (so shadow placements never consume the window) and
+        # BEFORE the real submit, on EVERY caller (runner first-dispatch AND
+        # retry-queue re-dispatch), so a rate-limited order never reaches Bybit.
+        # Returns the non-retryable "safety_cap_rate_limit" sentinel: the runner
+        # drops it on first dispatch (never enqueues — see _execute_place_intent);
+        # an already-enqueued item that trips this on re-dispatch is not
+        # re-submitted and simply exhausts its bounded retry budget.
+        if self._safety_caps is not None:
+            now = self._clock()  # read once: same instant gates the window + throttle
+            if self._safety_caps.rate_limited(now):
+                if (now - self._rate_limit_warn_last) >= _RATE_LIMIT_WARN_THROTTLE_SEC:
+                    self._rate_limit_warn_last = now
+                    logger.warning(
+                        f"Safety cap rate limit: dropping {intent.side} order "
+                        f"{intent.symbol} qty={intent.qty} price={intent.price} "
+                        f"link_id={unique_link_id} (not submitted, not enqueued)"
+                    )
+                return OrderResult(
+                    success=False,
+                    order_link_id=unique_link_id,
+                    error="safety_cap_rate_limit",
+                )
+
         try:
             # Determine position index based on direction
             position_idx = self._get_position_idx(intent.direction)
@@ -292,6 +338,10 @@ class IntentExecutor:
             )
 
             self._auth_failure_count = 0
+            # Feature 0079 — count this accepted real submission toward the C4
+            # trailing-60s window (only real successes, never shadow).
+            if self._safety_caps is not None:
+                self._safety_caps.record_accepted_submission(self._clock())
             return OrderResult(
                 success=True,
                 order_id=order_id,

--- a/apps/gridbot/src/gridbot/orchestrator.py
+++ b/apps/gridbot/src/gridbot/orchestrator.py
@@ -36,6 +36,7 @@ from gridbot.config import GridbotConfig, AccountConfig, StrategyConfig
 from gridbot.executor import IntentExecutor
 from gridbot.notifier import Notifier
 from gridbot.runner import StrategyRunner
+from gridbot.safety_caps import SafetyCaps
 from gridbot.reconciler import Reconciler
 from gridbot.retry_queue import RetryQueue
 from gridbot.position_fetcher import PositionFetcher, _POSITION_TICK_BASE
@@ -791,12 +792,25 @@ class Orchestrator:
         strat_id = strategy_config.strat_id
         account_name = strategy_config.account
 
+        # Feature 0079 (issue #182) — build ONE SafetyCaps per strat and pass
+        # the SAME instance (and the SAME monotonic clock) to both the executor
+        # (C4 rate-limit window) and the runner (C1/C2/C3) so they share one
+        # source of truth. Production clock is time.monotonic.
+        safety_caps_clock = time.monotonic
+        safety_caps = SafetyCaps(
+            strategy_config.safety_caps,
+            strat_id=strat_id,
+            clock=safety_caps_clock,
+        )
+
         # Get executor for this account (with correct shadow mode)
         base_executor = self._executors[account_name]
         executor = IntentExecutor(
             base_executor._client,
             shadow_mode=strategy_config.shadow_mode,
             on_cooldown_entered=lambda sid=strat_id: self._auth_cooldown.enter(sid),
+            safety_caps=safety_caps,
+            clock=safety_caps_clock,
         )
 
         # Create retry queue with dispatcher that routes by intent type
@@ -847,6 +861,8 @@ class Orchestrator:
             # Feature 0066 Phase 4 — real-time wallet preflight source.
             wallet_provider=wallet_provider,
             wallet_ws_max_age_seconds=self._config.wallet_ws_max_age_seconds,
+            # Feature 0079 (issue #182) — SAME SafetyCaps instance as the executor.
+            safety_caps=safety_caps,
         )
         self._runners[strat_id] = runner
         self._strategy_executors[strat_id] = executor

--- a/apps/gridbot/src/gridbot/runner.py
+++ b/apps/gridbot/src/gridbot/runner.py
@@ -59,6 +59,7 @@ from gridbot.executor import (  # noqa: E402
 )
 from gridbot.notifier import Notifier  # noqa: E402
 from gridbot.order_link_id import make_order_link_id  # noqa: E402
+from gridbot.safety_caps import SafetyCaps  # noqa: E402
 from gridbot.truncate_breaker import TruncateBreaker  # noqa: E402
 
 
@@ -105,6 +106,11 @@ _SAME_ORDER_WARN_THROTTLE_SEC = 60.0
 # WS position-size mismatches while dirty (REST baseline held each time). Signals
 # a WS feed stuck beyond the normal recovery window. Re-fires every multiple.
 _DIRTY_WS_MISMATCH_ALERT_THRESHOLD = 10
+
+# Feature 0079 (issue #182) — throttle the per-reason safety-cap rejection
+# WARNING to at most one per this many seconds per reason, so a cap held at its
+# threshold (e.g. notional pinned at C1) does not flood the log every tick.
+_SAFETY_CAP_WARN_THROTTLE_SEC = 60.0
 
 
 @dataclass
@@ -199,6 +205,7 @@ class StrategyRunner:
         clock: Optional[Callable[[], float]] = None,
         wallet_provider: Optional["WalletProvider"] = None,
         wallet_ws_max_age_seconds: float = 45.0,
+        safety_caps: Optional[SafetyCaps] = None,
     ):
         """Initialize strategy runner.
 
@@ -241,6 +248,13 @@ class StrategyRunner:
                 the preflight uses the position-cadence ``_available_balance``.
             wallet_ws_max_age_seconds: Max age (s) of a provider peek the preflight
                 will trust before failing open (feature 0066 Phase 4).
+            safety_caps: Optional shared ``SafetyCaps`` instance (feature 0079 /
+                issue #182). The runner ACCEPTS it (the orchestrator constructs
+                ONE per strat and passes the SAME object to this runner and the
+                IntentExecutor so C4's window and C1/C2/C3 share one source of
+                truth). When None (direct/test callers) every cap call is
+                short-circuited to allow / no-op; SafetyCaps itself also
+                short-circuits internally when its config.enabled is False.
         """
         # 0047: if a DB writer is wired, account_id MUST be explicitly set —
         # the dummy default would FK-mismatch with replay's account scope
@@ -335,6 +349,18 @@ class StrategyRunner:
         self._available_balance: Decimal = Decimal("0")
         self._total_available_balance: Decimal = Decimal("0")
         self._total_maintenance_margin: Decimal = Decimal("0")
+
+        # Feature 0079 (issue #182) — production safety caps. `_safety_caps` is
+        # the shared SafetyCaps (or None for direct/test callers → caps inert).
+        # `_long_position_value`/`_short_position_value` cache the latest
+        # per-direction notional from on_position_update so the place-path C1
+        # read is O(1). `_safety_cap_warn_last` throttles the per-reason
+        # rejection WARNING (one per reason per _SAFETY_CAP_WARN_THROTTLE_SEC)
+        # so a notional-at-cap storm does not flood the log (cf. feature 0067).
+        self._safety_caps = safety_caps
+        self._long_position_value: Decimal = Decimal("0")
+        self._short_position_value: Decimal = Decimal("0")
+        self._safety_cap_warn_last: dict[str, float] = {}
         # Raw low-balance predicate (single source of truth, recomputed each
         # on_position_update), shared by the moderate_liq_risk fix (3a) and
         # chase-close (3b). Each consumer applies its own kill-switch.
@@ -881,6 +907,18 @@ class StrategyRunner:
             # Build PositionState objects
             long_state = self._build_position_state(long_position, wallet_balance, DirectionType.LONG)
             short_state = self._build_position_state(short_position, wallet_balance, DirectionType.SHORT)
+
+            # Feature 0079 (issue #182) — cache per-direction notional for the
+            # place-path C1 read, and evaluate the C3 session-loss breaker.
+            # Realized PnL is price-independent, so this runs BEFORE the
+            # no-valid-price early-return below.
+            self._long_position_value = (
+                long_state.position_value if long_state else Decimal("0")
+            )
+            self._short_position_value = (
+                short_state.position_value if short_state else Decimal("0")
+            )
+            self._evaluate_loss_breaker(long_state, short_state)
 
             # Update position sizes (used by _is_good_to_place). While a
             # direction is dirty (feature 0064), the size write is gated so a
@@ -2060,6 +2098,39 @@ class StrategyRunner:
             )
             return
 
+        # Step 2.5 — production safety caps (feature 0079 / issue #182). Runs
+        # AFTER qty-resolve + the 110017 breaker and BEFORE the dirty refresh /
+        # _is_good_to_place guard, so a capped intent never reaches the strategy
+        # guard or the exchange. Inert when no SafetyCaps is wired (None) or its
+        # config is disabled. A capped intent is dropped, NOT enqueued.
+        if self._safety_caps is not None:
+            # C3 latch: once the session-loss breaker has tripped, suppress ALL
+            # new places (open AND reduce-only — it is a full circuit breaker;
+            # the trip ERROR/alert + working-order cancel already fired once in
+            # on_position_update).
+            if self._safety_caps.loss_tripped():
+                logger.debug(
+                    "%s: safety-cap loss breaker latched — dropping %s @ %s",
+                    self.strat_id, intent.side, intent.price,
+                )
+                return
+            open_order_count = sum(len(v) for v in limits.values())
+            if intent.reduce_only:
+                decision = self._safety_caps.allow_reduce_only(
+                    open_order_count=open_order_count
+                )
+            else:
+                total_notional = (
+                    self._long_position_value + self._short_position_value
+                )
+                decision = self._safety_caps.allow_open(
+                    total_notional=total_notional,
+                    open_order_count=open_order_count,
+                )
+            if not decision.allowed:
+                self._emit_safety_cap_rejection(intent, decision.reason)
+                return
+
         # Step 3 — dirty-mirror REST refresh before the guard (reduce-only only).
         # `dirty_refresh_enabled` is the FIRST term so flipping it off is a true
         # kill-switch. intent.direction is the position being closed (a
@@ -2135,6 +2206,17 @@ class StrategyRunner:
 
         tracked.mark_failed()
 
+        # Feature 0079 (issue #182) — a C4 rate-limit sentinel from the executor
+        # ("safety_cap_rate_limit") must be DROPPED, not enqueued (else the
+        # rate-limited intent re-storms the retry queue). Mirrors the 110007 /
+        # 110017 "drop, don't enqueue" decisions below.
+        if result.error and result.error.startswith("safety_cap"):
+            logger.warning(
+                "%s: %s on %s %s @ %s — dropping (not enqueued)",
+                self.strat_id, result.error, intent.direction, intent.side, intent.price,
+            )
+            return
+
         # Feature 0066 (issue #159) — 110007 "available balance not enough" on an
         # OPEN order: do NOT enqueue to the retry queue. A boundary race (balance
         # moved between the preflight read and submit) can still surface 110007;
@@ -2207,6 +2289,85 @@ class StrategyRunner:
 
         if not result.success and self._on_intent_failed:
             self._on_intent_failed(intent, result.error)
+
+    def _emit_safety_cap_rejection(self, intent: PlaceLimitIntent, reason: str) -> None:
+        """Log (throttled) + alert a safety-cap rejection (feature 0079).
+
+        The WARNING is throttled per reason (``_SAFETY_CAP_WARN_THROTTLE_SEC``)
+        so a cap pinned at its threshold does not flood the log every tick; the
+        Telegram alert is throttled by the notifier via ``error_key``. The
+        caller drops the intent (does NOT enqueue it).
+        """
+        now = self._clock()
+        last = self._safety_cap_warn_last.get(reason)
+        if last is None or (now - last) >= _SAFETY_CAP_WARN_THROTTLE_SEC:
+            self._safety_cap_warn_last[reason] = now
+            logger.warning(
+                "%s: safety cap '%s' rejecting %s %s @ %s (not enqueued)",
+                self.strat_id, reason, intent.direction, intent.side, intent.price,
+            )
+            if self._notifier is not None:
+                self._notifier.alert(
+                    f"Gridbot: safety cap '{reason}' tripped for {self.strat_id}",
+                    error_key=f"safety_cap_{reason}_{self.strat_id}",
+                )
+        else:
+            logger.debug(
+                "%s: safety cap '%s' rejecting %s @ %s (throttled)",
+                self.strat_id, reason, intent.side, intent.price,
+            )
+
+    def _evaluate_loss_breaker(
+        self,
+        long_state: Optional[PositionState],
+        short_state: Optional[PositionState],
+    ) -> None:
+        """C3 — evaluate the session realized-loss circuit breaker (feature 0079).
+
+        Uses the per-cycle "Realized" value (``cur_realized_pnl`` — the Bybit UI
+        Realized column), NOT the ~80x lifetime ``cumRealisedPnl``. On a NEW
+        trip: emit one ERROR + alert and cancel ALL working orders for the
+        symbol via ``_execute_cancel_intent`` (honors shadow mode + tracked-order
+        state). After the trip, every ``_execute_place_intent`` short-circuits
+        via ``loss_tripped()``. No-op when no SafetyCaps is wired.
+        """
+        if self._safety_caps is None:
+            return
+        session_realized_pnl = (
+            (long_state.cur_realized_pnl if long_state else Decimal("0"))
+            + (short_state.cur_realized_pnl if short_state else Decimal("0"))
+        )
+        newly_tripped = self._safety_caps.check_loss_breaker(
+            session_realized_pnl=session_realized_pnl,
+            now_utc=datetime.now(UTC),
+        )
+        if not newly_tripped:
+            return
+        logger.error(
+            "%s: SAFETY CAP session-loss breaker TRIPPED — session realized "
+            "PnL %s reached the configured loss limit; cancelling working "
+            "orders and suppressing new places",
+            self.strat_id, session_realized_pnl,
+        )
+        if self._notifier is not None:
+            self._notifier.alert(
+                f"Gridbot: safety-cap session-loss breaker tripped for "
+                f"{self.strat_id} (session realized {session_realized_pnl})",
+                error_key=f"safety_cap_loss_breaker_{self.strat_id}",
+            )
+        # Cancel all working orders (both directions). order['orderId'] is the
+        # wire id (get_limit_orders maps tracked.order_id → 'orderId'); a
+        # CancelIntent requires symbol + order_id + reason.
+        limits = self.get_limit_orders()
+        for side_orders in limits.values():
+            for order in side_orders:
+                self._execute_cancel_intent(
+                    CancelIntent(
+                        symbol=self._config.symbol,
+                        order_id=order["orderId"],
+                        reason="safety_cap_loss_breaker",
+                    )
+                )
 
     def inject_open_orders(self, orders: list[dict]) -> None:
         """Inject open orders from exchange (for reconciliation on startup).

--- a/apps/gridbot/src/gridbot/safety_caps.py
+++ b/apps/gridbot/src/gridbot/safety_caps.py
@@ -1,0 +1,178 @@
+"""Production safety caps (feature 0079 / issue #182).
+
+Hard, last-resort caps enforced OUTSIDE strategy logic so they cannot be
+overridden by grid-engine decisions. ``SafetyCaps`` owns all cap state and
+decision logic in ONE place (design goal: caps enforced in one place, not
+duplicated per strategy). It is pure: no network/DB imports. The orchestrator
+constructs a single instance per strategy and passes the SAME object to both
+the ``StrategyRunner`` (C1/C2 open-guard + C3 loss breaker) and the
+``IntentExecutor`` (C4 rate limit) so the C4 window and the loss latch are one
+source of truth.
+
+Four caps:
+- C1 max notional exposure per symbol — suppresses new OPENs; closes exempt.
+- C2 max open orders per strat — a pure count limit; blocks open AND close.
+- C3 session realized-loss circuit breaker — latches on trip; caller cancels
+  working orders once and then suppresses all places until recovery.
+- C4 max orders per minute — trailing-60s rate limit at the executor.
+
+Clock contract: the constructor takes ONLY an injectable monotonic
+``clock: Callable[[], float]`` (default ``time.monotonic``) used for the C4
+window. There is NO wall-clock/UTC source at ``__init__``. UTC enters only via
+the ``now_utc`` argument to :meth:`check_loss_breaker`; the C3 reset date is
+seeded lazily on the first such call.
+
+Shadow-mode note: C1/C2/C3 run in the runner BEFORE the executor, so in shadow
+mode a tripped cap still suppresses the "[SHADOW] Would place ..." log (the
+faithful behavior). C4 lives at the executor AFTER its shadow early-return, so
+shadow placements never consume the C4 window.
+"""
+
+import logging
+import time
+from collections import deque
+from dataclasses import dataclass
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Callable, Optional
+
+from gridbot.config import SafetyCapsConfig
+
+logger = logging.getLogger(__name__)
+
+# Trailing window length for the C4 rate limit, in seconds.
+_RATE_WINDOW_SECONDS = 60.0
+
+
+@dataclass(frozen=True)
+class CapDecision:
+    """Outcome of a place-path cap check.
+
+    ``reason`` is one of ``"max_notional"``, ``"max_open_orders"``,
+    ``"loss_breaker"``, ``"rate_limit"`` or ``""`` (allowed). Callers map a
+    non-empty reason to a throttled WARNING + ``notifier.alert(...,
+    error_key=f"safety_cap_{reason}_{strat_id}")``.
+    """
+
+    allowed: bool
+    reason: str
+
+
+_ALLOWED = CapDecision(allowed=True, reason="")
+
+
+class SafetyCaps:
+    """Single source of truth for all production safety caps of one strategy."""
+
+    def __init__(
+        self,
+        config: SafetyCapsConfig,
+        strat_id: str,
+        clock: Callable[[], float] = time.monotonic,
+    ):
+        """Initialize.
+
+        Args:
+            config: The per-strategy ``SafetyCapsConfig``.
+            strat_id: Strategy id, for log messages.
+            clock: Monotonic clock for the C4 window; injectable for tests.
+        """
+        self._config = config
+        self._strat_id = strat_id
+        self._clock = clock
+
+        # C3 latch state.
+        self._loss_tripped: bool = False
+        # UTC calendar date the latch is bound to. None until the first
+        # check_loss_breaker seeds it lazily from that call's now_utc (the
+        # constructor has no UTC source — see module docstring).
+        self._loss_reset_utc_date: Optional[date] = None
+
+        # C4 trailing-window of accepted-submission monotonic timestamps.
+        self._rate_window: deque[float] = deque()
+
+    def allow_open(
+        self, *, total_notional: Decimal, open_order_count: int
+    ) -> CapDecision:
+        """C1 + C2 gate for an OPEN place intent.
+
+        C1 (notional) is checked before C2 (count); the first failing cap is
+        reported. Both are inert when the master switch is off or the cap value
+        is ``None``.
+        """
+        if not self._config.enabled:
+            return _ALLOWED
+        cap_notional = self._config.max_notional_per_symbol
+        if cap_notional is not None and total_notional >= cap_notional:
+            return CapDecision(allowed=False, reason="max_notional")
+        cap_orders = self._config.max_open_orders
+        if cap_orders is not None and open_order_count >= cap_orders:
+            return CapDecision(allowed=False, reason="max_open_orders")
+        return _ALLOWED
+
+    def allow_reduce_only(self, *, open_order_count: int) -> CapDecision:
+        """C2 gate for a reduce-only place intent (C1 never blocks closes)."""
+        if not self._config.enabled:
+            return _ALLOWED
+        cap_orders = self._config.max_open_orders
+        if cap_orders is not None and open_order_count >= cap_orders:
+            return CapDecision(allowed=False, reason="max_open_orders")
+        return _ALLOWED
+
+    def check_loss_breaker(
+        self, *, session_realized_pnl: Decimal, now_utc: datetime
+    ) -> bool:
+        """C3 evaluation. Returns True only on the transition into a trip.
+
+        Called from the position-update path (where realized PnL lands), not
+        the place path. A True return means the caller should cancel working
+        orders once and alert. ``loss_tripped()`` is the cheap read for the
+        place path thereafter.
+        """
+        if not self._config.enabled:
+            return False
+        cap = self._config.session_loss_limit
+        if cap is None:
+            return False
+
+        # Seed-if-unset, then UTC-midnight auto-reset.
+        if self._loss_reset_utc_date is None:
+            self._loss_reset_utc_date = now_utc.date()
+        if (
+            self._config.session_loss_auto_reset_utc_midnight
+            and now_utc.date() > self._loss_reset_utc_date
+        ):
+            self._loss_tripped = False
+            self._loss_reset_utc_date = now_utc.date()
+            logger.info(
+                "%s: session-loss breaker auto-reset at UTC midnight (date=%s)",
+                self._strat_id,
+                self._loss_reset_utc_date,
+            )
+
+        if not self._loss_tripped and session_realized_pnl <= -cap:
+            self._loss_tripped = True
+            return True
+        return False
+
+    def loss_tripped(self) -> bool:
+        """Cheap read for the place path: True while the C3 latch is set."""
+        return self._loss_tripped
+
+    def record_accepted_submission(self, now: float) -> None:
+        """Append an accepted real submission to the C4 window."""
+        if not self._config.enabled or self._config.max_orders_per_minute is None:
+            return
+        self._rate_window.append(now)
+
+    def rate_limited(self, now: float) -> bool:
+        """C4: evict the trailing-60s window, then True when count >= cap."""
+        if not self._config.enabled:
+            return False
+        cap = self._config.max_orders_per_minute
+        if cap is None:
+            return False
+        cutoff = now - _RATE_WINDOW_SECONDS
+        while self._rate_window and self._rate_window[0] <= cutoff:
+            self._rate_window.popleft()
+        return len(self._rate_window) >= cap

--- a/apps/gridbot/tests/test_config.py
+++ b/apps/gridbot/tests/test_config.py
@@ -11,6 +11,7 @@ from pydantic import ValidationError
 from gridbot.config import (
     AccountConfig,
     StrategyConfig,
+    SafetyCapsConfig,
     GridbotConfig,
     load_config,
 )
@@ -415,5 +416,98 @@ class TestLoadConfig:
         try:
             with pytest.raises(ValueError):
                 load_config(config_path)
+        finally:
+            Path(config_path).unlink()
+
+
+class TestSafetyCapsConfig:
+    """Feature 0079 (issue #182) — production safety caps config."""
+
+    _BASE = dict(
+        strat_id="btc_main", account="main", symbol="BTCUSDT",
+        tick_size=Decimal("0.1"),
+    )
+
+    def test_safety_caps_defaults_disabled(self):
+        """An existing YAML (no safety_caps block) loads with every cap disabled.
+
+        Safe-defaults contract: enabled=True wires the machinery but every
+        per-cap value is None, so upgrade is byte-for-byte the pre-0079 path
+        (no order is ever rejected until the operator opts a cap in).
+        """
+        strategy = StrategyConfig(**self._BASE)
+        caps = strategy.safety_caps
+        assert isinstance(caps, SafetyCapsConfig)
+        assert caps.enabled is True
+        assert caps.max_notional_per_symbol is None
+        assert caps.max_open_orders is None
+        assert caps.session_loss_limit is None
+        assert caps.session_loss_auto_reset_utc_midnight is True
+        assert caps.max_orders_per_minute is None
+
+    def test_safety_caps_explicit_values_and_decimal_coercion(self):
+        """Money fields coerce str/float → Decimal; counts stay int."""
+        strategy = StrategyConfig(
+            **self._BASE,
+            safety_caps={
+                "enabled": True,
+                "max_notional_per_symbol": "500.5",
+                "max_open_orders": 40,
+                "session_loss_limit": 25,
+                "session_loss_auto_reset_utc_midnight": False,
+                "max_orders_per_minute": 30,
+            },
+        )
+        caps = strategy.safety_caps
+        assert caps.max_notional_per_symbol == Decimal("500.5")
+        assert isinstance(caps.max_notional_per_symbol, Decimal)
+        assert caps.max_open_orders == 40
+        assert caps.session_loss_limit == Decimal("25")
+        assert isinstance(caps.session_loss_limit, Decimal)
+        assert caps.session_loss_auto_reset_utc_midnight is False
+        assert caps.max_orders_per_minute == 30
+
+    def test_safety_caps_invalid_values_rejected(self):
+        """Money caps use > 0; count caps use ge=1; degenerate YAML rejected."""
+        with pytest.raises(ValidationError):
+            StrategyConfig(**self._BASE, safety_caps={"max_notional_per_symbol": 0})
+        with pytest.raises(ValidationError):
+            StrategyConfig(**self._BASE, safety_caps={"max_notional_per_symbol": "-1"})
+        with pytest.raises(ValidationError):
+            StrategyConfig(**self._BASE, safety_caps={"max_open_orders": 0})  # ge=1
+        with pytest.raises(ValidationError):
+            StrategyConfig(**self._BASE, safety_caps={"session_loss_limit": 0})  # > 0
+        with pytest.raises(ValidationError):
+            StrategyConfig(**self._BASE, safety_caps={"max_orders_per_minute": 0})  # ge=1
+
+    def test_safety_caps_loaded_from_yaml(self):
+        """A safety_caps: block under a strategy round-trips through load_config."""
+        yaml_text = """
+accounts:
+  - name: main
+    api_key: k
+    api_secret: s
+    testnet: true
+strategies:
+  - strat_id: btc_main
+    account: main
+    symbol: BTCUSDT
+    tick_size: "0.1"
+    safety_caps:
+      max_notional_per_symbol: "1000"
+      max_open_orders: 50
+      session_loss_limit: "40"
+      max_orders_per_minute: 20
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_text)
+            config_path = f.name
+        try:
+            cfg = load_config(config_path)
+            caps = cfg.strategies[0].safety_caps
+            assert caps.max_notional_per_symbol == Decimal("1000")
+            assert caps.max_open_orders == 50
+            assert caps.session_loss_limit == Decimal("40")
+            assert caps.max_orders_per_minute == 20
         finally:
             Path(config_path).unlink()

--- a/apps/gridbot/tests/test_executor.py
+++ b/apps/gridbot/tests/test_executor.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock, MagicMock
 import pytest
 
 from gridcore.intents import PlaceLimitIntent, CancelIntent
+from gridbot.config import SafetyCapsConfig
 from gridbot.executor import (
     IntentExecutor,
     OrderResult,
@@ -17,6 +18,7 @@ from gridbot.executor import (
     is_network_error,
     is_duplicate_link_error,
 )
+from gridbot.safety_caps import SafetyCaps
 from bybit_adapter.error_codes import (
     ORDER_QTY_TRUNCATED_TO_ZERO,
     INSUFFICIENT_BALANCE,
@@ -645,3 +647,89 @@ class TestAuthErrorDetection:
         # More failures during cooldown — callback should not fire again
         executor.execute_place(place_intent)
         assert callback.call_count == 1
+
+
+class _FakeClock:
+    """Deterministic monotonic clock for the C4 window."""
+
+    def __init__(self, t: float = 1000.0):
+        self.t = t
+
+    def __call__(self) -> float:
+        return self.t
+
+
+class TestExecutorRateLimitC4:
+    """Feature 0079 (issue #182) — C4 max-orders-per-minute at the executor.
+
+    The executor is the single live-submit choke point (catches retry-queue
+    re-dispatch that bypasses the runner), so C4 lives here.
+    """
+
+    def _caps(self, clock, cap=2):
+        return SafetyCaps(
+            SafetyCapsConfig(max_orders_per_minute=cap),
+            strat_id="btcusdt_test",
+            clock=clock,
+        )
+
+    def test_blocks_above_cap_and_does_not_submit(self, mock_rest_client, place_intent):
+        clock = _FakeClock(1000.0)
+        caps = self._caps(clock, cap=2)
+        ex = IntentExecutor(mock_rest_client, safety_caps=caps, clock=clock)
+
+        # First two real submissions succeed and consume the window.
+        assert ex.execute_place(place_intent).success is True
+        assert ex.execute_place(place_intent).success is True
+        assert mock_rest_client.place_order.call_count == 2
+
+        # Third within the window is rate-limited: non-retryable sentinel,
+        # and place_order is NOT called again.
+        result = ex.execute_place(place_intent)
+        assert result.success is False
+        assert result.error == "safety_cap_rate_limit"
+        assert mock_rest_client.place_order.call_count == 2
+
+    def test_recovers_after_window_decay(self, mock_rest_client, place_intent):
+        clock = _FakeClock(1000.0)
+        caps = self._caps(clock, cap=2)
+        ex = IntentExecutor(mock_rest_client, safety_caps=caps, clock=clock)
+        ex.execute_place(place_intent)
+        ex.execute_place(place_intent)
+        assert ex.execute_place(place_intent).error == "safety_cap_rate_limit"
+
+        # Advance the clock past the 60s window — submissions resume.
+        clock.t = 1061.0
+        result = ex.execute_place(place_intent)
+        assert result.success is True
+        assert mock_rest_client.place_order.call_count == 3
+
+    def test_shadow_mode_does_not_consume_window(self, mock_rest_client, place_intent):
+        clock = _FakeClock(1000.0)
+        caps = self._caps(clock, cap=2)
+        ex = IntentExecutor(
+            mock_rest_client, shadow_mode=True, safety_caps=caps, clock=clock
+        )
+        # Many shadow placements never reach the gate / record path.
+        for _ in range(10):
+            assert ex.execute_place(place_intent).success is True
+        assert caps.rate_limited(clock()) is False
+        mock_rest_client.place_order.assert_not_called()
+
+    def test_inert_when_no_caps(self, mock_rest_client, place_intent):
+        ex = IntentExecutor(mock_rest_client)  # no safety_caps
+        for _ in range(5):
+            assert ex.execute_place(place_intent).success is True
+        assert mock_rest_client.place_order.call_count == 5
+
+    def test_failed_submit_does_not_consume_window(self, mock_rest_client, place_intent):
+        """Only REAL successes record into the C4 window — a failed/raised
+        submit must not consume a slot (record happens after place_order)."""
+        clock = _FakeClock(1000.0)
+        caps = self._caps(clock, cap=2)
+        mock_rest_client.place_order = MagicMock(side_effect=Exception("boom"))
+        ex = IntentExecutor(mock_rest_client, safety_caps=caps, clock=clock)
+        for _ in range(5):
+            assert ex.execute_place(place_intent).success is False
+        # No accepted submission recorded → window empty → not rate-limited.
+        assert caps.rate_limited(clock()) is False

--- a/apps/gridbot/tests/test_runner.py
+++ b/apps/gridbot/tests/test_runner.py
@@ -10,10 +10,11 @@ import pytest
 from gridcore import TickerEvent, ExecutionEvent, OrderUpdateEvent, EventType, InstrumentInfo
 from gridcore.intents import PlaceLimitIntent, CancelIntent
 
-from gridbot.config import StrategyConfig
+from gridbot.config import StrategyConfig, SafetyCapsConfig
 from gridbot.executor import IntentExecutor, OrderResult, CancelResult
 from gridbot.retry_queue import RetryQueue
 from gridbot.runner import StrategyRunner, TrackedOrder
+from gridbot.safety_caps import SafetyCaps
 
 EMPTY_LIMITS: dict[str, list[dict]] = {'long': [], 'short': []}
 
@@ -4530,3 +4531,192 @@ class TestOnGridChangeExchangeTsPropagation:
         assert all(ts == exec_ts for ts in observed)
         # Ticker ts must NOT bleed in via stale _current_exchange_ts.
         assert ticker_ts not in observed
+
+
+class TestSafetyCapsIntegration:
+    """Feature 0079 (issue #182) — caps wired through the runner dispatch path."""
+
+    def _runner(self, strategy_config, mock_executor, instrument_info, caps, **kw):
+        r = StrategyRunner(
+            strategy_config=strategy_config,
+            executor=mock_executor,
+            instrument_info=instrument_info,
+            safety_caps=caps,
+            **kw,
+        )
+        r._wallet_balance = Decimal("10000")
+        return r
+
+    def _open(self, side="Buy", direction="long", price="50000", qty="0.001"):
+        return PlaceLimitIntent.create(
+            symbol="BTCUSDT", side=side, price=Decimal(price), qty=Decimal(qty),
+            grid_level=1, direction=direction, reduce_only=False,
+        )
+
+    def _close(self, side="Sell", direction="long", price="51000", qty="0.001"):
+        return PlaceLimitIntent.create(
+            symbol="BTCUSDT", side=side, price=Decimal(price), qty=Decimal(qty),
+            grid_level=1, direction=direction, reduce_only=True,
+        )
+
+    def test_c1_suppresses_open_but_allows_reduce_only_close(
+        self, strategy_config, mock_executor, instrument_info
+    ):
+        caps = SafetyCaps(
+            SafetyCapsConfig(max_notional_per_symbol="500"), strat_id="btcusdt_test"
+        )
+        r = self._runner(strategy_config, mock_executor, instrument_info, caps)
+        # Exposure at the C1 cap.
+        r._long_position_value = Decimal("500")
+        r._short_position_value = Decimal("0")
+
+        # OPEN is suppressed before the executor.
+        r._execute_place_intent(self._open(), {"long": [], "short": []})
+        mock_executor.execute_place.assert_not_called()
+
+        # Reduce-only close is C1-exempt and reaches the executor (position big
+        # enough to pass _is_good_to_place).
+        r._long_position.size = Decimal("1.0")
+        r._execute_place_intent(self._close(), {"long": [], "short": []})
+        mock_executor.execute_place.assert_called_once()
+
+    def test_c2_blocks_open_and_reduce_only(
+        self, strategy_config, mock_executor, instrument_info
+    ):
+        caps = SafetyCaps(
+            SafetyCapsConfig(max_open_orders=2), strat_id="btcusdt_test"
+        )
+        r = self._runner(strategy_config, mock_executor, instrument_info, caps)
+        r._long_position.size = Decimal("1.0")
+        # Two working orders == cap.
+        limits = {
+            "long": [
+                {"orderId": "a", "orderLinkId": "a", "price": "49000",
+                 "qty": "0.001", "side": "Buy", "reduceOnly": False},
+                {"orderId": "b", "orderLinkId": "b", "price": "49500",
+                 "qty": "0.001", "side": "Buy", "reduceOnly": False},
+            ],
+            "short": [],
+        }
+        r._execute_place_intent(self._open(), limits)
+        r._execute_place_intent(self._close(), limits)
+        mock_executor.execute_place.assert_not_called()
+
+    def test_c3_trip_cancels_working_orders_then_suppresses_places(
+        self, strategy_config, mock_executor, instrument_info
+    ):
+        caps = SafetyCaps(
+            SafetyCapsConfig(session_loss_limit="25"), strat_id="btcusdt_test"
+        )
+        r = self._runner(strategy_config, mock_executor, instrument_info, caps)
+        # One working order so the trip has something to cancel.
+        intent = self._open(price="49000", qty="0.01")
+        tracked = TrackedOrder(
+            client_order_id=intent.client_order_id, intent=intent, status="placed"
+        )
+        tracked.order_id = "wire_1"
+        r._tracked_orders[intent.client_order_id] = tracked
+
+        # A position update whose session realized PnL breaches the limit trips C3.
+        r.on_position_update(
+            long_position={
+                "size": "0.01", "avgPrice": "50000",
+                "curRealisedPnl": "-30", "leverage": "10",
+            },
+            short_position=None,
+            wallet_balance=10000.0,
+            last_close=50000.0,
+        )
+        assert caps.loss_tripped() is True
+        # Working order cancelled once via the executor (wire id, not link id).
+        mock_executor.execute_cancel.assert_called_once()
+        cancel_arg = mock_executor.execute_cancel.call_args.args[0]
+        assert cancel_arg.order_id == "wire_1"
+        assert cancel_arg.symbol == "BTCUSDT"
+        assert cancel_arg.reason == "safety_cap_loss_breaker"
+
+        # Subsequent places are suppressed by the latch.
+        mock_executor.execute_place.reset_mock()
+        r._execute_place_intent(self._open(), {"long": [], "short": []})
+        mock_executor.execute_place.assert_not_called()
+
+    def test_rate_limit_sentinel_is_dropped_not_enqueued(
+        self, strategy_config, mock_executor, instrument_info
+    ):
+        # Disable the preflight so the OPEN reaches the executor unconditionally.
+        cfg = strategy_config.model_copy(
+            update={"preflight_balance_check_enabled": False}
+        )
+        on_failed = Mock()
+        mock_executor.execute_place = MagicMock(
+            return_value=OrderResult(success=False, error="safety_cap_rate_limit")
+        )
+        r = StrategyRunner(
+            strategy_config=cfg,
+            executor=mock_executor,
+            instrument_info=instrument_info,
+            on_intent_failed=on_failed,
+        )
+        r._wallet_balance = Decimal("10000")
+        r._execute_place_intent(self._open(), {"long": [], "short": []})
+        # C4 sentinel must NOT be enqueued to the retry queue.
+        on_failed.assert_not_called()
+
+    def test_non_cap_failure_still_enqueues(
+        self, strategy_config, mock_executor, instrument_info
+    ):
+        """Discriminator: a non-safety_cap failure (110072) still enqueues."""
+        cfg = strategy_config.model_copy(
+            update={"preflight_balance_check_enabled": False}
+        )
+        on_failed = Mock()
+        mock_executor.execute_place = MagicMock(
+            return_value=OrderResult(
+                success=False, error="place_order failed (ErrCode: 110072) duplicate"
+            )
+        )
+        r = StrategyRunner(
+            strategy_config=cfg,
+            executor=mock_executor,
+            instrument_info=instrument_info,
+            on_intent_failed=on_failed,
+        )
+        r._wallet_balance = Decimal("10000")
+        r._execute_place_intent(self._open(), {"long": [], "short": []})
+        on_failed.assert_called_once()
+
+    def test_c3_trip_cancels_working_orders_in_shadow_mode(
+        self, shadow_config, mock_executor, instrument_info
+    ):
+        """C3 cancel routes through the executor even in shadow mode (the runner
+        dispatches the CancelIntent; the executor honors shadow downstream)."""
+        mock_executor.shadow_mode = True
+        caps = SafetyCaps(
+            SafetyCapsConfig(session_loss_limit="25"), strat_id="btcusdt_shadow"
+        )
+        r = StrategyRunner(
+            strategy_config=shadow_config,
+            executor=mock_executor,
+            instrument_info=instrument_info,
+            safety_caps=caps,
+        )
+        r._wallet_balance = Decimal("10000")
+        intent = self._open(price="49000", qty="0.01")
+        tracked = TrackedOrder(
+            client_order_id=intent.client_order_id, intent=intent, status="placed"
+        )
+        tracked.order_id = "wire_1"
+        r._tracked_orders[intent.client_order_id] = tracked
+
+        r.on_position_update(
+            long_position={
+                "size": "0.01", "avgPrice": "50000",
+                "curRealisedPnl": "-30", "leverage": "10",
+            },
+            short_position=None,
+            wallet_balance=10000.0,
+            last_close=50000.0,
+        )
+        assert caps.loss_tripped() is True
+        mock_executor.execute_cancel.assert_called_once()
+        assert mock_executor.execute_cancel.call_args.args[0].order_id == "wire_1"

--- a/apps/gridbot/tests/test_safety_caps.py
+++ b/apps/gridbot/tests/test_safety_caps.py
@@ -1,0 +1,248 @@
+"""Tests for the SafetyCaps helper (feature 0079 / issue #182).
+
+SafetyCaps owns all production-safety-cap state and decision logic in one
+place. Tested in isolation with an injected fake monotonic clock and an
+explicit ``now_utc`` so trip + recovery semantics are deterministic.
+"""
+
+from datetime import datetime, UTC
+from decimal import Decimal
+
+import pytest
+
+from gridbot.config import SafetyCapsConfig
+from gridbot.safety_caps import SafetyCaps, CapDecision
+
+
+class _FakeClock:
+    """Deterministic monotonic clock; advance via ``.t``."""
+
+    def __init__(self, t: float = 1000.0):
+        self.t = t
+
+    def __call__(self) -> float:
+        return self.t
+
+
+def _caps(clock=None, **caps_kwargs) -> SafetyCaps:
+    return SafetyCaps(
+        SafetyCapsConfig(**caps_kwargs),
+        strat_id="btcusdt_test",
+        clock=clock or _FakeClock(),
+    )
+
+
+_DAY1 = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+_DAY2 = datetime(2026, 1, 2, 0, 30, 0, tzinfo=UTC)
+
+
+class TestCapDecision:
+    def test_is_frozen(self):
+        d = CapDecision(allowed=False, reason="max_notional")
+        with pytest.raises(Exception):
+            d.allowed = True  # frozen dataclass
+
+
+class TestC1MaxNotional:
+    """C1 — max total position notional per symbol; OPEN-only, closes exempt."""
+
+    def test_allows_below_cap(self):
+        caps = _caps(max_notional_per_symbol="500")
+        assert caps.allow_open(
+            total_notional=Decimal("499"), open_order_count=0
+        ).allowed is True
+
+    def test_rejects_at_cap(self):
+        caps = _caps(max_notional_per_symbol="500")
+        d = caps.allow_open(total_notional=Decimal("500"), open_order_count=0)
+        assert d.allowed is False
+        assert d.reason == "max_notional"
+
+    def test_rejects_above_cap(self):
+        caps = _caps(max_notional_per_symbol="500")
+        assert caps.allow_open(
+            total_notional=Decimal("600"), open_order_count=0
+        ).allowed is False
+
+    def test_reduce_only_never_blocked_by_notional(self):
+        """C1 must NOT block reduce-only closes (de-risking always proceeds)."""
+        caps = _caps(max_notional_per_symbol="500")
+        # reduce-only takes no notional arg; far above the C1 cap it still allows.
+        assert caps.allow_reduce_only(open_order_count=0).allowed is True
+
+    def test_none_disables_c1(self):
+        caps = _caps()  # all None
+        assert caps.allow_open(
+            total_notional=Decimal("10_000_000"), open_order_count=0
+        ).allowed is True
+
+
+class TestC2MaxOpenOrders:
+    """C2 — pure count limit; blocks BOTH open and reduce-only."""
+
+    def test_allows_below_cap(self):
+        caps = _caps(max_open_orders=3)
+        assert caps.allow_open(
+            total_notional=Decimal("0"), open_order_count=2
+        ).allowed is True
+
+    def test_rejects_open_at_cap(self):
+        caps = _caps(max_open_orders=3)
+        d = caps.allow_open(total_notional=Decimal("0"), open_order_count=3)
+        assert d.allowed is False
+        assert d.reason == "max_open_orders"
+
+    def test_rejects_reduce_only_at_cap(self):
+        caps = _caps(max_open_orders=3)
+        d = caps.allow_reduce_only(open_order_count=3)
+        assert d.allowed is False
+        assert d.reason == "max_open_orders"
+
+    def test_auto_recovers_when_count_drops(self):
+        caps = _caps(max_open_orders=3)
+        assert caps.allow_open(
+            total_notional=Decimal("0"), open_order_count=3
+        ).allowed is False
+        assert caps.allow_open(
+            total_notional=Decimal("0"), open_order_count=2
+        ).allowed is True
+
+
+class TestC1C2Precedence:
+    def test_notional_checked_before_count(self):
+        """When both would trip, C1 (notional) reports first."""
+        caps = _caps(max_notional_per_symbol="500", max_open_orders=3)
+        d = caps.allow_open(total_notional=Decimal("600"), open_order_count=5)
+        assert d.allowed is False
+        assert d.reason == "max_notional"
+
+
+class TestC3LossBreaker:
+    """C3 — session realized-loss circuit breaker; latch + recovery."""
+
+    def test_does_not_trip_above_limit(self):
+        caps = _caps(session_loss_limit="25")
+        assert caps.check_loss_breaker(
+            session_realized_pnl=Decimal("-10"), now_utc=_DAY1
+        ) is False
+        assert caps.loss_tripped() is False
+
+    def test_trips_once_at_limit(self):
+        caps = _caps(session_loss_limit="25")
+        assert caps.check_loss_breaker(
+            session_realized_pnl=Decimal("-25"), now_utc=_DAY1
+        ) is True
+        assert caps.loss_tripped() is True
+
+    def test_latch_idempotent(self):
+        caps = _caps(session_loss_limit="25")
+        assert caps.check_loss_breaker(
+            session_realized_pnl=Decimal("-25"), now_utc=_DAY1
+        ) is True
+        # Already tripped → subsequent worse losses are not "newly tripped".
+        assert caps.check_loss_breaker(
+            session_realized_pnl=Decimal("-40"), now_utc=_DAY1
+        ) is False
+        assert caps.loss_tripped() is True
+
+    def test_recovery_utc_midnight(self):
+        caps = _caps(session_loss_limit="25",
+                     session_loss_auto_reset_utc_midnight=True)
+        caps.check_loss_breaker(session_realized_pnl=Decimal("-25"), now_utc=_DAY1)
+        assert caps.loss_tripped() is True
+        # Next UTC date with recovered PnL clears the latch.
+        assert caps.check_loss_breaker(
+            session_realized_pnl=Decimal("0"), now_utc=_DAY2
+        ) is False
+        assert caps.loss_tripped() is False
+
+    def test_can_retrip_on_new_day(self):
+        caps = _caps(session_loss_limit="25",
+                     session_loss_auto_reset_utc_midnight=True)
+        caps.check_loss_breaker(session_realized_pnl=Decimal("-25"), now_utc=_DAY1)
+        # New day, still in loss → resets then trips again.
+        assert caps.check_loss_breaker(
+            session_realized_pnl=Decimal("-25"), now_utc=_DAY2
+        ) is True
+        assert caps.loss_tripped() is True
+
+    def test_recovery_manual_only(self):
+        caps = _caps(session_loss_limit="25",
+                     session_loss_auto_reset_utc_midnight=False)
+        caps.check_loss_breaker(session_realized_pnl=Decimal("-25"), now_utc=_DAY1)
+        assert caps.loss_tripped() is True
+        # New UTC date does NOT clear when auto-reset is off.
+        caps.check_loss_breaker(session_realized_pnl=Decimal("0"), now_utc=_DAY2)
+        assert caps.loss_tripped() is True
+
+    def test_none_disables_c3(self):
+        caps = _caps()  # session_loss_limit None
+        assert caps.check_loss_breaker(
+            session_realized_pnl=Decimal("-99999"), now_utc=_DAY1
+        ) is False
+        assert caps.loss_tripped() is False
+
+
+class TestC4RateLimit:
+    """C4 — max accepted real submissions per trailing 60s."""
+
+    def test_not_limited_below_cap(self):
+        clock = _FakeClock(1000.0)
+        caps = _caps(clock=clock, max_orders_per_minute=3)
+        caps.record_accepted_submission(clock())
+        caps.record_accepted_submission(clock())
+        assert caps.rate_limited(clock()) is False
+
+    def test_limited_at_cap_within_window(self):
+        clock = _FakeClock(1000.0)
+        caps = _caps(clock=clock, max_orders_per_minute=3)
+        for _ in range(3):
+            caps.record_accepted_submission(clock())
+        # Same instant — all three inside the 60s window.
+        assert caps.rate_limited(clock()) is True
+        # 30s later still within window.
+        assert caps.rate_limited(1030.0) is True
+
+    def test_recovery_after_window_decay(self):
+        clock = _FakeClock(1000.0)
+        caps = _caps(clock=clock, max_orders_per_minute=3)
+        for _ in range(3):
+            caps.record_accepted_submission(clock())
+        # Advance > 60s past every recorded submission → window evicts.
+        assert caps.rate_limited(1061.0) is False
+
+    def test_none_disables_c4(self):
+        clock = _FakeClock(1000.0)
+        caps = _caps(clock=clock)  # max_orders_per_minute None
+        for _ in range(100):
+            caps.record_accepted_submission(clock())
+        assert caps.rate_limited(clock()) is False
+
+
+class TestMasterKillSwitch:
+    """enabled=False → every cap inert regardless of per-cap values."""
+
+    def test_all_caps_inert_when_disabled(self):
+        clock = _FakeClock(1000.0)
+        caps = SafetyCaps(
+            SafetyCapsConfig(
+                enabled=False,
+                max_notional_per_symbol="1",
+                max_open_orders=1,
+                session_loss_limit="1",
+                max_orders_per_minute=1,
+            ),
+            strat_id="btcusdt_test",
+            clock=clock,
+        )
+        assert caps.allow_open(
+            total_notional=Decimal("10_000"), open_order_count=99
+        ).allowed is True
+        assert caps.allow_reduce_only(open_order_count=99).allowed is True
+        assert caps.check_loss_breaker(
+            session_realized_pnl=Decimal("-10_000"), now_utc=_DAY1
+        ) is False
+        assert caps.loss_tripped() is False
+        for _ in range(10):
+            caps.record_accepted_submission(clock())
+        assert caps.rate_limited(clock()) is False

--- a/docs/features/0079_PLAN.md
+++ b/docs/features/0079_PLAN.md
@@ -1,0 +1,362 @@
+# Feature 0079 — Production safety caps (exposure / order / loss / rate limits)
+
+## Context
+
+GitHub issue #182 (P1). Add **hard safety caps outside strategy logic** —
+exposure limits, max open orders, loss/drawdown circuit breakers, and an
+order-rate limit — that **cannot be overridden by grid-engine decisions**.
+Today risk controls are embedded in strategy/runner logic (`min_liq_ratio`,
+`max_liq_ratio`, low-balance preflight, the `_is_good_to_place` "same-order
+guards"). The #159 low-balance storm showed the need for **last-resort caps**
+independent of strategy code paths. `max_margin` is a declared-but-never-read
+dead YAML field (`RULES.md` line 48) — the bot has **no automatic position
+cap today**; that is exactly the gap this feature closes.
+
+Verbatim design goals from the issue:
+- Caps enforced in **one place** (orchestrator or executor layer), not
+  duplicated per strategy.
+- Configurable via `gridbot.yaml` with **safe defaults**.
+- **Fail-closed**: when a cap trips, stop placing new orders and surface a
+  clear alert/log.
+- **Must not break shadow mode / replay parity** where applicable.
+
+Verbatim non-goals: do NOT replace `min_liq_ratio` / low-balance preflight
+(caps are **additive**); no giant risk-framework rewrite.
+
+### Concrete cap decisions (issue says "refine during implementation")
+
+Four caps, all enforced inside the **live** dispatch path only
+(`StrategyRunner` + `IntentExecutor`), which the backtest/replay engines never
+use (`BacktestRunner` is a separate class; grep confirms `apps/backtest`,
+`apps/replay`, `apps/comparator` import neither `gridbot.runner.StrategyRunner`
+nor `gridbot.executor`). This is what preserves replay/backtest parity by
+construction — gridcore stays pure and the cap code never runs there.
+
+| Cap | Trips when | Fail-closed action | Recovery |
+|-----|-----------|--------------------|----------|
+| **C1 Max notional exposure / symbol** | live total position notional (`long.position_value + short.position_value`, USDT) ≥ cap | suppress new **OPEN** place intents (reduce-only/closes always allowed) | auto: re-allows next tick once exposure drops back under cap |
+| **C2 Max open orders / strat** | tracked `placed` order count ≥ cap | reject the **place** intent (open AND reduce-only — it is a count limit) | auto: re-allows as soon as count < cap |
+| **C3 Session realized-loss breaker** | session realized PnL ≤ −cap (USDT) | **trip latch**: cancel all working orders for the symbol once, then suppress ALL new place intents | latched until **UTC-midnight auto-reset** (default) or process restart; config flag to require manual restart |
+| **C4 Max orders / minute (rate)** | accepted submissions in trailing 60 s ≥ cap | reject the **place** intent at the executor (last line) | auto: trailing-window decay |
+
+Precedence within `_execute_place_intent`: existing qty-resolve and 110017
+breaker run first (unchanged); the new caps are evaluated **after** them and
+**before** `_is_good_to_place`, so a capped intent never reaches the
+strategy's reduce-only/duplicate guard or the exchange. C4 also re-checks at
+the `IntentExecutor` layer so retry-queue re-dispatch is rate-limited too.
+
+---
+
+## Phase 1 — Data layer (config model + safe defaults + example YAML)
+
+### `apps/gridbot/src/gridbot/config.py` — `StrategyConfig`
+
+Add a nested optional Pydantic model `SafetyCapsConfig(BaseModel)` and a field
+`safety_caps: SafetyCapsConfig = Field(default_factory=SafetyCapsConfig)` on
+`StrategyConfig` (so existing YAMLs load unchanged and get defaults).
+
+`SafetyCapsConfig` fields (all `Decimal` for money via the existing
+`tick_size`-style `field_validator(..., mode="before")` Decimal coercion;
+counts are `int`; the master switch is `bool`):
+
+- `enabled: bool = True` — master kill-switch; when False every cap is inert
+  (no state, no checks, no logs) — the byte-for-byte pre-0079 path.
+- `max_notional_per_symbol: Optional[Decimal] = None` — C1 cap in USDT;
+  `None` disables C1. Validator: `> 0` when set.
+- `max_open_orders: Optional[int] = None` — C2 cap; `None` disables. `ge=1`.
+- `session_loss_limit: Optional[Decimal] = None` — C3 cap, **positive USDT
+  magnitude** (loss tripped when realized ≤ −value); `None` disables. `> 0`.
+- `session_loss_auto_reset_utc_midnight: bool = True` — C3 recovery mode;
+  False = stay latched until process restart.
+- `max_orders_per_minute: Optional[int] = None` — C4 cap; `None` disables.
+  `ge=1`.
+
+Defaults are intentionally `None`/disabled per-cap so an existing deployment
+sees **no behavioral change** until the operator opts in; `enabled=True` only
+governs whether the (still all-`None`) machinery is wired. This is the "safe
+defaults" reading that does not silently start rejecting live orders on
+upgrade. (Document this choice in the YAML comment block.)
+
+Reuse the module's existing `from decimal import Decimal` and the
+`field_validator(mode="before")` Decimal-coercion pattern already used for
+`tick_size`. Do NOT add caps to `GridbotConfig` (root) — they are per-strat,
+matching how `min_liq_ratio` etc. live on `StrategyConfig`.
+
+### `apps/gridbot/conf/gridbot.yaml.example`
+
+Under the first strategy (`btcusdt_main`), add a documented `safety_caps:`
+block with each field, its unit, its trip behavior, and its recovery
+semantics, plus a one-line note that omitting a field disables that cap and
+that these caps are last-resort and additive to `min_liq_ratio` /
+low-balance preflight. Leave the second strategy without the block to
+demonstrate the all-defaults (disabled) path.
+
+---
+
+## Phase 2 — Enforcement engine (`SafetyCaps` helper + runner wiring)
+
+### New file: `apps/gridbot/src/gridbot/safety_caps.py`
+
+A single small class `SafetyCaps` owning all cap state and decision logic, so
+the rules live in **one place** (design goal). Pure-ish: takes a
+`SafetyCapsConfig`, a `strat_id` (for logs), a `Notifier`, and an injectable
+`clock: Callable[[], float]` (default `time.monotonic`, mirroring
+`StrategyRunner`'s existing `_clock`). No network/DB imports.
+
+State held on the instance:
+- C3 latch: `_loss_tripped: bool = False`, `_loss_reset_utc_date: date | None
+  = None` (the UTC calendar date the latch is bound to, for midnight
+  auto-reset). **Init contract** (the constructor only gets the monotonic
+  `clock: Callable[[], float]` — there is NO wall-clock/UTC source at
+  `__init__`): `_loss_reset_utc_date` starts `None` and is seeded LAZILY on
+  the first `check_loss_breaker` call from that call's `now_utc.date()` (the
+  caller supplies `now_utc=datetime.now(UTC)`). Monotonic stays the only
+  constructor clock; UTC enters only via the `now_utc` argument. This gives the
+  midnight-reset test a defined start date (it passes a fixed `now_utc`, then a
+  later one on the next UTC date).
+- C4 window: `deque[float]` of accepted-submission monotonic timestamps;
+  evict entries older than 60 s on each check.
+- (C1/C2 are stateless — read live values at decision time.)
+
+Methods (all return a small immutable result so the caller logs/alerts
+consistently; no exceptions for normal trips):
+
+1. `allow_open(self, *, total_notional: Decimal, open_order_count: int) -> CapDecision`
+   — C1 + C2 for OPEN intents. C1: reject if
+   `max_notional_per_symbol is not None and total_notional >= cap`.
+   C2: reject if `max_open_orders is not None and open_order_count >= cap`.
+2. `allow_reduce_only(self, *, open_order_count: int) -> CapDecision`
+   — C2 only (C1 never blocks closes; closes reduce exposure).
+3. `check_loss_breaker(self, *, session_realized_pnl: Decimal, now_utc: datetime) -> bool`
+   — C3 evaluation, called from the position-update path (where realized PnL
+   lands), NOT the place path. Steps:
+   a. Seed-if-unset: if `_loss_reset_utc_date is None`, set it to
+      `now_utc.date()` (lazy init — see State init contract). Then if
+      `session_loss_auto_reset_utc_midnight` and `now_utc.date()` >
+      `_loss_reset_utc_date`: clear `_loss_tripped`, advance the bound date to
+      `now_utc.date()` (log INFO "session-loss breaker auto-reset at UTC
+      midnight").
+   b. If not already tripped and `session_loss_limit is not None` and
+      `session_realized_pnl <= -cap`: set `_loss_tripped=True`, return
+      `newly_tripped=True` (caller cancels working orders + alerts).
+4. `loss_tripped(self) -> bool` — cheap read for the place path.
+5. `record_accepted_submission(self, now: float) -> None` — append to C4
+   window (called only on a real accepted submit, not a shadow log).
+6. `rate_limited(self, now: float) -> bool` — C4: evict-then-count the
+   trailing-60 s window; True when count ≥ cap. (Used by the executor.)
+
+`CapDecision` = frozen dataclass `{allowed: bool, reason: str}` where `reason`
+is one of `"max_notional"`, `"max_open_orders"`, `"loss_breaker"`,
+`"rate_limit"`, `""`. The caller maps `reason` to a throttled WARNING + a
+`notifier.alert(..., error_key=f"safety_cap_{reason}_{strat_id}")`.
+
+### `apps/gridbot/src/gridbot/runner.py` — wiring
+
+`StrategyRunner.__init__`:
+- Gain a new param `safety_caps: Optional[SafetyCaps] = None` and store it as
+  `self._safety_caps`. The runner **accepts** the instance, it does NOT
+  construct one — the orchestrator builds it and passes the SAME object to the
+  runner and the executor so C4's window and C1/C2/C3 share one source of truth
+  (see Phase 3). When `safety_caps is None` (direct/test callers), the runner
+  treats caps as inert (every cap call short-circuits to allow / no-op).
+  `SafetyCaps` itself short-circuits internally when `config.enabled is False`,
+  so when constructed-but-disabled every method allows (kept simple inside
+  `SafetyCaps`, not at the call site).
+- NOTE on clock: the runner already takes `clock: Optional[Callable[[], float]]
+  = None` and stores `self._clock = clock or time.monotonic` (runner.py:199,
+  273). The orchestrator's `_init_strategy` does NOT currently pass `clock` to
+  `StrategyRunner`, so it defaults to `time.monotonic` in production. The
+  `SafetyCaps` clock (for C4's monotonic window) and the executor's C4 clock
+  MUST be that **same callable** — the orchestrator passes one `clock` value to
+  all three (runner, executor, SafetyCaps). For production this is
+  `time.monotonic`; tests inject one fake clock everywhere.
+
+`_execute_place_intent` (insert a **Step 2.5**, after the qty-resolve Step 1
+and the 110017 breaker `is_blocked` Step 2, and **before** Step 3 dirty-refresh
+/ Step 4 `_is_good_to_place`):
+- Compute `total_notional = self._long_position.position_value +
+  self._short_position.position_value` and
+  `open_order_count = sum(len(v) for v in self.get_limit_orders().values())`
+  (or reuse the `limits` arg already passed in — it is the same snapshot).
+  NOTE: `_long_position`/`_short_position` carry `.size` but the live
+  `position_value` is on the `PositionState` built in `on_position_update`;
+  store the latest per-direction `position_value` on the runner there (see
+  below) so the place path reads a cached value without recomputing.
+- If `self._safety_caps.loss_tripped()`: drop the intent (DEBUG, the trip
+  WARNING/alert was already emitted once when it tripped) and return.
+- For an OPEN intent call `allow_open(...)`; for reduce-only call
+  `allow_reduce_only(...)`. On `allowed is False`: log a throttled WARNING
+  with the `reason`, fire the notifier alert (throttled via `error_key`), and
+  return WITHOUT submitting and WITHOUT enqueueing to the retry queue (a
+  capped intent must not retry-storm — mirrors the 110007 "drop, don't
+  enqueue" decision in this same method).
+
+`on_position_update` (where realized PnL and `position_value` already land via
+`_build_position_state`, ~runner.py:1072-1124):
+- Cache `self._long_position_value` / `self._short_position_value` from the
+  built `long_state`/`short_state` (`position_value` field) for the place
+  path's C1 read. (These are already computed there for the low-balance
+  predicate `total_position_value`; reuse it.)
+- Compute `session_realized_pnl` = `long_state.cur_realized_pnl +
+  short_state.cur_realized_pnl` (the per-cycle "Realized" value, NOT the ~80x
+  `cum_realized_pnl` lifetime figure — see runner.py:1086-1090 comment). This
+  is the **session** loss signal. Call
+  `self._safety_caps.check_loss_breaker(session_realized_pnl=...,
+  now_utc=datetime.now(UTC))`. If it returns newly-tripped:
+  - Emit a single ERROR + `notifier.alert(..., error_key=
+    f"safety_cap_loss_breaker_{strat_id}")`.
+  - Cancel all working orders for the symbol: iterate
+    `get_limit_orders()` (returns `{'long':[...], 'short':[...]}`, each order
+    dict carrying `orderId` = the Bybit wire id and `orderLinkId` = the client
+    id) and route each through `_execute_cancel_intent` (preferred — keeps
+    tracked-order state consistent and honors shadow mode via the executor).
+    For each order across BOTH the `'long'` and `'short'` lists build
+    `CancelIntent(symbol=self._config.symbol, order_id=order['orderId'],
+    reason="safety_cap_loss_breaker")` — note `CancelIntent`
+    (`packages/gridcore/src/gridcore/intents.py:138-148`) has THREE required
+    fields `symbol`, `order_id`, `reason`; `order_id` must be the wire
+    `orderId`, NOT the `orderLinkId`. (Do NOT call the REST
+    `cancel_all_orders` directly — it bypasses shadow mode and the
+    tracked-order bookkeeping.)
+  - After this trip, every subsequent `_execute_place_intent` short-circuits
+    via `loss_tripped()`.
+
+Rationale for splitting C3 evaluation into `on_position_update` (not the place
+path): realized PnL only changes on fills, surfaced through position updates;
+checking it per-place would be redundant and would read stale cached PnL.
+
+### Shadow-mode handling
+
+`IntentExecutor.execute_place` already short-circuits in shadow mode and
+returns a synthetic success **without** hitting Bybit. The runner-level caps
+(C1/C2/C3) run **before** the executor, so in shadow mode a tripped cap still
+suppresses the "[SHADOW] Would place ..." log — which is the correct, faithful
+behavior (a shadow run should show the cap firing). C4 (executor-level rate
+limit, below) must **only count real submissions**: in shadow mode the
+executor returns before reaching the rate-limit gate, so shadow placements do
+not consume the C4 window. Document this in the `SafetyCaps` docstring.
+
+---
+
+## Phase 3 — Executor rate-limit (C4, last line of defense)
+
+### `apps/gridbot/src/gridbot/executor.py` — `IntentExecutor`
+
+C4 must catch **all** real submissions, including retry-queue re-dispatch
+(which calls `executor.execute_place` directly, bypassing the runner — see
+`orchestrator._dispatch_intent`). So C4 lives at the executor, the single
+choke point for live submits.
+
+- `IntentExecutor.__init__`: add optional `safety_caps: Optional[SafetyCaps] =
+  None` and `clock: Callable[[], float] = time.monotonic`. The orchestrator
+  passes the **same** `SafetyCaps` instance it constructs for the runner so
+  C4's window and the runner's C1/C2/C3 share one object (single source of
+  truth). When `None` (direct/test callers), C4 is inert.
+- `execute_place`: after the `shadow_mode` early-return (so shadow never
+  consumes the window) and before the real `place_order` try-block:
+  - `if self._safety_caps is not None and self._safety_caps.rate_limited(
+    self._clock()):` return `OrderResult(success=False,
+    order_link_id=unique_link_id, error="safety_cap_rate_limit")` — a
+    **non-retryable** sentinel. Log a throttled WARNING.
+  - On a successful real `place_order`, call
+    `self._safety_caps.record_accepted_submission(self._clock())`.
+- The runner's failure branch in `_execute_place_intent` must treat
+  `error == "safety_cap_rate_limit"` like the 110007 drop: do **not** enqueue
+  to the retry queue (else the rate-limited intent re-storms the queue). Add a
+  cheap `error.startswith("safety_cap")` check alongside the existing
+  `is_insufficient_balance` drop.
+
+### Orchestrator wiring — `apps/gridbot/src/gridbot/orchestrator.py`
+
+In `_init_strategy` (where the per-strategy `IntentExecutor` is constructed
+~line 796, and `StrategyRunner` ~line 831): pick one `clock` callable for this
+strat (production: `time.monotonic`), then build ONE
+`SafetyCaps(strategy_config.safety_caps, strat_id=strat_id,
+notifier=self._notifier, clock=clock)`. Pass the SAME `caps` instance and the
+SAME `clock` to BOTH `IntentExecutor(..., safety_caps=caps, clock=clock)` and
+`StrategyRunner(..., safety_caps=caps)` so the executor's C4 window, the
+runner's C1/C2/C3, and SafetyCaps' own monotonic clock are all one object /
+one callable. The orchestrator is the sole constructor of `SafetyCaps`; the
+runner only accepts it. No orchestrator-loop changes — caps are evaluated
+inline on the existing dispatch path.
+
+---
+
+## Phase 4 — Tests + RULES.md
+
+### Unit tests (trip + recovery per cap)
+
+New `apps/gridbot/tests/test_safety_caps.py` (`SafetyCaps` in isolation, with
+an injected fake clock and a fixed `now_utc`):
+- **C1**: `allow_open` rejects at/above `max_notional_per_symbol`, allows
+  below; `allow_reduce_only` always allows regardless of notional.
+- **C2**: rejects at/above `max_open_orders` for both open and reduce-only;
+  allows below; auto-recovers when count drops (call again with lower count).
+- **C3 trip**: `check_loss_breaker` returns newly-tripped exactly once when
+  realized ≤ −limit; `loss_tripped()` True thereafter; subsequent calls return
+  not-newly-tripped (latch idempotent).
+- **C3 recovery — UTC midnight**: with `auto_reset=True`, advancing `now_utc`
+  to the next UTC date clears the latch (and `loss_tripped()` flips back).
+- **C3 recovery — manual**: with `auto_reset=False`, advancing the date does
+  NOT clear; latch persists.
+- **C4 trip**: `rate_limited` False until `max_orders_per_minute` submissions
+  recorded within 60 s, True at the cap; **recovery**: advance the fake clock
+  > 60 s, window evicts, `rate_limited` False again.
+- **enabled=False**: every method allows / never trips.
+
+Integration-ish tests in the existing runner/executor test modules
+(`apps/gridbot/tests/test_runner.py`, `test_executor.py` — match existing
+mock-executor/mock-rest patterns; hermetic, no network):
+- `_execute_place_intent` suppresses an OPEN when C1 trips but still places a
+  reduce-only close (C1 close-exempt).
+- A tripped C3 latch cancels working orders (assert `_execute_cancel_intent` /
+  mock executor `execute_cancel` called per tracked order) and suppresses
+  subsequent places.
+- A capped/rate-limited place is **not** enqueued to the retry queue (assert
+  `on_intent_failed` NOT called for `safety_cap_*` errors).
+- `IntentExecutor.execute_place` returns the non-retryable sentinel when
+  `rate_limited` and does NOT call `rest_client.place_order`; shadow mode does
+  not consume the C4 window.
+
+### `RULES.md` — cap-precedence entry (acceptance criterion)
+
+Add a subsection under the gridbot risk section (near the 0066 preflight
+block, ~line 342, and update the dead-`max_margin` note at line 48). Document:
+- The four caps, their config fields, units, and disabled-by-`None` defaults.
+- **Precedence**: caps are evaluated in `_execute_place_intent` AFTER qty
+  resolve + the 110017 breaker and BEFORE `_is_good_to_place`; C4 re-checks at
+  `IntentExecutor.execute_place` (covers retry-queue re-dispatch). Caps are
+  **additive and last-resort** — they do NOT replace `min_liq_ratio` /
+  `max_liq_ratio` / low-balance preflight; when a cap and a strategy guard
+  both want to reject, the cap wins (it runs first / fail-closed).
+- C1 and C3 never block reduce-only closes (de-risking must always proceed);
+  C2 is a pure count limit and blocks both.
+- C3 latch + UTC-midnight auto-reset vs manual-restart flag; the
+  cancel-working-orders-once-on-trip behavior.
+- Caps are **live-only** (`StrategyRunner` / `IntentExecutor`); backtest/replay
+  use `BacktestRunner` and never see them → **replay/backtest parity is
+  preserved by construction**. Note `max_margin` remains dead/unused (caps do
+  not revive it; C1 supersedes its original intent with a real notional cap).
+- Shadow mode: runner-level caps DO fire (and suppress the `[SHADOW]` log);
+  the executor-level C4 window is NOT consumed by shadow placements.
+
+---
+
+## Files touched
+
+- `apps/gridbot/src/gridbot/config.py` — add `SafetyCapsConfig`, `safety_caps`
+  field on `StrategyConfig`.
+- `apps/gridbot/src/gridbot/safety_caps.py` — **new** `SafetyCaps` +
+  `CapDecision`.
+- `apps/gridbot/src/gridbot/runner.py` — construct/accept `SafetyCaps`; Step
+  2.5 in `_execute_place_intent`; C3 eval + cancel-working-orders in
+  `on_position_update`; cache per-direction `position_value`; drop (not
+  enqueue) `safety_cap_*` failures.
+- `apps/gridbot/src/gridbot/executor.py` — `safety_caps`/`clock` params; C4
+  gate + `record_accepted_submission` in `execute_place`.
+- `apps/gridbot/src/gridbot/orchestrator.py` — build one `SafetyCaps` per
+  strat in `_init_strategy`, pass to both runner and executor.
+- `apps/gridbot/conf/gridbot.yaml.example` — documented `safety_caps:` block.
+- `apps/gridbot/tests/test_safety_caps.py` — **new** unit tests.
+- `apps/gridbot/tests/test_runner.py`, `test_executor.py` — integration tests.
+- `RULES.md` — cap-precedence subsection; update the dead-`max_margin` note.


### PR DESCRIPTION
## Summary

Closes #182. Hard, **last-resort safety caps enforced outside strategy logic** in one place (`gridbot/safety_caps.py`), additive to `min_liq_ratio` / low-balance preflight (not a replacement). The orchestrator builds ONE `SafetyCaps` per strat and shares the same instance + monotonic clock with the runner (C1/C2/C3) and the executor (C4).

| Cap | Trips when | Fail-closed action | Recovery |
|-----|-----------|--------------------|----------|
| **C1** `max_notional_per_symbol` (USDT) | long+short position notional ≥ cap | suppress new OPENs (closes exempt) | auto, next tick under cap |
| **C2** `max_open_orders` | tracked placed count ≥ cap | reject place (open AND reduce-only) | auto, count < cap |
| **C3** `session_loss_limit` (USDT) | session realized PnL ≤ −cap | **full circuit breaker**: cancel working orders once, then suppress ALL places | UTC-midnight auto-reset or manual restart |
| **C4** `max_orders_per_minute` | accepted submits in trailing 60s ≥ cap | reject at executor (non-retryable, dropped not enqueued) | trailing-window decay |

## Design

- Caps run as **Step 2.5** in `_execute_place_intent` (after the 110017 breaker, before `_is_good_to_place`), so a capped intent never reaches the strategy guard or the exchange.
- **Safe defaults**: every cap defaults `None` (disabled) with an `enabled` master switch → existing YAML is byte-for-byte unchanged on upgrade.
- **Replay/backtest parity by construction**: caps are live-only (`StrategyRunner`/`IntentExecutor`); backtest/replay use `BacktestRunner` and never see them.
- **Shadow mode**: runner caps fire (suppress the `[SHADOW]` log); C4 sits after the executor's shadow early-return, so shadow never consumes its window.
- C3 evaluates off summed `cur_realized_pnl` (the Bybit UI "Realized", not the ~80x lifetime `cumRealisedPnl`); cancel uses the wire `orderId`.

## Acceptance criteria (issue #182)

- [x] Caps documented in `gridbot.yaml.example`
- [x] Enforcement point (`IntentExecutor` + `StrategyRunner`, wired by `Orchestrator`)
- [x] Unit tests for trip + recovery per cap
- [x] `RULES.md` cap-precedence entry (+ dead-`max_margin` note)

## Testing

755 gridbot tests pass (new `test_safety_caps.py` unit trip+recovery + runner/executor integration). Ruff clean on changed files. Plan-debate (2 iters) + adversarial diff review (0 confirmed defects) + review-fix-loop (0 criticals; 3 minor warnings fixed).

## ⚠️ Design note for reviewers

**C3 is a full halt**: on trip it cancels all working orders (including resting reduce-only closes) and suppresses every new place until UTC-midnight reset or restart — so the position rides with no automatic closing orders until reset. This is the plan-specified circuit-breaker behavior; flagged for explicit confirmation given liquidation risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)