### PR TITLE
fix(gridbot): enforce 110017 breaker on retry-queue re-dispatch

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -580,11 +580,13 @@ builds ONE instance per strat in `_init_strategy` and passes the SAME object
     window — **shadow placements do not**.
 - **Retry-queue cap enforcement (critical)**: place retries are dispatched via
   `StrategyRunner.retry_dispatch_place` (orchestrator wires this in
-  `_init_strategy`), which re-applies C1/C2/C3 before calling the executor — the
-  executor alone only enforces C4. On C3 trip the retry queue is **cleared**
-  (mirrors auth-cooldown). `RetryQueue.is_paused` also gates on
-  `loss_tripped()`. Cap-blocked retries return `error.startswith("safety_cap")`
-  and are **dropped** from the queue (not re-backed-off).
+  `_init_strategy`), which re-applies the 110017 truncate breaker (Step 2) and
+  C1/C2/C3 before calling the executor — the executor alone only enforces C4. On
+  C3 trip the retry queue is **cleared** (mirrors auth-cooldown).
+  `RetryQueue.is_paused` also gates on `loss_tripped()`. Cap-blocked retries
+  return `error.startswith("safety_cap")` and breaker-blocked retries return
+  `error="truncate_breaker_blocked"`; both are **dropped** from the queue (not
+  re-backed-off).
 - **Precedence**: caps run in `_execute_place_intent` as **Step 2.5** — AFTER
   qty-resolve (Step 1) + the 110017 breaker (Step 2) and BEFORE the dirty refresh
   / `_is_good_to_place` guard — so a capped intent never reaches the strategy

--- a/apps/gridbot/src/gridbot/retry_queue.py
+++ b/apps/gridbot/src/gridbot/retry_queue.py
@@ -228,12 +228,19 @@ class RetryQueue:
                     logger.info(f"Retry succeeded: {type(item.intent).__name__}")
                     items_to_remove.append(item)
                     processed += 1
-                elif result.error and result.error.startswith("safety_cap"):
+                elif result.error and (
+                    result.error.startswith("safety_cap")
+                    or result.error == "truncate_breaker_blocked"
+                ):
                     # Feature 0079 — cap-blocked retries are dropped, not
                     # re-backed-off (mirrors runner drop-not-enqueue on first
-                    # dispatch for safety_cap sentinels).
+                    # dispatch for safety_cap sentinels). The truncate-breaker
+                    # sentinel mirrors Step 2 silent drop on first dispatch.
                     logger.warning(
-                        "Retry dropped (safety cap): %s — %s",
+                        "Retry dropped (%s): %s — %s",
+                        "truncate breaker"
+                        if result.error == "truncate_breaker_blocked"
+                        else "safety cap",
                         type(item.intent).__name__, result.error,
                     )
                     items_to_remove.append(item)

--- a/apps/gridbot/src/gridbot/runner.py
+++ b/apps/gridbot/src/gridbot/runner.py
@@ -2333,7 +2333,24 @@ class StrategyRunner:
         ``_is_good_to_place`` via ``_execute_place_intent``; retries reuse the
         assigned wire ``order_link_id`` and only need a fresh cap read plus
         executor submit + tracking bookkeeping.
+
+        Re-checks the 110017 truncate breaker (Step 2 on first dispatch): a
+        queued place can outlive a breaker trip on the same ``(side, price)``
+        scope, so retries must honor the cooldown or they partially bypass the
+        0064 storm backstop.
         """
+        now = self._clock()
+        if self._truncate_breaker.is_blocked(intent.side, intent.price, now):
+            logger.debug(
+                "%s: 110017 breaker tripped — dropping retry %s @ %s",
+                self.strat_id, intent.side, intent.price,
+            )
+            return OrderResult(
+                success=False,
+                order_link_id=intent.order_link_id,
+                error="truncate_breaker_blocked",
+            )
+
         allowed, reason = self._evaluate_safety_caps(
             intent, self.get_limit_orders()
         )

--- a/apps/gridbot/tests/test_retry_queue.py
+++ b/apps/gridbot/tests/test_retry_queue.py
@@ -456,3 +456,23 @@ class TestRetryQueuePaused:
 
         assert processed == 1
         assert queue.size == 0
+
+    def test_process_due_drops_truncate_breaker_failure(self, place_intent):
+        """Breaker-blocked retries are removed, not re-backed-off."""
+        executor = Mock(
+            return_value=OrderResult(
+                success=False, error="truncate_breaker_blocked"
+            )
+        )
+        queue = RetryQueue(
+            executor_func=executor,
+            max_attempts=10,
+            initial_backoff_seconds=0.01,
+        )
+        queue.add(place_intent, "network error")
+        _force_due(queue)
+
+        processed = queue.process_due()
+
+        assert processed == 1
+        assert queue.size == 0

--- a/apps/gridbot/tests/test_runner.py
+++ b/apps/gridbot/tests/test_runner.py
@@ -4747,6 +4747,30 @@ class TestSafetyCapsIntegration:
         assert caps.loss_tripped() is True
         assert retry_queue.size == 0
 
+    def test_retry_dispatch_place_blocks_when_truncate_breaker_tripped(
+        self, strategy_config, mock_executor, instrument_info
+    ):
+        """Queued retries must honor the 110017 breaker cooldown on (side, price)."""
+        r = StrategyRunner(
+            strategy_config=strategy_config,
+            executor=mock_executor,
+            instrument_info=instrument_info,
+            clock=lambda: 0.0,
+        )
+        r._wallet_balance = Decimal("10000")
+        close = PlaceLimitIntent.create(
+            symbol="BTCUSDT", side="Sell", price=Decimal("51000"),
+            qty=Decimal("0.001"), grid_level=1, direction="long", reduce_only=True,
+        )
+        intent = self._assign_wire(close)
+        # Trip the breaker for this scope key (3× 110017 within the window).
+        for t in (0.0, 1.0, 2.0):
+            r._truncate_breaker.record_110017("Sell", Decimal("51000"), t)
+        result = r.retry_dispatch_place(intent)
+        assert result.success is False
+        assert result.error == "truncate_breaker_blocked"
+        mock_executor.execute_place.assert_not_called()
+
     def test_retry_dispatch_place_blocks_when_loss_breaker_latched(
         self, strategy_config, mock_executor, instrument_info
     ):


### PR DESCRIPTION
Clean-branch repeat of #198 (same fix, my branch).

## Bug — narrow but real

`retry_dispatch_place` (added in #197) re-applies C1/C2/C3 caps but
omitted Step 2 (`TruncateBreaker.is_blocked`) from the first-dispatch
pipeline. A retry enqueued from a network/110072 failure at scope
`(side, price)` could still submit to Bybit **after** the 110017
truncate breaker tripped on that same scope from later emissions —
partially bypassing the feature-0064 storm backstop. (The existing
first-dispatch 110017 comment already names this: *"the retry queue does
not exclude — partially bypassing the backstop"*.)

## Fix

- `retry_dispatch_place`: check `truncate_breaker.is_blocked` before
  submit (mirrors first-dispatch Step 2 precedence — runs before the
  Step 2.5 cap check); return `truncate_breaker_blocked` sentinel.
- `RetryQueue.process_due`: drop breaker-blocked retries (no backoff
  storm), mirroring the `safety_cap*` drop.

## Validation

- New tests: `test_retry_dispatch_place_blocks_when_truncate_breaker_tripped`,
  `test_process_due_drops_truncate_breaker_failure`.
- `ruff check .` clean; full gridbot suite **794 passed** locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)