### PR TITLE
fix(gridbot): trip C3 loss breaker on flat-position curRealisedPnl

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -563,8 +563,11 @@ builds ONE instance per strat in `_init_strategy` and passes the SAME object
     rejects BOTH open and reduce-only at/above the cap.
   - **C3 `session_loss_limit`** (positive USDT magnitude) + flag
     `session_loss_auto_reset_utc_midnight`. Evaluated in `on_position_update`
-    (where realized PnL lands) off the per-cycle `cur_realized_pnl` sum (the
-    Bybit UI "Realized", NOT the ~80x lifetime `cumRealisedPnl`). On trip it is a
+    (where realized PnL lands) off the per-cycle `curRealisedPnl` sum read
+    directly from the raw long/short WS payloads (`runner._cur_realized_pnl_from_raw`),
+    NOT from `_build_position_state` (which returns `None` at `size == 0` and
+    would miss the closing-fill loss). Uses the Bybit UI "Realized", NOT the ~80x
+    lifetime `cumRealisedPnl`. On trip it is a
     **full circuit breaker**: cancel ALL working orders once (via
     `_execute_cancel_intent` → honors shadow mode + tracked-order state; uses the
     wire `orderId`, not `orderLinkId`) then suppress ALL new places (open AND

--- a/apps/gridbot/src/gridbot/runner.py
+++ b/apps/gridbot/src/gridbot/runner.py
@@ -14,7 +14,7 @@ import time
 from collections import OrderedDict, deque
 from dataclasses import dataclass, field, replace
 from datetime import datetime, UTC, timedelta
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from typing import Optional, Callable, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -2492,7 +2492,7 @@ class StrategyRunner:
             return Decimal("0")
         try:
             return Decimal(str(raw))
-        except Exception:
+        except (TypeError, ValueError, InvalidOperation):
             return Decimal("0")
 
     def _evaluate_loss_breaker(

--- a/apps/gridbot/src/gridbot/runner.py
+++ b/apps/gridbot/src/gridbot/runner.py
@@ -969,7 +969,7 @@ class StrategyRunner:
             self._short_position_value = (
                 short_state.position_value if short_state else Decimal("0")
             )
-            self._evaluate_loss_breaker(long_state, short_state)
+            self._evaluate_loss_breaker(long_position, short_position)
 
             # Update position sizes (used by _is_good_to_place). While a
             # direction is dirty (feature 0064), the size write is gated so a
@@ -2477,14 +2477,32 @@ class StrategyRunner:
                 self.strat_id, reason, intent.side, intent.price,
             )
 
+    @staticmethod
+    def _cur_realized_pnl_from_raw(position_data: Optional[dict]) -> Decimal:
+        """Read Bybit ``curRealisedPnl`` from a raw position payload.
+
+        Used by the C3 loss breaker independently of ``_build_position_state``,
+        which returns ``None`` when ``size == 0``. A closing fill often arrives
+        only on that flat payload, so the breaker must not discard it.
+        """
+        if not position_data:
+            return Decimal("0")
+        raw = position_data.get("curRealisedPnl")
+        if raw in (None, ""):
+            return Decimal("0")
+        try:
+            return Decimal(str(raw))
+        except Exception:
+            return Decimal("0")
+
     def _evaluate_loss_breaker(
         self,
-        long_state: Optional[PositionState],
-        short_state: Optional[PositionState],
+        long_position: Optional[dict],
+        short_position: Optional[dict],
     ) -> None:
         """C3 — evaluate the session realized-loss circuit breaker (feature 0079).
 
-        Uses the per-cycle "Realized" value (``cur_realized_pnl`` — the Bybit UI
+        Uses the per-cycle "Realized" value (``curRealisedPnl`` — the Bybit UI
         Realized column), NOT the ~80x lifetime ``cumRealisedPnl``. On a NEW
         trip: emit one ERROR + alert and cancel ALL working orders for the
         symbol via ``_execute_cancel_intent`` (honors shadow mode + tracked-order
@@ -2494,8 +2512,8 @@ class StrategyRunner:
         if self._safety_caps is None:
             return
         session_realized_pnl = (
-            (long_state.cur_realized_pnl if long_state else Decimal("0"))
-            + (short_state.cur_realized_pnl if short_state else Decimal("0"))
+            self._cur_realized_pnl_from_raw(long_position)
+            + self._cur_realized_pnl_from_raw(short_position)
         )
         newly_tripped = self._safety_caps.check_loss_breaker(
             session_realized_pnl=session_realized_pnl,

--- a/apps/gridbot/tests/test_runner.py
+++ b/apps/gridbot/tests/test_runner.py
@@ -4967,6 +4967,39 @@ class TestSafetyCapsIntegration:
         r._execute_place_intent(self._open(), {"long": [], "short": []})
         mock_executor.execute_place.assert_not_called()
 
+    def test_c3_trip_on_flat_position_cur_realised_pnl(
+        self, strategy_config, mock_executor, instrument_info
+    ):
+        """C3 must read curRealisedPnl from size=0 payloads (closing fill).
+
+        _build_position_state returns None when size==0, so evaluating C3 only
+        from PositionState would miss the session loss on the flat update.
+        """
+        caps = SafetyCaps(
+            SafetyCapsConfig(session_loss_limit="25"), strat_id="btcusdt_test"
+        )
+        r = self._runner(strategy_config, mock_executor, instrument_info, caps)
+        intent = self._open(price="49000", qty="0.01")
+        tracked = TrackedOrder(
+            client_order_id=intent.client_order_id, intent=intent, status="placed"
+        )
+        tracked.order_id = "wire_1"
+        r._tracked_orders[intent.client_order_id] = tracked
+
+        r.on_position_update(
+            long_position={
+                "size": "0",
+                "avgPrice": "0",
+                "curRealisedPnl": "-30",
+                "leverage": "10",
+            },
+            short_position={"size": "0", "curRealisedPnl": "0"},
+            wallet_balance=10000.0,
+            last_close=50000.0,
+        )
+        assert caps.loss_tripped() is True
+        mock_executor.execute_cancel.assert_called_once()
+
     def test_rate_limit_sentinel_is_dropped_not_enqueued(
         self, strategy_config, mock_executor, instrument_info
     ):

--- a/apps/gridbot/tests/test_runner.py
+++ b/apps/gridbot/tests/test_runner.py
@@ -981,6 +981,33 @@ class TestBuildPositionStateRealizedPnl:
         assert state.cur_realized_pnl == Decimal("0")
 
 
+class TestCurRealizedPnlFromRaw:
+    """_cur_realized_pnl_from_raw reads curRealisedPnl off raw position payloads."""
+
+    def test_positive_value_parsed(self):
+        pos = {"size": "1.0", "curRealisedPnl": "5.50"}
+        assert StrategyRunner._cur_realized_pnl_from_raw(pos) == Decimal("5.50")
+
+    def test_negative_value_parsed(self):
+        pos = {"size": "0", "curRealisedPnl": "-30.25"}
+        assert StrategyRunner._cur_realized_pnl_from_raw(pos) == Decimal("-30.25")
+
+    def test_none_position_data_default_zero(self):
+        assert StrategyRunner._cur_realized_pnl_from_raw(None) == Decimal("0")
+
+    def test_absent_key_default_zero(self):
+        pos = {"size": "1.0", "avgPrice": "50000"}
+        assert StrategyRunner._cur_realized_pnl_from_raw(pos) == Decimal("0")
+
+    def test_empty_string_default_zero(self):
+        pos = {"size": "1.0", "curRealisedPnl": ""}
+        assert StrategyRunner._cur_realized_pnl_from_raw(pos) == Decimal("0")
+
+    def test_malformed_value_default_zero(self):
+        pos = {"size": "1.0", "curRealisedPnl": "not-a-number"}
+        assert StrategyRunner._cur_realized_pnl_from_raw(pos) == Decimal("0")
+
+
 class TestStrategyRunnerOrderUpdate:
     """Tests for order update events."""
     def test_on_order_update_fills_tracked(self, runner, mock_executor):
@@ -4994,6 +5021,44 @@ class TestSafetyCapsIntegration:
                 "leverage": "10",
             },
             short_position={"size": "0", "curRealisedPnl": "0"},
+            wallet_balance=10000.0,
+            last_close=50000.0,
+        )
+        assert caps.loss_tripped() is True
+        mock_executor.execute_cancel.assert_called_once()
+
+    def test_c3_trip_on_combined_long_short_realized_pnl(
+        self, strategy_config, mock_executor, instrument_info
+    ):
+        """C3 sums realized PnL across both sides: neither leg alone trips.
+
+        long -15 + short -12 = -27 breaches the 25 limit even though each
+        side individually stays under it.
+        """
+        caps = SafetyCaps(
+            SafetyCapsConfig(session_loss_limit="25"), strat_id="btcusdt_test"
+        )
+        r = self._runner(strategy_config, mock_executor, instrument_info, caps)
+        intent = self._open(price="49000", qty="0.01")
+        tracked = TrackedOrder(
+            client_order_id=intent.client_order_id, intent=intent, status="placed"
+        )
+        tracked.order_id = "wire_1"
+        r._tracked_orders[intent.client_order_id] = tracked
+
+        r.on_position_update(
+            long_position={
+                "size": "0.5",
+                "avgPrice": "50000",
+                "curRealisedPnl": "-15",
+                "leverage": "10",
+            },
+            short_position={
+                "size": "0.5",
+                "avgPrice": "50000",
+                "curRealisedPnl": "-12",
+                "leverage": "10",
+            },
             wallet_balance=10000.0,
             last_close=50000.0,
         )


### PR DESCRIPTION
## Bug and impact

When `session_loss_limit` (C3, feature 0079) is enabled, a closing fill that realizes a loss beyond the limit could fail to trip the circuit breaker. The bot would keep placing orders and leave working limits live after the configured session loss was breached — a fail-open on the exact event the breaker exists to catch.

**Trigger:** a position fully closes (WS payload `size=0`) with `curRealisedPnl <= -session_loss_limit`. The cycle's realized PnL often appears only on that flat update.

## Root cause

`_evaluate_loss_breaker` summed `cur_realized_pnl` from `PositionState` objects built by `_build_position_state`, which returns `None` when `size == 0` (runner.py). Flat payloads carrying the closing loss were discarded before the breaker evaluated them.

## Fix

- Read `curRealisedPnl` directly from the raw long/short WS payloads via new `_cur_realized_pnl_from_raw`, bypassing only the size==0 gate. Value source and per-cycle "Realized" semantics (NOT lifetime `cumRealisedPnl`) are unchanged; the trip latch in `SafetyCaps.check_loss_breaker` stays sticky, so one flat payload suffices.
- RULES.md C3 section updated to document the raw-payload read.

## Validation

- Regression test `test_c3_trip_on_flat_position_cur_realised_pnl` proven RED on unfixed source (breaker not tripped), GREEN with fix.
- `uv run pytest apps/gridbot` — 806 passed.
- `ruff check apps/gridbot` — clean.

Supersedes #216 (bot-authored); bug and fix independently verified against `main`, then re-implemented on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)