### PR TITLE
fix(gridbot): make never-fetched account eligible on first rotation tick

### DIFF
--- a/apps/gridbot/src/gridbot/position_fetcher.py
+++ b/apps/gridbot/src/gridbot/position_fetcher.py
@@ -556,8 +556,11 @@ class PositionFetcher:
         for offset in range(n):
             idx = (start_idx + offset) % n
             account_name, runners = accounts[idx]
-            last = self._last_position_fetch.get(account_name, 0.0)
-            if (now - last) < per_account_floor:
+            # A never-fetched account is always eligible. Defaulting to 0.0
+            # would skip it while time.monotonic() < floor — on Linux that is
+            # seconds since boot, so fresh CI VMs silently no-op'd here.
+            last = self._last_position_fetch.get(account_name)
+            if last is not None and (now - last) < per_account_floor:
                 continue
             try:
                 self._fetch_one_account(account_name, runners)

--- a/apps/gridbot/tests/test_orchestrator.py
+++ b/apps/gridbot/tests/test_orchestrator.py
@@ -1695,6 +1695,28 @@ class TestOrchestratorPositionCheckRotation:
     @patch("gridbot.orchestrator.BybitRestClient")
     @patch("gridbot.orchestrator.PublicWebSocketClient")
     @patch("gridbot.orchestrator.PrivateWebSocketClient")
+    def test_first_fetch_eligible_regardless_of_monotonic_start(
+        self, mock_private_ws, mock_public_ws, mock_rest_client, gridbot_config,
+    ):
+        """Never-fetched account is eligible even when time.monotonic() < floor.
+
+        On Linux time.monotonic() is seconds since boot; fresh CI VMs start
+        near zero, so the old `last = .get(name, 0.0)` default made the first
+        rotation fetch a no-op until uptime exceeded the 60s floor.
+        """
+        orchestrator = self._make_orch_with_accounts(gridbot_config, 1)
+        fetcher = orchestrator._position_fetcher
+        fetcher._fetch_one_account = Mock()
+        assert fetcher._last_position_fetch == {}  # never fetched
+
+        with patch("gridbot.position_fetcher.time.monotonic", return_value=30.0):
+            fetcher._fetch_positions_rotation_tick()
+
+        fetcher._fetch_one_account.assert_called_once()
+
+    @patch("gridbot.orchestrator.BybitRestClient")
+    @patch("gridbot.orchestrator.PublicWebSocketClient")
+    @patch("gridbot.orchestrator.PrivateWebSocketClient")
     def test_per_account_floor_skips_recently_fetched(
         self, mock_private_ws, mock_public_ws, mock_rest_client, gridbot_config,
     ):


### PR DESCRIPTION
## Summary
- Root-causes the flaky `TestOrchestratorPositionCheck` CI failures (CI run 51 on main, PR #217, and earlier): the rotation tick defaulted a never-fetched account's last-fetch timestamp to `0.0`, so the eligibility check degenerated to `time.monotonic() < floor`. On Linux `monotonic` is seconds since boot — fresh CI VMs start near zero, so the first rotation fetch silently no-op'd until VM uptime exceeded the 60s per-account floor. Local macOS uptime is days, hence CI-only.
- Fix: treat a missing timestamp as always eligible (`last is None` → fetch). Semantic bug too, not just a test flake — a never-fetched account should never wait out the floor.
- Regression test `test_first_fetch_eligible_regardless_of_monotonic_start` pins `time.monotonic` to 30.0 (< 60s floor) with an empty `_last_position_fetch`; fails on the old code, passes with the fix.

## Testing
- Repro test red on unfixed code → green with fix
- Full gridbot suite: 814 passed
- `make lint` clean
- Existing rotation/floor tests unaffected (they set `_last_position_fetch` explicitly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)