### PR TITLE
feat(gridbot): fail closed when startup reconciliation fails (#206)

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -912,6 +912,23 @@ Valid: `New`, `PartiallyFilled`, `Filled`, `Cancelled`, `Rejected`, `Untriggered
 - Data flow: `WebSocket → Orchestrator → StrategyRunner → GridEngine.on_event() → Intents → Executor → Bybit REST`
 - Shadow mode: `shadow_mode=True` → intents logged, not executed; returns `shadow_{client_order_id}`
 
+### Startup reconciliation is fail-closed (Feature 0086, issue #206)
+
+`start()` retries a failed startup reconciliation in place (backoffs
+`_STARTUP_RECONCILE_BACKOFFS = (2.0, 5.0, 10.0)`, 4 attempts total per
+strategy). On exhaustion it emits a notifier alert
+(`startup_reconcile_<strat_id>`) and raises `StartupReconciliationError` —
+the process exits 1 with ZERO orders placed; any pre-existing exchange grid
+is left untouched. Rationale: the bot must never trade on an unconfirmed
+open-order book — a startup with empty local state places a duplicate grid
+over live legacy orders, and same-price duplicates are never cancelled by
+the engine (price-keyed dict in `engine.py:_place_grid_orders` collapses
+them; open gap, fix 2 of the #206 analysis). Mid-run order sync keeps
+warn-and-retry semantics (stopping a bot managing a live grid is riskier);
+sync failures now also alert (`order_sync_<strat_id>`, both `result.errors`
+and exception paths). Repro/regression: `test_issue_206_startup_reconcile_race.py`,
+`TestStartupReconcileRetry` in `test_orchestrator.py`.
+
 ### Health status file — check health without tailing logs (Feature 0082, issue #185)
 
 The bot writes a machine-readable JSON snapshot to `status_file_path` (default

--- a/apps/gridbot/src/gridbot/orchestrator.py
+++ b/apps/gridbot/src/gridbot/orchestrator.py
@@ -57,9 +57,18 @@ _RETRY_TICK_INTERVAL = 1.0  # seconds between retry-queue drains
 _WS_RECONNECT_SLOW_THRESHOLD = 5.0  # log a warning if a single WS disconnect+connect takes longer
 _MAX_TICK_BACKOFF = 30.0  # cap (s) on main-loop backoff after consecutive _tick() failures
 _UNKNOWN_ORDER_DEBOUNCE_SEC = 2.0  # min interval between WS-triggered fast-track order syncs
+_STARTUP_RECONCILE_BACKOFFS = (2.0, 5.0, 10.0)  # sleeps between startup reconcile attempts (0086)
 
 
 logger = logging.getLogger(__name__)
+
+
+class StartupReconciliationError(Exception):
+    """Raised when startup reconciliation fails after all retries.
+
+    Trading must not start on unconfirmed exchange order state (issue #206).
+    main.py catches startup exceptions and returns exit code 1.
+    """
 
 
 def _ensure_utc_aware(dt: datetime) -> datetime:
@@ -308,6 +317,11 @@ class Orchestrator:
 
         After start() returns, call run() to enter the blocking polling
         loop, or stop() to tear everything down.
+
+        Raises:
+            StartupReconciliationError: startup reconciliation failed after
+                all retries (fail closed, issue #206) — no orders were
+                placed; main.py converts this into exit code 1.
         """
         if self._running:
             return
@@ -330,17 +344,13 @@ class Orchestrator:
             self._pending_executions[strat_id] = deque()
             self._pending_orders[strat_id] = deque()
 
-        # Perform startup reconciliation
+        # Perform startup reconciliation. Fail closed: if open-order state
+        # cannot be confirmed after retries, abort startup (issue #206).
         for runner in self._runners.values():
             account_name = self._get_account_for_strategy(runner.strat_id)
             reconciler = self._reconcilers.get(account_name)
             if reconciler:
-                result = reconciler.reconcile_startup(runner)
-                logger.info(
-                    f"{runner.strat_id}: Reconciliation complete - "
-                    f"fetched={result.orders_fetched}, injected={result.orders_injected}, "
-                    f"untracked={result.untracked_orders_on_exchange}"
-                )
+                self._reconcile_startup_with_retry(runner, reconciler)
 
         # Create database Run records (populates _run_ids)
         self._create_run_records()
@@ -405,6 +415,53 @@ class Orchestrator:
         self._start_time = time.monotonic()
         self._write_health_snapshot(overall=HealthState.STARTING)
         logger.info(f"Orchestrator started with {len(self._runners)} strategies")
+
+    def _reconcile_startup_with_retry(
+        self, runner: StrategyRunner, reconciler: Reconciler
+    ) -> None:
+        """Run startup reconciliation, retrying transient failures in place.
+
+        One initial attempt plus one retry per _STARTUP_RECONCILE_BACKOFFS
+        entry. On exhaustion, alert and raise StartupReconciliationError so
+        start() aborts before any order is placed (issue #206). Sleeping here
+        is safe: the main loop is not running yet and WebSockets are not
+        connected.
+        """
+        attempts = 1 + len(_STARTUP_RECONCILE_BACKOFFS)
+        for attempt in range(1, attempts + 1):
+            result = reconciler.reconcile_startup(runner)
+            if not result.errors:
+                if attempt > 1:
+                    logger.warning(
+                        "%s: Startup reconciliation recovered on attempt %d/%d",
+                        runner.strat_id, attempt, attempts,
+                    )
+                logger.info(
+                    f"{runner.strat_id}: Reconciliation complete - "
+                    f"fetched={result.orders_fetched}, injected={result.orders_injected}, "
+                    f"untracked={result.untracked_orders_on_exchange}"
+                )
+                return
+            if attempt < attempts:
+                backoff = _STARTUP_RECONCILE_BACKOFFS[attempt - 1]
+                logger.warning(
+                    "%s: Startup reconciliation attempt %d/%d failed (%s), "
+                    "retrying in %.0fs",
+                    runner.strat_id, attempt, attempts, result.errors, backoff,
+                )
+                time.sleep(backoff)
+
+        last_error = result.errors[-1]
+        self._notifier.alert(
+            f"Gridbot: startup reconciliation failed for {runner.strat_id} "
+            f"after {attempts} attempts - {last_error}. Aborting startup, "
+            f"no orders placed.",
+            error_key=f"startup_reconcile_{runner.strat_id}",
+        )
+        raise StartupReconciliationError(
+            f"{runner.strat_id}: startup reconciliation failed after "
+            f"{attempts} attempts: {last_error}"
+        )
 
     def run(self) -> None:
         """Main polling loop. Blocks until request_stop() / stop().
@@ -1742,6 +1799,11 @@ class Orchestrator:
                                 "%s: Order sync completed with errors: %s",
                                 runner.strat_id, result.errors,
                             )
+                            self._notifier.alert(
+                                f"Gridbot: order sync failed for "
+                                f"{runner.strat_id} - {result.errors[-1]}",
+                                error_key=f"order_sync_{runner.strat_id}",
+                            )
                         elif result.orders_injected > 0 or result.untracked_orders_on_exchange > 0:
                             logger.info(
                                 "%s: Order sync - fetched=%d, injected=%d, untracked=%d",
@@ -1756,6 +1818,10 @@ class Orchestrator:
 
                     except Exception as e:
                         logger.error("%s: Order sync error: %s", runner.strat_id, e)
+                        self._notifier.alert_exception(
+                            f"order_sync {runner.strat_id}", e,
+                            error_key=f"order_sync_{runner.strat_id}",
+                        )
         except Exception as e:
             logger.error("Order sync sweep error: %s", e)
 

--- a/apps/gridbot/tests/test_issue_206_startup_reconcile_race.py
+++ b/apps/gridbot/tests/test_issue_206_startup_reconcile_race.py
@@ -1,0 +1,277 @@
+"""Tests for issue #206 — startup reconciliation failure handling.
+
+Original fail-open scenario (pre-0086 behavior, mirrors the orchestrator flow):
+
+1. Startup reconciliation REST call fails once (transient timeout).
+   ``Reconciler.reconcile_startup`` swallows the exception into
+   ``result.errors`` (reconciler.py:95-98) and the orchestrator ignores
+   ``result.errors`` entirely (orchestrator.py:333-343) — startup proceeds
+   with an EMPTY local order book while the old grid is still live on the
+   exchange.
+2. First ticker arrives (orchestrator._tick step 3 runs BEFORE the
+   first-tick order sync in step 4): the engine builds a fresh grid over
+   the empty state and places new orders at price levels where the old
+   exchange orders already sit → live duplicates.
+3. First-tick order sync (``reconcile_reconnect``) then injects the old
+   orders — state is repaired, but the damage is not:
+4. On the next ticker the engine indexes limits with a price-keyed dict
+   (engine.py:359 ``limit_prices = {float(limit['price']): limit ...}``)
+   which collapses same-price duplicates — the shadowed order is neither
+   'outside_grid' nor 'side_mismatch', so it is NEVER cancelled. Double
+   exposure persists until filled.
+
+Feature 0086 fixed the fail-open startup (fail-closed + alert); the
+orchestrator-level test below asserts the fixed behavior. The runner-level
+test still documents the engine same-price duplicate-collapse gap (fix 2 of
+the issue #206 analysis), which is tracked separately.
+"""
+
+import logging
+from datetime import datetime, UTC
+from decimal import Decimal
+from unittest.mock import Mock, MagicMock, patch
+
+import pytest
+
+from gridcore import TickerEvent, EventType, InstrumentInfo
+from gridcore.intents import PlaceLimitIntent
+
+from gridbot.config import GridbotConfig, AccountConfig, StrategyConfig
+from gridbot.executor import IntentExecutor, OrderResult, CancelResult
+from gridbot.notifier import Notifier
+from gridbot.orchestrator import Orchestrator, StartupReconciliationError
+from gridbot.reconciler import Reconciler
+from gridbot.runner import StrategyRunner
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def strategy_config():
+    """Sample strategy configuration."""
+    return StrategyConfig(
+        strat_id="btcusdt_test",
+        account="test_account",
+        symbol="BTCUSDT",
+        tick_size=Decimal("0.1"),
+        grid_count=20,
+        grid_step=0.2,
+        shadow_mode=False,
+    )
+
+
+@pytest.fixture
+def instrument_info():
+    """Sample instrument info for qty rounding."""
+    return InstrumentInfo(
+        symbol="BTCUSDT",
+        qty_step=Decimal("0.001"),
+        tick_size=Decimal("0.1"),
+        min_qty=Decimal("0.001"),
+        max_qty=Decimal("1000"),
+    )
+
+
+@pytest.fixture
+def recording_executor():
+    """Mock executor that assigns unique exchange order IDs and records intents."""
+    executor = Mock(spec=IntentExecutor)
+    executor.shadow_mode = False
+    executor.auth_cooldown = False
+    executor.placed_intents = []
+    executor.cancelled_intents = []
+
+    def _place(intent):
+        executor.placed_intents.append(intent)
+        return OrderResult(
+            success=True, order_id=f"new-{len(executor.placed_intents)}"
+        )
+
+    def _cancel(intent):
+        executor.cancelled_intents.append(intent)
+        return CancelResult(success=True)
+
+    executor.execute_place = MagicMock(side_effect=_place)
+    executor.execute_cancel = MagicMock(side_effect=_cancel)
+    return executor
+
+
+@pytest.fixture
+def runner(strategy_config, recording_executor, instrument_info):
+    """Real StrategyRunner + real engine; only the executor is mocked."""
+    r = StrategyRunner(
+        strategy_config=strategy_config,
+        executor=recording_executor,
+        instrument_info=instrument_info,
+    )
+    # Set wallet balance so qty_calculator can resolve (x0.001 = 0.1% of wallet)
+    r._wallet_balance = Decimal("10000")
+    return r
+
+
+def _ticker(price: str) -> TickerEvent:
+    p = Decimal(price)
+    return TickerEvent(
+        event_type=EventType.TICKER,
+        symbol="BTCUSDT",
+        exchange_ts=datetime.now(UTC),
+        local_ts=datetime.now(UTC),
+        last_price=p,
+        mark_price=p,
+        bid1_price=p - Decimal("1"),
+        ask1_price=p + Decimal("1"),
+        funding_rate=Decimal("0.0001"),
+    )
+
+
+def _exchange_order_dict(intent: PlaceLimitIntent, order_id: str, *, link_id: str | None) -> dict:
+    """Order dict in the shape get_open_orders() returns."""
+    d = {
+        "orderId": order_id,
+        "symbol": intent.symbol,
+        "price": str(intent.price),
+        "qty": "0.001",
+        "side": intent.side,
+        "reduceOnly": intent.reduce_only,
+    }
+    if link_id is not None:
+        d["orderLinkId"] = link_id
+    return d
+
+
+class TestStartupReconcileFailClosed:
+    """Orchestrator-level: startup reconciliation errors abort startup (0086)."""
+
+    @patch("gridbot.orchestrator.time.sleep")
+    @patch("gridbot.orchestrator.BybitRestClient")
+    @patch("gridbot.orchestrator.PublicWebSocketClient")
+    @patch("gridbot.orchestrator.PrivateWebSocketClient")
+    def test_startup_reconcile_error_aborts_startup_and_alerts(
+        self, mock_private_ws, mock_public_ws, mock_rest_client, mock_sleep,
+    ):
+        """Fix for issue #206: persistent get_open_orders failure at startup
+        raises StartupReconciliationError and emits a notifier alert — the
+        bot never goes live on an unconfirmed order book."""
+        config = GridbotConfig(
+            accounts=[AccountConfig(
+                name="test_account", api_key="k", api_secret="s", testnet=True,
+            )],
+            strategies=[StrategyConfig(
+                strat_id="btcusdt_test", account="test_account",
+                symbol="BTCUSDT", tick_size=Decimal("0.1"),
+                grid_count=20, grid_step=0.2, shadow_mode=False,
+            )],
+            database_url="sqlite:///:memory:",
+            position_check_interval=60.0,
+        )
+        notifier = Mock(spec=Notifier)
+        orchestrator = Orchestrator(config, notifier=notifier)
+        mock_rest_client.return_value.get_open_orders = Mock(
+            side_effect=RuntimeError("REST timeout during startup reconcile")
+        )
+
+        try:
+            with pytest.raises(StartupReconciliationError):
+                orchestrator.start()
+
+            assert orchestrator.running is False
+            alert_texts = [
+                str(c.args[0]) for c in notifier.alert.call_args_list
+            ]
+            assert any("startup reconciliation failed" in t for t in alert_texts)
+        finally:
+            orchestrator.stop()
+
+
+class TestStartupReconcileRaceDuplicates:
+    """Runner-level: the full duplicate-order mechanism, step by step."""
+
+    def test_race_places_duplicates_and_sync_cannot_heal_them(
+        self, runner, recording_executor,
+    ):
+        """REPRO issue #206: failed startup reconcile → first ticker places a
+        fresh grid over live legacy orders → order sync adopts the legacy
+        orders → next ticker never cancels the same-price duplicates."""
+        rest = Mock()
+        reconciler = Reconciler(rest)
+
+        # --- Step 1: startup reconcile fails transiently (swallowed).
+        rest.get_open_orders = Mock(
+            side_effect=RuntimeError("REST timeout during startup reconcile")
+        )
+        result = reconciler.reconcile_startup(runner)
+        assert result.errors, "startup reconcile must have recorded the error"
+        assert result.orders_injected == 0
+        logger.info("STEP1: startup reconcile failed, errors=%s", result.errors)
+
+        # --- Step 2: first ticker (orchestrator._tick step 3) — engine
+        # builds grid on EMPTY state and places new orders.
+        runner.on_ticker(_ticker("50000"))
+        new_intents = list(recording_executor.placed_intents)
+        assert new_intents, "engine placed a fresh grid"
+        logger.info(
+            "STEP2: engine placed %d new orders at prices %s",
+            len(new_intents), [str(i.price) for i in new_intents],
+        )
+
+        # The exchange ALSO still holds the legacy grid from the previous
+        # session at (some of) the same price levels. Pick one Buy and one
+        # Sell level actually placed in step 2.
+        legacy_buy_src = next(i for i in new_intents if i.side == "Buy")
+        legacy_sell_src = next(i for i in new_intents if i.side == "Sell")
+        legacy_orders = [
+            _exchange_order_dict(legacy_buy_src, "legacy-buy", link_id=None),
+            _exchange_order_dict(legacy_sell_src, "legacy-sell", link_id=None),
+        ]
+
+        # DUPLICATES EXIST: new orders were placed at prices where legacy
+        # orders already sit (the bot could not know — reconcile had failed).
+        dup_prices = {str(legacy_buy_src.price), str(legacy_sell_src.price)}
+        logger.warning("STEP2: duplicate exposure at prices %s", dup_prices)
+
+        # --- Step 3: first-tick order sync (orchestrator._tick step 4).
+        # Exchange now reports legacy + new orders; legacy ones are unknown
+        # to the runner and get injected.
+        new_order_dicts = [
+            _exchange_order_dict(
+                intent, f"new-{n}", link_id=intent.client_order_id,
+            )
+            for n, intent in enumerate(new_intents, start=1)
+        ]
+        rest.get_open_orders = Mock(return_value=legacy_orders + new_order_dicts)
+        sync_result = reconciler.reconcile_reconnect(runner)
+        assert sync_result.untracked_orders_on_exchange == 2
+        assert sync_result.orders_injected == 2
+        logger.info(
+            "STEP3: order sync adopted %d legacy orders", sync_result.orders_injected,
+        )
+
+        # --- Step 4: next ticker. State is now "repaired", but the engine
+        # indexes limits by price (engine.py:359) — same-price duplicates
+        # collapse and the shadowed order is never cancelled.
+        recording_executor.cancelled_intents.clear()
+        runner.on_ticker(_ticker("50000"))
+
+        cancelled_ids = {
+            c.order_id for c in recording_executor.cancelled_intents
+        }
+        # BUG: neither legacy duplicate is cancelled.
+        assert "legacy-buy" not in cancelled_ids
+        assert "legacy-sell" not in cancelled_ids
+        logger.warning(
+            "STEP4: cancels issued=%s — legacy duplicates survive", cancelled_ids,
+        )
+
+        # BUG: both duplicates remain tracked as live → 2x exposure at
+        # those grid levels until one side fills.
+        limits = runner.get_limit_orders()
+        all_limits = limits["long"] + limits["short"]
+        for price in dup_prices:
+            at_price = [lim for lim in all_limits if str(lim["price"]) == price]
+            assert len(at_price) == 2, (
+                f"expected duplicate pair at {price}, got {at_price}"
+            )
+        logger.warning(
+            "FINAL: %d live orders across %d tracked; duplicate pairs at %s",
+            len(all_limits), runner.get_tracked_order_count()["placed"], dup_prices,
+        )

--- a/apps/gridbot/tests/test_orchestrator.py
+++ b/apps/gridbot/tests/test_orchestrator.py
@@ -580,6 +580,138 @@ class TestOrchestratorLifecycle:
         orchestrator.stop()
 
 
+class TestStartupReconcileRetry:
+    """Tests for fail-closed startup reconciliation with retry (feature 0086)."""
+
+    @patch("gridbot.orchestrator.time.sleep")
+    @patch("gridbot.orchestrator.BybitRestClient")
+    @patch("gridbot.orchestrator.PublicWebSocketClient")
+    @patch("gridbot.orchestrator.PrivateWebSocketClient")
+    def test_startup_reconcile_recovers_after_transient_failure(
+        self, mock_private_ws, mock_public_ws, mock_rest_client, mock_sleep,
+        gridbot_config,
+    ):
+        """A transient get_open_orders failure is retried in place; startup completes."""
+        notifier = Mock(spec=Notifier)
+        orchestrator = Orchestrator(gridbot_config, notifier=notifier)
+        mock_rest_client.return_value.get_open_orders = Mock(
+            side_effect=[RuntimeError("transient timeout"), [], [], []]
+        )
+
+        orchestrator.start()
+        try:
+            assert orchestrator.running is True
+            mock_sleep.assert_called_once_with(2.0)
+            notifier.alert.assert_not_called()
+        finally:
+            orchestrator.stop()
+
+    @patch("gridbot.orchestrator.time.sleep")
+    @patch("gridbot.orchestrator.BybitRestClient")
+    @patch("gridbot.orchestrator.PublicWebSocketClient")
+    @patch("gridbot.orchestrator.PrivateWebSocketClient")
+    def test_startup_reconcile_success_first_try_no_sleep(
+        self, mock_private_ws, mock_public_ws, mock_rest_client, mock_sleep,
+        gridbot_config,
+    ):
+        """Successful first attempt behaves as before: no sleeps, no alerts."""
+        notifier = Mock(spec=Notifier)
+        orchestrator = Orchestrator(gridbot_config, notifier=notifier)
+        mock_rest_client.return_value.get_open_orders = Mock(return_value=[])
+
+        orchestrator.start()
+        try:
+            assert orchestrator.running is True
+            mock_sleep.assert_not_called()
+            notifier.alert.assert_not_called()
+        finally:
+            orchestrator.stop()
+
+    @patch("gridbot.orchestrator.time.sleep")
+    @patch("gridbot.orchestrator.BybitRestClient")
+    @patch("gridbot.orchestrator.PublicWebSocketClient")
+    @patch("gridbot.orchestrator.PrivateWebSocketClient")
+    def test_startup_reconcile_exhausted_raises_and_alerts(
+        self, mock_private_ws, mock_public_ws, mock_rest_client, mock_sleep,
+        gridbot_config,
+    ):
+        """All attempts failing raises StartupReconciliationError with one alert."""
+        from gridbot.orchestrator import StartupReconciliationError
+
+        notifier = Mock(spec=Notifier)
+        orchestrator = Orchestrator(gridbot_config, notifier=notifier)
+        mock_rest_client.return_value.get_open_orders = Mock(
+            side_effect=RuntimeError("persistent failure")
+        )
+
+        try:
+            with pytest.raises(StartupReconciliationError):
+                orchestrator.start()
+
+            assert orchestrator.running is False
+            assert mock_sleep.call_count == 3  # backoffs 2.0, 5.0, 10.0
+            notifier.alert.assert_called_once()
+            assert (
+                notifier.alert.call_args.kwargs["error_key"]
+                == "startup_reconcile_btcusdt_test"
+            )
+            # Abort happens before run records, WS connect, and the main loop.
+            assert orchestrator._run_ids == {}
+            mock_public_ws.return_value.connect.assert_not_called()
+            mock_private_ws.return_value.connect.assert_not_called()
+            mock_rest_client.return_value.place_order.assert_not_called()
+        finally:
+            orchestrator.stop()
+
+    def test_order_sync_errors_emit_throttled_alert(self, gridbot_config):
+        """Periodic order sync errors alert via notifier with a throttle key."""
+        notifier = Mock(spec=Notifier)
+        orchestrator = Orchestrator(gridbot_config, notifier=notifier)
+
+        mock_runner = Mock()
+        mock_runner.strat_id = "btcusdt_test"
+        mock_runner.symbol = "BTCUSDT"
+        orchestrator._account_to_runners = {"test_account": [mock_runner]}
+        orchestrator._reconcilers = {
+            "test_account": Mock(
+                reconcile_reconnect=Mock(
+                    return_value=ReconciliationResult(errors=["REST timeout"])
+                )
+            )
+        }
+
+        orchestrator._order_sync_once()
+
+        notifier.alert.assert_called_once()
+        assert (
+            notifier.alert.call_args.kwargs["error_key"]
+            == "order_sync_btcusdt_test"
+        )
+
+    def test_order_sync_exception_emits_throttled_alert(self, gridbot_config):
+        """A reconcile_reconnect raise mid-sweep alerts and does not kill the sweep."""
+        notifier = Mock(spec=Notifier)
+        orchestrator = Orchestrator(gridbot_config, notifier=notifier)
+
+        mock_runner = Mock()
+        mock_runner.strat_id = "btcusdt_test"
+        mock_runner.symbol = "BTCUSDT"
+        orchestrator._account_to_runners = {"test_account": [mock_runner]}
+        orchestrator._reconcilers = {
+            "test_account": Mock(
+                reconcile_reconnect=Mock(side_effect=RuntimeError("inject failed"))
+            )
+        }
+
+        orchestrator._order_sync_once()
+
+        notifier.alert_exception.assert_called_once()
+        assert (
+            notifier.alert_exception.call_args.kwargs["error_key"]
+            == "order_sync_btcusdt_test"
+        )
+
+
 class TestOrchestratorGuardClauses:
     """Tests for guard clauses in start/stop and request_stop."""
 

--- a/docs/features/0086_PLAN.md
+++ b/docs/features/0086_PLAN.md
@@ -1,0 +1,142 @@
+# Feature 0086 — Fail closed when startup reconciliation fails (issue #206, fixes 1 + 3)
+
+## Context
+
+Line references below are as of `main@76aaf79` (pre-feature state).
+
+During `Orchestrator.start()`, `Reconciler.reconcile_startup()` swallows
+`get_open_orders` exceptions into `ReconciliationResult.errors`
+(`apps/gridbot/src/gridbot/reconciler.py:95-98`), and the orchestrator ignores
+`result.errors` entirely (`apps/gridbot/src/gridbot/orchestrator.py:333-343`) —
+the bot goes live with an empty local order book while the previous grid may
+still be live on the exchange. Reproduced end-to-end in
+`apps/gridbot/tests/test_issue_206_startup_reconcile_race.py`: the first ticker
+then places a duplicate grid over the legacy orders, and same-price duplicates
+are never cancelled afterwards.
+
+Scope of this feature (per issue #206 analysis):
+
+- **Fix 1 — fail-closed startup**: retry startup reconciliation in place; if it
+  still fails, alert and abort startup (process exits 1). Whole-process abort,
+  not per-strategy: one REST client per account, so a persistent failure is
+  almost certainly account-level; and nothing has been placed yet, so aborting
+  is free. Mid-run behavior (periodic order sync) keeps its
+  warn-and-retry-next-cycle semantics — stopping a bot that is already managing
+  a live grid is riskier than a stale sync.
+- **Fix 3 — observability**: notifier alerts on reconciliation errors (startup
+  and periodic sync), and stop logging a misleading
+  "Reconciliation complete" line when the result carries errors.
+
+Out of scope (tracked separately): engine-level cancellation of same-price
+duplicate orders (`engine.py:359` price-keyed dict collapse — issue #206
+analysis, fix 2), and any per-strategy safe-mode / `trading_enabled` machinery.
+
+## Files and changes
+
+### `apps/gridbot/src/gridbot/orchestrator.py`
+
+1. **New module-level constant** near the other `_UPPER_SNAKE` timing
+   constants: `_STARTUP_RECONCILE_BACKOFFS = (2.0, 5.0, 10.0)` — sleep seconds
+   between startup reconciliation attempts (1 initial attempt + one retry per
+   backoff entry = 4 attempts max).
+
+2. **New exception** `StartupReconciliationError(Exception)` at module level
+   (control-flow exception precedent: `StartupTimeoutError` in
+   `position_fetcher.py:82-84`). Raised only from `start()`; `main.py:157-159`
+   already converts any startup exception into log + exit code 1 — no
+   `main.py` change needed.
+
+3. **`start()` startup-reconciliation loop (lines 333-343)** — replace the body
+   with a call to a new private method `_reconcile_startup_with_retry(runner,
+   reconciler)`:
+   - Attempt `reconciler.reconcile_startup(runner)`.
+   - If `result.errors` is empty: log the existing
+     "Reconciliation complete - fetched=... injected=... untracked=..." INFO
+     line (unchanged wording for log parsers) and return.
+   - If `result.errors` is non-empty and backoffs remain: log WARNING with the
+     attempt number and error text, `time.sleep(backoff)`, retry.
+   - On success after ≥1 retry: log WARNING noting it recovered after N
+     attempts (so a flaky REST at startup stays visible), then the same
+     "complete" INFO line.
+   - On exhaustion: `self._notifier.alert(...)` with strat_id and the last
+     error text, `error_key=f"startup_reconcile_{strat_id}"`, then raise
+     `StartupReconciliationError`. The raise propagates out of `start()`;
+     `main.py` logs it and returns exit code 1. The `finally:
+     orchestrator.stop()` in `main.py` is a no-op here (`stop()` early-returns
+     when `_started` is False) — and that is fine: reconciliation runs before
+     run-record creation, the grid-state writer start, and
+     `_connect_websockets`, so at the point of the raise there is nothing to
+     tear down (no threads, no WS connections, no DB rows).
+   - The raise from the FIRST strategy that exhausts its retries aborts the
+     whole startup. Strategies are retried sequentially, so each strategy
+     that recovers after retries adds its consumed backoff (up to ~17s) to
+     startup latency before a later strategy can still abort; only order
+     safety is bounded, not startup time.
+   - Retry covers `result.errors` only (the swallowed `get_open_orders`
+     failure — the transient case). An unexpected exception escaping
+     `reconcile_startup()` itself (e.g. from `inject_open_orders`, a code
+     bug, not a transient) intentionally propagates un-retried: `main.py`'s
+     generic startup handler already fail-closes with exit 1. Alerting on
+     generic startup exceptions is a pre-existing, feature-independent gap —
+     out of scope.
+   - Applies uniformly to shadow-mode strategies (uniformity over
+     special-casing; a persistent account-level REST failure would block them
+     anyway).
+
+4. **`_order_sync_once()` (lines 1740-1744)** — two additions, same
+   `error_key=f"order_sync_{strat_id}"`:
+   - In the `result.errors` branch: keep the existing WARNING log, add
+     `self._notifier.alert(...)` with the strat_id and error text.
+   - In the per-runner `except Exception` (line 1757, currently log-only):
+     add `self._notifier.alert_exception(...)` so a reconcile that raises
+     (rather than recording errors) also reaches the operator.
+   Throttling note: `Notifier.alert()` logs every call and throttles only the
+   Telegram send (60s default, `notifier.py:17,67-77`); with the 61s default
+   `order_sync_interval` a sustained outage sends roughly one Telegram
+   message per sync cycle per strategy — acceptable visibility, matching the
+   behavior of the existing periodic-check alerts.
+
+### `apps/gridbot/src/gridbot/reconciler.py`
+
+No changes. Errors are already surfaced via `result.errors`; the decision to
+act on them belongs to the caller.
+
+### Tests
+
+**`apps/gridbot/tests/test_orchestrator.py`** — new class
+`TestStartupReconcileRetry` (patch `time.sleep` in all retry tests to keep
+them instant; the name `TestStartupReconcileFailClosed` is used by the
+orchestrator-level test in `test_issue_206_startup_reconcile_race.py`):
+
+- All attempts fail → `start()` raises `StartupReconciliationError`, notifier
+  alert called once with the strat_id, `orchestrator.running` stays False, no
+  order placement was attempted, no WS connect was attempted, and no DB run
+  records were created.
+- First attempt fails, second succeeds → `start()` completes, no raise, no
+  alert; recovery WARNING logged.
+- First attempt succeeds → no sleep called, behavior identical to today.
+- Periodic `_order_sync_once` with `result.errors` → notifier alert called
+  with `error_key="order_sync_<strat_id>"`; sweep continues (no raise).
+- Periodic `_order_sync_once` where `reconcile_reconnect` raises →
+  `alert_exception` called with the same error_key; sweep continues.
+
+**`apps/gridbot/tests/test_issue_206_startup_reconcile_race.py`** — update the
+orchestrator-level test `TestStartupReconcileFailOpen`: with the fix, a raising
+`get_open_orders` must produce `StartupReconciliationError` and a notifier
+alert (invert the `# BUG:` asserts; rename class/test accordingly). The
+runner-level test `TestStartupReconcileRaceDuplicates` stays as-is: it drives
+`Reconciler` directly and documents the engine duplicate-collapse gap (fix 2,
+out of scope here).
+
+## Algorithm — startup reconciliation with retry
+
+1. For each runner in `self._runners.values()` (existing loop order):
+2. `attempts = 1 + len(_STARTUP_RECONCILE_BACKOFFS)`; for each attempt:
+   a. `result = reconciler.reconcile_startup(runner)`.
+   b. `result.errors` empty → success; break to next runner.
+   c. Backoffs remaining → WARNING log, sleep next backoff, continue.
+3. All attempts failed → notifier alert (strat_id + last error), raise
+   `StartupReconciliationError(strat_id, last_error)`.
+4. Resulting process behavior: transient REST hiccup → recovered in-place,
+   normal start; persistent failure → alert + exit 1 with zero orders placed
+   or cancelled; the pre-existing exchange grid is left untouched.

--- a/docs/features/0086_REVIEW.md
+++ b/docs/features/0086_REVIEW.md
@@ -1,0 +1,96 @@
+# Feature 0086 — Code Review (fail-closed startup reconciliation, issue #206)
+
+Reviewed diff: `origin/main@76aaf79` → working tree, branch
+`feature/0086-fail-closed-startup-reconcile`.
+Files: `orchestrator.py` (+75/-7), `test_orchestrator.py` (+132),
+`test_issue_206_startup_reconcile_race.py` (new), `0086_PLAN.md` (new).
+
+## 1. Plan conformance — PASS
+
+Checked every plan item against the diff:
+
+| Plan item | Code | Verdict |
+|---|---|---|
+| `_STARTUP_RECONCILE_BACKOFFS = (2.0, 5.0, 10.0)` by other timing constants | `orchestrator.py:60` | match |
+| `StartupReconciliationError` module-level, `StartupTimeoutError` precedent | `orchestrator.py:66-71` | match |
+| `start()` loop delegates to `_reconcile_startup_with_retry` | `orchestrator.py:342-348` | match |
+| 1 + 3 retries, WARNING per failed attempt, recovery WARNING | `orchestrator.py:425-447` | match |
+| Unchanged "Reconciliation complete" INFO wording (log parsers) | `orchestrator.py:430-434` | match |
+| Exhaustion → alert (`startup_reconcile_<strat>`) → raise; main.py untouched | `orchestrator.py:449-459`, `main.py:157-159` | match |
+| `_order_sync_once`: alert on `result.errors` + `alert_exception` on raise, shared `order_sync_<strat>` key | `orchestrator.py:1797-1801,1816-1819` | match |
+| `reconciler.py` unchanged | — | match |
+| Test list (5 orchestrator tests + repro-file inversion) | `test_orchestrator.py:583-712`, repro file | match¹ |
+
+¹ One gap found during this review and fixed: the exhausted test now also
+asserts `place_order` was never called ("no order placement was attempted"
+was claimed by the plan but not asserted).
+
+## 2. Bugs — none found
+
+- `result` after the loop is always bound (`attempts >= 1` guaranteed).
+- Loop indexing `_STARTUP_RECONCILE_BACKOFFS[attempt - 1]` is safe: only
+  reached when `attempt < attempts = 1 + len(backoffs)`.
+- Raise ordering (alert before raise) means a Telegram send failure inside
+  `alert()` cannot suppress the abort — `Notifier.alert` swallows send
+  errors internally (`notifier.py:79-86`).
+- Abort point precedes run records, grid-state writer start, and WS
+  connect; `stop()` no-op via `_started` guard is correct (verified in
+  round-1/2 external reviews).
+
+## 3. Data alignment — n/a
+
+No new external payload parsing; retry loop consumes the existing
+`ReconciliationResult` dataclass only.
+
+## 4. Over-engineering — none
+
+~50 code lines. No new config surface, no per-strategy safe-mode machinery,
+no speculative state. Matches the "minimum code" bar.
+
+## 5. Style — consistent
+
+- Lazy `%` logging for new WARNING/ERROR lines, f-string preserved on the
+  relocated INFO line (matches surrounding file conventions).
+- `_UPPER_SNAKE` module constant, `_leading_underscore` method, Google-style
+  docstrings — all consistent.
+- `alert_exception` context format `"order_sync <strat>"` mirrors the
+  existing `"ws_reset <account>/<kind>"` pattern.
+
+## 6. Tests — PASS
+
+- `TestStartupReconcileRetry` (4 tests): transient recovery (sleep 2.0 once,
+  no alert), first-try success (no sleep), exhaustion (raise + single alert
+  with correct error_key + no run records / WS connect / order placement),
+  periodic-sync `result.errors` alert, periodic-sync exception alert.
+- Repro file: orchestrator-level fail-closed test + runner-level
+  duplicate-collapse documentation test (real engine, mocked executor).
+- All hermetic (REST/WS classes patched), `time.sleep` patched in retry
+  tests, suite runs in ~2.6s. Full gridbot suite: 821 passed, ruff clean.
+
+## Notes (pre-existing, out of scope)
+
+- If an account has no reconciler in `self._reconcilers`, startup
+  reconciliation is silently skipped (`orchestrator.py:346-348` guard) —
+  pre-existing behavior; unreachable in practice because `_init_account`
+  always registers one per account.
+- Engine same-price duplicate collapse (`engine.py:359`) remains open —
+  fix 2 of the issue #206 analysis, tracked separately.
+
+## External review trail
+
+- codex plan review (3 rounds): 8 findings → 5 accepted (doc corrections,
+  sync exception alert, test hardening), 2 rejected with evidence, round 3
+  clean.
+- cursor agent plan review (2 passes): 1 valid mismatch (plan test-class
+  name), fixed; verification table otherwise all-match.
+- 5-category subagent code review (1 iteration): 0 critical; start()
+  docstring `Raises:` added; warnings/info triaged in session notes.
+- codex code review per code_review.md (1 round): NO P1/P2 FINDINGS.
+  P3: "recovers on final attempt" test not added (accepted gap); stale
+  "fail-open" repro-file header — fixed.
+- cursor agent code review per code_review.md (1 round): NO P1/P2
+  FINDINGS; 17-point verification log all-PASS. 6 P3s noted and accepted
+  (caplog recovery-warning check, final-attempt recovery case,
+  multi-runner sweep-continues assert, exception base-class precedent
+  Exception vs RuntimeError, repro alert assert tightness, pre-existing
+  orchestrator.py size).


### PR DESCRIPTION
Closes #206 (fixes 1 + 3 of the issue analysis; fix 2 — engine same-price duplicate collapse — tracked separately).

## Problem

Startup reconciliation errors were swallowed (`reconciler.py` records them in `result.errors`, orchestrator ignored them). A transient REST failure at startup left the bot live with an empty local order book while the previous grid was still on the exchange: the first ticker placed a duplicate grid over the legacy orders, and same-price duplicates are never cancelled by the engine. Reproduced end-to-end in `test_issue_206_startup_reconcile_race.py`.

## Change

- `start()` retries reconciliation in place (`_STARTUP_RECONCILE_BACKOFFS = (2.0, 5.0, 10.0)`, 4 attempts per strategy). On exhaustion: notifier alert (`startup_reconcile_<strat_id>`) + `StartupReconciliationError` → exit 1, zero orders placed, pre-existing exchange grid untouched. Abort happens before run records / grid-state writer / WS connect.
- Mid-run periodic order sync keeps warn-and-retry semantics but now alerts on both `result.errors` and exception paths (`order_sync_<strat_id>`, notifier-throttled).
- Plan `docs/features/0086_PLAN.md`, review trail `docs/features/0086_REVIEW.md`, RULES.md section.

## Tests

- `TestStartupReconcileRetry` (5): transient recovery, first-try no-sleep, exhaustion (raise + single alert + no run records / WS connect / order placement), sync `result.errors` alert, sync exception alert.
- Repro file: orchestrator-level fail-closed test + runner-level engine duplicate-collapse documentation test (real engine, mocked executor).
- Full gridbot suite 821 passed, ruff clean.

## Review trail

5 independent cycles pre-PR: codex plan review ×3 rounds, cursor plan review ×2, 5-category subagent code review, codex code review (NO P1/P2), cursor code review (NO P1/P2, 17-point verification log). Details in `0086_REVIEW.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)