### PR TITLE
feat(0080): namespace orderLinkId client_order_id by strat_id (#183)

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -568,6 +568,7 @@ short with mult=2.0; the grown open exceeded free margin → 110007 every attemp
   - `build_grid()` validates no duplicate prices
   - When adding params: if it affects uniqueness → add to `_IDENTITY_PARAMS`; if not → don't
   - See `docs/features/ORDER_IDENTITY_DESIGN.md`
+  - **Feature 0080 (issue #183) — strat_id namespacing**: `create(strat_id=...)` salts the hash by `strat_id` so two strategies on the same `(account, symbol)` get DISTINCT prefixes. `strat_id` is a SALT, NOT in `_IDENTITY_PARAMS`; the `None` default reproduces the pre-0080 hash byte-for-byte (back-compat for callers + historical rows — only the 3 production call sites thread it). Wire form `{hash16}-{millis}` and `extract_client_order_prefix` unchanged; Bybit `orderLinkId` ≤ 36 chars (`gridbot.order_link_id._BYBIT_ORDER_LINK_ID_MAX`; `make_order_link_id` raises if over). **Replay must salt with the live `strat_id`** or the comparator's `client_order_id` join breaks — the recording's strat_id is on NO DB row, so supply it via config; `apps/replay/src/replay/engine.py` resolves precedence `ReplayStrategyConfig.strat_id` → `seed.strat_id` → synthetic `replay_{symbol}`. For blank-start comparison set `strategy.strat_id` to the recording's live id. `validate_no_shared_symbol` still rejects co-location (positionIdx/cancel-on-mismatch sharing remains the blocker, not the prefix).
 
 ### PnL Calculations (`pnl.py`)
 

--- a/apps/gridbot/src/gridbot/config.py
+++ b/apps/gridbot/src/gridbot/config.py
@@ -437,24 +437,26 @@ class GridbotConfig(BaseModel):
     def validate_no_shared_symbol(self):
         """Reject multiple strategies on the same (account, symbol) pair.
 
-        Even though orderLinkId IS sent to Bybit (deterministic prefix +
-        millis suffix post-2026-05-08), it cannot disambiguate two
-        strategies on the same (account, symbol). The deterministic prefix
-        is a SHA of (symbol, side, price, direction) — both strategies
-        would compute the SAME prefix for the same logical order, and the
-        wire-form suffix only differs across re-placements, not across
-        strategies. So at runtime there is no way to tell which strategy
-        placed a given open order, and two strategies on the same pair
-        would cancel each other's orders on every tick via the engine's
-        cancel-on-mismatch pass (gridcore/engine.py:_place_grid_orders).
+        Feature 0080 (issue #183) namespaced the deterministic client_order_id
+        prefix by strat_id (the SHA input is now
+        (strat_id, symbol, side, price, direction)), so the orderLinkId-prefix
+        collision that originally motivated this guard is RESOLVED — two
+        strategies now compute DISTINCT prefixes for the same logical order.
+
+        This validator is NOT relaxed, however: Bybit hedge-mode positionIdx is
+        shared per (account, symbol), and the engine's cancel-on-mismatch pass
+        (gridcore/engine.py:_place_grid_orders) would still make two co-located
+        strategies fight over the same position buckets every tick. That
+        position-bucket sharing is an independent blocker 0080 does not address,
+        so co-location stays rejected until a future positionIdx-sharing fix
+        lands. If you need a second strategy on the same symbol today, use a
+        different account.
 
         bbu2 makes this configuration unrepresentable by construction: its
         amounts[].strat field is a scalar pointing at a single pair_timeframes
         entry, and each pair_timeframe has a single symbol, so the bad config
         cannot be written. Our schema is more flexible, so we reconstruct
-        the same invariant as a pydantic validator. There is no escape hatch —
-        if you need a second strategy on the same symbol, use a different
-        account.
+        the same invariant as a pydantic validator.
         """
         seen: dict[tuple[str, str], str] = {}
         for strategy in self.strategies:
@@ -463,14 +465,14 @@ class GridbotConfig(BaseModel):
                 raise ValueError(
                     f"Strategies '{seen[key]}' and '{strategy.strat_id}' share "
                     f"account='{strategy.account}' symbol='{strategy.symbol}'. "
-                    f"This is not allowed: the deterministic client_order_id "
-                    f"prefix is a SHA of (symbol, side, price, direction), so "
-                    f"two strategies on the same (account, symbol) compute the "
-                    f"same orderLinkId prefix and cannot be distinguished at "
-                    f"runtime — they would cancel each other's orders every "
-                    f"tick. bbu2 makes this unrepresentable by construction; "
-                    f"here we reject it at config load. Use a different "
-                    f"account for the second strategy."
+                    f"The orderLinkId-prefix collision is resolved by feature "
+                    f"0080 (client_order_id is now namespaced by strat_id), but "
+                    f"co-location is still not allowed: Bybit hedge-mode "
+                    f"positionIdx and the engine's cancel-on-mismatch pass are "
+                    f"shared per (account, symbol), so the two strategies would "
+                    f"fight over the same position buckets every tick. Use a "
+                    f"different account for the second strategy until a "
+                    f"positionIdx-sharing fix lands."
                 )
             seen[key] = strategy.strat_id
         return self

--- a/apps/gridbot/src/gridbot/order_link_id.py
+++ b/apps/gridbot/src/gridbot/order_link_id.py
@@ -3,6 +3,13 @@
 from datetime import UTC, datetime
 from typing import Callable
 
+# Bybit V5 caps orderLinkId at 36 characters. The wire form is
+# f"{client_order_id}-{millis}" = 16 + 1 + 13 = 30 chars; feature 0080 (issue
+# #183) namespaces the hash INPUT only (not the wire form), so length is
+# unchanged. Guard against future format drift — an over-length id is a
+# guaranteed exchange reject, so fail fast at construction.
+_BYBIT_ORDER_LINK_ID_MAX = 36
+
 
 def _now_utc_ms() -> int:
     """Current UTC epoch time in milliseconds."""
@@ -15,4 +22,10 @@ def make_order_link_id(
     now_ms: Callable[[], int] = _now_utc_ms,
 ) -> str:
     """Build the wire-form orderLinkId for one placement lifecycle."""
-    return f"{client_order_id}-{now_ms()}"
+    wire_id = f"{client_order_id}-{now_ms()}"
+    if len(wire_id) > _BYBIT_ORDER_LINK_ID_MAX:
+        raise ValueError(
+            f"orderLinkId {wire_id!r} exceeds Bybit's "
+            f"{_BYBIT_ORDER_LINK_ID_MAX}-char limit ({len(wire_id)} chars)"
+        )
+    return wire_id

--- a/apps/gridbot/src/gridbot/runner.py
+++ b/apps/gridbot/src/gridbot/runner.py
@@ -1834,6 +1834,7 @@ class StrategyRunner:
             symbol=self._config.symbol, side=close_side, price=chase_price,
             qty=qty, grid_level=-1, direction=direction,
             reduce_only=True, post_only=True,
+            strat_id=self._config.strat_id,
         )
 
     def _enter_chase(self, direction: str, price: float) -> None:
@@ -2277,6 +2278,7 @@ class StrategyRunner:
                 grid_level=0,
                 direction=direction,
                 reduce_only=reduce_only,
+                strat_id=self._config.strat_id,
             )
 
             # Prefer orderLinkId prefix as key for backward compatibility:

--- a/apps/gridbot/tests/test_config.py
+++ b/apps/gridbot/tests/test_config.py
@@ -323,13 +323,22 @@ class TestGridbotConfig:
         assert len(config.get_strategies_for_account("multi")) == 2
 
     def test_shared_symbol_rejected(self):
-        """Two strategies on same (account, symbol) are rejected by default."""
+        """Two strategies on same (account, symbol) are still rejected.
+
+        Feature 0080 resolved the orderLinkId-prefix-collision reason, but the
+        guard stays because positionIdx/cancel-on-mismatch sharing remains a
+        blocker — the message must reflect that updated rationale.
+        """
         account = AccountConfig(name="acc", api_key="k", api_secret="s")
         strategies = [
             StrategyConfig(strat_id="s1", account="acc", symbol="BTCUSDT", tick_size=Decimal("0.1")),
             StrategyConfig(strat_id="s2", account="acc", symbol="BTCUSDT", tick_size=Decimal("0.1")),
         ]
         with pytest.raises(ValueError, match="share account.*symbol"):
+            GridbotConfig(accounts=[account], strategies=strategies)
+        # New rationale wording (feature 0080): prefix collision resolved, but
+        # positionIdx sharing remains the blocker.
+        with pytest.raises(ValueError, match="positionIdx"):
             GridbotConfig(accounts=[account], strategies=strategies)
 
     def test_same_symbol_different_accounts_ok(self):

--- a/apps/gridbot/tests/test_executor.py
+++ b/apps/gridbot/tests/test_executor.py
@@ -283,6 +283,31 @@ class TestExecutorPlaceOrder:
         assert order_link_id.partition("-")[2].isdigit()
         assert result.order_link_id == order_link_id
 
+    def test_strat_id_namespaced_intent_emitted_on_shadow_wire(self, shadow_executor):
+        """Feature 0080: the strat-namespaced client_order_id reaches the wire id.
+
+        create(strat_id=...) salts the deterministic id upstream; both the real
+        and shadow paths emit it verbatim as the orderLinkId prefix with no
+        executor change (acceptance #2). Shadow path asserted here.
+        """
+        plain = PlaceLimitIntent.create(
+            symbol="BTCUSDT", side="Sell", price=Decimal("50000.0"),
+            qty=Decimal("0.001"), grid_level=10, direction="short",
+        )
+        owned = PlaceLimitIntent.create(
+            symbol="BTCUSDT", side="Sell", price=Decimal("50000.0"),
+            qty=Decimal("0.001"), grid_level=10, direction="short",
+            strat_id="ownerA",
+        )
+        assert owned.client_order_id != plain.client_order_id  # salting changed the id
+
+        result = shadow_executor.execute_place(owned)
+
+        assert result.success is True
+        assert result.order_id == f"shadow_{owned.client_order_id}"
+        assert result.order_link_id.startswith(f"{owned.client_order_id}-")
+        assert result.order_link_id.partition("-")[2].isdigit()
+
     def test_post_only_intent_passes_postonly_tif(self, executor, mock_rest_client):
         """Feature 0066: post_only=True → place_order time_in_force='PostOnly'."""
         intent = PlaceLimitIntent.create(

--- a/apps/gridbot/tests/test_order_link_id.py
+++ b/apps/gridbot/tests/test_order_link_id.py
@@ -1,7 +1,9 @@
 """Tests for gridbot.order_link_id helpers."""
 
+import pytest
+
 from gridcore.intents import extract_client_order_prefix
-from gridbot.order_link_id import make_order_link_id
+from gridbot.order_link_id import _BYBIT_ORDER_LINK_ID_MAX, make_order_link_id
 
 
 def test_make_order_link_id_uses_prefix_and_millis():
@@ -15,3 +17,16 @@ def test_make_order_link_id_round_trips_to_prefix():
     link_id = make_order_link_id(prefix, now_ms=lambda: 1715170800000)
 
     assert extract_client_order_prefix(link_id) == prefix
+
+
+def test_make_order_link_id_within_bybit_limit():
+    """Feature 0080: a 16-hex prefix + millis is 30 chars, under the 36 limit."""
+    link_id = make_order_link_id("0123456789abcdef", now_ms=lambda: 1715170800000)
+
+    assert len(link_id) <= _BYBIT_ORDER_LINK_ID_MAX
+
+
+def test_make_order_link_id_rejects_overlength():
+    """Feature 0080: an over-length wire id raises (guaranteed exchange reject)."""
+    with pytest.raises(ValueError, match="36-char limit"):
+        make_order_link_id("x" * 30, now_ms=lambda: 1715170800000)

--- a/apps/replay/src/replay/config.py
+++ b/apps/replay/src/replay/config.py
@@ -29,6 +29,17 @@ class ReplayStrategyConfig(BaseModel):
 
     tick_size: Decimal = Field(..., description="Price tick size for rounding")
 
+    # Feature 0080 (issue #183): the deterministic client_order_id is namespaced
+    # by strat_id. To match orders recorded by the LIVE strategy, replay must salt
+    # with the SAME strat_id. Set this to the recording's live strat_id when
+    # comparing against recorded executions (blank-start OR seeded). When None,
+    # falls back to seed.strat_id (if seeding), then a synthetic id.
+    strat_id: Optional[str] = Field(
+        default=None,
+        description="Live strategy id used to namespace client_order_id hashes "
+        "for comparator matching (feature 0080). None -> seed.strat_id -> synthetic.",
+    )
+
     # Grid parameters
     grid_count: int = Field(default=50, ge=4, description="Total grid levels")
     grid_step: float = Field(default=0.2, gt=0, description="Grid step percentage")

--- a/apps/replay/src/replay/engine.py
+++ b/apps/replay/src/replay/engine.py
@@ -334,7 +334,20 @@ class ReplayEngine:
         )
 
         # 2. Build backtest components
-        strat_id = f"replay_{config.symbol.lower()}"
+        # Feature 0080 (issue #183): client_order_id is now namespaced by strat_id.
+        # Recorded LIVE orders were salted with the live strat_id, so replay MUST
+        # salt with the SAME id to keep the comparator's (client_order_id,
+        # occurrence) join and the seed round-trip matching. The recording's
+        # strat_id is NOT stored on the Order/PrivateExecution/Strategy DB rows, so
+        # it must be supplied via config. Precedence: explicit strategy.strat_id
+        # (set when comparing against a recording, incl. blank-start) -> seed.strat_id
+        # (when seeding) -> synthetic id (no recorded orders to match).
+        if config.strategy.strat_id:
+            strat_id = config.strategy.strat_id
+        elif config.seed.enabled and config.seed.strat_id:
+            strat_id = config.seed.strat_id
+        else:
+            strat_id = f"replay_{config.symbol.lower()}"
         strategy_config = BacktestStrategyConfig(
             strat_id=strat_id,
             symbol=config.symbol,

--- a/docs/features/0080_PLAN.md
+++ b/docs/features/0080_PLAN.md
@@ -1,0 +1,360 @@
+# 0080 — Order ownership prefix (strat_id) in orderLinkId
+
+GitHub issue **#183 (P1)**. Embed strategy/bot identity into the deterministic
+`client_order_id` so orders are attributable to a specific `strat_id` at the
+exchange and in forensics, **removing the orderLinkId-prefix collision that was
+ONE of the reasons two strategies cannot share an `(account, symbol)`**.
+
+**Scope note (see F-1-3 / item 5):** 0080 resolves the *prefix-collision*
+blocker only. It does NOT fully permit two strats on the same
+`(account, symbol)`, because Bybit hedge-mode `positionIdx` and the engine's
+cancel-on-mismatch pass are still shared per `(account, symbol)` — an
+independent blocker out of scope for 0080. The validator therefore stays a
+guard; only its rationale/message is updated. Fully permitting co-located
+strats requires a separate positionIdx-sharing fix (future feature).
+
+## Context
+
+Current deterministic identity (`docs/features/ORDER_IDENTITY_DESIGN.md`,
+`packages/gridcore/src/gridcore/intents.py`):
+
+```
+client_order_id = sha256("{symbol}_{side}_{price}_{direction}")[:16]   # 16 hex chars
+wire orderLinkId = f"{client_order_id}-{now_utc_ms}"                    # 16 + 1 + 13 = 30 chars
+```
+
+The wire suffix (`-{millis}`, HOTFIX 2026-05-08) defeats Bybit's
+`orderLinkId` caching (ErrCode 110072). `extract_client_order_prefix`
+(`intents.py:16`) recovers the deterministic id by partitioning on the FIRST
+`-`.
+
+**Problem.** The hash has no `strat_id`. Two strategies on the same
+`(account, symbol)` compute the SAME prefix for the same logical order, so they
+cannot be told apart at the exchange or in the DB, and would cancel each
+other's orders every tick. `validate_no_shared_symbol`
+(`apps/gridbot/src/gridbot/config.py:436`) rejects that config outright.
+
+**Hard constraint — Bybit V5 `orderLinkId` ≤ 36 chars** (see Sources). Current
+wire form is 30 chars, leaving ~6 chars of slack. There is NO length constant
+in the codebase today; this plan adds one.
+
+**Beware #110 (prefix reuse).** Identity is `(symbol, side, price, direction)`
+ONLY — `grid_level`, `qty`, `reduce_only`, `post_only` are deliberately
+excluded so orders survive `center_grid()` rebalancing. Adding `strat_id` to
+the hash input must NOT change that exclusion set; it only namespaces the hash
+per strategy. The deterministic-survival property must be preserved.
+
+## Options evaluated
+
+**Option 1 — prefix strat slug into the hash input:**
+`sha256("{strat_id}_{symbol}_{side}_{price}_{direction}")[:16]`.
+- Wire form unchanged: `{hash16}-{millis}` = 30 chars. Fits 36 trivially.
+- `extract_client_order_prefix` partition-on-`-` logic UNCHANGED (no new
+  delimiter). Snapshot loader / runner matching unchanged in shape.
+- Two strats on same `(account, symbol)` now get DISTINCT prefixes → validator
+  can allow it; orders are disambiguated by the (already different) prefix.
+- Cost: `strat_id` is NOT recoverable from the wire id (it's hashed in, not
+  carried). Forensic attribution is by hash-prefix equality, not by reading the
+  slug. A raw Bybit-UI glance still can't read the slug.
+- **Cost (verified) — the hash input must use the SAME `strat_id` on the live
+  and replay sides or the replay/comparator pipeline silently breaks.** The
+  comparator joins live vs backtest STRICTLY on `(client_order_id, occurrence)`
+  (`apps/comparator/src/comparator/matcher.py:48-66`). The backtest's
+  `client_order_id` is whatever the replay-side `GridEngine` computed via
+  `PlaceLimitIntent.create` (live and backtest share the ONE engine call site,
+  `engine.py:430`). Today replay constructs `strat_id = f"replay_{symbol}"`
+  (`apps/replay/src/replay/engine.py:337`) and threads it into
+  `BacktestStrategyConfig` → `GridEngine.strat_id`. If `create` salts the hash
+  by that synthetic id while the live recorder's `order_link_id` was salted by
+  the real live id (e.g. `ltcusdt_test`), the two prefixes diverge,
+  `matched_keys` becomes empty, and pos-parity/drift metrics are destroyed. The
+  seed round-trip breaks the same way: `snapshot_loader.load_active_orders`
+  (`:828`) recovers the LIVE wire prefix (`client_id = order_link_id or
+  order_id`), but replay's recreated intents would carry the `replay_<symbol>`
+  prefix. **Mitigation (designed below): replay derives the hash `strat_id`
+  from the original live `strat_id`, which it already has —
+  `ReplayConfig.seed.strat_id` (`config.py:145`, required when seeding). Note
+  the DB tables the matcher/seed read (`Order`, `PrivateExecution`,
+  `shared/db/src/grid_db/models.py:271,309`) do NOT carry a `strat_id` column —
+  only grid/wallet snapshots do — so the original live id must come from
+  `seed.strat_id`, not from a per-order column.**
+
+**Option 2 — namespaced wire form `{strat_slug}-{hash16}-{millis}`:**
+- Carries the slug ON THE WIRE (human-readable in Bybit UI). Best raw
+  forensics.
+- BREAKS the 36-char budget: 16 + 13 + 2 delimiters = 31 already; any slug ≥ 6
+  chars (e.g. `ltcusdt_test` = 12) overflows. Would force truncating the hash
+  or the millis, weakening either identity or the 110072 fix.
+- BREAKS `extract_client_order_prefix` (partition-on-first-`-` would return the
+  slug, not the hash) → touches runner matching, reconcile, snapshot loader,
+  and every test asserting the 16-hex prefix. High blast radius.
+
+**Option 3 — configurable `order_link_prefix` per strategy in YAML:**
+- Same wire-form/length and delimiter problems as Option 2 if carried on the
+  wire; if only hashed in, it's Option 1 with an extra config knob.
+- Adds an operator-managed uniqueness burden (two strats could be mis-typed to
+  the same prefix, re-introducing the #110 collision the validator exists to
+  prevent). `strat_id` is already a required, validated-unique-ish field.
+
+### RECOMMENDATION: **Option 1.**
+
+It satisfies every acceptance criterion within the 36-char limit with the
+smallest blast radius: the wire form, `extract_client_order_prefix`, runner
+matching, reconcile, and snapshot loader all stay structurally identical — only
+the hash INPUT gains a `strat_id` component. Forensic attribution is preserved
+because the per-strat prefix is now distinct (no collision) and the DB's grid/
+wallet snapshots carry `strat_id` so a window's orders are run-attributable.
+(The matcher's `Order`/`PrivateExecution` rows do NOT store `strat_id`; replay
+recovers the live id from `seed.strat_id` — see Files item 6 — so the hash
+matches across the boundary.) It removes the orderLinkId-prefix collision that
+`validate_no_shared_symbol` was guarding against — but that validator is NOT
+relaxed by 0080 (positionIdx/cancel-on-mismatch sharing remains; see item 5 /
+scope note); only its message is updated. It cannot re-introduce #110: identity
+params are unchanged, and two strats deterministically diverge instead of
+colliding.
+
+## Files / functions to change
+
+1. **`packages/gridcore/src/gridcore/intents.py`**
+   - `PlaceLimitIntent.create(...)`: add an **OPTIONAL** keyword
+     `strat_id: str | None = None` parameter (NOT required). Mirror the
+     feature-0066 `post_only` default pattern so the change is surgical and
+     back-compatible.
+     - **Default-preserves the OLD hash.** Today
+       `id_string = "{symbol}_{side}_{price}_{direction}"` (built dynamically
+       from `_IDENTITY_PARAMS`, `intents.py:118-123`). When `strat_id is None`,
+       produce that EXACT string (byte-for-byte) so:
+       (a) the ~100 existing test call sites that omit `strat_id` keep passing
+           unchanged (verified counts below);
+       (b) historical recorded rows placed by the old hash still match via the
+           unchanged `extract_client_order_prefix` (no orphaning — see Migration
+           Note).
+     - When `strat_id` is not None, prepend it:
+       `id_string = "{strat_id}_{symbol}_{side}_{price}_{direction}"`. Implement
+       WITHOUT mutating `_IDENTITY_PARAMS` (it's consumed via `locals()` and must
+       NOT gain `strat_id`); compute the salted string explicitly, e.g.
+       `id_string = f"{strat_id}_{id_string}" if strat_id is not None else id_string`.
+     - `strat_id` is a namespacing salt applied in `create`, NOT a
+       `compare=`/dedup field on the dataclass (two strats never share a
+       runner/engine instance, so intra-engine dedup is unaffected). Document the
+       new hash recipe + the `None`-default back-compat rule in the docstring.
+   - Call-site blast radius (verified by grep `PlaceLimitIntent.create`):
+     **3 production call sites** (`engine.py:430`, `runner.py:1833`,
+     `runner.py:2272`) get `strat_id=` threaded (items 2–3). **~100 test call
+     sites** (notably `apps/gridbot/tests/test_runner.py` ×64,
+     `test_executor.py`, `test_orchestrator.py`, `test_retry_queue.py`,
+     `test_snapshot_loader.py`, `packages/gridcore/tests/*`,
+     `apps/backtest/tests/*`) need NO change because the `None` default
+     reproduces the old id. Only ADD new tests for the salted path (Step-by-step
+     7), don't churn the existing ones.
+   - `extract_client_order_prefix`: UNCHANGED.
+
+2. **`packages/gridcore/src/gridcore/engine.py:430`**
+   - The `PlaceLimitIntent.create(...)` call site: pass `strat_id=self.strat_id`
+     (already available as `self.strat_id`, set at `engine.py:73`).
+
+3. **`apps/gridbot/src/gridbot/runner.py`**
+   - `runner.py:1833` and `runner.py:2272` (`PlaceLimitIntent.create` call
+     sites): pass `strat_id=self._config.strat_id`.
+   - `_build_chase_order` (`runner.py:1833` region) likewise.
+   - `make_order_link_id` usage (`runner.py:2028`, `executor.py`): UNCHANGED —
+     wire form stays `{prefix}-{millis}`.
+
+4. **`apps/gridbot/src/gridbot/executor.py`**
+   - `execute_place` real path AND `[SHADOW]` path already build the wire id via
+     `intent.order_link_id or make_order_link_id(intent.client_order_id)`. Since
+     `client_order_id` now carries the strat-namespaced hash, BOTH paths emit
+     the new format with NO code change. Acceptance (2) is satisfied by the
+     upstream `create` change; verify with a shadow-path test.
+
+5. **`apps/gridbot/src/gridbot/config.py`**
+   - **DECISION (resolved): do NOT relax the rejection.** Keep
+     `validate_no_shared_symbol` (`:436`) rejecting two strategies on the same
+     `(account, symbol)`. Rationale: 0080 fixes only the orderLinkId-prefix
+     collision; Bybit hedge-mode `positionIdx` is shared per `(account, symbol)`
+     and the engine's cancel-on-mismatch pass would still make two co-located
+     strats fight over the same position buckets — an independent blocker 0080
+     does not address. Silently allowing co-location would be a regression, not
+     a fix.
+   - **Change only the docstring + error message** to state that the
+     orderLinkId-prefix reason is RESOLVED by 0080, but position-bucket sharing
+     (`positionIdx` + cancel-on-mismatch) remains the blocker, and reference the
+     future positionIdx-sharing fix as the path to lifting this guard.
+   - Update the existing `validate_no_shared_symbol` test to assert the new
+     message wording (still rejects). No behavioral relaxation, so no new
+     "permits two strats" test is added here.
+
+6. **`apps/replay/src/replay/engine.py:337` (REQUIRED for pipeline parity)**
+   - Today: `strat_id = f"replay_{config.symbol.lower()}"`, threaded into
+     `BacktestStrategyConfig` → the shared `GridEngine`. With `strat_id` now in
+     the hash input, this synthetic id would make every replay-side
+     `client_order_id` diverge from the live recorder's prefix, emptying the
+     comparator's `matched_keys` and breaking the seed round-trip (see Options /
+     Cost (verified)).
+   - Fix: derive the engine `strat_id` from the ORIGINAL live id when known —
+     `strat_id = config.seed.strat_id if config.seed.enabled and
+     config.seed.strat_id else f"replay_{config.symbol.lower()}"`. `seed.strat_id`
+     is already required when seeding (`config.py:145,225`) and is the same id
+     the live engine used to salt the recorded `order_link_id`s, so replay-side
+     hashes now reproduce the live prefix byte-for-byte. When seed is disabled
+     (blank-start replay) there are no live orders to match, so the synthetic
+     fallback is harmless.
+   - This keeps `apps/comparator/src/comparator/matcher.py` UNCHANGED (it stays
+     strat-agnostic, joining on the now-aligned `client_order_id`) and
+     `comparator/loader.py`'s `extract_client_order_prefix` join UNCHANGED.
+
+7. **`apps/replay/src/replay/snapshot_loader.py`**
+   - `load_active_orders` (`:828`) keys via `extract_client_order_prefix(...) or
+     order_id`. Logic UNCHANGED (still a 16-hex prefix). Add a test that a
+     recorded order whose wire id was produced by the new strat-namespaced hash
+     (salted by the LIVE `strat_id`) round-trips through the loader and matches a
+     replay-side `PlaceLimitIntent.create(strat_id=<live strat_id>)` of the same
+     logical order — i.e. a **cross-strat-boundary match test** proving the
+     live-prefix == replay-prefix when replay uses `seed.strat_id`. Add a second
+     assertion that using a DIFFERENT (synthetic) replay strat_id would NOT
+     match, documenting why item 6 is required.
+
+8. **`docs/features/ORDER_IDENTITY_DESIGN.md`** (acceptance 1)
+   - Update "Identity Parameters" / "Client Order ID Generation" to document
+     the `strat_id`-namespaced hash input, the 36-char wire budget, why
+     `strat_id` is a hash salt and not an `_IDENTITY_PARAMS` entry, and the
+     collision-rules table (below). Add 0080 to Implementation History.
+   - Document the replay/comparator boundary rule: replay MUST salt the hash
+     with the live `strat_id` (`seed.strat_id`) to match recorded orders.
+
+9. **`RULES.md`** (per CLAUDE.md workflow step 6)
+   - Short note: orderLinkId prefix now namespaced by `strat_id`; wire form and
+     `extract_client_order_prefix` unchanged; 36-char Bybit limit; reference
+     #110.
+
+## Step-by-step
+
+1. Add `_BYBIT_ORDER_LINK_ID_MAX = 36` constant (in `order_link_id.py`) and an
+   assertion/guard in `make_order_link_id` that the produced wire id length
+   ≤ 36 (fail-fast; today it's always 30, but the guard documents the budget
+   and catches future format drift). Decide: hard `raise` vs. `logger.error`.
+   RECOMMENDED hard `raise` in `make_order_link_id` — an over-length id is a
+   guaranteed 10001 reject at the exchange, better to fail at construction.
+2. Add OPTIONAL `strat_id: str | None = None` param to
+   `PlaceLimitIntent.create`. When None, keep `id_string` byte-for-byte as today
+   (`"{symbol}_{side}_{price}_{direction}"`). When set, prepend it
+   (`"{strat_id}_{symbol}_{side}_{price}_{direction}"`). Keep `[:16]` slice and
+   `_IDENTITY_PARAMS` unchanged. Update docstring (incl. the None-default
+   back-compat rule).
+3. Thread `strat_id` through the **3 production** `create` call sites only
+   (engine.py:430 → `self.strat_id`; runner.py:1833 chase + runner.py:2272
+   reconcile-rebuild → `self._config.strat_id`). Leave the ~100 test call sites
+   alone — the None default keeps them green. Grep `PlaceLimitIntent.create`
+   repo-wide to confirm no other PRODUCTION site was missed.
+4. Confirm executor real + shadow paths need no edit (they consume
+   `client_order_id`); add/extend a shadow-path test asserting the emitted
+   `link_id` prefix equals the strat-namespaced hash.
+5. `validate_no_shared_symbol`: keep the rejection (per item 5 decision);
+   update ONLY its docstring + error message to say the orderLinkId-prefix
+   reason is resolved by 0080 but positionIdx/cancel-on-mismatch sharing remains
+   the blocker. Update the existing test to assert the new message.
+6. Update `ORDER_IDENTITY_DESIGN.md` and `RULES.md`.
+7. Tests (acceptance 5):
+   - **Uniqueness across strats:** two `create(...)` calls with identical
+     `(symbol, side, price, direction)` but different `strat_id` → DIFFERENT
+     `client_order_id` (and thus different wire prefix). Include the "different
+     accounts" framing from the issue.
+   - **Stability within a strat:** same `(strat_id, symbol, side, price,
+     direction)` → SAME id across calls (deterministic-identity preserved;
+     guards #110).
+   - **grid_level still excluded:** same id regardless of `grid_level` (port the
+     existing `test_grid_level_does_not_affect_id`).
+   - **Wire length:** `make_order_link_id` output ≤ 36 for representative
+     strat_ids; over-length input raises.
+   - **None-default == old hash (back-compat):** `create(...)` WITHOUT
+     `strat_id` produces the SAME `client_order_id` as the pre-0080 code for the
+     same `(symbol, side, price, direction)` (pin a known-good hex literal).
+     Guards the ~100 test call sites and historical-row matching.
+   - **Cross-strat-boundary match (replay/comparator):** a recorded wire id
+     produced by the LIVE engine (salted with live `strat_id`) → after
+     `extract_client_order_prefix` → EQUALS replay-side
+     `create(strat_id=<live strat_id>)` prefix (proves item 6's `seed.strat_id`
+     plumbing keeps `matcher.match` matching). And the NEGATIVE: replay-side
+     `create(strat_id=f"replay_{symbol}")` does NOT match — documents why the
+     engine.py:337 change is required.
+   - **Snapshot-loader round-trip:** recorded wire id → `extract_client_order_prefix`
+     → matches replay `create(strat_id=...)` prefix.
+   - **Collision rules documented** (see table).
+
+## Collision rules (to document)
+
+| Same? | symbol | side | price | direction | strat_id | → client_order_id |
+|---|---|---|---|---|---|---|
+| identity   | =  | =  | =  | =  | =  | SAME (deterministic survival) |
+| cross-strat| =  | =  | =  | =  | ≠  | DIFFERENT (the #183 fix)      |
+| diff order | any one differs            | any | DIFFERENT                     |
+
+Theoretical 16-hex (64-bit) prefix birthday collision across distinct inputs is
+~negligible at our order volume and is the SAME risk profile as today; not
+introduced by this change.
+
+## MIGRATION NOTE (in-flight orders on deploy)
+
+On deploy, every still-resting order placed by the OLD hash carries the OLD
+(non-namespaced) `orderLinkId` prefix. On first tick after restart the engine
+recomputes `client_order_id` with the NEW strat-namespaced hash, so the new
+prefix will NOT match any resting order's old prefix.
+
+**Intent-vs-key divergence for adopted legacy orders (explicit).** The
+open-order adoption path (`runner.py:2272-2338`) keeps the TWO ids divergent
+for an adopted legacy order:
+- the tracking KEY is `client_id = extract_client_order_prefix(order_link_id)
+  or order_id` (runner.py:2289-2290, 2333) — i.e. the OLD wire prefix recovered
+  from the exchange's `orderLinkId`;
+- the recreated `intent.client_order_id` would be the NEW strat-salted hash IF
+  `strat_id=` were threaded at that call. (Note: as written, the `:2272`
+  `create(...)` call in this plan threads `strat_id=self._config.strat_id` per
+  Files item 3, so post-0080 the adopted order has
+  `TrackedOrder.client_order_id` = OLD prefix ≠ `tracked.intent.client_order_id`
+  = NEW salted hash. Pre-0080 they coincided.)
+
+This divergence is **benign**, because **the reconcile/cancel-on-mismatch pass
+matches by PRICE and cancels by EXCHANGE orderId — never by the hash prefix or
+by `intent.client_order_id`** (verified):
+- `get_limit_orders` (runner.py:634-654) emits one dict per tracked order with
+  `orderId = tracked.order_id` (real exchange id) and `price =
+  tracked.intent.price`. The adopted legacy order is present here regardless of
+  its key↔intent id mismatch.
+- The engine's `_place_grid_orders` (engine.py:359,370) builds
+  `limit_prices = {float(limit['price']): limit}` and looks up the grid level by
+  PRICE (`limit_prices.get(grid_item['price'])`). A resting limit at a valid
+  grid price with the matching side → NO place, NO cancel. The freshly-computed
+  intent's salted id is never compared against the adopted order's key.
+- `_cancel_limit` (engine.py:268-274) emits `CancelIntent(order_id=
+  limit['orderId'])` — the exchange orderId, not the prefix. So even a
+  side-mismatch / outside-grid cancel targets the order by its exchange id, not
+  by hash identity.
+
+**Confirmed (a): the engine reconciles by tracked PRICE + exchange orderId, not
+by `intent.client_order_id`.** Therefore the prefix renaming is INVISIBLE to
+reconciliation:
+- An adopted legacy order resting at a valid grid price with the correct side
+  is matched by price and LEFT ALONE — **no double-place, no cancel/replace**.
+- The only churn is the ordinary one: orders that are side-mismatched or outside
+  the rebuilt grid get a single cancel (by exchange orderId) and the grid level
+  is re-placed under the new salted id — the SAME bounded, one-time
+  reconciliation as any config-change rebuild, NOT an unbounded loop and NOT a
+  prefix-driven mass cancel. No verify-no-double-place step is required beyond
+  the standard quiet-window orphan check below.
+
+- RECOMMENDED rollout: deploy during a quiet window; expect AT MOST the ordinary
+  price/side reconciliation sweep (no extra sweep from the prefix change);
+  verify post-restart that no order is orphaned (cross-check against
+  `project_orphan_wait_limit_after_walk` known gap). No DB migration is required.
+  Historical recorded rows keep their old (non-namespaced) prefixes; they are
+  matched via the unchanged `extract_client_order_prefix`, and a replay over a
+  PRE-0080 window must seed/recreate intents with `strat_id=None` (the
+  None-default reproduces the old hash) — only POST-0080 windows whose live
+  engine salted by `strat_id` use `seed.strat_id`. NOTE: the
+  `Order`/`PrivateExecution` rows do NOT carry a `strat_id` column (only
+  grid/wallet snapshots do), so window-level attribution and the correct salt
+  for replay both come from the run/seed context, not a per-order column.
+
+## Sources
+- Bybit V5 Place Order — `orderLinkId` ≤ 36 chars:
+  https://bybit-exchange.github.io/docs/v5/order/create-order

--- a/docs/features/ORDER_IDENTITY_DESIGN.md
+++ b/docs/features/ORDER_IDENTITY_DESIGN.md
@@ -28,6 +28,53 @@ def create_client_order_id(symbol, side, price, direction):
 
 **Result:** Same `(symbol, side, price, direction)` → Same `client_order_id`
 
+### Strategy Namespacing (Feature 0080, issue #183, 2026-06-17)
+
+`PlaceLimitIntent.create` accepts an OPTIONAL `strat_id` that namespaces the
+hash so two strategies on the same `(account, symbol)` no longer collide on the
+deterministic prefix:
+
+```python
+# strat_id is a SALT, not an _IDENTITY_PARAMS entry:
+if strat_id is not None:
+    id_string = f"{strat_id}_{symbol}_{side}_{price}_{direction}"
+else:
+    id_string = f"{symbol}_{side}_{price}_{direction}"   # pre-0080, byte-for-byte
+client_order_id = sha256(id_string.encode()).hexdigest()[:16]
+```
+
+- **`strat_id` is a salt, NOT in `_IDENTITY_PARAMS`.** Adding it to the param set
+  would also feed dedup/equality; instead it is applied only inside `create`, so
+  the survive-rebalance property and intra-engine dedup are unchanged.
+- **`None` default = old hash byte-for-byte.** Existing callers and historical
+  recorded rows keep the same id; only the 3 production call sites
+  (`engine.py`, `runner.py` ×2) thread `strat_id`.
+- **Wire form unchanged:** `{hash16}-{millis}` = 30 chars. Bybit caps
+  `orderLinkId` at **36 chars** (`gridbot.order_link_id._BYBIT_ORDER_LINK_ID_MAX`);
+  `make_order_link_id` raises if exceeded. `extract_client_order_prefix`
+  (partition-on-first-`-`) is unchanged.
+
+#### Collision rules
+
+| symbol | side | price | direction | strat_id | → client_order_id |
+|--------|------|-------|-----------|----------|-------------------|
+| = | = | = | = | = | SAME (deterministic survival) |
+| = | = | = | = | ≠ | DIFFERENT (the #183 fix) |
+| any one differs | | | | any | DIFFERENT |
+
+#### Replay / comparator boundary rule
+
+The comparator joins live vs backtest trades on `client_order_id`. Recorded LIVE
+orders were salted with the live `strat_id`, so **replay MUST salt with the same
+live id**. The recording's `strat_id` is NOT stored on any `Order` /
+`PrivateExecution` / `Strategy` DB row, so it is supplied via config:
+`apps/replay/src/replay/engine.py` resolves the engine `strat_id` with precedence
+`ReplayStrategyConfig.strat_id` → `seed.strat_id` (when seeding) → synthetic
+`replay_{symbol}` (no recorded orders to match). When comparing a **blank-start**
+replay against recorded executions, set `strategy.strat_id` to the recording's
+live id — otherwise the synthetic fallback diverges and the match rate collapses.
+A replay over a PRE-0080 window uses `strat_id=None`, reproducing the old hash.
+
 ## Key Design Decision: grid_level Excluded from Hash
 
 ### Rationale
@@ -160,6 +207,18 @@ _IDENTITY_PARAMS = ['symbol', 'side', 'price', 'direction']
 - Orders survive grid rebalancing
 - Safety checks prevent price collisions
 - Full tracking capability retained
+
+### Strategy Namespacing (Feature 0080, 2026-06-17)
+
+```python
+# strat_id salted into the hash INPUT (not _IDENTITY_PARAMS); None = pre-0080 hash
+id_string = f"{strat_id}_{symbol}_{side}_{price}_{direction}"  # when strat_id set
+```
+
+- Two strats on the same `(account, symbol)` get DISTINCT prefixes (issue #183).
+- Resolves the orderLinkId-prefix reason in `validate_no_shared_symbol`; that
+  guard STAYS (positionIdx / cancel-on-mismatch sharing remains a blocker).
+- Wire form + `extract_client_order_prefix` unchanged; 36-char Bybit limit guarded.
 
 ## Testing
 

--- a/packages/gridcore/src/gridcore/engine.py
+++ b/packages/gridcore/src/gridcore/engine.py
@@ -435,4 +435,5 @@ class GridEngine:
             grid_level=grid_level,
             direction=direction,
             reduce_only=self._REDUCE_ONLY_MAP[(direction, grid['side'])],
+            strat_id=self.strat_id,
         )

--- a/packages/gridcore/src/gridcore/intents.py
+++ b/packages/gridcore/src/gridcore/intents.py
@@ -84,6 +84,7 @@ class PlaceLimitIntent:
         direction: str,
         reduce_only: bool = False,
         post_only: bool = False,
+        strat_id: str | None = None,
     ) -> "PlaceLimitIntent":
         """
         Factory method to create a PlaceLimitIntent with deterministic client_order_id.
@@ -111,6 +112,13 @@ class PlaceLimitIntent:
             reduce_only: Whether this is a reduce-only order (NOT part of identity hash)
             post_only: Whether this is a post-only (maker-only) order for
                 chase-close (NOT part of identity hash; feature 0066)
+            strat_id: Optional strategy identifier (feature 0080, issue #183).
+                When provided, namespaces the deterministic hash so two strategies
+                on the same (account, symbol) produce DISTINCT client_order_ids.
+                It is a salt applied here, NOT an _IDENTITY_PARAMS entry (dedup and
+                the survive-rebalance property are unaffected). When None (default),
+                the hash is byte-for-byte identical to the pre-0080 id, preserving
+                existing callers and historical-row matching.
 
         Returns:
             PlaceLimitIntent with deterministic client_order_id
@@ -120,6 +128,12 @@ class PlaceLimitIntent:
         params = locals()
         id_components = [str(params[param]) for param in cls._IDENTITY_PARAMS]
         id_string = "_".join(id_components)
+        # Feature 0080 (issue #183): namespace the identity hash by strat_id so two
+        # strategies on the same (account, symbol) produce DISTINCT client_order_ids.
+        # strat_id is a salt, NOT an _IDENTITY_PARAMS entry. When None, id_string is
+        # byte-for-byte the pre-0080 value (back-compat for callers + historical rows).
+        if strat_id is not None:
+            id_string = f"{strat_id}_{id_string}"
         deterministic_id = hashlib.sha256(id_string.encode()).hexdigest()[:16]
 
         return cls(

--- a/packages/gridcore/tests/test_intents.py
+++ b/packages/gridcore/tests/test_intents.py
@@ -87,3 +87,88 @@ def test_post_only_default_false_preserves_identity():
     assert maker == plain                                   # compare=False
     assert hash(maker) == hash(plain)
     assert "post_only" not in PlaceLimitIntent._IDENTITY_PARAMS
+
+
+# --- Feature 0080 (issue #183): strat_id namespacing of the identity hash ---
+
+# Pinned reference: pre-0080 hash of ("BTCUSDT","Buy","50000.0","long") with no
+# strat_id. Guards the None-default back-compat (existing callers + historical
+# recorded rows) against any formula drift.
+_OLD_HASH_NO_STRAT = "bedf732012a9abc1"
+
+
+def test_strat_id_none_default_preserves_old_hash():
+    """strat_id=None reproduces the pre-0080 client_order_id byte-for-byte."""
+    plain = _make_place_intent()  # no strat_id passed
+    explicit_none = PlaceLimitIntent.create(
+        symbol="BTCUSDT", side="Buy", price=Decimal("50000.0"), qty=Decimal("0.001"),
+        grid_level=10, direction="long", strat_id=None,
+    )
+    assert plain.client_order_id == _OLD_HASH_NO_STRAT
+    assert explicit_none.client_order_id == _OLD_HASH_NO_STRAT
+
+
+def test_strat_id_namespaces_client_order_id():
+    """Same (symbol,side,price,direction), different strat_id -> DIFFERENT id.
+
+    The #183 fix: two strategies (e.g. on different accounts) no longer collide
+    on the deterministic prefix.
+    """
+    base = dict(symbol="BTCUSDT", side="Buy", price=Decimal("50000.0"),
+                qty=Decimal("0.001"), grid_level=10, direction="long")
+    s1 = PlaceLimitIntent.create(**base, strat_id="s1")
+    s2 = PlaceLimitIntent.create(**base, strat_id="s2")
+    none = PlaceLimitIntent.create(**base)
+    assert s1.client_order_id != s2.client_order_id
+    assert s1.client_order_id != none.client_order_id
+    assert s2.client_order_id != none.client_order_id
+
+
+def test_strat_id_stable_within_a_strat():
+    """Same (strat_id,symbol,side,price,direction) -> SAME id (deterministic; #110)."""
+    base = dict(symbol="BTCUSDT", side="Buy", price=Decimal("50000.0"),
+                qty=Decimal("0.001"), grid_level=10, direction="long")
+    first = PlaceLimitIntent.create(**base, strat_id="s1")
+    second = PlaceLimitIntent.create(**base, strat_id="s1")
+    assert first.client_order_id == second.client_order_id
+
+
+def test_strat_id_does_not_change_identity_param_set():
+    """strat_id is a salt, not an identity field; grid_level still excluded."""
+    base = dict(symbol="BTCUSDT", side="Buy", price=Decimal("50000.0"),
+                qty=Decimal("0.001"), direction="long")
+    lvl1 = PlaceLimitIntent.create(**base, grid_level=1, strat_id="s1")
+    lvl2 = PlaceLimitIntent.create(**base, grid_level=99, strat_id="s1")
+    assert lvl1.client_order_id == lvl2.client_order_id  # grid_level still excluded
+    assert "strat_id" not in PlaceLimitIntent._IDENTITY_PARAMS
+
+
+def test_strat_id_cross_strat_boundary_match():
+    """Replay must salt with the LIVE strat_id to match recorded orders.
+
+    A live order recorded under strat_id='ltcusdt_test' yields a wire prefix
+    that a replay-side create(strat_id='ltcusdt_test') reproduces, but a
+    synthetic replay strat_id ('replay_ltcusdt') does NOT. This is why
+    replay/engine.py derives strat_id from seed.strat_id (feature 0080) — the
+    comparator joins live vs backtest on client_order_id.
+    """
+    live = PlaceLimitIntent.create(
+        symbol="LTCUSDT", side="Buy", price=Decimal("44.0"), qty=Decimal("0.2"),
+        grid_level=5, direction="long", strat_id="ltcusdt_test",
+    )
+    recorded_wire = f"{live.client_order_id}-1715170800000"
+
+    replay_live = PlaceLimitIntent.create(
+        symbol="LTCUSDT", side="Buy", price=Decimal("44.0"), qty=Decimal("0.2"),
+        grid_level=5, direction="long", strat_id="ltcusdt_test",
+    )
+    replay_synthetic = PlaceLimitIntent.create(
+        symbol="LTCUSDT", side="Buy", price=Decimal("44.0"), qty=Decimal("0.2"),
+        grid_level=5, direction="long", strat_id="replay_ltcusdt",
+    )
+
+    # Positive: replay salted with the live strat_id matches the recorded prefix
+    # (snapshot-loader round-trip via extract_client_order_prefix).
+    assert extract_client_order_prefix(recorded_wire) == replay_live.client_order_id
+    # Negative: a synthetic replay strat_id would NOT match (documents engine.py:337).
+    assert extract_client_order_prefix(recorded_wire) != replay_synthetic.client_order_id

--- a/tests/integration/test_replay_e2e.py
+++ b/tests/integration/test_replay_e2e.py
@@ -207,6 +207,9 @@ def _make_replay_config() -> ReplayConfig:
         run_id=RUN_ID,
         symbol=SYMBOL,
         strategy=ReplayStrategyConfig(
+            # Feature 0080: salt the replay hash with the recording's live strat_id
+            # so client_order_ids match the recorded executions (comparator join).
+            strat_id=STRAT_ID,
             tick_size=Decimal(TICK_SIZE),
             grid_count=GRID_COUNT,
             grid_step=GRID_STEP,


### PR DESCRIPTION
## Summary
Embeds strategy identity in the deterministic `client_order_id` so two strategies on the same `(account, symbol)` get DISTINCT prefixes and orders are attributable to a `strat_id`. Designed via adversarial plan-debate (3 iterations; the critical finding caught a replay/comparator break before coding).

- **`intents.PlaceLimitIntent.create`** — optional `strat_id` salt; `None` reproduces the pre-0080 hash **byte-for-byte** (back-compat for ~108 call sites + historical rows). `strat_id` is a salt, NOT an `_IDENTITY_PARAMS` entry.
- **`order_link_id`** — guard the **36-char** Bybit `orderLinkId` limit (fail fast at construction).
- **3 production `create` sites** thread `strat_id` (engine.py, runner.py ×2).
- **`config.validate_no_shared_symbol`** — kept (positionIdx/cancel-on-mismatch sharing still blocks co-location); docstring + message updated to note the prefix reason is resolved by 0080.
- **Replay** — engine `strat_id` precedence `ReplayStrategyConfig.strat_id → seed.strat_id → synthetic` (new optional config field) so the comparator's `client_order_id` join keeps matching recorded executions on **blank-start AND seeded** replays. (The recording's strat_id is on no DB row, so it's supplied via config.)
- **Docs** — `ORDER_IDENTITY_DESIGN.md` (collision-rules table, replay boundary rule, history) + `RULES.md`.

## Verification
- `uv run ruff check .` → All checks passed (lint green repo-wide).
- `make test` green: gridcore 406, gridbot 720, replay 141, backtest 507, integration 53.
- New tests: uniqueness across strats, stability within a strat, `None`==old-hash (pinned literal), grid_level still excluded, cross-strat-boundary match (±), wire-length guard, shadow-path emit, validator wording, **replay E2E blank-start match restored to 100%** (the gap surfaced during impl and fixed via the explicit config field).

## Notes
- `tests/integration` includes the previously-broken E2E match-rate tests, now passing.
- gridbot `test_position_check_uses_ws_data` has flaked in CI (order-dependent, unrelated to this change) — may reappear.

Plan: `docs/features/0080_PLAN.md`.

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)