### PR TITLE
feat(0082): operational observability — health states + metrics (#185)

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -899,6 +899,27 @@ Valid: `New`, `PartiallyFilled`, `Filled`, `Cancelled`, `Rejected`, `Untriggered
 - Data flow: `WebSocket → Orchestrator → StrategyRunner → GridEngine.on_event() → Intents → Executor → Bybit REST`
 - Shadow mode: `shadow_mode=True` → intents logged, not executed; returns `shadow_{client_order_id}`
 
+### Health status file — check health without tailing logs (Feature 0082, issue #185)
+
+The bot writes a machine-readable JSON snapshot to `status_file_path` (default
+`/tmp/gridbot_status.json`, config key; `status_file_enabled=false` disables) every
+~10s health sweep and once as `state="starting"` at the end of `start()`. Read it
+with `jq . /tmp/gridbot_status.json` (or `jq .state ...`) for an instant read — no
+log parsing.
+
+- **`state`** — worst-wins overall: `circuit_open` (C3 loss breaker latched) >
+  `auth_cooldown` > `degraded` (dirty-REST failures / C4 rate-limit) >
+  `healthy`; `starting` pre-loop. Per-strat breakdown under `strategies[]` (with a
+  `shadow` flag — live↔shadow snapshot shape is identical).
+- **`metrics`** — process-lifetime monotonic counters (reset on restart): orders
+  placed / placed_shadow / rejected-by-reason, `rest_errors_by_code`, cancels /
+  cancels_failed, `ws_reconnects`. **`gauges`** — point-in-time: runners, auth-cooldown active/cycles,
+  loss-breaker latched, preflight skips, uptime.
+- Last-value-wins snapshot, NOT a time series — no history/rotation (non-goal: no
+  Prometheus). Additive, no trading impact. **Complements** the `gridbot-health` skill
+  (which owns the durable cross-restart `health_state.json` ledger); this file does
+  not touch `health_state.json`.
+
 ### Key Patterns
 
 - **Order tracking**: `TrackedOrder` dataclass, deterministic 16-char hex `client_order_id`

--- a/RULES.md
+++ b/RULES.md
@@ -905,7 +905,23 @@ The bot writes a machine-readable JSON snapshot to `status_file_path` (default
 `/tmp/gridbot_status.json`, config key; `status_file_enabled=false` disables) every
 ~10s health sweep and once as `state="starting"` at the end of `start()`. Read it
 with `jq . /tmp/gridbot_status.json` (or `jq .state ...`) for an instant read — no
-log parsing.
+log parsing. Example:
+
+```json
+{
+  "state": "healthy",
+  "generated_at": "2026-06-18T12:00:00+00:00",
+  "strategies": [
+    {"strat_id": "ltcusdt_test", "symbol": "LTCUSDT", "state": "healthy",
+     "shadow": false, "net_position_size": 1.2, "preflight_skips": 0}
+  ],
+  "metrics": {"orders_placed": 42, "orders_placed_shadow": 0, "orders_rejected": {},
+              "cancels": 7, "cancels_failed": 0, "rest_errors_by_code": {},
+              "ws_reconnects": {}},
+  "gauges": {"runners": 1, "auth_cooldown_active": 0, "loss_breaker_latched": 0,
+             "preflight_skips": 0, "auth_cooldown_cycles": 0, "uptime_seconds": 3600.0}
+}
+```
 
 - **`state`** — worst-wins overall: `circuit_open` (C3 loss breaker latched) >
   `auth_cooldown` > `degraded` (dirty-REST failures / C4 rate-limit) >

--- a/apps/gridbot/src/gridbot/auth_cooldown_manager.py
+++ b/apps/gridbot/src/gridbot/auth_cooldown_manager.py
@@ -59,6 +59,10 @@ class AuthCooldownManager:
         self._auth_cooldown_until: dict[str, datetime] = {}  # strat_id -> expiry
         self._auth_cooldown_cycles: dict[str, int] = {}  # strat_id -> cumulative cycle count
 
+    def cooldown_cycles(self, strat_id: str) -> int:
+        """Cumulative auth-cooldown cycles for ``strat_id`` (feature 0082 metric)."""
+        return self._auth_cooldown_cycles.get(strat_id, 0)
+
     def enter(self, strat_id: str) -> None:
         """Called by executor when auth cooldown activates.
 

--- a/apps/gridbot/src/gridbot/config.py
+++ b/apps/gridbot/src/gridbot/config.py
@@ -452,9 +452,10 @@ class GridbotConfig(BaseModel):
         description=(
             "Path for the periodic JSON health/metrics snapshot (feature 0082). "
             "Note: /tmp may not persist across reboots on some systems — choose a "
-            "durable path for production monitoring. The file holds strat_id / "
-            "symbol / net position size (no secrets); set appropriate file "
-            "permissions if writing outside /tmp."
+            "durable path for production monitoring (e.g. /var/lib/gridbot/status.json "
+            "— ensure the dir exists and is writable by the bot). The file holds "
+            "strat_id / symbol / net position size (no secrets); set appropriate "
+            "file permissions if writing outside /tmp."
         ),
     )
     status_file_enabled: bool = Field(

--- a/apps/gridbot/src/gridbot/config.py
+++ b/apps/gridbot/src/gridbot/config.py
@@ -446,6 +446,16 @@ class GridbotConfig(BaseModel):
         description="Database connection URL",
     )
 
+    # Feature 0082 (issue #185) — operational observability status file.
+    status_file_path: str = Field(
+        default="/tmp/gridbot_status.json",
+        description="Path for the periodic JSON health/metrics snapshot (feature 0082).",
+    )
+    status_file_enabled: bool = Field(
+        default=True,
+        description="When False the health status file is not written (no-op writer).",
+    )
+
     # Timing
     position_check_interval: float = Field(
         default=63.0,

--- a/apps/gridbot/src/gridbot/config.py
+++ b/apps/gridbot/src/gridbot/config.py
@@ -452,7 +452,9 @@ class GridbotConfig(BaseModel):
         description=(
             "Path for the periodic JSON health/metrics snapshot (feature 0082). "
             "Note: /tmp may not persist across reboots on some systems — choose a "
-            "durable path for production monitoring."
+            "durable path for production monitoring. The file holds strat_id / "
+            "symbol / net position size (no secrets); set appropriate file "
+            "permissions if writing outside /tmp."
         ),
     )
     status_file_enabled: bool = Field(

--- a/apps/gridbot/src/gridbot/config.py
+++ b/apps/gridbot/src/gridbot/config.py
@@ -449,7 +449,11 @@ class GridbotConfig(BaseModel):
     # Feature 0082 (issue #185) — operational observability status file.
     status_file_path: str = Field(
         default="/tmp/gridbot_status.json",
-        description="Path for the periodic JSON health/metrics snapshot (feature 0082).",
+        description=(
+            "Path for the periodic JSON health/metrics snapshot (feature 0082). "
+            "Note: /tmp may not persist across reboots on some systems — choose a "
+            "durable path for production monitoring."
+        ),
     )
     status_file_enabled: bool = Field(
         default=True,

--- a/apps/gridbot/src/gridbot/executor.py
+++ b/apps/gridbot/src/gridbot/executor.py
@@ -207,6 +207,9 @@ class IntentExecutor:
             clock: Monotonic clock for the C4 window; MUST be the same callable
                 the shared SafetyCaps uses (the orchestrator passes one value to
                 both). Defaults to ``time.monotonic``; injectable for tests.
+            health_metrics: Optional shared ``HealthMetrics`` collector (feature
+                0082 / issue #185). The orchestrator passes its shared instance;
+                None for direct/test callers (then metric recording is inert).
         """
         self._client = rest_client
         self._shadow_mode = shadow_mode

--- a/apps/gridbot/src/gridbot/executor.py
+++ b/apps/gridbot/src/gridbot/executor.py
@@ -37,9 +37,9 @@ AUTH_ERROR_CODES = {10003, 10004, 10005, 33004}
 # rest_errors_by_code key used by HealthMetrics. The C4 "rate_limit" sentinel is
 # NOT a REST error (no submit reached Bybit) and never reaches _handle_error.
 _CATEGORY_TO_REST_CODE = {
-    "insufficient_balance": "110007",
-    "truncate": "110017",
-    "duplicate_link": "110072",
+    "insufficient_balance": str(INSUFFICIENT_BALANCE),
+    "truncate": str(ORDER_QTY_TRUNCATED_TO_ZERO),
+    "duplicate_link": str(ORDER_LINK_ID_DUPLICATE),
     "auth": "auth",
     "network": "network",
 }

--- a/apps/gridbot/src/gridbot/executor.py
+++ b/apps/gridbot/src/gridbot/executor.py
@@ -36,7 +36,7 @@ AUTH_ERROR_CODES = {10003, 10004, 10005, 33004}
 # Feature 0082 (issue #185) — map a coarse error category to the
 # rest_errors_by_code key used by HealthMetrics. The C4 "rate_limit" sentinel is
 # NOT a REST error (no submit reached Bybit) and never reaches _handle_error.
-_REST_CODE_BY_CATEGORY = {
+_CATEGORY_TO_REST_CODE = {
     "insufficient_balance": "110007",
     "truncate": "110017",
     "duplicate_link": "110072",
@@ -280,7 +280,7 @@ class IntentExecutor:
         """Track auth errors and enter cooldown if threshold reached."""
         if self._health_metrics is not None:
             self._health_metrics.record_rest_error(
-                _REST_CODE_BY_CATEGORY.get(self._classify_error(error), "other")
+                _CATEGORY_TO_REST_CODE.get(self._classify_error(error), "other")
             )
         if self._is_auth_error(error):
             self._auth_failure_count += 1

--- a/apps/gridbot/src/gridbot/executor.py
+++ b/apps/gridbot/src/gridbot/executor.py
@@ -21,6 +21,7 @@ from gridcore.intents import PlaceLimitIntent, CancelIntent
 from gridcore.position import DirectionType
 from gridbot.order_link_id import make_order_link_id
 from gridbot.safety_caps import SafetyCaps
+from gridbot.health import HealthMetrics
 
 
 logger = logging.getLogger(__name__)
@@ -31,6 +32,17 @@ _RATE_LIMIT_WARN_THROTTLE_SEC = 60.0
 
 # Bybit error codes that indicate auth/permission problems (not retryable)
 AUTH_ERROR_CODES = {10003, 10004, 10005, 33004}
+
+# Feature 0082 (issue #185) — map a coarse error category to the
+# rest_errors_by_code key used by HealthMetrics. The C4 "rate_limit" sentinel is
+# NOT a REST error (no submit reached Bybit) and never reaches _handle_error.
+_REST_CODE_BY_CATEGORY = {
+    "insufficient_balance": "110007",
+    "truncate": "110017",
+    "duplicate_link": "110072",
+    "auth": "auth",
+    "network": "network",
+}
 
 # Matches both our _check_response format [NNNNN] and pybit's native format (ErrCode: NNNNN)
 _ERR_CODE_RE = re.compile(r"(?:\[(\d+)\]|\(ErrCode:\s*(\d+)\))")
@@ -176,6 +188,7 @@ class IntentExecutor:
         on_cooldown_entered: Optional[Callable[[], None]] = None,
         safety_caps: Optional[SafetyCaps] = None,
         clock: Callable[[], float] = time.monotonic,
+        health_metrics: Optional[HealthMetrics] = None,
     ):
         """Initialize executor.
 
@@ -209,6 +222,10 @@ class IntentExecutor:
         self._safety_caps = safety_caps
         self._clock = clock
         self._rate_limit_warn_last: float = 0.0
+        # Feature 0082 (issue #185) — optional process-lifetime metrics collector.
+        # The orchestrator passes its shared HealthMetrics; None for direct/test
+        # callers (then every record_* below is skipped — no behavior change).
+        self._health_metrics = health_metrics
 
     @property
     def shadow_mode(self) -> bool:
@@ -240,8 +257,28 @@ class IntentExecutor:
             return code in AUTH_ERROR_CODES
         return False
 
+    def _classify_error(self, error: str) -> str:
+        """Coarse error category for feature 0082 metrics (reject reason / REST code)."""
+        if error == "safety_cap_rate_limit":
+            return "rate_limit"
+        if self._is_auth_error(error):
+            return "auth"
+        if is_insufficient_balance(error):
+            return "insufficient_balance"
+        if is_truncate_error(error):
+            return "truncate"
+        if is_duplicate_link_error(error):
+            return "duplicate_link"
+        if is_network_error(error):
+            return "network"
+        return "other"
+
     def _handle_error(self, error: str) -> None:
         """Track auth errors and enter cooldown if threshold reached."""
+        if self._health_metrics is not None:
+            self._health_metrics.record_rest_error(
+                _REST_CODE_BY_CATEGORY.get(self._classify_error(error), "other")
+            )
         if self._is_auth_error(error):
             self._auth_failure_count += 1
             logger.warning(
@@ -277,6 +314,8 @@ class IntentExecutor:
                 f"reduce_only={intent.reduce_only} "
                 f"client_id={intent.client_order_id} link_id={unique_link_id}"
             )
+            if self._health_metrics is not None:
+                self._health_metrics.record_place(shadow=True)
             return OrderResult(
                 success=True,
                 order_id=f"shadow_{intent.client_order_id}",
@@ -301,6 +340,8 @@ class IntentExecutor:
                         f"{intent.symbol} qty={intent.qty} price={intent.price} "
                         f"link_id={unique_link_id} (not submitted, not enqueued)"
                     )
+                if self._health_metrics is not None:
+                    self._health_metrics.record_reject("rate_limit")
                 return OrderResult(
                     success=False,
                     order_link_id=unique_link_id,
@@ -342,6 +383,8 @@ class IntentExecutor:
             # trailing-60s window (only real successes, never shadow).
             if self._safety_caps is not None:
                 self._safety_caps.record_accepted_submission(self._clock())
+            if self._health_metrics is not None:
+                self._health_metrics.record_place(shadow=False)
             return OrderResult(
                 success=True,
                 order_id=order_id,
@@ -351,6 +394,8 @@ class IntentExecutor:
         except Exception as e:
             logger.error(f"Failed to place order: {e}")
             self._handle_error(str(e))
+            if self._health_metrics is not None:
+                self._health_metrics.record_reject(self._classify_error(str(e)))
             return OrderResult(
                 success=False,
                 order_link_id=unique_link_id,
@@ -391,11 +436,15 @@ class IntentExecutor:
                     f"order_id={intent.order_id} (may already be filled/cancelled)"
                 )
 
+            if self._health_metrics is not None:
+                self._health_metrics.record_cancel(success=success)
             return CancelResult(success=success)
 
         except Exception as e:
             logger.error(f"Failed to cancel order: {e}")
             self._handle_error(str(e))
+            if self._health_metrics is not None:
+                self._health_metrics.record_cancel(success=False)
             return CancelResult(success=False, error=str(e))
 
     def execute_batch(

--- a/apps/gridbot/src/gridbot/health.py
+++ b/apps/gridbot/src/gridbot/health.py
@@ -50,7 +50,10 @@ def worst_state(states: Iterable[HealthState]) -> HealthState:
         if state not in _PRECEDENCE:
             # A new enum value added without a precedence entry would land here;
             # warn so the gap is visible rather than silently down-ranked.
-            logger.warning("Unknown health state ignored in precedence: %s", state)
+            logger.warning(
+                "Unknown health state ignored in precedence: %s (type=%s)",
+                state, type(state).__name__,
+            )
             continue
         if _PRECEDENCE.index(state) > _PRECEDENCE.index(worst):
             worst = state
@@ -61,7 +64,11 @@ class HealthMetrics:
     """Process-lifetime monotonic counters (reset only on restart).
 
     Inert by construction: a caller that holds no reference simply never
-    increments. All methods are O(1) and main-thread-only.
+    increments. All methods are O(1).
+
+    Thread safety: every ``record_*`` method MUST be called from the main thread
+    only (the executor / runner / orchestrator choke points) — the same threading
+    model as SafetyCaps and AuthCooldownManager; no locking is used.
     """
 
     def __init__(self) -> None:
@@ -166,6 +173,11 @@ class HealthStatusWriter:
                 os.fsync(f.fileno())
             os.replace(tmp_path, self._path)
         except BaseException:
+            # BaseException (not Exception) is intentional, mirroring
+            # GridStateStore._atomic_write: remove the half-written .tmp even on
+            # KeyboardInterrupt/SystemExit, then re-raise so the interrupt still
+            # propagates. The caller (_write_health_snapshot) catches Exception, so
+            # a re-raised interrupt is never swallowed — only tmp cleanup is added.
             try:
                 os.remove(tmp_path)
             except FileNotFoundError:

--- a/apps/gridbot/src/gridbot/health.py
+++ b/apps/gridbot/src/gridbot/health.py
@@ -13,7 +13,7 @@ import logging
 import os
 from collections import defaultdict
 from enum import StrEnum
-from typing import Iterable, Optional
+from typing import Any, Iterable, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -113,13 +113,14 @@ def build_snapshot(
     gauges: dict,
     generated_at: str,
     overall: Optional[HealthState] = None,
-) -> dict:
+) -> dict[str, Any]:
     """Pure builder: assemble the status snapshot dict.
 
     ``strat_states`` is a list of per-strat dicts each carrying at least
     ``{"strat_id": str, "state": HealthState, "shadow": bool}``. ``overall`` lets
     the caller force a state (e.g. STARTING before the loop); otherwise the worst
-    per-strat state wins. ``generated_at`` is supplied by the caller (UTC iso).
+    per-strat state wins. ``generated_at`` is supplied by the caller — a UTC
+    ISO-8601 string (e.g. ``datetime.now(UTC).isoformat()``); not validated here.
     """
     if overall is None:
         overall = worst_state(s["state"] for s in strat_states) if strat_states else HealthState.HEALTHY

--- a/apps/gridbot/src/gridbot/health.py
+++ b/apps/gridbot/src/gridbot/health.py
@@ -48,6 +48,9 @@ def worst_state(states: Iterable[HealthState]) -> HealthState:
     worst = HealthState.HEALTHY
     for state in states:
         if state not in _PRECEDENCE:
+            # A new enum value added without a precedence entry would land here;
+            # warn so the gap is visible rather than silently down-ranked.
+            logger.warning("Unknown health state ignored in precedence: %s", state)
             continue
         if _PRECEDENCE.index(state) > _PRECEDENCE.index(worst):
             worst = state
@@ -120,6 +123,8 @@ def build_snapshot(
     """
     if overall is None:
         overall = worst_state(s["state"] for s in strat_states) if strat_states else HealthState.HEALTHY
+    # str(...) coerces HealthState (a StrEnum) to a plain str — redundant for
+    # json.dump (StrEnum serializes as its value) but explicit about the contract.
     return {
         "state": str(overall),
         "generated_at": generated_at,

--- a/apps/gridbot/src/gridbot/health.py
+++ b/apps/gridbot/src/gridbot/health.py
@@ -1,0 +1,167 @@
+"""Operational observability: health-state snapshot + process-lifetime metrics.
+
+Feature 0082 (issue #185). Additive, no trading-logic change. Counters are
+incremented on the MAIN thread only (runner ticker / retry drain / orchestrator
+sweep all run there), the same model as SafetyCaps / AuthCooldownManager — no
+locking required. A snapshot is built once per ~10s health sweep and written to a
+JSON status file; it COMPLEMENTS the gridbot-health CLI (it does NOT touch the
+skill-owned health_state.json).
+"""
+
+import json
+import logging
+import os
+from collections import defaultdict
+from enum import StrEnum
+from typing import Iterable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class HealthState(StrEnum):
+    """Overall bot health. ``str``-valued so it serializes directly to JSON."""
+
+    STARTING = "starting"
+    HEALTHY = "healthy"
+    DEGRADED = "degraded"
+    AUTH_COOLDOWN = "auth_cooldown"
+    CIRCUIT_OPEN = "circuit_open"
+
+
+# Worst-wins precedence (higher index = worse) over the runtime states. STARTING
+# is a pre-loop marker, not part of the comparison — the orchestrator sets it
+# explicitly before the first sweep.
+_PRECEDENCE = [
+    HealthState.HEALTHY,
+    HealthState.DEGRADED,
+    HealthState.AUTH_COOLDOWN,
+    HealthState.CIRCUIT_OPEN,
+]
+
+
+def worst_state(states: Iterable[HealthState]) -> HealthState:
+    """Return the worst (highest-precedence) state; HEALTHY if none given.
+
+    States outside the precedence ladder (e.g. STARTING, a pre-loop marker set
+    only via ``overall=``) are ignored so a stray value can never raise.
+    """
+    worst = HealthState.HEALTHY
+    for state in states:
+        if state not in _PRECEDENCE:
+            continue
+        if _PRECEDENCE.index(state) > _PRECEDENCE.index(worst):
+            worst = state
+    return worst
+
+
+class HealthMetrics:
+    """Process-lifetime monotonic counters (reset only on restart).
+
+    Inert by construction: a caller that holds no reference simply never
+    increments. All methods are O(1) and main-thread-only.
+    """
+
+    def __init__(self) -> None:
+        self.orders_placed = 0
+        self.orders_placed_shadow = 0
+        self.orders_rejected: dict[str, int] = defaultdict(int)
+        self.cancels = 0
+        self.cancels_failed = 0
+        self.rest_errors_by_code: dict[str, int] = defaultdict(int)
+        self.ws_reconnects: dict[str, int] = defaultdict(int)  # 'public' / 'private'
+
+    def record_place(self, *, shadow: bool) -> None:
+        if shadow:
+            self.orders_placed_shadow += 1
+        else:
+            self.orders_placed += 1
+
+    def record_reject(self, reason: str) -> None:
+        self.orders_rejected[reason] += 1
+
+    def record_cancel(self, *, success: bool) -> None:
+        if success:
+            self.cancels += 1
+        else:
+            self.cancels_failed += 1
+
+    def record_rest_error(self, code: str) -> None:
+        self.rest_errors_by_code[code] += 1
+
+    def record_ws_reconnect(self, kind: str) -> None:
+        self.ws_reconnects[kind] += 1
+
+    def as_dict(self) -> dict:
+        return {
+            "orders_placed": self.orders_placed,
+            "orders_placed_shadow": self.orders_placed_shadow,
+            "orders_rejected": dict(self.orders_rejected),
+            "cancels": self.cancels,
+            "cancels_failed": self.cancels_failed,
+            "rest_errors_by_code": dict(self.rest_errors_by_code),
+            "ws_reconnects": dict(self.ws_reconnects),
+        }
+
+
+def build_snapshot(
+    *,
+    strat_states: list[dict],
+    metrics: HealthMetrics,
+    gauges: dict,
+    generated_at: str,
+    overall: Optional[HealthState] = None,
+) -> dict:
+    """Pure builder: assemble the status snapshot dict.
+
+    ``strat_states`` is a list of per-strat dicts each carrying at least
+    ``{"strat_id": str, "state": HealthState, "shadow": bool}``. ``overall`` lets
+    the caller force a state (e.g. STARTING before the loop); otherwise the worst
+    per-strat state wins. ``generated_at`` is supplied by the caller (UTC iso).
+    """
+    if overall is None:
+        overall = worst_state(s["state"] for s in strat_states) if strat_states else HealthState.HEALTHY
+    return {
+        "state": str(overall),
+        "generated_at": generated_at,
+        "strategies": [{**s, "state": str(s["state"])} for s in strat_states],
+        "metrics": metrics.as_dict(),
+        "gauges": gauges,
+    }
+
+
+class HealthStatusWriter:
+    """Atomically write the health snapshot to a JSON status file.
+
+    Replicates the ``GridStateStore._atomic_write`` tmp+flush+fsync+os.replace
+    pattern (packages/gridcore/src/gridcore/persistence.py) against its own path —
+    it does NOT call into GridStateStore. When ``enabled`` is False, ``write`` is a
+    no-op (tests / standalone).
+    """
+
+    def __init__(self, status_file_path: str, enabled: bool = True) -> None:
+        self._path = status_file_path
+        self._enabled = enabled
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def write(self, snapshot: dict) -> None:
+        if not self._enabled:
+            return
+        dir_path = os.path.dirname(self._path)
+        if dir_path:
+            os.makedirs(dir_path, exist_ok=True)
+        tmp_path = self._path + ".tmp"
+        try:
+            with open(tmp_path, "w") as f:
+                json.dump(snapshot, f, indent=2)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, self._path)
+        except BaseException:
+            try:
+                os.remove(tmp_path)
+            except FileNotFoundError:
+                pass
+            raise

--- a/apps/gridbot/src/gridbot/orchestrator.py
+++ b/apps/gridbot/src/gridbot/orchestrator.py
@@ -41,6 +41,12 @@ from gridbot.reconciler import Reconciler
 from gridbot.retry_queue import RetryQueue
 from gridbot.position_fetcher import PositionFetcher, _POSITION_TICK_BASE
 from gridbot.auth_cooldown_manager import AuthCooldownManager
+from gridbot.health import (
+    HealthMetrics,
+    HealthState,
+    HealthStatusWriter,
+    build_snapshot,
+)
 from gridbot.writers import GridStateWriter
 
 _HEALTH_CHECK_INTERVAL = 10  # seconds
@@ -132,6 +138,19 @@ class Orchestrator:
         # tripped breaker cannot itself spam REST during an outage. strat_id ->
         # monotonic ts of the last forced reconcile.
         self._force_reconcile_last_at: dict[str, float] = {}
+
+        # Feature 0082 (issue #185) — operational observability. HealthMetrics is
+        # the shared process-lifetime counter set (passed by-ref into each executor);
+        # _safety_caps mirrors the per-strat caps so the sweep can read
+        # loss_tripped()/rate_limited(); the writer emits the JSON status snapshot.
+        self._health_metrics = HealthMetrics()
+        self._health_writer = HealthStatusWriter(
+            self._config.status_file_path,
+            enabled=self._config.status_file_enabled,
+        )
+        self._safety_caps: dict[str, SafetyCaps] = {}  # strat_id -> caps (health sweep)
+        self._start_time: Optional[float] = None
+        self._status_write_warn_last: float = 0.0
 
         # Feature 0069 (issue #151) — state-divergence detector. Logic lives on
         # the orchestrator (no separate class). All four signals converge on
@@ -377,6 +396,10 @@ class Orchestrator:
 
         self._running = True
         self._started = True
+        # Feature 0082 — uptime origin + emit the initial `starting` snapshot
+        # before run() enters the blocking poll loop.
+        self._start_time = time.monotonic()
+        self._write_health_snapshot(overall=HealthState.STARTING)
         logger.info(f"Orchestrator started with {len(self._runners)} strategies")
 
     def run(self) -> None:
@@ -811,6 +834,7 @@ class Orchestrator:
             on_cooldown_entered=lambda sid=strat_id: self._auth_cooldown.enter(sid),
             safety_caps=safety_caps,
             clock=safety_caps_clock,
+            health_metrics=self._health_metrics,
         )
 
         # Create retry queue with dispatcher that routes by intent type
@@ -866,6 +890,8 @@ class Orchestrator:
         )
         self._runners[strat_id] = runner
         self._strategy_executors[strat_id] = executor
+        # Feature 0082 — retain caps so _health_check_once can read circuit/C4 state.
+        self._safety_caps[strat_id] = safety_caps
 
         logger.info(
             f"Initialized strategy: {strat_id} (symbol={strategy_config.symbol}, "
@@ -1153,6 +1179,7 @@ class Orchestrator:
                         pub_ws.disconnect()
                         pub_ws.connect()  # re-subscribes automatically via callbacks
                         logger.info(f"Public WS reconnected for {account_name}")
+                        self._health_metrics.record_ws_reconnect("public")
                     except Exception as e:
                         self._notifier.alert_exception(
                             f"Public WS reconnect {account_name}", e,
@@ -1179,6 +1206,7 @@ class Orchestrator:
                         priv_ws.disconnect()
                         priv_ws.connect()  # re-subscribes automatically via callbacks
                         logger.info(f"Private WS reconnected for {account_name}")
+                        self._health_metrics.record_ws_reconnect("private")
                     except Exception as e:
                         self._notifier.alert_exception(
                             f"Private WS reconnect {account_name}", e,
@@ -1196,10 +1224,86 @@ class Orchestrator:
                     # reconnected; schedule a forced reconcile (drained next _tick).
                     # Private-only — the public branch above does NOT enqueue.
                     self._enqueue_post_recovery_reconcile(account_name)
+
+            # Feature 0082 (issue #185) — emit the health/metrics snapshot at the
+            # end of the sweep. The writer is guarded, but the whole sweep is also
+            # wrapped, so a status-write failure can never perturb the loop.
+            self._write_health_snapshot()
         except Exception as e:
             self._notifier.alert_exception(
                 "_health_check_once", e, error_key="health_check_loop",
             )
+
+    def _write_health_snapshot(self, overall: Optional[HealthState] = None) -> None:
+        """Build the health/metrics snapshot and write it atomically (feature 0082).
+
+        ``overall`` forces the state (e.g. STARTING before the loop); otherwise the
+        worst per-strat state wins. Any failure is logged (throttled) and swallowed
+        so a status-write error NEVER perturbs the trading loop.
+        """
+        try:
+            now = time.monotonic()
+            uptime = (now - self._start_time) if self._start_time is not None else 0.0
+            strat_states: list[dict] = []
+            auth_active = 0
+            loss_latched = 0
+            preflight_skips = 0
+            auth_cooldown_cycles = 0
+            for strat_id, runner in self._runners.items():
+                caps = self._safety_caps.get(strat_id)
+                executor = self._strategy_executors.get(strat_id)
+                in_cooldown = bool(executor and executor.auth_cooldown)
+                circuit = bool(caps and caps.loss_tripped())
+                degraded = bool(
+                    (caps and caps.rate_limited(now))
+                    or runner.dirty_rest_refresh_failure_count > 0
+                )
+                if circuit:
+                    state = HealthState.CIRCUIT_OPEN
+                elif in_cooldown:
+                    state = HealthState.AUTH_COOLDOWN
+                elif degraded:
+                    state = HealthState.DEGRADED
+                else:
+                    state = HealthState.HEALTHY
+                # Gauges count the underlying condition regardless of which state
+                # won the worst-wins precedence (a strat both circuit_open AND in
+                # cooldown contributes to BOTH gauges).
+                if circuit:
+                    loss_latched += 1
+                if in_cooldown:
+                    auth_active += 1
+                preflight_skips += runner.preflight_skip_count
+                auth_cooldown_cycles += self._auth_cooldown.cooldown_cycles(strat_id)
+                strat_states.append({
+                    "strat_id": strat_id,
+                    "symbol": runner.symbol,
+                    "state": state,
+                    "shadow": runner.shadow_mode,
+                    "net_position_size": runner.net_position_size,
+                    "preflight_skips": runner.preflight_skip_count,
+                })
+            gauges = {
+                "runners": len(self._runners),
+                "auth_cooldown_active": auth_active,
+                "loss_breaker_latched": loss_latched,
+                "preflight_skips": preflight_skips,
+                "auth_cooldown_cycles": auth_cooldown_cycles,
+                "uptime_seconds": round(uptime, 1),
+            }
+            snapshot = build_snapshot(
+                strat_states=strat_states,
+                metrics=self._health_metrics,
+                gauges=gauges,
+                generated_at=datetime.now(UTC).isoformat(),
+                overall=overall,
+            )
+            self._health_writer.write(snapshot)
+        except Exception as e:
+            warn_now = time.monotonic()
+            if (warn_now - self._status_write_warn_last) >= 60.0:
+                self._status_write_warn_last = warn_now
+                logger.warning("Health status write failed (throttled): %s", e)
 
     def _ws_health_check_once(self) -> None:
         """TCP-level WS socket probe with active reset on dead sockets.

--- a/apps/gridbot/src/gridbot/orchestrator.py
+++ b/apps/gridbot/src/gridbot/orchestrator.py
@@ -149,6 +149,9 @@ class Orchestrator:
             enabled=self._config.status_file_enabled,
         )
         self._safety_caps: dict[str, SafetyCaps] = {}  # strat_id -> caps (health sweep)
+        # strat_id -> dirty-REST count observed at the previous sweep, so degraded
+        # keys off a RECENT delta (not the sticky monotonic absolute) — review #195.
+        self._dirty_rest_last_count: dict[str, int] = {}
         self._start_time: Optional[float] = None
         self._status_write_warn_last: float = 0.0
 
@@ -1254,9 +1257,15 @@ class Orchestrator:
                 executor = self._strategy_executors.get(strat_id)
                 in_cooldown = bool(executor and executor.auth_cooldown)
                 circuit = bool(caps and caps.loss_tripped())
+                # Degraded keys off a RECENT soft signal, not a sticky absolute:
+                # a new dirty-REST failure SINCE THE LAST SWEEP (delta), or a
+                # sustained C4 rate-limit. The monotonic count would otherwise pin
+                # degraded forever after one transient failure (review #195 P1).
+                cur_dirty = runner.dirty_rest_refresh_failure_count
+                prev_dirty = self._dirty_rest_last_count.get(strat_id, cur_dirty)
+                self._dirty_rest_last_count[strat_id] = cur_dirty
                 degraded = bool(
-                    (caps and caps.rate_limited(now))
-                    or runner.dirty_rest_refresh_failure_count > 0
+                    (caps and caps.rate_limited(now)) or cur_dirty > prev_dirty
                 )
                 if circuit:
                     state = HealthState.CIRCUIT_OPEN

--- a/apps/gridbot/src/gridbot/orchestrator.py
+++ b/apps/gridbot/src/gridbot/orchestrator.py
@@ -51,6 +51,7 @@ from gridbot.writers import GridStateWriter
 
 _HEALTH_CHECK_INTERVAL = 10  # seconds
 _WS_HEALTH_CHECK_INTERVAL = 10.0  # seconds — bbu2 ENSURE_SOCKET_INTERVAL parity
+_STATUS_WRITE_WARN_THROTTLE = 60.0  # seconds — throttle health status-write error logs (0082)
 _CHECK_INTERVAL = 0.1  # 100 ms main loop tick (bbu2 value)
 _RETRY_TICK_INTERVAL = 1.0  # seconds between retry-queue drains
 _WS_RECONNECT_SLOW_THRESHOLD = 5.0  # log a warning if a single WS disconnect+connect takes longer
@@ -1310,7 +1311,7 @@ class Orchestrator:
             self._health_writer.write(snapshot)
         except Exception as e:
             warn_now = time.monotonic()
-            if (warn_now - self._status_write_warn_last) >= 60.0:
+            if (warn_now - self._status_write_warn_last) >= _STATUS_WRITE_WARN_THROTTLE:
                 self._status_write_warn_last = warn_now
                 logger.warning("Health status write failed (throttled): %s", e)
 

--- a/apps/gridbot/src/gridbot/runner.py
+++ b/apps/gridbot/src/gridbot/runner.py
@@ -317,6 +317,9 @@ class StrategyRunner:
         }
         # Monotonic count of breaker trips that fired a forced reconcile.
         self._truncate_breaker_reconcile_count: int = 0
+        # Feature 0082 (issue #185) — monotonic process-lifetime count of genuine
+        # preflight skips (distinct from the resettable _skip_window summary dict).
+        self._preflight_skip_count: int = 0
         # Observability (review v3): monotonic count of dirty REST refreshes that
         # failed (get_positions raised / unparseable size) — surfaced by the
         # health sweep so persistent REST issues blocking self-heal are visible.
@@ -498,6 +501,19 @@ class StrategyRunner:
         signal without per-occurrence ERROR spam.
         """
         return self._truncate_breaker_reconcile_count
+
+    @property
+    def preflight_skip_count(self) -> int:
+        """Monotonic count of genuine preflight (low-balance) skips for the runner
+        lifetime (feature 0082). Distinct from the per-summary-window `_skip_window`
+        dict (which resets each flush); read/summed by the health sweep."""
+        return self._preflight_skip_count
+
+    @property
+    def net_position_size(self) -> float:
+        """Signed net position size (long - short) as a float, for the health
+        snapshot gauge (feature 0082). Read-only; no behavior change."""
+        return float(self._long_position.size - self._short_position.size)
 
     @property
     def dirty_rest_refresh_failure_count(self) -> int:
@@ -1628,6 +1644,7 @@ class StrategyRunner:
             # summary works even when transition logging is off (M1). Reset only
             # by the summary flush itself.
             self._skip_window[key] = self._skip_window.get(key, 0) + 1
+            self._preflight_skip_count += 1
             self._skip_window_avail_min = (
                 avail_f if self._skip_window_avail_min is None
                 else min(self._skip_window_avail_min, avail_f))

--- a/apps/gridbot/tests/test_executor_health.py
+++ b/apps/gridbot/tests/test_executor_health.py
@@ -1,0 +1,68 @@
+"""Executor <-> HealthMetrics integration (feature 0082 / issue #185)."""
+
+from decimal import Decimal
+from unittest.mock import MagicMock, Mock
+
+from gridcore.intents import PlaceLimitIntent
+from gridbot.executor import IntentExecutor
+from gridbot.health import HealthMetrics
+
+
+def _intent():
+    return PlaceLimitIntent.create(
+        symbol="BTCUSDT", side="Buy", price=Decimal("50000.0"),
+        qty=Decimal("0.001"), grid_level=10, direction="long",
+    )
+
+
+def _client(place_ok=True, error=None):
+    c = Mock()
+    if place_ok:
+        c.place_order = MagicMock(return_value={"orderId": "oid1"})
+    else:
+        c.place_order = MagicMock(side_effect=Exception(error))
+    c.cancel_order = MagicMock(return_value=True)
+    return c
+
+
+def test_live_place_success_bumps_orders_placed():
+    m = HealthMetrics()
+    ex = IntentExecutor(_client(), shadow_mode=False, health_metrics=m)
+    ex.execute_place(_intent())
+    assert m.orders_placed == 1
+    assert m.orders_placed_shadow == 0
+
+
+def test_shadow_place_bumps_shadow_only():
+    m = HealthMetrics()
+    ex = IntentExecutor(_client(), shadow_mode=True, health_metrics=m)
+    ex.execute_place(_intent())
+    assert m.orders_placed_shadow == 1
+    assert m.orders_placed == 0
+    assert not m.rest_errors_by_code  # shadow never touches the wire
+
+
+def test_insufficient_balance_failure_bumps_reject_and_rest_code():
+    m = HealthMetrics()
+    ex = IntentExecutor(
+        _client(place_ok=False, error="Bybit API error in place_order: [110007] ab not enough"),
+        shadow_mode=False, health_metrics=m,
+    )
+    res = ex.execute_place(_intent())
+    assert res.success is False
+    assert m.orders_rejected["insufficient_balance"] == 1
+    assert m.rest_errors_by_code["110007"] == 1
+    assert m.orders_placed == 0
+
+
+def test_cancel_success_bumps_cancels():
+    m = HealthMetrics()
+    ex = IntentExecutor(_client(), shadow_mode=False, health_metrics=m)
+    from gridcore.intents import CancelIntent
+    ex.execute_cancel(CancelIntent(symbol="BTCUSDT", order_id="x", reason="rebuild"))
+    assert m.cancels == 1 and m.cancels_failed == 0
+
+
+def test_metrics_optional_none_is_inert():
+    ex = IntentExecutor(_client(), shadow_mode=False)  # no health_metrics
+    assert ex.execute_place(_intent()).success is True

--- a/apps/gridbot/tests/test_health.py
+++ b/apps/gridbot/tests/test_health.py
@@ -1,0 +1,139 @@
+"""Unit tests for gridbot.health (feature 0082 / issue #185)."""
+
+import json
+
+import pytest
+
+from gridbot.health import (
+    HealthMetrics,
+    HealthState,
+    HealthStatusWriter,
+    build_snapshot,
+    worst_state,
+)
+
+
+class TestWorstState:
+    def test_empty_is_healthy(self):
+        assert worst_state([]) == HealthState.HEALTHY
+
+    def test_single(self):
+        assert worst_state([HealthState.DEGRADED]) == HealthState.DEGRADED
+
+    @pytest.mark.parametrize("states, expected", [
+        ([HealthState.HEALTHY, HealthState.DEGRADED], HealthState.DEGRADED),
+        ([HealthState.DEGRADED, HealthState.AUTH_COOLDOWN], HealthState.AUTH_COOLDOWN),
+        ([HealthState.AUTH_COOLDOWN, HealthState.CIRCUIT_OPEN], HealthState.CIRCUIT_OPEN),
+        ([HealthState.HEALTHY, HealthState.CIRCUIT_OPEN, HealthState.DEGRADED], HealthState.CIRCUIT_OPEN),
+    ])
+    def test_precedence_worst_wins(self, states, expected):
+        assert worst_state(states) == expected
+
+    def test_state_is_str_valued(self):
+        assert HealthState.CIRCUIT_OPEN == "circuit_open"
+        assert json.dumps({"s": HealthState.AUTH_COOLDOWN}) == '{"s": "auth_cooldown"}'
+
+
+class TestHealthMetrics:
+    def test_record_place_live_vs_shadow(self):
+        m = HealthMetrics()
+        m.record_place(shadow=False)
+        m.record_place(shadow=True)
+        m.record_place(shadow=True)
+        assert m.orders_placed == 1
+        assert m.orders_placed_shadow == 2
+
+    def test_record_reject_by_reason(self):
+        m = HealthMetrics()
+        m.record_reject("insufficient_balance")
+        m.record_reject("insufficient_balance")
+        m.record_reject("auth")
+        assert m.orders_rejected == {"insufficient_balance": 2, "auth": 1}
+
+    def test_record_cancel(self):
+        m = HealthMetrics()
+        m.record_cancel(success=True)
+        m.record_cancel(success=False)
+        assert m.cancels == 1 and m.cancels_failed == 1
+
+    def test_record_rest_error_and_ws(self):
+        m = HealthMetrics()
+        m.record_rest_error("110007")
+        m.record_rest_error("110007")
+        m.record_ws_reconnect("public")
+        assert m.rest_errors_by_code == {"110007": 2}
+        assert m.ws_reconnects == {"public": 1}
+
+    def test_as_dict_is_json_serializable(self):
+        m = HealthMetrics()
+        m.record_place(shadow=False)
+        m.record_reject("other")
+        json.dumps(m.as_dict())  # must not raise
+
+
+class TestBuildSnapshot:
+    def _metrics(self):
+        m = HealthMetrics()
+        m.record_place(shadow=False)
+        return m
+
+    def test_overall_is_worst_strat_state(self):
+        snap = build_snapshot(
+            strat_states=[
+                {"strat_id": "a", "state": HealthState.HEALTHY, "shadow": False},
+                {"strat_id": "b", "state": HealthState.AUTH_COOLDOWN, "shadow": False},
+            ],
+            metrics=self._metrics(),
+            gauges={"runners": 2},
+            generated_at="2026-06-18T00:00:00Z",
+        )
+        assert snap["state"] == "auth_cooldown"
+        # per-strat states serialize as plain strings
+        assert snap["strategies"][1]["state"] == "auth_cooldown"
+        assert snap["metrics"]["orders_placed"] == 1
+        assert snap["gauges"]["runners"] == 2
+        json.dumps(snap)  # fully serializable
+
+    def test_overall_override(self):
+        snap = build_snapshot(
+            strat_states=[],
+            metrics=self._metrics(),
+            gauges={},
+            generated_at="2026-06-18T00:00:00Z",
+            overall=HealthState.STARTING,
+        )
+        assert snap["state"] == "starting"
+
+    def test_no_strats_defaults_healthy(self):
+        snap = build_snapshot(
+            strat_states=[], metrics=self._metrics(), gauges={},
+            generated_at="2026-06-18T00:00:00Z",
+        )
+        assert snap["state"] == "healthy"
+
+
+class TestHealthStatusWriter:
+    def test_writes_valid_json(self, tmp_path):
+        path = str(tmp_path / "status.json")
+        HealthStatusWriter(path).write({"state": "healthy", "n": 1})
+        with open(path) as f:
+            assert json.load(f) == {"state": "healthy", "n": 1}
+
+    def test_disabled_is_noop(self, tmp_path):
+        path = tmp_path / "status.json"
+        HealthStatusWriter(str(path), enabled=False).write({"state": "healthy"})
+        assert not path.exists()
+
+    def test_atomic_no_tmp_left_on_failure(self, tmp_path, monkeypatch):
+        path = str(tmp_path / "status.json")
+        writer = HealthStatusWriter(path)
+
+        def boom(*a, **k):
+            raise OSError("disk full")
+
+        monkeypatch.setattr("os.replace", boom)
+        with pytest.raises(OSError):
+            writer.write({"state": "healthy"})
+        # tmp file cleaned up; no garbage and no partial status file
+        assert not (tmp_path / "status.json.tmp").exists()
+        assert not (tmp_path / "status.json").exists()

--- a/apps/gridbot/tests/test_orchestrator_health_status.py
+++ b/apps/gridbot/tests/test_orchestrator_health_status.py
@@ -118,3 +118,31 @@ def test_starting_snapshot_written_on_start(_mock_priv, _mock_pub, _mock_rest, t
     snap = _read(cfg.status_file_path)
     assert snap["state"] == "starting"
     assert snap["gauges"]["uptime_seconds"] >= 0
+
+
+@patch("gridbot.orchestrator.BybitRestClient")
+@patch("gridbot.orchestrator.PublicWebSocketClient")
+@patch("gridbot.orchestrator.PrivateWebSocketClient")
+def test_health_status_degraded_delta_then_recovery(
+    _mock_priv, _mock_pub, _mock_rest, tmp_path,
+):
+    cfg = _config(tmp_path)
+    orch = Orchestrator(cfg)
+    orch._init_account(cfg.accounts[0])
+    orch._init_strategy(cfg.strategies[0])
+    path = cfg.status_file_path
+    runner = orch._runners["btcusdt_test"]
+
+    # Baseline sweep: no failures -> healthy (seeds the last-count for the delta).
+    orch._health_check_once()
+    assert _read(path)["state"] == "healthy"
+
+    # Simulate a NEW dirty-REST failure since the last sweep (delta > 0) -> degraded.
+    runner._dirty_rest_refresh_failure_count += 1
+    orch._health_check_once()
+    assert _read(path)["state"] == "degraded"
+
+    # No NEW failure on the next sweep -> delta clears -> recovers to healthy.
+    # Guards against the sticky monotonic-absolute bug (review #195 P1).
+    orch._health_check_once()
+    assert _read(path)["state"] == "healthy"

--- a/apps/gridbot/tests/test_orchestrator_health_status.py
+++ b/apps/gridbot/tests/test_orchestrator_health_status.py
@@ -1,0 +1,120 @@
+"""Integration: health-status file state transitions (feature 0082 / issue #185).
+
+Drives the real auth-cooldown and circuit-breaker trip conditions through the
+orchestrator and asserts the JSON status file reflects the transitions, including
+recovery and live<->shadow parity.
+"""
+
+import json
+from datetime import datetime, UTC, timedelta
+from decimal import Decimal
+from unittest.mock import patch
+
+from gridbot.config import (
+    AccountConfig,
+    GridbotConfig,
+    SafetyCapsConfig,
+    StrategyConfig,
+)
+from gridbot.orchestrator import Orchestrator
+
+
+def _config(tmp_path, shadow=False):
+    return GridbotConfig(
+        accounts=[AccountConfig(name="acc", api_key="k", api_secret="s", testnet=True)],
+        strategies=[StrategyConfig(
+            strat_id="btcusdt_test", account="acc", symbol="BTCUSDT",
+            tick_size=Decimal("0.1"), grid_count=20, grid_step=0.2,
+            shadow_mode=shadow,
+            safety_caps=SafetyCapsConfig(enabled=True, session_loss_limit=Decimal("10")),
+        )],
+        database_url="sqlite:///:memory:",
+        position_check_interval=60.0,
+        status_file_path=str(tmp_path / "status.json"),
+        status_file_enabled=True,
+    )
+
+
+def _read(path):
+    with open(path) as f:
+        return json.load(f)
+
+
+@patch("gridbot.orchestrator.BybitRestClient")
+@patch("gridbot.orchestrator.PublicWebSocketClient")
+@patch("gridbot.orchestrator.PrivateWebSocketClient")
+def test_health_status_auth_cooldown_then_recovery_then_circuit(
+    _mock_priv, _mock_pub, _mock_rest, tmp_path,
+):
+    cfg = _config(tmp_path)
+    orch = Orchestrator(cfg)
+    orch._init_account(cfg.accounts[0])
+    orch._init_strategy(cfg.strategies[0])
+    path = cfg.status_file_path
+    executor = orch._strategy_executors["btcusdt_test"]
+
+    # --- auth_cooldown trip (drive max_auth_failures consecutive auth errors) ---
+    for _ in range(5):
+        executor._handle_error("Bybit API error: [10003] auth failure")
+    assert executor.auth_cooldown is True
+    orch._health_check_once()
+    snap = _read(path)
+    assert snap["state"] == "auth_cooldown"
+    assert snap["strategies"][0]["state"] == "auth_cooldown"
+    assert snap["strategies"][0]["strat_id"] == "btcusdt_test"
+    assert snap["gauges"]["auth_cooldown_active"] == 1
+    assert snap["gauges"]["auth_cooldown_cycles"] >= 1
+
+    # --- recovery: expire the cooldown -> back to healthy ---
+    orch._auth_cooldown.sweep_expired(datetime.now(UTC) + timedelta(days=1))
+    assert executor.auth_cooldown is False
+    orch._health_check_once()
+    assert _read(path)["state"] == "healthy"
+
+    # --- circuit_open: trip C3 via the orchestrator's _safety_caps map ---
+    caps = orch._safety_caps["btcusdt_test"]
+    assert caps.check_loss_breaker(
+        session_realized_pnl=Decimal("-50"), now_utc=datetime.now(UTC)
+    ) is True
+    orch._health_check_once()
+    snap2 = _read(path)
+    assert snap2["state"] == "circuit_open"
+    assert snap2["gauges"]["loss_breaker_latched"] == 1
+
+
+@patch("gridbot.orchestrator.BybitRestClient")
+@patch("gridbot.orchestrator.PublicWebSocketClient")
+@patch("gridbot.orchestrator.PrivateWebSocketClient")
+def test_health_status_shadow_parity(_mock_priv, _mock_pub, _mock_rest, tmp_path):
+    cfg = _config(tmp_path, shadow=True)
+    orch = Orchestrator(cfg)
+    orch._init_account(cfg.accounts[0])
+    orch._init_strategy(cfg.strategies[0])
+    path = cfg.status_file_path
+
+    # A shadow strat still flips to circuit_open (C3 runs independent of submit).
+    orch._safety_caps["btcusdt_test"].check_loss_breaker(
+        session_realized_pnl=Decimal("-50"), now_utc=datetime.now(UTC)
+    )
+    orch._health_check_once()
+    snap = _read(path)
+    assert snap["state"] == "circuit_open"
+    assert snap["strategies"][0]["shadow"] is True
+    # Identical snapshot shape in shadow vs live (parity).
+    assert set(snap.keys()) == {"state", "generated_at", "strategies", "metrics", "gauges"}
+    assert snap["metrics"]["orders_placed"] == 0  # no real submit in shadow
+
+
+@patch("gridbot.orchestrator.BybitRestClient")
+@patch("gridbot.orchestrator.PublicWebSocketClient")
+@patch("gridbot.orchestrator.PrivateWebSocketClient")
+def test_starting_snapshot_written_on_start(_mock_priv, _mock_pub, _mock_rest, tmp_path):
+    cfg = _config(tmp_path)
+    orch = Orchestrator(cfg)
+    orch._init_account(cfg.accounts[0])
+    orch._init_strategy(cfg.strategies[0])
+    # start() sets _start_time and writes the `starting` snapshot before run().
+    orch.start()
+    snap = _read(cfg.status_file_path)
+    assert snap["state"] == "starting"
+    assert snap["gauges"]["uptime_seconds"] >= 0

--- a/apps/gridbot/tests/test_orchestrator_health_status.py
+++ b/apps/gridbot/tests/test_orchestrator_health_status.py
@@ -146,3 +146,32 @@ def test_health_status_degraded_delta_then_recovery(
     # Guards against the sticky monotonic-absolute bug (review #195 P1).
     orch._health_check_once()
     assert _read(path)["state"] == "healthy"
+
+
+@patch("gridbot.orchestrator.BybitRestClient")
+@patch("gridbot.orchestrator.PublicWebSocketClient")
+@patch("gridbot.orchestrator.PrivateWebSocketClient")
+def test_health_status_degraded_requires_new_failure_not_sticky(
+    _mock_priv, _mock_pub, _mock_rest, tmp_path,
+):
+    """Degraded keys off a strict delta (cur > prev), not the absolute count.
+
+    A strat that ALREADY had dirty-REST failures before the first sweep must NOT
+    be stuck degraded: the first sweep seeds prev=cur (so cur > prev is False),
+    and a later sweep at the SAME count stays healthy. Proves `>` not `>=`.
+    """
+    cfg = _config(tmp_path)
+    orch = Orchestrator(cfg)
+    orch._init_account(cfg.accounts[0])
+    orch._init_strategy(cfg.strategies[0])
+    path = cfg.status_file_path
+    runner = orch._runners["btcusdt_test"]
+
+    # Pre-existing (historical) failures already on the monotonic counter.
+    runner._dirty_rest_refresh_failure_count = 3
+    orch._health_check_once()
+    assert _read(path)["state"] == "healthy"  # seeded prev=cur -> no delta
+
+    # Same count on the next sweep -> still healthy (strict >, not >=).
+    orch._health_check_once()
+    assert _read(path)["state"] == "healthy"

--- a/docs/features/0082_PLAN.md
+++ b/docs/features/0082_PLAN.md
@@ -1,0 +1,313 @@
+# Feature 0082 — Operational Observability (health states + metrics)
+
+Issue #185 (P2). Move the live gridbot beyond logs-only: an explicit health-state
+snapshot + a small counter/gauge set, exported once per health sweep to a JSON
+status file. Additive only — no trading-logic change, live↔shadow parity.
+
+## Context (verified against current code)
+
+- `Orchestrator._health_check_once` (orchestrator.py:1099) is the per-tick health
+  sweep, time-gated every `_HEALTH_CHECK_INTERVAL` = 10 s (orchestrator.py:46,
+  scheduled at 552-564). It already calls `self._auth_cooldown.sweep_expired(...)`
+  and walks every runner + WS client. This is the natural aggregation/emit point.
+- Health-relevant signals already exist, scattered:
+  - Auth cooldown: `AuthCooldownManager._auth_cooldown_until` /
+    `_auth_cooldown_cycles` (auth_cooldown_manager.py:59-60); per-executor
+    `IntentExecutor.auth_cooldown` / `auth_failure_count` (executor.py:219-226).
+  - Safety caps / circuit: `SafetyCaps.loss_tripped()` (C3 latch, safety_caps.py:158),
+    `rate_limited(now)` (C4, :168). C3 trip is the natural `circuit_open` state.
+    NOTE — these are NOT reachable from `_health_check_once` today. Each strat's
+    `SafetyCaps` is built function-local in `_init_strategy` (orchestrator.py:800),
+    passed by-ref into the executor (:812) and runner (:865), then goes out of
+    scope. The orchestrator keeps `self._runners` + `self._strategy_executors`
+    but NO caps map, and `IntentExecutor._safety_caps` (executor.py:209) is
+    private with no accessor. So the sweep cannot read `loss_tripped()` /
+    `rate_limited()` without new wiring — see the explicit wiring step below.
+  - Runner monotonic counters: `truncate_breaker_reconcile_count` (runner.py:493),
+    `dirty_rest_refresh_failure_count` (runner.py:502) — already read by the sweep.
+  - REST error classifiers: `is_truncate_error` 110017, `is_insufficient_balance`
+    110007, `is_duplicate_link_error` 110072, `is_network_error` (executor.py:39-121).
+  - WS reconnect branches: orchestrator.py:1146-1198 (public/private reconnect in
+    `_health_check_once`) and `_ws_health_check_once` resets (1216-1258).
+  - Preflight skips: runner `_skip_window` (runner.py:405-407) already counts genuine
+    preflight skips per summary window.
+- Shadow vs live: `IntentExecutor.shadow_mode` (executor.py:214) and
+  `StrategyRunner.shadow_mode` (runner.py:519). In shadow mode `execute_place`
+  early-returns a synthetic success (executor.py:273-284). The counter set must be
+  populated identically in both modes (see Parity below).
+- Atomic JSON write convention is ESTABLISHED:
+  `GridStateStore._atomic_write` (packages/gridcore/src/gridcore/persistence.py:283-306)
+  = write `<path>.tmp`, `json.dump`, `f.flush()`, `os.fsync`, `os.replace`, cleanup
+  tmp on failure. It is PRIVATE and hard-bound to `self.file_path` (writes the
+  full grid-state data dict), so it CANNOT be called for an arbitrary status
+  path. `HealthStatusWriter` REPLICATES this tmp+fsync+os.replace pattern against
+  its own `status_file_path`; it does NOT call into `GridStateStore`. (A shared
+  free-function helper is optional but out of scope — keep it surgical.)
+- `gridbot-health` CLI tails `/tmp/gridbot.log` and persists durable ledgers in
+  `health_state.json`. This feature COMPLEMENTS it: a separate machine-readable
+  status artifact the CLI (or any operator/script) can read without log parsing.
+  It does NOT write to `health_state.json` (that file is owned by the skill).
+
+## Export surface decision — JSON status file (RECOMMENDED), not HTTP /health
+
+Evaluated both:
+
+- HTTP `/health` endpoint: pull-model, standard for liveness probes. Costs: a bound
+  port, a background server thread (the bot is a tight 100 ms single-threaded poll
+  loop — adding a socket-serving thread is new concurrency + a failure surface), a
+  security/exposure surface on a mainnet-trading daemon, and config for bind
+  address/port. Disproportionate for a single-host daemon.
+- Periodic JSON status file: push-model, atomic write once per 10 s sweep. Zero new
+  threads/ports/sockets. Matches the existing file-based monitoring convention
+  (`gridbot-health` + `health_state.json` + `grid_anchor.json`), reuses the proven
+  `_atomic_write` pattern, and is trivially consumable (`cat`, `jq`, the skill).
+
+RECOMMENDATION: **JSON status file.** It aligns with the existing file-based
+operability story, adds no concurrency/network surface, honors the non-goal "no full
+Prometheus/Grafana," and keeps scope surgical. Default path
+`/tmp/gridbot_status.json` (sibling of `/tmp/gridbot.log`), overridable via config.
+
+## Health-state enum (single overall state + reason)
+
+New `HealthState` str-enum (str-valued for JSON), in a new module
+`apps/gridbot/src/gridbot/health.py`. Values, in precedence order (worst wins when
+computing the overall state):
+
+- `circuit_open` — any strat's C3 loss breaker latched (`SafetyCaps.loss_tripped()`),
+  read via the new per-strat `self._safety_caps[strat_id]` map populated in
+  `_init_strategy` (see Wiring below).
+- `auth_cooldown` — any strat currently in auth cooldown
+  (`_auth_cooldown_until` non-empty, or any executor `.auth_cooldown` True).
+- `degraded` — at least one soft signal: a WS reconnect in the last sweep, a
+  non-zero `dirty_rest_refresh_failure_count` delta, sustained rate-limit (C4), or a
+  recent REST-error burst (see counters).
+- `healthy` — none of the above; loop alive and runners present.
+- `starting` — emitted once at the END of `start()` (orchestrator.py:382, after
+  `self._running`/`self._started` are set), BEFORE the separate blocking poll loop
+  `run()` (orchestrator.py:384) enters — i.e. after init completes but before the
+  first `_health_check_once` sweep — so a freshly-launched bot is not misread as
+  healthy/stale.
+
+The snapshot carries the overall state AND a per-strategy breakdown so an operator
+sees which strat tripped. Precedence is computed in `health.py` from the inputs, not
+hard-coded at the call site.
+
+## Counter / gauge set
+
+A new `HealthMetrics` collector (in `health.py`), a plain object holding process-
+lifetime monotonic counters (reset only on restart — matches the existing
+`truncate_breaker_reconcile_count` semantics) plus point-in-time gauges. Counters
+are incremented at the existing choke points; gauges are read at snapshot time.
+
+Counters (monotonic, per process; keyed by strat_id where natural):
+- `orders_placed` — real accepted submissions (executor.py:340, success path).
+- `orders_placed_shadow` — shadow synthetic successes (executor.py:280) — kept
+  separate so live and shadow are both visible without conflating volumes.
+- `orders_rejected` — `execute_place` failure path (executor.py:354), labeled by a
+  coarse reason derived from the existing classifiers: `auth`, `insufficient_balance`
+  (110007), `truncate` (110017), `duplicate_link` (110072), `rate_limit`
+  (safety_cap sentinel), `network`, `other`.
+- `cancels`, `cancels_failed` — executor cancel paths (executor.py:382/394/398).
+- `rest_errors_by_code` — dict {code→count} from the same classifiers (110007/
+  110017/110072/auth-codes/network/other), incremented in `IntentExecutor._handle_error`
+  + the place/cancel failure paths.
+- `ws_reconnects` — split `public` / `private`, incremented in the reconnect
+  branches (orchestrator.py:1154/1180) and the `_ws_health_check_once` reset paths.
+- `preflight_skips` — process-lifetime monotonic. DO NOT sum `_skip_window`: that
+  dict is RESET to `{}` every summary window in `_emit_skip_summary`
+  (runner.py:1789), so summing it is a sawtooth, not monotonic. Instead add a NEW
+  `_preflight_skip_count: int` on `StrategyRunner`, incremented at the SAME genuine
+  preflight-skip site (runner.py:1630, alongside the `_skip_window` bump), exposed
+  via a new public read-only property `preflight_skip_count` (mirroring
+  `truncate_breaker_reconcile_count` at runner.py:493). The sweep sums THAT property
+  across runners. (`_skip_window` keeps its summary-log role unchanged.)
+- `auth_cooldown_cycles` — surfaced from `AuthCooldownManager._auth_cooldown_cycles`.
+- `loss_breaker_trips` — incremented on the C3 True transition.
+
+Gauges (sampled at sweep time):
+- `runners` (count), `position_size` per strat, `auth_cooldown_active` (count),
+  `loss_breaker_latched` (count), `last_sweep_ts` (UTC iso), `uptime_seconds`,
+  `shadow` flag per strat.
+- `position_size` per strat is NOT exposed today — `StrategyRunner` keeps
+  `_long_position`/`_short_position` PRIVATE (runner.py:445) with no public
+  position accessor. Add a small public read-only property `net_position_size`
+  (→ `float(self._long_position.size - self._short_position.size)`) on
+  `StrategyRunner` and read THAT; do not reach into the privates.
+- `uptime_seconds` / start origin: add `self._start_time: Optional[float] = None`
+  in `Orchestrator.__init__`, set `self._start_time = time.monotonic()` at the END
+  of `start()` (orchestrator.py:382, where the `starting` snapshot is written), and
+  compute `uptime_seconds = time.monotonic() - self._start_time` at snapshot time.
+  The first (`starting`) snapshot thus reports `uptime_seconds ≈ 0`.
+
+Retention: in-memory only, process-lifetime monotonic; the JSON file is overwritten
+each sweep (last-value-wins snapshot, not a time series). No history, no rotation —
+deliberately matches the non-goal "no Prometheus." The `gridbot-health` skill remains
+the cross-restart durable ledger.
+
+## Wiring — make `SafetyCaps` + runner position reachable from the sweep
+
+The sweep needs three things `_health_check_once` cannot read today. All additive:
+
+1. **`SafetyCaps` per strat.** Add `self._safety_caps: dict[str, SafetyCaps] = {}`
+   in `Orchestrator.__init__`. In `_init_strategy`, after the local `safety_caps`
+   is built (orchestrator.py:800) and the executor/runner are registered
+   (`self._strategy_executors[strat_id] = executor`, :868), also set
+   `self._safety_caps[strat_id] = safety_caps`. The sweep then reads
+   `caps.loss_tripped()` / `caps.rate_limited(now)` per strat → `circuit_open` /
+   C4-degraded. (Same instance as executor+runner; no new object.)
+2. **Runner position.** New public `StrategyRunner.net_position_size` property
+   (see Gauges). The sweep reads it per runner for the `position_size` gauge.
+3. **Preflight skips.** New `StrategyRunner._preflight_skip_count` +
+   `preflight_skip_count` property (see Counters). The sweep sums it across runners.
+
+## Emission / aggregation
+
+- `HealthMetrics` is constructed in `Orchestrator.__init__` and held as
+  `self._health_metrics`. It is passed by reference into each `IntentExecutor`
+  (constructor kwarg, optional — `None` for direct/test callers, inert like the
+  existing `safety_caps` arg) so the executor increments place/reject/cancel/REST
+  counters at its existing choke points. WS-reconnect and preflight counters are
+  incremented by the orchestrator/runner directly.
+- At the END of `_health_check_once` (after the existing sweep work), the
+  orchestrator builds a `HealthSnapshot` (overall state via the precedence rules +
+  per-strat breakdown + counters/gauges) and writes it atomically to the status path
+  via a new `HealthStatusWriter` (reuses the `_atomic_write` tmp+fsync+os.replace
+  pattern). Wrapped in try/except so a status-write failure NEVER perturbs the trading
+  loop (logged once, throttled). Cadence = the 10 s health-sweep interval (no new
+  timer).
+- `starting` state: write one snapshot at the end of `start()` before the loop runs.
+
+## Parity (live ↔ shadow)
+
+The snapshot shape is identical in both modes — same keys, same enum. Differences are
+data, not structure: shadow increments `orders_placed_shadow` and never
+`orders_placed`/`rest_errors_by_code` (no real submit). The per-strat breakdown
+carries a `shadow: true/false` flag. C1/C2/C3 run in the runner before the executor,
+so a shadow run still reflects `circuit_open` when the loss breaker trips (faithful) —
+verify in tests. No `if shadow:` branch in the snapshot builder beyond reading the
+runner's existing `shadow_mode` property.
+
+## Config
+
+Add to `GridbotConfig` (config.py:437):
+- `status_file_path: str = "/tmp/gridbot_status.json"` — where to write the snapshot.
+- `status_file_enabled: bool = True` — master switch (off → writer is a no-op, for
+  tests / standalone). Existing YAMLs load unchanged (defaults).
+
+Wire the path from `main.py` (orchestrator.py:121 construction site) — pass via a new
+optional `Orchestrator.__init__` kwarg sourced from config, mirroring `anchor_store_path`.
+
+## Files
+
+New:
+- `apps/gridbot/src/gridbot/health.py` — `HealthState` enum, `HealthMetrics`
+  collector, `HealthSnapshot` builder (pure: inputs → dict), `HealthStatusWriter`
+  (atomic JSON write).
+- `apps/gridbot/tests/test_health.py` — unit tests for the enum precedence, the
+  snapshot builder, and the atomic writer.
+- `apps/gridbot/tests/test_orchestrator_health_status.py` — integration: state
+  transition on auth_cooldown (and circuit_open) trip.
+
+Changed:
+- `orchestrator.py` — construct `HealthMetrics`/`HealthStatusWriter` +
+  `self._safety_caps: dict[str, SafetyCaps]` + `self._start_time` in `__init__`;
+  populate `self._safety_caps[strat_id] = safety_caps` and pass metrics into
+  executors at `_init_strategy` (orchestrator.py:800/868); increment WS-reconnect
+  counters in the existing reconnect branches; read `caps.loss_tripped()` /
+  `caps.rate_limited()` per strat + `runner.net_position_size` /
+  `runner.preflight_skip_count` per runner in `_health_check_once`; build + write
+  the snapshot at the end of `_health_check_once`; set `self._start_time` and write
+  `starting` at end of `start()`.
+- `runner.py` — add `self._preflight_skip_count` (incremented at runner.py:1630)
+  with a public `preflight_skip_count` property; add a public `net_position_size`
+  property. No behavior change (both additive, monotonic/read-only).
+- `executor.py` — accept optional `health_metrics` kwarg (inert when None); increment
+  placed/shadow/rejected(+reason)/cancel/rest-error counters at the existing paths.
+  No behavior change.
+- `config.py` — two new `GridbotConfig` fields (above).
+- `main.py` — pass `status_file_path` / `status_file_enabled` into `Orchestrator`.
+- `RULES.md` — operator doc (below).
+
+## Step-by-step
+
+1. Write `health.py`: `HealthState` enum; `HealthMetrics` (counters/gauges + thread
+   note — incremented on the main thread at the executor/orchestrator choke points,
+   matching the existing main-thread-only model); pure `build_snapshot(...)` →ordered
+   dict applying the worst-wins precedence; `HealthStatusWriter` that REPLICATES the
+   tmp+fsync+os.replace atomic-write pattern from
+   `GridStateStore._atomic_write` (packages/gridcore/.../persistence.py:283-306)
+   against its own `status_file_path` (it does not call into `GridStateStore`).
+2. Unit-test `health.py` (TDD): precedence (circuit_open > auth_cooldown > degraded >
+   healthy), each trip input maps to the right state, snapshot dict shape stable,
+   writer produces valid JSON and is atomic (tmp cleaned on simulated failure).
+3. Add the two `GridbotConfig` fields; assert defaults in `test_config.py`.
+4. Thread `health_metrics` into `IntentExecutor`; increment at existing place/cancel/
+   `_handle_error` paths. Extend `test_executor.py`: a place success bumps
+   `orders_placed`; a 110007 failure bumps `orders_rejected[insufficient_balance]` +
+   `rest_errors_by_code[110007]`; shadow place bumps `orders_placed_shadow` only.
+5. Wiring (additive): add `self._safety_caps: dict[str, SafetyCaps]`,
+   `self._start_time`, metrics, and writer in `Orchestrator.__init__`; in
+   `_init_strategy` set `self._safety_caps[strat_id] = safety_caps` and pass metrics
+   into the executor; add `StrategyRunner._preflight_skip_count` +
+   `preflight_skip_count` and `net_position_size` properties. In
+   `_health_check_once` read caps (`loss_tripped`/`rate_limited`) per strat from the
+   map and `runner.net_position_size` / `runner.preflight_skip_count` per runner; add
+   WS-reconnect increments; build+write snapshot at end (try/except, throttled-log on
+   failure). Set `self._start_time` and write `starting` at end of `start()`.
+6. Integration test (below).
+7. RULES.md operator section.
+8. `uv run pytest apps/gridbot/tests/`, `make lint`, `make test`.
+
+## State-transition test (required acceptance)
+
+`test_orchestrator_health_status.py` (mirrors `test_auth_cooldown_manager.py` /
+`test_orchestrator.py` setup — in-memory config, mock REST, `status_file_path` →
+tmp_path):
+- Build an orchestrator with one strat, write to a `tmp_path` status file.
+- Drive an executor to `max_auth_failures` consecutive auth errors so
+  `_on_cooldown_entered` → `AuthCooldownManager.enter` latches cooldown.
+- Call `_health_check_once`; read the JSON file; assert `state == "auth_cooldown"`
+  and the per-strat breakdown flags that strat, `auth_cooldown_cycles >= 1`.
+- Advance the clock past expiry; `_health_check_once` again; assert state returns to
+  `healthy` (cooldown swept, expiry map empty).
+- Second transition (`circuit_open`): trip the strat's `SafetyCaps` via the
+  orchestrator's `self._safety_caps[strat_id]` map (call `check_loss_breaker` with
+  loss ≤ −limit so `loss_tripped()` latches); sweep; assert the sweep read it through
+  that map → `state == "circuit_open"` and `loss_breaker_latched >= 1`. (This is the
+  accessor the wiring step adds; the test fails today because the map does not exist.)
+- Parity: same assertions hold for a `shadow_mode=True` strat (state still flips;
+  `orders_placed` stays 0, `orders_placed_shadow` may be >0).
+
+Unit-level `HealthMetrics`/precedence tests in `test_health.py` cover the rest.
+
+## RULES.md doc (operator: check health without tailing logs)
+
+Add a subsection under the gridbot app section: the bot writes
+`/tmp/gridbot_status.json` (configurable) every ~10 s — a machine-readable snapshot
+of overall `state` (healthy/degraded/circuit_open/auth_cooldown/starting), per-strat
+breakdown, and process-lifetime counters (orders placed/rejected-by-reason, REST
+errors by code, WS reconnects, preflight skips, cooldown cycles, loss-breaker trips).
+Operators run `jq . /tmp/gridbot_status.json` (or `jq .state ...`) for an instant
+read; the `gridbot-health` skill complements this (durable cross-restart ledgers from
+the log). Note: counters reset on restart; the file is last-value-wins, not a time
+series. Document the config keys (`status_file_path`, `status_file_enabled`) and that
+it is additive/no-trading-impact.
+
+## What could break / risks
+
+- Status-write I/O failure must never wedge the loop — guarded by try/except +
+  throttled log (mirrors the existing periodic-check error handling at
+  orchestrator.py:556-564). Tested via a writer that raises.
+- Double-counting preflight skips — read the runner's existing skip counter; do NOT
+  add a second increment in the skip path.
+- Counter increments on the executor are main-thread (runner ticker / retry drain),
+  same model as `safety_caps`/`auth_cooldown` — no new locking required; state the
+  invariant in the module docstring.
+- Keep `HealthMetrics` increments O(1) and off any per-message WS-thread path (the
+  100 ms loop budget is tight); only the executor/orchestrator main-thread choke
+  points touch it.
+
+## Non-goals (explicit)
+
+No HTTP server, no Prometheus/Grafana exporter, no metric history/rotation, no change
+to `gridbot-health` or `health_state.json`, no trading-logic change.


### PR DESCRIPTION
## Summary
Moves the live gridbot beyond logs-only: a structured **health-state snapshot + process-lifetime metrics**, written once per ~10s health sweep to a JSON status file. Additive, **no trading-logic change**, live↔shadow parity. Designed via adversarial plan-debate (2 iterations; the critical finding caught that `circuit_open` would have been unreachable without new wiring).

- **`health.py`** — `HealthState` enum (worst-wins: circuit_open > auth_cooldown > degraded > healthy, + starting), `HealthMetrics` collector, pure `build_snapshot`, `HealthStatusWriter` (atomic tmp+fsync+os.replace).
- **`executor.py`** — optional `health_metrics` kwarg (inert when None, mirrors the 0079 `safety_caps` pattern); counts placed / placed_shadow / rejected-by-reason / cancels / `rest_errors_by_code` at the existing choke points.
- **`orchestrator.py`** — per-strat `_safety_caps` map so the sweep can read `loss_tripped()`/`rate_limited()`; builds + atomically writes the snapshot at the end of `_health_check_once` (guarded — a write failure never perturbs the 100ms loop); WS-reconnect counters; `starting` snapshot in `start()`.
- **`runner.py`** — public `preflight_skip_count` (new monotonic counter, not the resettable `_skip_window`) + `net_position_size`.
- **`config.py`** — `status_file_path` / `status_file_enabled`. **`auth_cooldown_manager.py`** — public `cooldown_cycles`. **`RULES.md`** — operator doc (`jq` the status file).

## Export surface
**JSON status file** (default `/tmp/gridbot_status.json`) — HTTP `/health` rejected (no port/thread/security surface on a mainnet daemon; matches the existing file-based monitoring story; honors non-goal "no Prometheus"). **Complements** the `gridbot-health` skill (does not touch `health_state.json`).

## Verification
- `make lint` green · `make test` green; 465 existing gridbot tests no-regression (None default = inert).
- New tests (26): health unit (precedence/metrics/snapshot/atomic writer), executor↔metrics integration, orchestrator **state transitions** (auth_cooldown → recovery → circuit_open, shadow parity, starting).

## Notes
- Sourced the status path from `config` directly → **no `main.py` change** needed (simpler than the plan's kwarg approach).
- Applied 5 self-review fixes pre-PR (worst_state guard, gauge decoupling when circuit+cooldown co-occur, `makedirs exist_ok`, 2 doc corrections).

Plan: `docs/features/0082_PLAN.md`.

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)