### PR TITLE
feat(gridcore): cancel same-price duplicate grid orders (#220)

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -921,9 +921,12 @@ strategy). On exhaustion it emits a notifier alert
 the process exits 1 with ZERO orders placed; any pre-existing exchange grid
 is left untouched. Rationale: the bot must never trade on an unconfirmed
 open-order book — a startup with empty local state places a duplicate grid
-over live legacy orders, and same-price duplicates are never cancelled by
-the engine (price-keyed dict in `engine.py:_place_grid_orders` collapses
-them; open gap, fix 2 of the #206 analysis). Mid-run order sync keeps
+over live legacy orders. Same-price duplicates now self-heal within one
+ticker (feature 0087, issue #220): `engine.py:_place_grid_orders` groups
+limits into round-8 price buckets, keeps one survivor per price (preference:
+grid-side match > fill history > first-in-list) and cancels the shadowed
+extras with `CancelIntent(reason='duplicate')` — the proactive complement
+to the reactive 0031/0046 post-fill layer. Mid-run order sync keeps
 warn-and-retry semantics (stopping a bot managing a live grid is riskier);
 sync failures now also alert (`order_sync_<strat_id>`, both `result.errors`
 and exception paths). Repro/regression: `test_issue_206_startup_reconcile_race.py`,

--- a/apps/gridbot/tests/test_issue_206_startup_reconcile_race.py
+++ b/apps/gridbot/tests/test_issue_206_startup_reconcile_race.py
@@ -14,16 +14,15 @@ Original fail-open scenario (pre-0086 behavior, mirrors the orchestrator flow):
    exchange orders already sit → live duplicates.
 3. First-tick order sync (``reconcile_reconnect``) then injects the old
    orders — state is repaired, but the damage is not:
-4. On the next ticker the engine indexes limits with a price-keyed dict
-   (engine.py:359 ``limit_prices = {float(limit['price']): limit ...}``)
-   which collapses same-price duplicates — the shadowed order is neither
-   'outside_grid' nor 'side_mismatch', so it is NEVER cancelled. Double
-   exposure persists until filled.
+4. On the next ticker the engine groups same-price limits into buckets,
+   keeps one survivor per price, and cancels the shadowed duplicates with
+   ``CancelIntent(reason='duplicate')`` (feature 0087, issue #220) — the
+   duplicate exposure self-heals within one ticker.
 
 Feature 0086 fixed the fail-open startup (fail-closed + alert); the
-orchestrator-level test below asserts the fixed behavior. The runner-level
-test still documents the engine same-price duplicate-collapse gap (fix 2 of
-the issue #206 analysis), which is tracked separately.
+orchestrator-level test below asserts that behavior. Feature 0087 (issue
+#220, fix 2 of the issue #206 analysis) closed the engine same-price
+duplicate-collapse gap; the runner-level test below asserts the healing.
 """
 
 import logging
@@ -186,12 +185,13 @@ class TestStartupReconcileFailClosed:
 class TestStartupReconcileRaceDuplicates:
     """Runner-level: the full duplicate-order mechanism, step by step."""
 
-    def test_race_places_duplicates_and_sync_cannot_heal_them(
+    def test_race_places_duplicates_and_engine_heals_them(
         self, runner, recording_executor,
     ):
-        """REPRO issue #206: failed startup reconcile → first ticker places a
-        fresh grid over live legacy orders → order sync adopts the legacy
-        orders → next ticker never cancels the same-price duplicates."""
+        """Issue #206 race + feature 0087 healing: failed startup reconcile →
+        first ticker places a fresh grid over live legacy orders → order sync
+        adopts the legacy orders → next ticker cancels the same-price
+        duplicates (reason='duplicate'), one survivor per level."""
         rest = Mock()
         reconciler = Reconciler(rest)
 
@@ -246,32 +246,51 @@ class TestStartupReconcileRaceDuplicates:
             "STEP3: order sync adopted %d legacy orders", sync_result.orders_injected,
         )
 
-        # --- Step 4: next ticker. State is now "repaired", but the engine
-        # indexes limits by price (engine.py:359) — same-price duplicates
-        # collapse and the shadowed order is never cancelled.
+        # --- Step 4: next ticker. State is now "repaired"; the engine's
+        # duplicate pass (feature 0087) groups same-price limits into
+        # buckets, keeps one survivor per price and cancels the shadowed
+        # legacy duplicates with reason='duplicate'.
         recording_executor.cancelled_intents.clear()
+        placed_before_heal = len(recording_executor.placed_intents)
         runner.on_ticker(_ticker("50000"))
 
         cancelled_ids = {
             c.order_id for c in recording_executor.cancelled_intents
         }
-        # BUG: neither legacy duplicate is cancelled.
-        assert "legacy-buy" not in cancelled_ids
-        assert "legacy-sell" not in cancelled_ids
-        logger.warning(
-            "STEP4: cancels issued=%s — legacy duplicates survive", cancelled_ids,
+        # Fixed (0087): both shadowed legacy duplicates are cancelled ...
+        assert "legacy-buy" in cancelled_ids
+        assert "legacy-sell" in cancelled_ids
+        # ... with reason='duplicate' on each legacy cancel.
+        legacy_cancels = [
+            c for c in recording_executor.cancelled_intents
+            if c.order_id in ("legacy-buy", "legacy-sell")
+        ]
+        assert all(c.reason == "duplicate" for c in legacy_cancels)
+        # No order got two CancelIntents in the healing tick.
+        all_cancel_ids = [
+            c.order_id for c in recording_executor.cancelled_intents
+        ]
+        assert len(all_cancel_ids) == len(set(all_cancel_ids))
+        # The healing tick placed nothing at the duplicated prices — the
+        # surviving twin satisfies the level (no cancel-all-then-replace).
+        healing_places = recording_executor.placed_intents[placed_before_heal:]
+        assert not [i for i in healing_places if str(i.price) in dup_prices]
+        logger.info(
+            "STEP4: cancels issued=%s — legacy duplicates healed", cancelled_ids,
         )
 
-        # BUG: both duplicates remain tracked as live → 2x exposure at
-        # those grid levels until one side fills.
+        # Fixed (0087): exactly one live order remains per formerly
+        # duplicated price, and the survivor is the bot's own order (the
+        # legacy twin was cancelled).
         limits = runner.get_limit_orders()
         all_limits = limits["long"] + limits["short"]
         for price in dup_prices:
             at_price = [lim for lim in all_limits if str(lim["price"]) == price]
-            assert len(at_price) == 2, (
-                f"expected duplicate pair at {price}, got {at_price}"
+            assert len(at_price) == 1, (
+                f"expected single survivor at {price}, got {at_price}"
             )
-        logger.warning(
-            "FINAL: %d live orders across %d tracked; duplicate pairs at %s",
+            assert at_price[0]["orderId"].startswith("new-")
+        logger.info(
+            "FINAL: %d live orders across %d tracked; single survivor at %s",
             len(all_limits), runner.get_tracked_order_count()["placed"], dup_prices,
         )

--- a/docs/features/0087_PLAN.md
+++ b/docs/features/0087_PLAN.md
@@ -1,0 +1,346 @@
+# Feature 0087 — Engine cancels same-price duplicate grid orders
+
+## Context
+
+`GridEngine._place_grid_orders` indexes resting limit orders in a
+**price-keyed dict** (`packages/gridcore/src/gridcore/engine.py:359`):
+
+```python
+limit_prices = {float(limit['price']): limit for limit in sorted_limits}
+```
+
+Two live orders at the same price collapse to a single dict entry — the
+later one wins, the earlier is shadowed and becomes invisible to the
+engine. None of the existing cancel branches fire for the shadow:
+`side_mismatch` doesn't (side is correct), `outside_grid` doesn't (price
+is on-grid), and the over-limit `rebuild` branch's threshold
+(`len(limits) > len(self.grid.grid) + 10`, engine.py:305) is far away.
+The shadowed duplicate rests until filled → **2x size at that grid
+level, invisible to risk logic** in the pre-fill window.
+
+This is **fix 2 of the issue #206 analysis** (fixes 1+3 shipped as
+feature 0086, PR #219). Severity **P3, defense-in-depth**: the main entry
+(dirty startup after failed reconciliation) is closed by 0086's
+fail-closed startup, and the 0080 migration-retry entry was point-fixed
+in commit `5a358d6`. Feature 0031/0046 `same_order_error` bounds damage
+*after* both duplicates fill. What remains uncovered is the pre-fill
+double exposure and the collateral of 0031 latching (whole-strategy
+placement freeze once the duplicates fill). This fix makes any
+two-orders-one-price state **self-heal within one ticker**.
+
+gridcore is pure logic, zero external deps, `Decimal` for price/qty
+(never `float`), 80% coverage gate.
+
+## Files changed
+
+### `packages/gridcore/src/gridcore/engine.py`
+
+`_place_grid_orders` (lines 340–394) — the core change.
+
+Replace the price → single-order dict (line 359) with a price → **list of
+orders** mapping, keep exactly one working order (the survivor) per price,
+and emit a `CancelIntent(reason='duplicate')` for every non-survivor.
+
+**Single-algorithm design (one owner for survivor identity, one
+CancelIntent per order).** The two mechanisms in the previous draft (an
+in-loop survivor selection inside the grid loop AND a separate pass over
+`limits_by_price`) could double-schedule an order — the grid loop might
+`side_mismatch`-cancel an order the separate pass keeps, or two passes
+could each emit a cancel for the same orderId. Collapse to **one** ordered
+algorithm so each order gets **at most one** CancelIntent and survivor
+identity has a single owner:
+
+1. **Build buckets.** Group `sorted_limits` into
+   `limits_by_price: dict[float, list[dict]]`, keyed by
+   `round(float(limit['price']), 8)` — the **same** rounding used by the
+   `grid_price_set` / `outside_grid` test at engine.py:387–390. Using the
+   raw `float(price)` would define price-equality differently from the rest
+   of the function, so two "same price" orders differing below 8 decimals
+   (or float-vs-Decimal-string round skew) could split into two singletons
+   and slip the len>1 test. `sorted_limits` is already price-sorted, so
+   order within a bucket is stable/deterministic.
+
+2. **Pick one survivor per bucket, up front (before the grid loop).** For
+   each bucket, choose exactly one survivor and collect all non-survivors
+   into a duplicate-cancel list:
+   - Survivor rule: `_select_survivor(bucket, grid_side)`. Preference
+     order: (1) an order whose `side` matches the grid level's side at that
+     price, when the bucket's price is an active (non-WAIT) grid level —
+     pass `grid_side=None` for WAIT/off-grid buckets, where no side
+     preference applies; (2) within the side-preferred candidates, an order
+     with fill history (`_has_fill_history`); (3) deterministic tie-break:
+     **first in the already price-sorted list**. Side comes BEFORE fill
+     history: a wrong-side order is cancelled by the existing
+     `side_mismatch` branch regardless of fill state, so keeping a filled
+     wrong-side order as survivor self-defeats — it takes the
+     `side_mismatch` cancel + replace anyway while the correct-side
+     duplicate was already `duplicate`-cancelled, churning the whole level.
+     Consequence for the issue's partial-fill acceptance criterion: the
+     "order with fill history is never cancelled" guarantee holds **within
+     same-side comparisons** only; a wrong-side order (filled or not) is
+     cancelled either way under existing engine semantics — this fix does
+     not change that. Without preference (1) at all, a mixed-side bucket
+     could keep a wrong-side order and `duplicate`-cancel the correct-side
+     one (lost queue position, transient gap). Mixed-side same-price
+     buckets are exotic (known duplicate entries are same-side pairs) but
+     this feature exists precisely for unknown entry states.
+   - **`grid_side` resolution uses the same round-8 keying.** Build the
+     price → side map from `self.grid.grid` keyed by
+     `round(grid_item['price'], 8)` and look up with the bucket's (already
+     rounded) key. Raw-price equality against the rounded bucket key would
+     silently miss whenever `round(p, 8) != p` (grid.py:93 formats to 10
+     decimals), setting `grid_side=None` and disabling the side preference
+     exactly where it should apply.
+   - **Honest scope of the fill-history guard (F-1-1).** On the live tick
+     path the guard is a **no-op**: `_place_grid_orders` is called only
+     from `_check_and_place` (call site engine.py:318; the ticker path
+     reaches `_check_and_place` via engine.py:191–192), where `limits`
+     come from `StrategyRunner.get_limit_orders()`
+     (runner.py:688–716), which emits only
+     `{orderId, orderLinkId, price, qty, side, reduceOnly}` — **no
+     `cumExecQty`**. So `_has_fill_history` returns `False` for every live
+     order and the survivor always falls to the first-in-list tie-break.
+     The exchange-shaped dict that carries `cumExecQty` (from
+     `reconcile_reconnect`) is consumed by the reconciler/`inject_open_orders`,
+     never passed to `_place_grid_orders`. **Decision: accept first-in-list
+     as the live survivor rule.** This is tolerable because (a) the
+     *filled* case is already bounded by the 0031/0046 post-fill
+     `same_order_error` layer — this feature only closes the *pre-fill*
+     double-exposure window, and (b) among two same-price same-side resting
+     orders that have NOT filled, either is an equally valid survivor; the
+     replacement placed for the cancelled one (if the grid still wants that
+     level) restores the intended single order. The `_has_fill_history`
+     guard is kept as **defence for the exchange-shaped path only** (any
+     future caller that does pass `cumExecQty`), not presented as a live
+     safety guarantee. Threading `cumExecQty` through `get_limit_orders`/
+     `TrackedOrder` is explicitly **out of scope** (see Out of scope).
+   - Emit `CancelIntent(reason='duplicate')` for every non-survivor via
+     `self._cancel_limit(extra, 'duplicate')`. Note: the single-CancelIntent
+     guarantee is enforced **structurally** by step 3's re-sourcing (later
+     branches simply never see non-survivors) — no `cancelled_ids`
+     bookkeeping set is needed in the implementation; the "no orderId in
+     two CancelIntents" property is asserted in tests instead.
+
+3. **Rebuild BOTH survivor-derived structures.** Two structures currently
+   read the raw limit set and MUST be re-sourced from survivors, or a
+   non-survivor slips a second CancelIntent:
+   - **The O(1) grid-loop lookup.** Replace line 359's `limit_prices` with a
+     survivor-only map:
+     `limit_prices = {price: survivor for price, survivor in survivors.items()}`
+     (keyed by the rounded price from step 1). The grid loop (line 368) then
+     sees only survivors — a non-survivor is never evaluated by the
+     `side_mismatch`/place logic, so it can never receive a second
+     (side_mismatch) CancelIntent on top of its `duplicate` one.
+     **The lookup side MUST round too:** line 370's
+     `limit_prices.get(grid_item['price'])` currently uses the raw grid
+     price, and grid prices are formatted to 10 decimals
+     (`float(f'{rounded:.10f}')`, grid.py:93) — so a grid price can carry
+     precision beyond 8 decimals. Keying the map by `round(price, 8)` while
+     looking up with the raw price breaks the invariant whenever
+     `round(p, 8) != p`: the lookup misses, the engine emits a spurious
+     `PlaceLimitIntent` while the survivor still rests — creating exactly
+     the duplicate this feature removes. Change the lookup to
+     `limit_prices.get(round(grid_item['price'], 8))` so key and lookup use
+     the same 8-decimal price-equality definition.
+     Assumption (documented, not guarded): no two DISTINCT grid levels
+     share one round-8 key. Grid prices are tick-size multiples
+     (grid.py:93), so distinct levels differ by ≥ tick_size; collision
+     requires tick_size < 1e-8, which no traded symbol has — and the
+     pre-existing round-8 `grid_price_set` convention (engine.py:387)
+     already assumes the same.
+   - **The `outside_grid` sweep source (engine.py:388–389).** This
+     comprehension iterates `sorted_limits` **directly**, NOT `limit_prices`,
+     so rebuilding `limit_prices` alone does NOT protect it. Change its
+     iteration source from `sorted_limits` to the survivor list. Concrete
+     edit — replace:
+
+     ```python
+     outside_limits = [
+         limit for limit in sorted_limits
+         if round(float(limit['price']), 8) not in grid_price_set
+     ]
+     ```
+
+     with iteration over the survivors (e.g. `for limit in survivors.values()`,
+     which are already the rounded-price → survivor entries from step 2). If
+     the sweep is left reading `sorted_limits`, a non-survivor whose price is
+     ALSO off-grid receives BOTH a `duplicate` CancelIntent (step 2) and an
+     `outside_grid` CancelIntent (line 392) — a double-cancel for one
+     orderId, violating the at-most-one-CancelIntent guarantee. (This is not
+     a WAIT-only edge: any duplicate bucket at an off-grid price is affected.)
+
+4. **Run the existing grid loop + outside_grid sweep against survivors
+   only.** With both structures in step 3 re-sourced from survivors, the
+   `side_mismatch` / place-if-missing loop and the `outside_grid` sweep are
+   otherwise unchanged; they operate on the survivor set. This guarantees
+   exactly one CancelIntent per order: `duplicate` for non-survivors, or
+   (mutually exclusive) at most one of `side_mismatch` / `outside_grid` for a
+   survivor.
+
+5. **Single-order-per-price case (overwhelmingly common path).** A bucket
+   of length 1 has that lone order as survivor, no duplicate cancel, and
+   identical output to today.
+
+Interaction notes:
+- **WAIT-level duplicates self-heal via the up-front survivor pass, not a
+  second independent pass (F-1-2/F-1-3).** A duplicate at a WAIT-level
+  price survives both existing branches (WAIT is filtered out of
+  `sorted_grids` at engine.py:363 so the grid loop never visits it; its
+  price IS in `grid_price_set` because WAIT levels are in `self.grid.grid`,
+  so `outside_grid` won't cancel it either). Because the survivor pass in
+  step 2 runs over **every** bucket (independent of which grid levels the
+  loop visits), a WAIT-level bucket with len>1 still collapses to one
+  survivor and emits `duplicate` cancels for the rest. Keying buckets by
+  `round(float(price), 8)` (step 1) keeps this consistent with the
+  `grid_price_set` membership test, so near-equal duplicates are grouped
+  the same way the rest of the function defines "same price".
+- The `outside_grid` sweep (lines 387–392) now iterates the survivor set
+  (per step 3, its comprehension source is changed from `sorted_limits` to
+  `survivors.values()`) — an off-grid survivor is still caught there as
+  before, and a non-survivor is no longer visible to the sweep, so it cannot
+  collect an `outside_grid` cancel on top of its `duplicate` one.
+
+`_has_fill_history(limit: dict) -> bool` — new private helper. Reads
+`limit.get('cumExecQty')`, returns `True` when it parses to a nonzero
+`Decimal`, `False` when absent/zero/unparseable. Pure, no float math on
+the parsed value. On the live tick path this always returns `False` (key
+absent); it is functional only for exchange-shaped dicts.
+
+`_select_survivor(bucket: list[dict], grid_side) -> dict` — new private
+helper. Candidate pool: orders whose `side` matches `grid_side` when
+`grid_side` is not `None` and at least one matches; otherwise the whole
+bucket. Within the pool: first order with `_has_fill_history(...) == True`,
+else the pool's first entry (deterministic first-in-list). Pure.
+
+### `RULES.md`
+
+Lines ~923–926 document same-price duplicates as never cancelled
+(pre-fix behavior). Update to state the engine now self-heals them within
+one ticker via the survivor pass (`CancelIntent(reason='duplicate')`),
+complementing the reactive 0031/0046 post-fill layer.
+
+### `packages/gridcore/src/gridcore/intents.py`
+
+`CancelIntent` (lines 153–166) — extend the `reason` field's inline
+enumeration comment (line 162) to include `'duplicate'`. No structural
+change; `reason` is already a free-form `str`.
+
+## Tests
+
+### `apps/gridbot/tests/test_issue_206_startup_reconcile_race.py`
+
+`TestStartupReconcileRaceDuplicates.test_race_places_duplicates_and_sync_cannot_heal_them`
+currently ASSERTS the buggy behavior with `# BUG:` comments (lines
+258–273). Invert to assert the fix:
+
+- Rename the test to reflect healed behavior (e.g.
+  `test_race_places_duplicates_and_engine_heals_them`) and update the
+  class/method docstrings (the module docstring at lines 17–26 and the
+  STEP4 comment block at 249–251 describe the gap as permanent — update to
+  note it now self-heals).
+- Lines 258–260: assert the shadowed legacy duplicates ARE cancelled —
+  `"legacy-buy" in cancelled_ids` and `"legacy-sell" in cancelled_ids`.
+  (Why the *legacy* ids lose: the bot's own orders enter the tracked set
+  before `inject_open_orders` adds the legacy ones, and Python's stable
+  sort preserves insertion order among equal prices, so first-in-list
+  survivor = the bot's order. If tracked-order iteration order ever
+  changes, which id is cancelled flips — assert "one of the pair is
+  cancelled, one survives" if that coupling becomes a problem.)
+- Verify the emitted cancels carry `reason == 'duplicate'` (inspect
+  `recording_executor.cancelled_intents` — each is a `CancelIntent`).
+- Lines 267–273: assert exactly **one** live order remains per formerly
+  duplicated price (`len(at_price) == 1`), i.e. the pair collapsed to a
+  single survivor — AND that the survivor is the non-legacy twin (the
+  bot's own `new-*` order is still live), AND that the healing tick
+  emitted **no new `PlaceLimitIntent` at the duplicated prices**. Without
+  these, an implementation that `duplicate`-cancels EVERY bucket member
+  and then re-places at the level would still pass the cancelled-ids /
+  reason / len==1 checks while churning the whole level. Test mechanics:
+  the recording executor's `placed_intents` list is append-only and still
+  holds the STEP2 grid placements — snapshot `len(placed_intents)` (or
+  clear the list) right before the STEP4 tick, mirroring the existing
+  `cancelled_intents.clear()` at line 252, and assert only the
+  STEP4-emitted slice; otherwise the no-place assertion false-fails on
+  STEP2 leftovers.
+- Keep the STEP1–STEP3 setup (startup fail → fresh grid → sync injects
+  legacy) untouched; only STEP4's post-tick assertions flip.
+
+### `packages/gridcore/tests/` — engine unit tests
+
+Add focused gridcore-level tests (hermetic, no runner) for
+`_place_grid_orders` duplicate handling, so the 80% gate covers the new
+branch directly:
+
+- Two orders at one on-grid price, both correct side, neither with fill
+  history ⇒ one `CancelIntent(reason='duplicate')`, one survivor, and
+  **no `PlaceLimitIntent` at that price** — the survivor must satisfy the
+  grid level. Without this assertion, a lookup/rounding bug (survivor map
+  keyed rounded, lookup raw) would cancel the duplicate AND re-place at the
+  level — recreating the double exposure — while still passing the
+  cancel-count and single-CancelIntent checks.
+- Mixed-side duplicate at an on-grid price (one order matches the grid
+  level's side, one doesn't) ⇒ the **matching-side** order survives, the
+  mismatched one gets the `duplicate` cancel, and no `side_mismatch`
+  cancel/replace churn is emitted for the level.
+- **Precedence lock (side beats fill history):** mixed-side duplicate
+  where the WRONG-side order has `cumExecQty > 0` ⇒ the correct-side
+  fill-free order still survives; the filled wrong-side order gets the
+  `duplicate` cancel (it would have been `side_mismatch`-cancelled anyway),
+  and no `side_mismatch`/place churn is emitted.
+- **Bucket of ≥3 orders at one price** ⇒ exactly one survivor,
+  `len(bucket) - 1` `duplicate` cancels, no orderId in two CancelIntents.
+- **All-wrong-side duplicate** (both orders' side mismatches the grid
+  level): survivor selection falls back to the whole-bucket pool (no
+  side-match candidate) ⇒ one `duplicate` cancel for the non-survivor,
+  and the survivor still takes the existing `side_mismatch` cancel +
+  replacement in the grid loop (engine.py:372–379) — the level is
+  restored with a correct-side order, not left collapsed to one
+  wrong-side resting order. Still one CancelIntent per order (`duplicate`
+  for non-survivor, `side_mismatch` for survivor).
+- Duplicate where exactly one order has `cumExecQty` > 0 ⇒ the
+  **fill-free** order is cancelled, the partially-filled one survives.
+- Duplicate at a `WAIT`-level price ⇒ still cancelled to one survivor
+  (guards the up-front survivor-pass decision that covers WAIT buckets).
+- **Single-CancelIntent guarantee (on-grid):** a non-survivor at an on-grid
+  price that the grid loop also visits receives exactly ONE CancelIntent
+  (`reason == 'duplicate'`), never both `duplicate` and `side_mismatch` —
+  because the grid loop sees survivors only. Assert the total cancel count
+  and that no orderId appears in two CancelIntents.
+- **Single-CancelIntent guarantee (off-grid):** a duplicate bucket at an
+  OFF-grid price (price NOT in `grid_price_set`) collapses to one survivor;
+  the non-survivor receives exactly ONE CancelIntent (`reason ==
+  'duplicate'`), never both `duplicate` and `outside_grid`. Assert no
+  orderId appears in two CancelIntents and that the sole `outside_grid`
+  cancel (if any) targets the survivor, not the already-`duplicate`-cancelled
+  order. This proves step 3's re-sourcing of the sweep from survivors.
+- **Rounded-bucket grouping:** two orders whose prices differ **below the
+  8th decimal** (e.g. `44.1` vs `44.100000004` — both `round(..., 8)` to
+  `44.1`) are treated as the same bucket (matching `grid_price_set`
+  rounding) ⇒ collapse to one survivor. (Note: `44.10000001` differs AT
+  the 8th decimal and survives `round(..., 8)` as a distinct key — that
+  pair correctly stays two separate singleton buckets.)
+- Single order per price (no duplicates), prices exact grid prices ⇒
+  output byte-for-byte identical to pre-change (regression guard: no
+  spurious `'duplicate'` cancels). Scope note: the claim holds for
+  **exact-price** singletons; a singleton whose price differs from the
+  grid price only below `round(..., 8)` changes behavior BY DESIGN (raw
+  lookup missed it → spurious place; rounded lookup now matches it) — add
+  a separate near-equal singleton case asserting the new (correct)
+  behavior: level treated as occupied, no place intent.
+- `_has_fill_history` unit cases: absent key, `"0"`, `"0.001"`,
+  non-numeric.
+
+## Out of scope
+
+- No change to `TrackedOrder`, `get_limit_orders`, or the reconciler —
+  the fix is engine-local and consumes the existing limit-dict shape.
+  Consequence (accepted, see step 2 F-1-1): on the live tick path no order
+  carries `cumExecQty`, so the fill-history survivor guard is a no-op there
+  and the survivor is chosen by first-in-list. Threading fill state through
+  `get_limit_orders`/`TrackedOrder` to make the guard live-functional is
+  deliberately deferred — the filled-duplicate case is already covered by
+  the 0031/0046 post-fill layer, and this feature only targets the pre-fill
+  window.
+- No new config/flags. No change to the 0031/0046 post-fill
+  `same_order_error` reactive layer (this fix is the complementary
+  proactive layer).

--- a/docs/features/0087_REVIEW.md
+++ b/docs/features/0087_REVIEW.md
@@ -1,0 +1,46 @@
+# Feature 0087 — Review Trail
+
+Engine cancels same-price duplicate grid orders (issue #220).
+
+## Internal review loop (review-fix-loop-staged, 1/3 iterations)
+
+Five parallel category reviewers (quality, security, performance,
+testing, documentation) over the staged diff.
+
+- Criticals: 0 after triage. Two agent-tagged "criticals" reclassified
+  on inspection (stale docstring example list → INFO, fixed; performance
+  tags contradicted by the agent's own "no issues" conclusion). One
+  false claim rejected (`TestDuplicateOrderHealing` docstring exists).
+- Warning (accepted, not fixed): `grid_sides` dict rebuilt per tick —
+  51 iterations, mirrors the pre-existing per-tick `grid_price_set`
+  pattern; negligible.
+- Fixes applied: `CancelIntent` class docstring example list gained
+  "same-price duplicate".
+
+## External review trail (ext-code-review)
+
+- Engines: codex (read-only sandbox) + cursor agent (--mode ask), both
+  prompted from `commands/code_review.md`; 1 iteration.
+- codex: NO P1/P2, zero P3. (Could not run tests in read-only sandbox;
+  verification run by the orchestrator instead — see below.)
+- cursor: NO P1/P2, 3 P3 (verification log confirmed real file reads):
+  1. `_cancel_limit` docstring reason examples missing 'duplicate' —
+     FIXED (parity with `intents.py`).
+  2. `test_fill_history_order_survives` lacked the no-re-place
+     assertion other healing tests have — FIXED (assertion added).
+  3. `test_engine.py` ~1800 lines, healing classes a natural future
+     split into `test_engine_duplicate_healing.py` — ACCEPTED GAP
+     (file split out of scope for a surgical change).
+- Rejected findings: none.
+
+## Final verification
+
+- `uv run pytest`: 2832 passed, 3 skipped.
+- `make lint` (ruff): all checks passed.
+
+## Plan-review provenance
+
+The plan itself went through plan-debate (3 iterations, 4 findings,
+all closed by fix) and ext-plan-review (4 iterations, 15 findings,
+14 accepted, 1 reclassified P2→P3 with documented assumption) before
+implementation — see `docs/features/0087_PLAN.md`.

--- a/packages/gridcore/src/gridcore/engine.py
+++ b/packages/gridcore/src/gridcore/engine.py
@@ -10,7 +10,7 @@ Extracted from bbu2-master/strat.py Strat50 class with the following transformat
 
 import logging
 from datetime import datetime
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from typing import Callable, Optional
 
 from gridcore.config import GridConfig
@@ -260,7 +260,7 @@ class GridEngine:
 
         Args:
             limit: Limit order dict with 'orderId', 'price', 'side'
-            reason: Cancellation reason (e.g., 'rebuild', 'side_mismatch', 'outside_grid')
+            reason: Cancellation reason (e.g., 'rebuild', 'side_mismatch', 'outside_grid', 'duplicate')
 
         Returns:
             CancelIntent for the order
@@ -341,6 +341,12 @@ class GridEngine:
         """
         Generate intents for placing/canceling grid orders.
 
+        Same-price duplicates (two live orders at one price level) are
+        collapsed to a single survivor per price; the shadowed extras are
+        cancelled with reason='duplicate' (feature 0087, issue #220). All
+        price equality uses round(price, 8) — the same definition as the
+        outside-grid membership test.
+
         Reference: bbu2-master/strat.py:124-160
 
         Args:
@@ -355,8 +361,28 @@ class GridEngine:
         # Sort limits by price
         sorted_limits = sorted(limits, key=lambda d: float(d['price']))
 
-        # Create price→limit mapping for O(1) lookup
-        limit_prices = {float(limit['price']): limit for limit in sorted_limits}
+        # Group limits into same-price buckets (stable order within bucket)
+        limits_by_price: dict[float, list[dict]] = {}
+        for limit in sorted_limits:
+            limits_by_price.setdefault(round(float(limit['price']), 8), []).append(limit)
+
+        # Grid side per active (non-WAIT) level, for survivor preference
+        grid_sides = {
+            round(grid_item['price'], 8): grid_item['side']
+            for grid_item in self.grid.grid
+            if grid_item['side'] != GridSideType.WAIT
+        }
+
+        # Keep one survivor per price; cancel the shadowed duplicates.
+        # Later branches read only `survivors`, so a non-survivor can never
+        # collect a second (side_mismatch/outside_grid) CancelIntent.
+        survivors: dict[float, dict] = {}
+        for price, bucket in limits_by_price.items():
+            survivor = self._select_survivor(bucket, grid_sides.get(price))
+            survivors[price] = survivor
+            for extra in bucket:
+                if extra is not survivor:
+                    intents.append(self._cancel_limit(extra, 'duplicate'))
 
         # Find center and create sorted grid items
         center_index = self._get_wait_indices()
@@ -366,8 +392,8 @@ class GridEngine:
 
         # Check each grid level
         for index, grid_item in sorted_grids:
-            # Check if limit exists for this grid price
-            limit = limit_prices.get(grid_item['price'])
+            # Check if a surviving limit exists for this grid price
+            limit = survivors.get(round(grid_item['price'], 8))
 
             if limit:
                 # Cancel if side mismatch
@@ -383,15 +409,50 @@ class GridEngine:
                 if place_intent:
                     intents.append(place_intent)
 
-        # Cancel limits outside grid range
+        # Cancel surviving limits outside grid range
         grid_price_set = {round(grid_item['price'], 8) for grid_item in self.grid.grid}
         outside_limits = [
-            limit for limit in sorted_limits
-            if round(float(limit['price']), 8) not in grid_price_set
+            limit for price, limit in survivors.items()
+            if price not in grid_price_set
         ]
         intents.extend(self._cancel_all_limits(outside_limits, 'outside_grid'))
 
         return intents
+
+    @staticmethod
+    def _has_fill_history(limit: dict) -> bool:
+        """True when the order dict carries a nonzero cumExecQty.
+
+        Live tick-path order dicts do not include cumExecQty, so this
+        returns False there; it is functional only for exchange-shaped
+        dicts.
+        """
+        raw = limit.get('cumExecQty')
+        if raw in (None, ''):
+            return False
+        try:
+            return Decimal(str(raw)) > 0
+        except InvalidOperation:
+            return False
+
+    @staticmethod
+    def _select_survivor(bucket: list[dict], grid_side: Optional[str]) -> dict:
+        """Pick the order to keep from a same-price bucket.
+
+        Preference: (1) orders whose side matches the grid level's side
+        (a wrong-side survivor would be side_mismatch-cancelled anyway),
+        (2) within those, an order with fill history, (3) first in the
+        price-sorted bucket. Pure.
+        """
+        pool = bucket
+        if grid_side is not None:
+            matching = [order for order in bucket if order['side'] == grid_side]
+            if matching:
+                pool = matching
+        for order in pool:
+            if GridEngine._has_fill_history(order):
+                return order
+        return pool[0]
 
     def _create_place_intent(self, grid: dict, direction: str, grid_level: int) -> Optional[PlaceLimitIntent]:
         """

--- a/packages/gridcore/src/gridcore/intents.py
+++ b/packages/gridcore/src/gridcore/intents.py
@@ -155,11 +155,12 @@ class CancelIntent:
     Intent to cancel an existing order.
 
     The strategy emits this intent when it wants to cancel an order
-    (e.g., price outside grid range, side mismatch, grid rebuild).
+    (e.g., price outside grid range, side mismatch, grid rebuild,
+    same-price duplicate).
     """
     symbol: str
     order_id: str
-    reason: str  # 'side_mismatch', 'outside_grid', 'rebuild', etc.
+    reason: str  # 'side_mismatch', 'outside_grid', 'rebuild', 'duplicate', etc.
 
     # Optional fields for tracking
     price: Decimal | None = None

--- a/packages/gridcore/tests/test_engine.py
+++ b/packages/gridcore/tests/test_engine.py
@@ -1554,3 +1554,275 @@ class TestEngineNoRecenter:
             if isinstance(i, PlaceLimitIntent) and float(i.price) == fill_price
         ]
         assert place_at_fill2 == []
+
+
+class TestDuplicateOrderHealing:
+    """Feature 0087 (issue #220): same-price duplicate orders self-heal."""
+
+    def _engine_with_grid(self):
+        config = GridConfig(grid_count=50, grid_step=0.2)
+        engine = GridEngine(symbol='BTCUSDT', tick_size=Decimal('0.1'), config=config, strat_id='btcusdt_test')
+        event = TickerEvent(
+            event_type=EventType.TICKER,
+            symbol='BTCUSDT',
+            exchange_ts=datetime.now(UTC),
+            local_ts=datetime.now(UTC),
+            last_price=Decimal('100000.0'),
+            mark_price=Decimal('100000.0'),
+            bid1_price=Decimal('99999.0'),
+            ask1_price=Decimal('100001.0'),
+            funding_rate=Decimal('0.0001'),
+        )
+        engine.on_event(event, {'long': [], 'short': []})
+        return engine, event
+
+    @staticmethod
+    def _order(order_id, price, side, **extra):
+        d = {'orderId': order_id, 'price': str(price), 'side': side, 'qty': '0.001'}
+        d.update(extra)
+        return d
+
+    @staticmethod
+    def _intents_by_order_id(intents):
+        by_id = {}
+        for intent in intents:
+            if isinstance(intent, CancelIntent):
+                by_id.setdefault(intent.order_id, []).append(intent)
+        return by_id
+
+    def test_duplicate_pair_on_grid_one_cancel_one_survivor(self):
+        """Two correct-side orders at one grid price: one duplicate cancel, no re-place."""
+        engine, event = self._engine_with_grid()
+        buy_level = next(g for g in engine.grid.grid if g['side'] == 'Buy')
+        dup = [
+            self._order('dup-1', buy_level['price'], 'Buy'),
+            self._order('dup-2', buy_level['price'], 'Buy'),
+        ]
+
+        intents = engine.on_event(event, {'long': dup, 'short': []})
+
+        cancels = [i for i in intents if isinstance(i, CancelIntent) and i.reason == 'duplicate']
+        assert len(cancels) == 1
+        assert cancels[0].order_id == 'dup-2'
+        # Survivor satisfies the level: no place intent at that price
+        places_at_level = [
+            i for i in intents
+            if isinstance(i, PlaceLimitIntent) and float(i.price) == buy_level['price']
+            and i.direction == 'long'
+        ]
+        assert places_at_level == []
+        # No orderId gets two CancelIntents
+        by_id = self._intents_by_order_id(intents)
+        assert all(len(v) == 1 for v in by_id.values())
+
+    def test_fill_history_order_survives(self):
+        """Same-side duplicate where one order has cumExecQty>0: fill-free one is cancelled."""
+        engine, event = self._engine_with_grid()
+        buy_level = next(g for g in engine.grid.grid if g['side'] == 'Buy')
+        dup = [
+            self._order('fill-free', buy_level['price'], 'Buy'),
+            self._order('part-filled', buy_level['price'], 'Buy', cumExecQty='0.0005'),
+        ]
+
+        intents = engine.on_event(event, {'long': dup, 'short': []})
+
+        cancels = [i for i in intents if isinstance(i, CancelIntent) and i.reason == 'duplicate']
+        assert len(cancels) == 1
+        assert cancels[0].order_id == 'fill-free'
+        # Survivor satisfies the level: no re-place churn
+        places_at_level = [
+            i for i in intents
+            if isinstance(i, PlaceLimitIntent) and float(i.price) == buy_level['price']
+            and i.direction == 'long'
+        ]
+        assert places_at_level == []
+
+    def test_mixed_side_bucket_keeps_grid_side_order(self):
+        """Mixed-side duplicate at a grid level: matching-side order survives, no churn."""
+        engine, event = self._engine_with_grid()
+        buy_level = next(g for g in engine.grid.grid if g['side'] == 'Buy')
+        dup = [
+            self._order('wrong-side', buy_level['price'], 'Sell'),
+            self._order('right-side', buy_level['price'], 'Buy'),
+        ]
+
+        intents = engine.on_event(event, {'long': dup, 'short': []})
+
+        cancels = [i for i in intents if isinstance(i, CancelIntent)]
+        assert len(cancels) == 1
+        assert cancels[0].order_id == 'wrong-side'
+        assert cancels[0].reason == 'duplicate'
+        # No side_mismatch churn, no re-place at the level
+        places_at_level = [
+            i for i in intents
+            if isinstance(i, PlaceLimitIntent) and float(i.price) == buy_level['price']
+            and i.direction == 'long'
+        ]
+        assert places_at_level == []
+
+    def test_side_match_beats_fill_history(self):
+        """Precedence lock: filled wrong-side order loses to fill-free correct-side one."""
+        engine, event = self._engine_with_grid()
+        buy_level = next(g for g in engine.grid.grid if g['side'] == 'Buy')
+        dup = [
+            self._order('wrong-filled', buy_level['price'], 'Sell', cumExecQty='0.0005'),
+            self._order('right-empty', buy_level['price'], 'Buy'),
+        ]
+
+        intents = engine.on_event(event, {'long': dup, 'short': []})
+
+        cancels = [i for i in intents if isinstance(i, CancelIntent)]
+        assert len(cancels) == 1
+        assert cancels[0].order_id == 'wrong-filled'
+        assert cancels[0].reason == 'duplicate'
+        places_at_level = [
+            i for i in intents
+            if isinstance(i, PlaceLimitIntent) and float(i.price) == buy_level['price']
+            and i.direction == 'long'
+        ]
+        assert places_at_level == []
+
+    def test_wait_level_duplicate_heals(self):
+        """Duplicate at a WAIT-level price still collapses to one survivor."""
+        engine, event = self._engine_with_grid()
+        wait_level = next(g for g in engine.grid.grid if g['side'] == 'Wait')
+        dup = [
+            self._order('wait-1', wait_level['price'], 'Buy'),
+            self._order('wait-2', wait_level['price'], 'Buy'),
+        ]
+
+        intents = engine.on_event(event, {'long': dup, 'short': []})
+
+        cancels_for_pair = [
+            i for i in intents
+            if isinstance(i, CancelIntent) and i.order_id in ('wait-1', 'wait-2')
+        ]
+        assert len(cancels_for_pair) == 1
+        assert cancels_for_pair[0].reason == 'duplicate'
+        assert cancels_for_pair[0].order_id == 'wait-2'
+
+    def test_off_grid_duplicate_single_cancel_each(self):
+        """Off-grid duplicate: non-survivor gets 'duplicate', survivor gets 'outside_grid'."""
+        engine, event = self._engine_with_grid()
+        dup = [
+            self._order('off-1', '150000.0', 'Sell'),
+            self._order('off-2', '150000.0', 'Sell'),
+        ]
+
+        intents = engine.on_event(event, {'long': [], 'short': dup})
+
+        by_id = self._intents_by_order_id(intents)
+        assert all(len(v) == 1 for v in by_id.values())
+        assert by_id['off-2'][0].reason == 'duplicate'
+        assert by_id['off-1'][0].reason == 'outside_grid'
+
+    def test_three_order_bucket_two_duplicate_cancels(self):
+        """Bucket of 3 at one price: exactly one survivor, two duplicate cancels."""
+        engine, event = self._engine_with_grid()
+        buy_level = next(g for g in engine.grid.grid if g['side'] == 'Buy')
+        dup = [
+            self._order(f'tri-{n}', buy_level['price'], 'Buy') for n in (1, 2, 3)
+        ]
+
+        intents = engine.on_event(event, {'long': dup, 'short': []})
+
+        cancels = [i for i in intents if isinstance(i, CancelIntent) and i.reason == 'duplicate']
+        assert {c.order_id for c in cancels} == {'tri-2', 'tri-3'}
+        by_id = self._intents_by_order_id(intents)
+        assert all(len(v) == 1 for v in by_id.values())
+
+    def test_all_wrong_side_duplicate_restores_level(self):
+        """All-wrong-side bucket: duplicate cancel + side_mismatch on survivor + replacement."""
+        engine, event = self._engine_with_grid()
+        buy_level = next(g for g in engine.grid.grid if g['side'] == 'Buy')
+        dup = [
+            self._order('ws-1', buy_level['price'], 'Sell'),
+            self._order('ws-2', buy_level['price'], 'Sell'),
+        ]
+
+        intents = engine.on_event(event, {'long': dup, 'short': []})
+
+        by_id = self._intents_by_order_id(intents)
+        assert all(len(v) == 1 for v in by_id.values())
+        assert by_id['ws-2'][0].reason == 'duplicate'
+        assert by_id['ws-1'][0].reason == 'side_mismatch'
+        # Level restored with a correct-side order
+        replacements = [
+            i for i in intents
+            if isinstance(i, PlaceLimitIntent)
+            and float(i.price) == buy_level['price'] and i.side == 'Buy'
+            and i.direction == 'long'
+        ]
+        assert len(replacements) == 1
+
+    def test_near_equal_prices_group_into_one_bucket(self):
+        """Prices differing below the 8th decimal share one bucket (round-8 equality)."""
+        engine, event = self._engine_with_grid()
+        buy_level = next(g for g in engine.grid.grid if g['side'] == 'Buy')
+        near_equal = f"{buy_level['price'] + 4e-9:.10f}"
+        dup = [
+            self._order('exact', buy_level['price'], 'Buy'),
+            self._order('near', near_equal, 'Buy'),
+        ]
+
+        intents = engine.on_event(event, {'long': dup, 'short': []})
+
+        cancels = [i for i in intents if isinstance(i, CancelIntent) and i.reason == 'duplicate']
+        assert len(cancels) == 1
+        assert cancels[0].order_id == 'near'
+
+    def test_near_equal_singleton_occupies_level(self):
+        """Singleton whose price differs below round-8 from the grid price fills the level."""
+        engine, event = self._engine_with_grid()
+        buy_level = next(g for g in engine.grid.grid if g['side'] == 'Buy')
+        near_equal = f"{buy_level['price'] + 4e-9:.10f}"
+        single = [self._order('near-single', near_equal, 'Buy')]
+
+        intents = engine.on_event(event, {'long': single, 'short': []})
+
+        assert not [i for i in intents if isinstance(i, CancelIntent)]
+        places_at_level = [
+            i for i in intents
+            if isinstance(i, PlaceLimitIntent) and float(i.price) == buy_level['price']
+            and i.direction == 'long'
+        ]
+        assert places_at_level == []
+
+    def test_singletons_no_spurious_duplicate_cancels(self):
+        """Single order per price: no 'duplicate' cancels (regression guard)."""
+        engine, event = self._engine_with_grid()
+        buy_level = next(g for g in engine.grid.grid if g['side'] == 'Buy')
+        sell_level = next(g for g in engine.grid.grid if g['side'] == 'Sell')
+        singles_long = [self._order('s-buy', buy_level['price'], 'Buy')]
+        singles_short = [self._order('s-sell', sell_level['price'], 'Sell')]
+
+        intents = engine.on_event(event, {'long': singles_long, 'short': singles_short})
+
+        assert not [
+            i for i in intents
+            if isinstance(i, CancelIntent) and i.reason == 'duplicate'
+        ]
+
+
+class TestHasFillHistory:
+    """Unit cases for GridEngine._has_fill_history."""
+
+    def test_absent_key(self):
+        """No cumExecQty key means no fill history."""
+        assert GridEngine._has_fill_history({'orderId': 'x'}) is False
+
+    def test_zero(self):
+        """cumExecQty '0' means no fill history."""
+        assert GridEngine._has_fill_history({'cumExecQty': '0'}) is False
+
+    def test_nonzero(self):
+        """Nonzero cumExecQty means fill history."""
+        assert GridEngine._has_fill_history({'cumExecQty': '0.001'}) is True
+
+    def test_non_numeric(self):
+        """Unparseable cumExecQty is treated as no fill history."""
+        assert GridEngine._has_fill_history({'cumExecQty': 'abc'}) is False
+
+    def test_empty_string(self):
+        """Empty-string cumExecQty is treated as no fill history."""
+        assert GridEngine._has_fill_history({'cumExecQty': ''}) is False


### PR DESCRIPTION
## Summary
- Fixes #220 (fix 2 of the #206 analysis; fixes 1+3 shipped as 0086/PR #219)
- `GridEngine._place_grid_orders` groups resting limits into `round(price, 8)` buckets, keeps one survivor per level and emits `CancelIntent(reason='duplicate')` for shadowed extras — any two-orders-one-price state now self-heals within one ticker
- Survivor preference: grid-side match > fill history (`cumExecQty`, exchange-shaped dicts only) > first-in-list; grid loop and `outside_grid` sweep re-sourced from survivors so each order gets at most one CancelIntent
- Plan: `docs/features/0087_PLAN.md` (plan-debate 3 iters + ext-plan-review 4 iters); review trail: `docs/features/0087_REVIEW.md`

## Test plan
- [x] Inverted repro `TestStartupReconcileRaceDuplicates` (red on pre-fix code, green after): legacy duplicates cancelled with `reason='duplicate'`, single non-legacy survivor per level, no re-place churn
- [x] 17 new gridcore unit tests: duplicate pair, fill-history survivor, mixed-side, precedence lock, WAIT-level, off-grid single-CancelIntent, ≥3 bucket, all-wrong-side restore, round-8 grouping, near-equal singleton, singleton regression, `_has_fill_history` units
- [x] Full suite 2832 passed / 3 skipped; ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)