### PR TITLE
feat(live_check): replay-vs-live reconciliation CLI (feature 0088)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ test:
 	uv run pytest apps/replay/tests --cov=replay --cov-append -q
 	uv run pytest apps/backtest/tests --cov=backtest --cov-append -q
 	uv run pytest apps/pnl_checker/tests --cov=pnl_checker --cov-append -q
+	uv run pytest apps/live_check/tests --cov=live_check --cov-append -q
 	uv run pytest tests/integration/ --cov-append --cov-report=term-missing -v
 
 # Run cross-package integration tests only

--- a/RULES.md
+++ b/RULES.md
@@ -74,6 +74,7 @@ uv run pytest apps/gridbot/tests -v
 uv run pytest apps/backtest/tests -v
 uv run pytest apps/comparator/tests --cov=comparator --cov-report=term-missing -v
 uv run pytest apps/pnl_checker/tests --cov=pnl_checker --cov-report=term-missing -v
+uv run pytest apps/live_check/tests -v
 
 # Integration tests only
 make test-integration
@@ -1257,6 +1258,26 @@ Read-only tool comparing our PnL/margin calculations against Bybit exchange valu
 - **Tolerance scaling for percentages**: PnL % values are 100x USDT values. Use `PERCENTAGE_TOLERANCE_MULTIPLIER = 100` in `comparator.py` to scale tolerance for ROE comparisons.
 - **Test coverage**: Currently at 92%. Run: `uv run pytest apps/pnl_checker/tests --cov=pnl_checker --cov-report=term-missing -v`
 - **Workspace dependency**: `pnl-checker` must be in root `pyproject.toml` dev deps AND `tool.uv.sources` for test discovery to work.
+
+---
+
+## live_check — Replay-vs-Live Reconciliation (feature 0088)
+
+**Path**: `apps/live_check/` — CLI `uv run live-check` (`--once` default, `--watch <interval>`, `--per-fill`, `--curve`; window `--last 4h` / `--lag 2m`).
+
+Wraps `ReplayEngine` (seeded `event_follower`, never `last_cross`) per strat over a rolling window and compares against RECORDED ground truth only (never live Bybit REST). Verdict: `live_only==[] AND backtest_only==[]`, |Δrealized|<0.01, |Δcommission|<0.01, |Δunrealised|<0.50 (net per pair). Exit codes: 0 all-PASS, 1 FAIL/config error, 2 SKIP/no-data (zero-data window is NEVER a PASS).
+
+### Key Rules
+
+- **Read-only DB open**: `DatabaseSettings(read_only=True)` rewrites file SQLite URLs to `mode=ro&uri=true` (`grid_db/database.py`). `mode=ro` ONLY — `immutable=1` freezes the snapshot and `--watch` would miss new recorder rows. Ground-truth reads use `get_readonly_session()` (no auto-commit).
+- **`ReplayEngine(..., emit_backtest_snapshots=False)`** wires a no-op position-snapshot writer so `.run()` never inserts `source='backtest'` rows into the read-only live DB. Default True keeps all other callers unchanged.
+- **Symbol scoping is mandatory**: both strats share one run_id; `get_by_run_range` has NO symbol filter — ground-truth sums use direct `func.coalesce(func.sum(...), 0)` queries filtered by run_id + symbol + window.
+- **Matched gate ≠ raw exec count**: partial fills aggregate several `private_executions` rows into one `NormalizedTrade`; `live_exec_count` is display-only.
+- **Pre-0080 guard (two floors)**: `window.start >= run.start_ts` AND `>= 2026-06-17T23:07:00Z` (`window.POST_0080_CUTOFF`) — pre-0080 data collapses link_id matching (954→44).
+- **Freshness gate (`--watch`)**: probes `MAX(TickerSnapshot.exchange_ts)` per symbol (no run_id column; `PrivateExecution` would false-trip on quiet periods); threshold `max(2*lag, 5m)`; `None` ticker ts → SKIP line, never crash. Seed miss (`SeedDataQualityError`) → SKIP line, watch loop continues.
+- **`account_id` must be pre-queried** from the `Run` row before building `ReplayConfig` — `SeedConfig` requires it at construction time.
+- All query/comparison datetimes normalized to naive UTC (`window.to_naive_utc`) — SQLite stores tz-stripped; aware-vs-naive math raises `TypeError`.
+- Replay unrealised source: `ReplayResult.session.metrics.total_unrealized_pnl` (finalized `BacktestMetrics`) — NOT `ReplayResult.metrics` (comparator `ValidationMetrics`, no such field).
 
 ---
 

--- a/apps/live_check/conf/live_check.yaml
+++ b/apps/live_check/conf/live_check.yaml
@@ -1,0 +1,40 @@
+# live_check configuration (feature 0088).
+# Two strats mirroring live conf/gridbot_test.yaml geometry+risk.
+# amount x0.0005 matches live — omitting it would fall through to the replay
+# default x0.001 → wrong placed qty → event_follower divergence.
+# max_margin mirrors live and IS passed through to RiskConfig but is not
+# consumed by gridcore's risk-mgmt branches (does not affect reconcile).
+
+database_url: "sqlite:///recorder_ltcusdt_phase4.db"
+run_id: "580ca395"
+
+last: "4h"
+lag: "2m"
+
+strats:
+  - strat_id: solusdt_test
+    symbol: SOLUSDT
+    grid_step: 0.3
+    tick_size: "0.01"
+    grid_count: 30
+    min_total_margin: 2.5
+    amount: "x0.0005"
+    max_margin: 3.0
+    min_liq_ratio: 0.8
+    max_liq_ratio: 1.2
+    increase_same_position_on_low_margin: true
+    leverage: 10
+    enable_risk_multipliers: true
+  - strat_id: ltcusdt_test
+    symbol: LTCUSDT
+    grid_step: 0.4
+    tick_size: "0.1"
+    grid_count: 20
+    min_total_margin: 3
+    amount: "x0.0005"
+    max_margin: 5.0
+    min_liq_ratio: 0.8
+    max_liq_ratio: 1.2
+    increase_same_position_on_low_margin: true
+    leverage: 10
+    enable_risk_multipliers: true

--- a/apps/live_check/pyproject.toml
+++ b/apps/live_check/pyproject.toml
@@ -1,0 +1,31 @@
+[project]
+name = "live-check"
+version = "0.1.0"
+description = "Continuous replay-vs-live reconciliation checker (feature 0088)"
+requires-python = ">=3.11"
+dependencies = [
+    "replay",
+    "comparator",
+    "backtest",
+    "grid-db",
+    "gridbot",
+    "pyyaml>=6.0",
+    "pydantic>=2.0",
+]
+
+[tool.uv.sources]
+replay = { workspace = true }
+comparator = { workspace = true }
+backtest = { workspace = true }
+grid-db = { workspace = true }
+gridbot = { workspace = true }
+
+[project.scripts]
+live-check = "live_check.main:cli"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/live_check"]

--- a/apps/live_check/src/live_check/__init__.py
+++ b/apps/live_check/src/live_check/__init__.py
@@ -1,0 +1,1 @@
+"""live_check — continuous replay-vs-live reconciliation checker (feature 0088)."""

--- a/apps/live_check/src/live_check/config.py
+++ b/apps/live_check/src/live_check/config.py
@@ -193,4 +193,7 @@ def load_config(config_path: Optional[str] = None) -> LiveCheckConfig:
     with open(path) as f:
         data = yaml.safe_load(f)
 
+    if data is None:
+        raise ValueError(f"Empty or invalid YAML file: {config_path}")
+
     return LiveCheckConfig(**data)

--- a/apps/live_check/src/live_check/config.py
+++ b/apps/live_check/src/live_check/config.py
@@ -1,0 +1,196 @@
+"""Configuration models for the live_check app.
+
+Loads live_check configuration from YAML with Pydantic validation. Each
+strat entry mirrors the LIVE geometry+risk parameters (some via engine
+defaults, not the live yaml) so the event_follower replay reconciles
+against recorded ground truth without config-induced divergence.
+"""
+
+import os
+from decimal import Decimal
+from pathlib import Path
+from typing import Optional
+
+import yaml
+from pydantic import BaseModel, Field, field_validator
+
+from replay.config import ReplayStrategyConfig
+
+
+def _parse_decimal(v):
+    """Convert string/numeric to Decimal for Pydantic field validators."""
+    if isinstance(v, str):
+        return Decimal(v)
+    if isinstance(v, (int, float)):
+        return Decimal(str(v))
+    return v
+
+
+class VerdictThresholds(BaseModel):
+    """Pass/fail deltas for the three numeric verdict checks.
+
+    The fourth check (matched) is structural — ``live_only == [] AND
+    backtest_only == []`` — and has no numeric threshold.
+    """
+
+    realized: Decimal = Field(
+        default=Decimal("0.01"),
+        description="Max |replay total_realized_pnl - SUM closed_pnl|.",
+    )
+    commission: Decimal = Field(
+        default=Decimal("0.01"),
+        description="Max |replay total_commission - SUM exec_fee|.",
+    )
+    unrealised: Decimal = Field(
+        default=Decimal("0.50"),
+        description=(
+            "Max |replay unrealised - recorded net-per-pair unrealised|. "
+            "Mark-price snapshot-timing jitter is benign below this "
+            "(established finding)."
+        ),
+    )
+
+    @field_validator("realized", "commission", "unrealised", mode="before")
+    @classmethod
+    def parse_decimal_fields(cls, v):
+        """Convert string/numeric to Decimal."""
+        return _parse_decimal(v)
+
+
+class StratCheckConfig(BaseModel):
+    """Per-strat check configuration mirroring live geometry+risk.
+
+    ``leverage``, ``enable_risk_multipliers``, ``min_liq_ratio``,
+    ``max_liq_ratio`` mirror ENGINE DEFAULTS not present in
+    ``conf/gridbot_test.yaml`` — the mirror is geometry+risk parity,
+    not a 1:1 copy of the live yaml.
+    """
+
+    strat_id: str = Field(..., description="Live strategy id (0080 link_id salt)")
+    symbol: str = Field(..., description="Trading symbol, e.g. LTCUSDT")
+    tick_size: Decimal = Field(..., description="Price tick size for rounding")
+    grid_count: int = Field(..., description="Total grid levels")
+    grid_step: float = Field(..., gt=0, description="Grid step percentage")
+    # Required: live runs x0.0005 for both sol+ltc; omitting it would fall
+    # through to the ReplayStrategyConfig default x0.001 → wrong placed qty →
+    # event_follower live_only/qty-excess divergence.
+    amount: str = Field(
+        ..., description="Order amount: fixed USDT, or 'x0.0005' wallet fraction"
+    )
+    min_liq_ratio: float = Field(default=0.8, description="Minimum liquidation ratio")
+    max_liq_ratio: float = Field(default=1.2, description="Maximum liquidation ratio")
+    min_total_margin: float = Field(..., description="Minimum total margin (live value)")
+    increase_same_position_on_low_margin: bool = Field(
+        default=True,
+        description="Low-margin boost direction (live: true)",
+    )
+    leverage: int = Field(default=10, description="Position leverage")
+    enable_risk_multipliers: bool = Field(
+        default=True, description="Enable risk-based order size multipliers"
+    )
+    # Passed through to RiskConfig by replay/backtest but NOT consumed by
+    # gridcore's risk-mgmt branches beyond being stored — included only to
+    # mirror live config faithfully; does not affect event_follower reconcile.
+    max_margin: float = Field(..., gt=0, description="Maximum margin per position")
+
+    @field_validator("tick_size", mode="before")
+    @classmethod
+    def parse_decimal_fields(cls, v):
+        """Convert string/numeric to Decimal."""
+        return _parse_decimal(v)
+
+    def to_replay_strategy_config(self) -> ReplayStrategyConfig:
+        """Project this strat's geometry+risk into a ReplayStrategyConfig."""
+        return ReplayStrategyConfig(
+            tick_size=self.tick_size,
+            strat_id=self.strat_id,
+            grid_count=self.grid_count,
+            grid_step=self.grid_step,
+            amount=self.amount,
+            max_margin=self.max_margin,
+            enable_risk_multipliers=self.enable_risk_multipliers,
+            min_liq_ratio=self.min_liq_ratio,
+            max_liq_ratio=self.max_liq_ratio,
+            min_total_margin=self.min_total_margin,
+            increase_same_position_on_low_margin=(
+                self.increase_same_position_on_low_margin
+            ),
+            leverage=self.leverage,
+        )
+
+
+class LiveCheckConfig(BaseModel):
+    """Root configuration for the live_check app."""
+
+    database_url: str = Field(
+        default="sqlite:///recorder_ltcusdt_phase4.db",
+        description="Live recorder SQLite database (opened READ-ONLY)",
+    )
+    run_id: Optional[str] = Field(
+        default="580ca395",
+        description="Recorder run_id; overridable via CLI, auto-discovers latest "
+        "recording run when null",
+    )
+    strats: list[StratCheckConfig] = Field(
+        ...,
+        min_length=1,
+        description="Strats to check (empty list would false-green a run)",
+    )
+    last: str = Field(default="4h", description="Default rolling window length")
+    lag: str = Field(
+        default="2m",
+        description="Window end lag behind now (lets recorder writes settle)",
+    )
+    staleness_threshold: Optional[str] = Field(
+        default=None,
+        description="Freshness gate trip point for --watch; None derives "
+        "max(2 * lag, 5 minutes)",
+    )
+    thresholds: VerdictThresholds = Field(
+        default_factory=VerdictThresholds,
+        description="Verdict pass/fail deltas",
+    )
+
+
+def load_config(config_path: Optional[str] = None) -> LiveCheckConfig:
+    """Load configuration from YAML file.
+
+    Args:
+        config_path: Path to config file. If None, checks:
+            1. LIVE_CHECK_CONFIG_PATH environment variable
+            2. conf/live_check.yaml
+            3. live_check.yaml
+
+    Returns:
+        Validated LiveCheckConfig.
+
+    Raises:
+        FileNotFoundError: If no config file found.
+    """
+    if config_path is None:
+        config_path = os.environ.get("LIVE_CHECK_CONFIG_PATH")
+
+    if config_path is None:
+        search_paths = [
+            Path("conf/live_check.yaml"),
+            Path("live_check.yaml"),
+        ]
+        for path in search_paths:
+            if path.exists():
+                config_path = str(path)
+                break
+
+    if config_path is None:
+        raise FileNotFoundError(
+            "No config file found. Set LIVE_CHECK_CONFIG_PATH or create "
+            "conf/live_check.yaml"
+        )
+
+    path = Path(config_path)
+    if not path.exists():
+        raise FileNotFoundError(f"Config file not found: {config_path}")
+
+    with open(path) as f:
+        data = yaml.safe_load(f)
+
+    return LiveCheckConfig(**data)

--- a/apps/live_check/src/live_check/ground_truth.py
+++ b/apps/live_check/src/live_check/ground_truth.py
@@ -1,0 +1,234 @@
+"""Recorded-row ground-truth queries for live_check.
+
+All reads run against a READ-ONLY session on the live recorder DB. Ground
+truth is recorded rows ONLY — never live Bybit REST (``pnl_checker`` is the
+wrong tool for historical reconcile).
+
+Per-symbol isolation: both live strats share one ``run_id``, so every
+realized/commission/count query here filters by ``symbol`` IN ADDITION to
+``run_id`` + window. ``PrivateExecutionRepository.get_by_run_range`` has no
+symbol filter and would commingle SOL and LTC — do not use it for sums.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from typing import Optional
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from grid_db import (
+    PositionSnapshotRepository,
+    PrivateExecution,
+    Run,
+    TickerSnapshot,
+)
+
+from live_check.window import Window, to_naive_utc
+
+_ZERO = Decimal("0")
+
+
+@dataclass(frozen=True)
+class GroundTruth:
+    """Recorded ground truth for one strat over one window."""
+
+    sum_realized: Decimal
+    sum_commission: Decimal
+    net_unrealised: Decimal
+    live_exec_count: int  # informational display ONLY — never the pass gate
+
+
+@dataclass(frozen=True)
+class ExecRow:
+    """Materialized raw execution row for the --per-fill table.
+
+    Plain dataclass (not the ORM row) so attribute access stays valid after
+    the read session closes (cf. feature 0038 DetachedInstanceError).
+    """
+
+    exec_id: str
+    exchange_ts: datetime
+    side: str
+    exec_price: Optional[Decimal]
+    exec_qty: Optional[Decimal]
+    closed_pnl: Optional[Decimal]
+    order_link_id: Optional[str]
+    # Bybit order id — pairing fallback for NULL order_link_id rows and part
+    # of the (client_id, order_id) join key (mirrors LiveTradeLoader).
+    order_id: str
+
+
+def _sum_column(
+    session: Session,
+    column,
+    run_id: str,
+    symbol: str,
+    start: datetime,
+    end: datetime,
+) -> Decimal:
+    """SUM a nullable PrivateExecution column with NULL→0 coalesce."""
+    value = (
+        session.query(func.coalesce(func.sum(column), 0))
+        .filter(
+            PrivateExecution.run_id == run_id,
+            PrivateExecution.symbol == symbol,
+            PrivateExecution.exchange_ts >= to_naive_utc(start),
+            PrivateExecution.exchange_ts <= to_naive_utc(end),
+        )
+        .scalar()
+    )
+    # Coalesce already maps NULL→0 at the SQL layer; the Python-side guard
+    # covers dialects/drivers that hand back None or a non-Decimal scalar.
+    if value is None:
+        return _ZERO
+    return Decimal(str(value))
+
+
+def sum_realized(
+    session: Session, run_id: str, symbol: str, start: datetime, end: datetime
+) -> Decimal:
+    """SUM ``closed_pnl`` over the window, scoped by run_id + symbol."""
+    return _sum_column(
+        session, PrivateExecution.closed_pnl, run_id, symbol, start, end
+    )
+
+
+def sum_commission(
+    session: Session, run_id: str, symbol: str, start: datetime, end: datetime
+) -> Decimal:
+    """SUM ``exec_fee`` over the window, scoped by run_id + symbol."""
+    return _sum_column(
+        session, PrivateExecution.exec_fee, run_id, symbol, start, end
+    )
+
+
+def net_unrealised_per_pair(
+    session: Session,
+    run_id: str,
+    account_id: str,
+    symbol: str,
+    at_ts: datetime,
+) -> Decimal:
+    """NET unrealised PnL per pair (long + short) at-or-before ``at_ts``.
+
+    Hedge mode: only the combined net per pair is meaningful — never quote
+    long-leg vs short-leg unrealised separately. Uses the existing
+    ``PositionSnapshotRepository.get_latest_before`` per side (``source='live'``)
+    — the repo already gives the correct per-side last-at-or-before row.
+    """
+    repo = PositionSnapshotRepository(session)
+    total = _ZERO
+    for side in ("Buy", "Sell"):
+        snap = repo.get_latest_before(
+            run_id=run_id,
+            account_id=account_id,
+            symbol=symbol,
+            side=side,
+            at_ts=to_naive_utc(at_ts),
+            source="live",
+        )
+        if snap is not None and snap.unrealised_pnl is not None:
+            total += Decimal(str(snap.unrealised_pnl))
+    return total
+
+
+def live_exec_count(
+    session: Session, run_id: str, symbol: str, start: datetime, end: datetime
+) -> int:
+    """COUNT of RAW execution rows over the window (display only).
+
+    Partial fills aggregate multiple raw execs into one ``NormalizedTrade``,
+    so this count ≠ ``matched_count`` on a correct run — it must never gate
+    the matched verdict.
+    """
+    return (
+        session.query(func.count(PrivateExecution.id))
+        .filter(
+            PrivateExecution.run_id == run_id,
+            PrivateExecution.symbol == symbol,
+            PrivateExecution.exchange_ts >= to_naive_utc(start),
+            PrivateExecution.exchange_ts <= to_naive_utc(end),
+        )
+        .scalar()
+        or 0
+    )
+
+
+def get_window_executions(
+    session: Session, run_id: str, symbol: str, start: datetime, end: datetime
+) -> list[ExecRow]:
+    """RAW execution rows over the window (symbol-scoped), for --per-fill.
+
+    One item per live execution (partial fills NOT aggregated), ordered
+    ``(exchange_ts, exec_id)`` to match the event_follower stream order.
+    """
+    rows = (
+        session.query(PrivateExecution)
+        .filter(
+            PrivateExecution.run_id == run_id,
+            PrivateExecution.symbol == symbol,
+            PrivateExecution.exchange_ts >= to_naive_utc(start),
+            PrivateExecution.exchange_ts <= to_naive_utc(end),
+        )
+        .order_by(PrivateExecution.exchange_ts, PrivateExecution.exec_id)
+        .all()
+    )
+    return [
+        ExecRow(
+            exec_id=r.exec_id,
+            exchange_ts=r.exchange_ts,
+            side=r.side,
+            exec_price=r.exec_price,
+            exec_qty=r.exec_qty,
+            closed_pnl=r.closed_pnl,
+            order_link_id=r.order_link_id,
+            order_id=r.order_id,
+        )
+        for r in rows
+    ]
+
+
+def latest_ticker_ts(session: Session, symbol: str) -> Optional[datetime]:
+    """Freshness probe: ``MAX(TickerSnapshot.exchange_ts)`` for the symbol.
+
+    Keyed by SYMBOL, not ``run_id`` (``TickerSnapshot`` has no run_id column).
+    Not ``PrivateExecution`` — fill-only streams false-trip the gate during
+    quiet-but-healthy periods. Returns None when no ticker rows exist.
+    """
+    return (
+        session.query(func.max(TickerSnapshot.exchange_ts))
+        .filter(TickerSnapshot.symbol == symbol)
+        .scalar()
+    )
+
+
+def get_run_start(session: Session, run_id: str) -> datetime:
+    """``Run.start_ts`` for the pre-0080 run floor guard."""
+    run = session.get(Run, run_id)
+    if run is None:
+        raise ValueError(f"Run '{run_id}' not found in database")
+    return run.start_ts
+
+
+def collect(
+    session: Session,
+    run_id: str,
+    account_id: str,
+    symbol: str,
+    window: Window,
+) -> GroundTruth:
+    """Gather all recorded ground truth for one strat over one window."""
+    return GroundTruth(
+        sum_realized=sum_realized(session, run_id, symbol, window.start, window.end),
+        sum_commission=sum_commission(
+            session, run_id, symbol, window.start, window.end
+        ),
+        net_unrealised=net_unrealised_per_pair(
+            session, run_id, account_id, symbol, window.end
+        ),
+        live_exec_count=live_exec_count(
+            session, run_id, symbol, window.start, window.end
+        ),
+    )

--- a/apps/live_check/src/live_check/main.py
+++ b/apps/live_check/src/live_check/main.py
@@ -275,6 +275,11 @@ def main(args) -> int:
         if args.watch:
             return run_watch(config, args, db)
         return run_single(config, args, db)
+    except KeyboardInterrupt:
+        # Ctrl-C out of the --watch sleep is a normal way to stop the loop —
+        # exit cleanly (conventional SIGINT code) instead of a traceback.
+        logger.info("live_check: interrupted, exiting")
+        return 130
     except ValueError as e:
         # Guard violations (pre-0080 floors, unknown run_id) and config errors.
         logger.error(str(e))

--- a/apps/live_check/src/live_check/main.py
+++ b/apps/live_check/src/live_check/main.py
@@ -1,0 +1,342 @@
+"""Main entry point for live_check (feature 0088).
+
+Usage:
+    uv run live-check                  # --once over the default 4h window
+    uv run live-check --watch 10m      # rolling one-line ticks
+    uv run live-check --per-fill --last 2h
+    uv run live-check --curve
+
+Exit codes (pinned so cron/automation never mistakes a zero-data window for
+success):
+    0 — all strats PASS.
+    1 — any strat FAIL (verdict diverges) OR a config error.
+    2 — SKIP / no-data / N/A (empty window, seed miss, stale data) or an
+        unexpected exception.
+"""
+
+import argparse
+import logging
+import sys
+import time
+from datetime import datetime, timezone
+from typing import Optional
+
+from grid_db import DatabaseFactory, DatabaseSettings, Run, RunRepository, redact_db_url
+from replay.snapshot_loader import SeedDataQualityError
+
+from live_check import ground_truth, render, runner
+from live_check.config import LiveCheckConfig, StratCheckConfig, load_config
+from live_check.verdict import evaluate
+from live_check.window import (
+    Window,
+    check_post_0080_floors,
+    compute_window,
+    freshness_skip_reason,
+    parse_duration,
+    staleness_threshold,
+    to_naive_utc,
+)
+
+logger = logging.getLogger(__name__)
+
+EXIT_PASS = 0
+EXIT_FAIL = 1
+EXIT_SKIP = 2
+
+_CURVE_CSV_DIR = "results/live_check"
+
+
+def setup_logging(debug: bool = False) -> None:
+    """Configure logging for live_check.
+
+    Args:
+        debug: Enable DEBUG level logging.
+    """
+    level = logging.DEBUG if debug else logging.INFO
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setLevel(level)
+    handler.setFormatter(
+        logging.Formatter(
+            "%(asctime)s %(levelname)-8s %(name)s: %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
+    )
+    root_logger = logging.getLogger()
+    root_logger.handlers.clear()
+    root_logger.setLevel(level)
+    root_logger.addHandler(handler)
+
+
+def check_strat(
+    strat: StratCheckConfig,
+    window: Window,
+    run_id: str,
+    account_id: str,
+    db: DatabaseFactory,
+    config: LiveCheckConfig,
+) -> tuple:
+    """Run one strat's replay + ground truth + verdict for a window.
+
+    Returns:
+        ``("skip", reason)`` for empty-window / no-ticker / seed-miss, else
+        ``("pass" | "fail", Verdict, ReplayResult)``.
+    """
+    with db.get_readonly_session() as session:
+        exec_count = ground_truth.live_exec_count(
+            session, run_id, strat.symbol, window.start, window.end
+        )
+        has_ticker = (
+            ground_truth.latest_ticker_ts(session, strat.symbol) is not None
+        )
+    # Empty-window guard: a zero-data window yields matched==0 and zero
+    # deltas — an all-PASS lie. Report SKIP instead, never PASS.
+    if exec_count == 0:
+        return ("skip", "no data in window (0 live executions)")
+    if not has_ticker:
+        return ("skip", "no ticker data")
+
+    try:
+        result = runner.run_strat(strat, window, run_id, account_id, db)
+    except SeedDataQualityError as e:
+        return ("skip", f"seed miss at {window.start.isoformat()}: {e}")
+
+    with db.get_readonly_session() as session:
+        truth = ground_truth.collect(
+            session, run_id, account_id, strat.symbol, window
+        )
+    v = evaluate(result, truth, config.thresholds)
+    return ("pass" if v.passed else "fail", v, result)
+
+
+def _resolve_run(db: DatabaseFactory, run_id: Optional[str]):
+    """Resolve (run_id, account_id, run_start) from config/CLI or discovery.
+
+    Pre-queries the ``Run`` row: ``SeedConfig`` requires ``account_id`` at
+    CONSTRUCTION time, so it must be known before ``build_replay_config``.
+    """
+    with db.get_readonly_session() as session:
+        if run_id is None:
+            run = RunRepository(session).get_latest_by_type("recording")
+            if run is None:
+                raise ValueError(
+                    f"No recording runs found in database "
+                    f"({redact_db_url(db.settings.get_database_url())})"
+                )
+        else:
+            run = session.get(Run, run_id)
+            if run is None:
+                raise ValueError(f"Run '{run_id}' not found in database")
+        return run.run_id, run.account_id, run.start_ts
+
+
+def _exit_code(outcomes: list[str]) -> int:
+    """FAIL(1) beats SKIP(2) beats PASS(0)."""
+    if any(o == "fail" for o in outcomes):
+        return EXIT_FAIL
+    if any(o == "skip" for o in outcomes):
+        return EXIT_SKIP
+    return EXIT_PASS
+
+
+def run_single(config: LiveCheckConfig, args, db: DatabaseFactory) -> int:
+    """--once / --per-fill / --curve: one window, one report, exit."""
+    run_id, account_id, run_start = _resolve_run(db, config.run_id)
+    window = compute_window(parse_duration(args.last), parse_duration(args.lag))
+    check_post_0080_floors(window.start, run_start)
+
+    outcomes: list[str] = []
+    results = []
+    for strat in config.strats:
+        outcome = check_strat(strat, window, run_id, account_id, db, config)
+        outcomes.append(outcome[0])
+        if outcome[0] == "skip":
+            print(f"{strat.strat_id} ({strat.symbol}) — SKIP: {outcome[1]}")
+        else:
+            results.append((strat, outcome[1], outcome[2]))
+
+    if results:
+        if args.per_fill:
+            with db.get_readonly_session() as session:
+                enriched = [
+                    (
+                        strat,
+                        v,
+                        result,
+                        ground_truth.get_window_executions(
+                            session, run_id, strat.symbol,
+                            window.start, window.end,
+                        ),
+                    )
+                    for strat, v, result in results
+                ]
+            print(render.render_per_fill(enriched))
+        elif args.curve:
+            print(render.render_curve(results, csv_dir=_CURVE_CSV_DIR))
+        else:
+            print(render.render_once(results))
+
+    return _exit_code(outcomes)
+
+
+def watch_tick(
+    config: LiveCheckConfig,
+    db: DatabaseFactory,
+    run_id: str,
+    account_id: str,
+    last,
+    lag,
+    threshold,
+    now: Optional[datetime] = None,
+) -> list[str]:
+    """One --watch tick: freshness gate + per-strat check, one line each.
+
+    ``last``/``lag`` are the RESOLVED CLI/config timedeltas — passed
+    explicitly so a ``--last`` override reaches the actual reconcile window
+    (reading ``config.last`` here would silently ignore the CLI flag).
+
+    Per-tick SKIP and FAIL become lines, never exceptions — the watch loop
+    must survive them.
+    """
+    window = compute_window(last, lag, now=now)
+    lines: list[str] = []
+    for strat in config.strats:
+        with db.get_readonly_session() as session:
+            ticker_ts = ground_truth.latest_ticker_ts(session, strat.symbol)
+        reason = freshness_skip_reason(ticker_ts, lag, threshold, now=now)
+        if reason is not None:
+            lines.append(f"{strat.strat_id} SKIP: {reason}")
+            continue
+        outcome = check_strat(strat, window, run_id, account_id, db, config)
+        if outcome[0] == "skip":
+            lines.append(f"{strat.strat_id} SKIP: {outcome[1]}")
+        else:
+            lines.append(
+                render.render_watch_line([(strat, outcome[1], outcome[2])])
+            )
+    return lines
+
+
+def run_watch(config: LiveCheckConfig, args, db: DatabaseFactory) -> int:
+    """--watch loop: recompute the rolling window every interval.
+
+    Exits ONLY on a fatal (guard violation, unexpected exception) — never on
+    a per-tick SKIP or FAIL.
+    """
+    run_id, account_id, run_start = _resolve_run(db, config.run_id)
+    interval = parse_duration(args.watch)
+    last = parse_duration(args.last)
+    lag = parse_duration(args.lag)
+    override = (
+        parse_duration(config.staleness_threshold)
+        if config.staleness_threshold is not None
+        else None
+    )
+    threshold = staleness_threshold(lag, override)
+
+    while True:
+        window = compute_window(last, lag)
+        check_post_0080_floors(window.start, run_start)
+        tick_ts = to_naive_utc(datetime.now(timezone.utc))
+        for line in watch_tick(
+            config, db, run_id, account_id, last, lag, threshold
+        ):
+            print(f"{tick_ts:%H:%M:%S} {line}")
+        time.sleep(interval.total_seconds())
+
+
+def main(args) -> int:
+    """Dispatch a live_check invocation; returns the process exit code."""
+    try:
+        config = load_config(args.config)
+    except (FileNotFoundError, ValueError) as e:
+        logger.error(f"Configuration error: {e}")
+        return EXIT_FAIL
+
+    if args.database_url:
+        config = config.model_copy(update={"database_url": args.database_url})
+    if args.run_id:
+        config = config.model_copy(update={"run_id": args.run_id})
+    if args.last is None:
+        args.last = config.last
+    if args.lag is None:
+        args.lag = config.lag
+
+    # READ-ONLY open (Phase 1B(a)): mode=ro only, never immutable=1. All
+    # ground-truth reads use get_readonly_session(); the replay engine gets
+    # the same factory with snapshot emission disabled (Phase 1B(b)).
+    db = DatabaseFactory(
+        DatabaseSettings(database_url=config.database_url, read_only=True)
+    )
+    logger.info(
+        "live_check: db=%s (read-only)", redact_db_url(config.database_url)
+    )
+
+    try:
+        if args.watch:
+            return run_watch(config, args, db)
+        return run_single(config, args, db)
+    except ValueError as e:
+        # Guard violations (pre-0080 floors, unknown run_id) and config errors.
+        logger.error(str(e))
+        return EXIT_FAIL
+    except SeedDataQualityError as e:
+        # Non-watch modes surface a seed miss as a clear no-data exit.
+        logger.error(f"Seed miss: {e}")
+        return EXIT_SKIP
+    except Exception:
+        logger.error("Unexpected error", exc_info=True)
+        return EXIT_SKIP
+
+
+def cli() -> None:
+    """Command-line interface entry point."""
+    parser = argparse.ArgumentParser(
+        description="live_check - replay-vs-live reconciliation checker",
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--once", action="store_true",
+        help="Run one check over the window and exit (default)",
+    )
+    mode.add_argument(
+        "--watch", type=str, default=None, metavar="INTERVAL",
+        help="Loop every INTERVAL (e.g. 10m), one line per tick per strat",
+    )
+    mode.add_argument(
+        "--per-fill", action="store_true",
+        help="Detailed table, one row per raw live execution",
+    )
+    mode.add_argument(
+        "--curve", action="store_true",
+        help="Cumulative realized sparklines + CSV export",
+    )
+    parser.add_argument(
+        "--last", type=str, default=None,
+        help="Window length (default from config, 4h)",
+    )
+    parser.add_argument(
+        "--lag", type=str, default=None,
+        help="Window end lag behind now (default from config, 2m)",
+    )
+    parser.add_argument(
+        "--config", "-c", type=str, default=None,
+        help="Path to configuration file (default: conf/live_check.yaml)",
+    )
+    parser.add_argument(
+        "--database-url", type=str, default=None,
+        help="Override recorder database URL",
+    )
+    parser.add_argument(
+        "--run-id", type=str, default=None,
+        help="Override recorder run_id",
+    )
+    parser.add_argument(
+        "--debug", action="store_true", help="Enable debug logging",
+    )
+    args = parser.parse_args()
+    setup_logging(args.debug)
+    sys.exit(main(args))
+
+
+if __name__ == "__main__":
+    cli()

--- a/apps/live_check/src/live_check/render.py
+++ b/apps/live_check/src/live_check/render.py
@@ -1,0 +1,247 @@
+"""Render modes for live_check output.
+
+Grain note (by design, not an inconsistency): ``--per-fill`` uses RAW
+execution grain (one row per live execution, keyed by exec_id) while
+``--curve`` uses aggregated trade grain (``match_result.matched``
+NormalizedTrade pairs). Per-fill drills into individual executions; curve
+compares cumulative trade-level realized point-by-point.
+"""
+
+import csv
+from collections import defaultdict
+from decimal import Decimal
+from pathlib import Path
+from typing import Optional
+
+from gridcore.intents import extract_client_order_prefix
+
+_ZERO = Decimal("0")
+
+_SPARK_CHARS = "▁▂▃▄▅▆▇█"
+
+
+def _flag(ok: bool) -> str:
+    return "✓" if ok else "✗"
+
+
+def _fmt(d: Decimal) -> str:
+    return f"{d:+.4f}"
+
+
+def render_once(results) -> str:
+    """Per-strat summary blocks for a single run.
+
+    Args:
+        results: list of ``(strat, Verdict, ReplayResult)`` tuples.
+    """
+    blocks = []
+    for strat, verdict, _result in results:
+        status = "PASS" if verdict.passed else "FAIL"
+        blocks.append(
+            "\n".join(
+                [
+                    f"=== {strat.strat_id} ({strat.symbol}) — {status} ===",
+                    f"  matched      {verdict.matched_count} trades "
+                    f"(raw execs: {verdict.live_exec_count}) "
+                    f"live_only={verdict.live_only_count} "
+                    f"backtest_only={verdict.backtest_only_count} "
+                    f"{_flag(verdict.matched_ok)}",
+                    f"  Δrealized    {_fmt(verdict.d_realized)} "
+                    f"{_flag(verdict.realized_ok)}",
+                    f"  Δcommission  {_fmt(verdict.d_commission)} "
+                    f"{_flag(verdict.commission_ok)}",
+                    f"  Δunrealised  {_fmt(verdict.d_unrealised)} "
+                    f"{_flag(verdict.unrealised_ok)}",
+                ]
+            )
+        )
+    return "\n\n".join(blocks)
+
+
+def render_watch_line(results, tick_ts=None) -> str:
+    """One-line traffic-light per strat for a watch tick.
+
+    Args:
+        results: list of ``(strat, Verdict, ReplayResult)`` tuples.
+        tick_ts: Optional tick timestamp prefix.
+    """
+    prefix = f"{tick_ts:%H:%M:%S} " if tick_ts is not None else ""
+    lines = []
+    for strat, verdict, _result in results:
+        lines.append(
+            f"{prefix}{strat.strat_id} {_flag(verdict.passed)} "
+            f"matched={verdict.matched_count} "
+            f"live_only={verdict.live_only_count} "
+            f"bt_only={verdict.backtest_only_count} "
+            f"Δr={_fmt(verdict.d_realized)} "
+            f"Δc={_fmt(verdict.d_commission)} "
+            f"Δu={_fmt(verdict.d_unrealised)}"
+        )
+    return "\n".join(lines)
+
+
+def render_per_fill(results) -> str:
+    """Detailed per-execution table: one row per RAW live execution.
+
+    Sources the live side from raw ``private_executions`` rows (which carry
+    exec_id — ``match_result.matched`` NormalizedTrades aggregate partial
+    fills and carry no exec_id, so they cannot build this table).
+
+    Pairing: in event_follower mode the engine flushes ONE ``BacktestTrade``
+    per order lifecycle (``_FillRollup``: VWAP price, summed qty/pnl), keyed
+    ``(client_order_id=link prefix, order_id)``. Live execs are therefore
+    grouped by the SAME key — ``extract_client_order_prefix`` strips the
+    live ``-{millis}`` orderLinkId suffix (raw link would never match), with
+    ``order_id`` fallback for NULL links — and each group's AGGREGATE
+    (Σqty, VWAP px, Σpnl) is compared against its bt trade. Rows still
+    render at raw-exec grain; the bt columns and ok flag are per-group.
+
+    Args:
+        results: list of ``(strat, Verdict, ReplayResult, exec_rows)``
+            tuples, where ``exec_rows`` are materialized
+            ``ground_truth.ExecRow`` items for the strat's window.
+    """
+    header = (
+        f"{'exec_id':<20} {'time':<19} {'side':<4} "
+        f"{'live_px':>10} {'bt_px':>10} {'dpx':>8} "
+        f"{'live_qty':>9} {'bt_qty':>9} {'live_pnl':>10} {'bt_pnl':>10} ok"
+    )
+    blocks = []
+    for strat, _verdict, result, exec_rows in results:
+        bt_by_key = {
+            (trade.client_order_id, trade.order_id): trade
+            for trade in result.session.trades
+        }
+
+        def _key(ex):
+            prefix = extract_client_order_prefix(ex.order_link_id)
+            return (prefix or ex.order_id, ex.order_id)
+
+        groups: dict[tuple, list] = defaultdict(list)
+        for ex in exec_rows:
+            groups[_key(ex)].append(ex)
+
+        group_ok: dict[tuple, bool] = {}
+        for key, execs in groups.items():
+            bt = bt_by_key.get(key)
+            if bt is None:
+                group_ok[key] = False
+                continue
+            qty_sum = sum((e.exec_qty or _ZERO) for e in execs)
+            pnl_sum = sum((e.closed_pnl or _ZERO) for e in execs)
+            notional = sum(
+                (e.exec_price or _ZERO) * (e.exec_qty or _ZERO) for e in execs
+            )
+            vwap = notional / qty_sum if qty_sum else _ZERO
+            group_ok[key] = (
+                qty_sum == bt.qty
+                and vwap == bt.price
+                and pnl_sum == bt.realized_pnl
+            )
+
+        lines = [f"=== {strat.strat_id} ({strat.symbol}) per-fill ===", header]
+        for ex in exec_rows:
+            key = _key(ex)
+            bt = bt_by_key.get(key)
+            live_px = ex.exec_price if ex.exec_price is not None else _ZERO
+            live_qty = ex.exec_qty if ex.exec_qty is not None else _ZERO
+            live_pnl = ex.closed_pnl if ex.closed_pnl is not None else _ZERO
+            if bt is not None:
+                dpx = live_px - bt.price
+                lines.append(
+                    f"{ex.exec_id:<20} {ex.exchange_ts:%Y-%m-%d %H:%M:%S} "
+                    f"{ex.side:<4} {live_px:>10.4f} {bt.price:>10.4f} "
+                    f"{dpx:>8.4f} {live_qty:>9.4f} {bt.qty:>9.4f} "
+                    f"{live_pnl:>10.4f} {bt.realized_pnl:>10.4f} "
+                    f"{_flag(group_ok[key])}"
+                )
+            else:
+                lines.append(
+                    f"{ex.exec_id:<20} {ex.exchange_ts:%Y-%m-%d %H:%M:%S} "
+                    f"{ex.side:<4} {live_px:>10.4f} {'—':>10} {'—':>8} "
+                    f"{live_qty:>9.4f} {'—':>9} {live_pnl:>10.4f} {'—':>10} ✗"
+                )
+        blocks.append("\n".join(lines))
+    return "\n\n".join(blocks)
+
+
+def _sparkline(values: list[Decimal]) -> str:
+    """ASCII sparkline over a numeric series (empty-safe)."""
+    if not values:
+        return "(no data)"
+    lo, hi = min(values), max(values)
+    span = hi - lo
+    if span == 0:
+        return _SPARK_CHARS[0] * len(values)
+    out = []
+    for v in values:
+        idx = int((v - lo) / span * (len(_SPARK_CHARS) - 1))
+        out.append(_SPARK_CHARS[idx])
+    return "".join(out)
+
+
+def render_curve(results, csv_dir: Optional[str] = None) -> str:
+    """Cumulative realized curves: live vs replay, matched-pair grain.
+
+    Both series walk the SAME ``match_result.matched`` pair sequence ordered
+    by ``NormalizedTrade.timestamp`` — live is the cumsum of each pair's
+    live-side realized, replay the cumsum of the bt side — so they are
+    point-by-point comparable. (Raw-exec cumsum would be a different grain:
+    partial fills change the point count.) Not built via ``EquityComparator``
+    — its loaders read wallet snapshots / full equity curves, neither of
+    which is this matched-pair cumulative-realized pair.
+
+    Args:
+        results: list of ``(strat, Verdict, ReplayResult)`` tuples.
+        csv_dir: When set, also writes ``curve_<strat_id>.csv`` per strat.
+
+    Returns:
+        Sparkline text block per strat.
+    """
+    blocks = []
+    for strat, _verdict, result in results:
+        pairs = sorted(
+            result.match_result.matched, key=lambda p: p.live.timestamp
+        )
+        live_cum: list[Decimal] = []
+        bt_cum: list[Decimal] = []
+        live_total = _ZERO
+        bt_total = _ZERO
+        for pair in pairs:
+            live_total += pair.live.realized_pnl
+            bt_total += pair.backtest.realized_pnl
+            live_cum.append(live_total)
+            bt_cum.append(bt_total)
+
+        blocks.append(
+            "\n".join(
+                [
+                    f"=== {strat.strat_id} ({strat.symbol}) cumulative "
+                    f"realized ({len(pairs)} matched pairs) ===",
+                    f"  live   {_sparkline(live_cum)} "
+                    f"(final {live_total:+.4f})",
+                    f"  replay {_sparkline(bt_cum)} "
+                    f"(final {bt_total:+.4f})",
+                ]
+            )
+        )
+
+        if csv_dir is not None:
+            path = Path(csv_dir) / f"curve_{strat.strat_id}.csv"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with open(path, "w", newline="") as f:
+                writer = csv.writer(f)
+                writer.writerow(
+                    ["timestamp", "client_order_id", "live_cum", "replay_cum"]
+                )
+                for pair, lv, bv in zip(pairs, live_cum, bt_cum):
+                    writer.writerow(
+                        [
+                            pair.live.timestamp.isoformat(),
+                            pair.live.client_order_id,
+                            str(lv),
+                            str(bv),
+                        ]
+                    )
+            blocks.append(f"  csv: {path}")
+    return "\n".join(blocks)

--- a/apps/live_check/src/live_check/runner.py
+++ b/apps/live_check/src/live_check/runner.py
@@ -1,0 +1,82 @@
+"""Replay orchestration for live_check — one seeded event_follower run per strat."""
+
+import logging
+
+from grid_db import DatabaseFactory
+
+from replay.config import FillSimulatorConfig, ReplayConfig, SeedConfig
+from replay.engine import ReplayEngine, ReplayResult
+
+from live_check.config import StratCheckConfig
+from live_check.window import Window
+
+logger = logging.getLogger(__name__)
+
+
+def build_replay_config(
+    strat: StratCheckConfig,
+    window: Window,
+    run_id: str,
+    database_url: str,
+    account_id: str,
+) -> ReplayConfig:
+    """Compose a per-strat ReplayConfig for a seeded event_follower run.
+
+    ``account_id`` MUST be passed in (pre-queried from the ``Run`` row by the
+    caller): ``SeedConfig.require_seed_fields_when_enabled`` rejects
+    ``enabled=True`` without it at CONSTRUCTION time — the engine's own
+    ``Run.account_id`` resolution happens too late.
+
+    Args:
+        strat: Strat geometry+risk mirror.
+        window: Rolling comparison window (naive-UTC).
+        run_id: Recorder run identifier.
+        database_url: Live recorder DB URL (opened read-only by the caller).
+        account_id: ``Run.account_id`` of the recorder run.
+
+    Returns:
+        ReplayConfig ready for ``ReplayEngine``.
+    """
+    return ReplayConfig(
+        database_url=database_url,
+        run_id=run_id,
+        symbol=strat.symbol,
+        start_ts=window.start,
+        end_ts=window.end,
+        strategy=strat.to_replay_strategy_config(),
+        seed=SeedConfig(
+            enabled=True,
+            at_ts=window.start,
+            account_id=account_id,
+            strat_id=strat.strat_id,
+        ),
+        fill_simulator=FillSimulatorConfig(mode="event_follower"),
+    )
+
+
+def run_strat(
+    strat: StratCheckConfig,
+    window: Window,
+    run_id: str,
+    account_id: str,
+    db: DatabaseFactory,
+) -> ReplayResult:
+    """Run one seeded event_follower replay for a strat over the window.
+
+    ``db`` is the READ-ONLY live recorder factory; snapshot emission is
+    disabled so the engine never writes ``source='backtest'`` rows into it
+    (Phase 1B(b)).
+    """
+    config = build_replay_config(
+        strat=strat,
+        window=window,
+        run_id=run_id,
+        database_url=db.settings.get_database_url(),
+        account_id=account_id,
+    )
+    engine = ReplayEngine(config, db=db, emit_backtest_snapshots=False)
+    logger.info(
+        "%s: replaying %s window %s → %s (event_follower, seeded)",
+        strat.strat_id, strat.symbol, window.start, window.end,
+    )
+    return engine.run()

--- a/apps/live_check/src/live_check/verdict.py
+++ b/apps/live_check/src/live_check/verdict.py
@@ -1,0 +1,98 @@
+"""Verdict evaluation for live_check — the four threshold checks.
+
+Pure functions over already-loaded data; no DB access.
+"""
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+from live_check.config import VerdictThresholds
+from live_check.ground_truth import GroundTruth
+
+
+@dataclass(frozen=True)
+class Verdict:
+    """Outcome of the four reconcile checks for one strat/window."""
+
+    live_only_count: int
+    backtest_only_count: int
+    matched_count: int
+    live_exec_count: int  # informational display only (raw exec rows)
+    d_realized: Decimal
+    d_commission: Decimal
+    d_unrealised: Decimal
+    matched_ok: bool
+    realized_ok: bool
+    commission_ok: bool
+    unrealised_ok: bool
+    passed: bool
+
+
+def evaluate(
+    replay_result,
+    ground_truth: GroundTruth,
+    thresholds: VerdictThresholds,
+) -> Verdict:
+    """Apply the four verdict checks to one strat's replay vs ground truth.
+
+    The matched check is structural: ``match_result.live_only == [] AND
+    match_result.backtest_only == []``. It is NOT ``matched_count ==
+    live_exec_count`` — ``matched`` counts aggregated NormalizedTrades while
+    ``live_exec_count`` counts RAW execution rows; partial fills make them
+    legitimately differ on a correct run.
+
+    Replay unrealised is read from
+    ``replay_result.session.metrics.total_unrealized_pnl`` (the finalized
+    ``BacktestMetrics``) — ``ReplayResult.metrics`` is a comparator
+    ``ValidationMetrics`` with no such field, and ``session`` has no
+    top-level ``total_unrealized_pnl`` attribute.
+
+    Args:
+        replay_result: ``ReplayResult`` from a finalized engine run.
+        ground_truth: Recorded sums for the same strat/window.
+        thresholds: Pass/fail deltas.
+
+    Returns:
+        Verdict with per-check flags and the overall pass.
+
+    Raises:
+        ValueError: When ``replay_result.session.metrics`` is None (result
+            built without ``finalize()``).
+    """
+    session_metrics = replay_result.session.metrics
+    if session_metrics is None:
+        raise ValueError(
+            "replay_result.session.metrics is None — the session was not "
+            "finalized; ReplayEngine.run() calls finalize() before returning, "
+            "so this result did not come from a completed run."
+        )
+
+    match_result = replay_result.match_result
+    live_only_count = len(match_result.live_only)
+    backtest_only_count = len(match_result.backtest_only)
+    matched_ok = live_only_count == 0 and backtest_only_count == 0
+
+    d_realized = session_metrics.total_realized_pnl - ground_truth.sum_realized
+    d_commission = session_metrics.total_commission - ground_truth.sum_commission
+    d_unrealised = (
+        session_metrics.total_unrealized_pnl - ground_truth.net_unrealised
+    )
+
+    realized_ok = abs(d_realized) < thresholds.realized
+    commission_ok = abs(d_commission) < thresholds.commission
+    unrealised_ok = abs(d_unrealised) < thresholds.unrealised
+
+    return Verdict(
+        live_only_count=live_only_count,
+        backtest_only_count=backtest_only_count,
+        matched_count=len(match_result.matched),
+        live_exec_count=ground_truth.live_exec_count,
+        d_realized=d_realized,
+        d_commission=d_commission,
+        d_unrealised=d_unrealised,
+        matched_ok=matched_ok,
+        realized_ok=realized_ok,
+        commission_ok=commission_ok,
+        unrealised_ok=unrealised_ok,
+        passed=matched_ok and realized_ok and commission_ok and unrealised_ok,
+    )

--- a/apps/live_check/src/live_check/window.py
+++ b/apps/live_check/src/live_check/window.py
@@ -1,0 +1,154 @@
+"""Window / lag computation and datetime guards for live_check.
+
+All datetimes used in queries or comparisons are normalized to NAIVE UTC —
+SQLite stores timestamps tz-stripped, and an aware-vs-naive comparison or
+subtraction raises ``TypeError`` (cf. ``comparator/loader.py:26``,
+``replay/engine.py`` tz handling).
+"""
+
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+# Feature 0080 merged 2026-06-17: orderLinkId hashes are salted by strat_id.
+# event_follower matches by link_id, so replaying PRE-0080 data collapses
+# matching (954→44). Windows must never start before this cutoff.
+POST_0080_CUTOFF = datetime(2026, 6, 17, 23, 7, 0)
+
+_MIN_STALENESS_THRESHOLD = timedelta(minutes=5)
+
+_DURATION_RE = re.compile(r"^(\d+)([smhd])$")
+
+_DURATION_UNITS = {
+    "s": timedelta(seconds=1),
+    "m": timedelta(minutes=1),
+    "h": timedelta(hours=1),
+    "d": timedelta(days=1),
+}
+
+
+def parse_duration(text: str) -> timedelta:
+    """Parse a duration like ``10m``, ``4h``, ``30s``, ``1d``.
+
+    Args:
+        text: Duration string — integer count plus one unit suffix.
+
+    Returns:
+        Equivalent timedelta.
+
+    Raises:
+        ValueError: On unparseable input.
+    """
+    match = _DURATION_RE.match(text.strip())
+    if not match:
+        raise ValueError(
+            f"Invalid duration {text!r}; expected forms like '30s', '2m', '4h', '1d'"
+        )
+    count, unit = match.groups()
+    return int(count) * _DURATION_UNITS[unit]
+
+
+def to_naive_utc(dt: datetime) -> datetime:
+    """Convert any datetime to naive UTC (aware → UTC then strip tzinfo)."""
+    if dt.tzinfo is not None:
+        return dt.astimezone(timezone.utc).replace(tzinfo=None)
+    return dt
+
+
+@dataclass(frozen=True)
+class Window:
+    """Rolling comparison window, naive-UTC bounds."""
+
+    start: datetime
+    end: datetime
+
+
+def compute_window(
+    last: timedelta,
+    lag: timedelta,
+    now: Optional[datetime] = None,
+) -> Window:
+    """Compute the rolling window ``[now − lag − last, now − lag]``.
+
+    The lag lets recorder writes settle so the check never races
+    un-flushed data.
+
+    Args:
+        last: Window length.
+        lag: End lag behind now.
+        now: Injectable current time (tests); defaults to UTC now.
+
+    Returns:
+        Window with naive-UTC start/end.
+    """
+    now = to_naive_utc(now if now is not None else datetime.now(timezone.utc))
+    end = now - lag
+    return Window(start=end - last, end=end)
+
+
+def check_post_0080_floors(window_start: datetime, run_start: datetime) -> None:
+    """Enforce both post-0080 floors on the window start (pitfall #1).
+
+    Args:
+        window_start: Rolling window start.
+        run_start: ``Run.start_ts`` of the configured recorder run.
+
+    Raises:
+        ValueError: When the window starts before the run start or before
+            the absolute 0080 merge cutoff.
+    """
+    start = to_naive_utc(window_start)
+    run_floor = to_naive_utc(run_start)
+    if start < run_floor:
+        raise ValueError(
+            f"Window start {start.isoformat()} precedes the configured run's "
+            f"start_ts {run_floor.isoformat()}. Replaying data outside the "
+            "recorded run gives no ground truth to reconcile against."
+        )
+    if start < POST_0080_CUTOFF:
+        raise ValueError(
+            f"Window start {start.isoformat()} precedes the 0080 orderLinkId "
+            f"salting cutoff {POST_0080_CUTOFF.isoformat()}Z. event_follower "
+            "matches by link_id, so PRE-0080 data collapses matching "
+            "(954→44 matched) and any reconcile would be silently bogus."
+        )
+
+
+def staleness_threshold(
+    lag: timedelta, override: Optional[timedelta] = None
+) -> timedelta:
+    """Freshness gate trip point: ``max(2 * lag, 5 minutes)`` unless overridden."""
+    if override is not None:
+        return override
+    return max(2 * lag, _MIN_STALENESS_THRESHOLD)
+
+
+def freshness_skip_reason(
+    latest_ticker_ts: Optional[datetime],
+    lag: timedelta,
+    threshold: timedelta,
+    now: Optional[datetime] = None,
+) -> Optional[str]:
+    """Return a SKIP reason when recorded ticker data is stale, else None.
+
+    Probes ``TickerSnapshot`` recency (per symbol) — NOT ``PrivateExecution``,
+    which is fill-only and would false-trip during quiet-but-healthy periods.
+
+    Args:
+        latest_ticker_ts: ``MAX(TickerSnapshot.exchange_ts)`` for the symbol,
+            or None when the DB has no ticker rows for it.
+        lag: Configured window lag.
+        threshold: Staleness threshold (see :func:`staleness_threshold`).
+        now: Injectable current time (tests); defaults to UTC now.
+
+    Returns:
+        Human-readable skip reason, or None when data is fresh.
+    """
+    if latest_ticker_ts is None:
+        return "no ticker data"
+    now = to_naive_utc(now if now is not None else datetime.now(timezone.utc))
+    age = now - lag - to_naive_utc(latest_ticker_ts)
+    if age > threshold:
+        return f"ticker data stale by {age} (threshold {threshold})"
+    return None

--- a/apps/live_check/tests/conftest.py
+++ b/apps/live_check/tests/conftest.py
@@ -1,0 +1,92 @@
+"""Test fixtures for live_check package."""
+
+from datetime import datetime, timedelta
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+
+from grid_db import DatabaseFactory, DatabaseSettings
+from grid_db.models import BybitAccount, Run, Strategy, User
+
+from live_check.config import LiveCheckConfig, StratCheckConfig
+
+RUN_ID = "test-run-id"
+
+
+@pytest.fixture
+def ts():
+    """Base timestamp: naive UTC, safely AFTER the 0080 cutoff."""
+    return datetime(2026, 7, 1, 12, 0, 0)
+
+
+@pytest.fixture
+def db():
+    """Create fresh in-memory database for each test."""
+    database = DatabaseFactory(
+        DatabaseSettings(db_type="sqlite", db_name=":memory:", echo_sql=False)
+    )
+    database.create_tables()
+    yield database
+    database.drop_tables()
+
+
+@pytest.fixture
+def seeded_run_account(db, ts):
+    """Insert User → BybitAccount → Strategy → recording Run for RUN_ID.
+
+    Returns a namespace with the account_id string so callers can reach the
+    UUID without holding an ORM session.
+    """
+    with db.get_session() as session:
+        user = User(username="testuser", email="t@example.com")
+        session.add(user)
+        session.flush()
+        account = BybitAccount(
+            user_id=user.user_id,
+            account_name="test_account",
+            environment="testnet",
+        )
+        session.add(account)
+        session.flush()
+        account_id = str(account.account_id)
+        strategy = Strategy(
+            account_id=account.account_id,
+            strategy_type="GridStrategy",
+            symbol="LTCUSDT",
+            config_json={},
+        )
+        session.add(strategy)
+        session.flush()
+        run = Run(
+            run_id=RUN_ID,
+            user_id=user.user_id,
+            account_id=account_id,
+            strategy_id=strategy.strategy_id,
+            run_type="recording",
+            start_ts=ts - timedelta(days=1),
+        )
+        session.add(run)
+        session.commit()
+    return SimpleNamespace(account_id=account_id, run_id=RUN_ID)
+
+
+@pytest.fixture
+def strat():
+    """One strat mirroring the live LTC geometry."""
+    return StratCheckConfig(
+        strat_id="ltcusdt_test",
+        symbol="LTCUSDT",
+        tick_size=Decimal("0.1"),
+        grid_count=20,
+        grid_step=0.4,
+        amount="x0.0005",
+        min_total_margin=3.0,
+        max_margin=5.0,
+    )
+
+
+@pytest.fixture
+def live_check_config(strat):
+    """Minimal LiveCheckConfig with the single test strat."""
+    return LiveCheckConfig(strats=[strat], run_id=RUN_ID)

--- a/apps/live_check/tests/test_config.py
+++ b/apps/live_check/tests/test_config.py
@@ -1,0 +1,18 @@
+"""Tests for live_check.config validation guards."""
+
+import pytest
+from pydantic import ValidationError
+
+from live_check.config import LiveCheckConfig
+
+
+class TestStratsValidation:
+    def test_empty_strats_rejected(self):
+        """An empty strat list is a config error, not a false-green run."""
+        with pytest.raises(ValidationError):
+            LiveCheckConfig(strats=[])
+
+    def test_missing_strats_rejected(self):
+        """strats is required."""
+        with pytest.raises(ValidationError):
+            LiveCheckConfig()

--- a/apps/live_check/tests/test_config.py
+++ b/apps/live_check/tests/test_config.py
@@ -3,7 +3,17 @@
 import pytest
 from pydantic import ValidationError
 
-from live_check.config import LiveCheckConfig
+from live_check.config import LiveCheckConfig, load_config
+
+
+class TestLoadConfig:
+    def test_empty_yaml_file_raises_value_error(self, tmp_path):
+        """yaml.safe_load returns None on an empty file — clean error, not
+        a TypeError from LiveCheckConfig(**None)."""
+        empty = tmp_path / "live_check.yaml"
+        empty.write_text("")
+        with pytest.raises(ValueError, match="Empty or invalid YAML"):
+            load_config(str(empty))
 
 
 class TestStratsValidation:

--- a/apps/live_check/tests/test_freshness.py
+++ b/apps/live_check/tests/test_freshness.py
@@ -1,0 +1,52 @@
+"""Tests for the --watch freshness gate."""
+
+from datetime import datetime, timedelta
+
+from live_check.window import freshness_skip_reason, staleness_threshold
+
+_NOW = datetime(2026, 7, 1, 12, 0, 0)
+_LAG = timedelta(minutes=2)
+
+
+class TestStalenessThreshold:
+    def test_default_is_max_of_2lag_and_5min(self):
+        """threshold = max(2*lag, 5 minutes)."""
+        assert staleness_threshold(timedelta(minutes=2)) == timedelta(minutes=5)
+        assert staleness_threshold(timedelta(minutes=10)) == timedelta(minutes=20)
+
+    def test_override_wins(self):
+        """Explicit override replaces the derived default."""
+        assert staleness_threshold(
+            timedelta(minutes=2), override=timedelta(minutes=30)
+        ) == timedelta(minutes=30)
+
+
+class TestFreshnessGate:
+    def test_fresh_ticker_passes(self):
+        """Recent ticker rows → no skip (quiet-but-healthy periods included:
+        the probe is TickerSnapshot, never PrivateExecution, so zero fills
+        with a flowing ticker does NOT trip the gate)."""
+        latest = _NOW - _LAG - timedelta(minutes=1)
+        threshold = staleness_threshold(_LAG)
+        assert freshness_skip_reason(latest, _LAG, threshold, now=_NOW) is None
+
+    def test_stale_ticker_skips(self):
+        """Ticker older than the threshold → skip with a stale reason."""
+        latest = _NOW - _LAG - timedelta(minutes=20)
+        threshold = staleness_threshold(_LAG)
+        reason = freshness_skip_reason(latest, _LAG, threshold, now=_NOW)
+        assert reason is not None
+        assert "stale" in reason
+
+    def test_none_ticker_ts_skips_no_crash(self):
+        """No ticker rows at all → SKIP reason 'no ticker data', never a
+        TypeError from subtracting None."""
+        threshold = staleness_threshold(_LAG)
+        reason = freshness_skip_reason(None, _LAG, threshold, now=_NOW)
+        assert reason == "no ticker data"
+
+    def test_boundary_at_threshold_passes(self):
+        """Age exactly == threshold is not yet stale (strict >)."""
+        threshold = staleness_threshold(_LAG)
+        latest = _NOW - _LAG - threshold
+        assert freshness_skip_reason(latest, _LAG, threshold, now=_NOW) is None

--- a/apps/live_check/tests/test_ground_truth.py
+++ b/apps/live_check/tests/test_ground_truth.py
@@ -1,0 +1,232 @@
+"""Tests for live_check.ground_truth — recorded-row queries."""
+
+from datetime import timedelta
+from decimal import Decimal
+
+import pytest
+
+from grid_db import PositionSnapshot, PrivateExecution, TickerSnapshot
+
+from live_check import ground_truth
+from live_check.window import Window
+
+RUN_ID = "test-run-id"
+
+
+def _insert_exec(db, *, exec_id, ts, symbol="LTCUSDT", side="Buy",
+                 price="80", qty="0.2", fee=None, pnl=None, link=None):
+    with db.get_session() as session:
+        session.add(PrivateExecution(
+            run_id=RUN_ID,
+            account_id="acc1",
+            symbol=symbol,
+            exec_id=exec_id,
+            order_id=f"oid-{exec_id}",
+            order_link_id=link,
+            exchange_ts=ts,
+            side=side,
+            exec_price=Decimal(price),
+            exec_qty=Decimal(qty),
+            exec_fee=Decimal(fee) if fee is not None else None,
+            closed_pnl=Decimal(pnl) if pnl is not None else None,
+        ))
+
+
+def _insert_position(db, account_id, *, ts, side, unrealised,
+                     symbol="LTCUSDT", source="live"):
+    with db.get_session() as session:
+        session.add(PositionSnapshot(
+            run_id=RUN_ID,
+            account_id=account_id,
+            symbol=symbol,
+            exchange_ts=ts,
+            local_ts=ts,
+            side=side,
+            size=Decimal("0.2"),
+            entry_price=Decimal("80"),
+            unrealised_pnl=(
+                Decimal(unrealised) if unrealised is not None else None
+            ),
+            source=source,
+        ))
+
+
+def _insert_ticker(db, *, ts, symbol="LTCUSDT", price="80"):
+    with db.get_session() as session:
+        session.add(TickerSnapshot(
+            symbol=symbol,
+            exchange_ts=ts,
+            local_ts=ts,
+            last_price=Decimal(price),
+            mark_price=Decimal(price),
+            bid1_price=Decimal(price) - Decimal("0.1"),
+            ask1_price=Decimal(price) + Decimal("0.1"),
+            funding_rate=Decimal("0.0001"),
+        ))
+
+
+class TestSums:
+    def test_sum_realized(self, db, seeded_run_account, ts):
+        """SUM closed_pnl over the window, symbol-scoped."""
+        _insert_exec(db, exec_id="e1", ts=ts, pnl="1.5", fee="0.01")
+        _insert_exec(db, exec_id="e2", ts=ts + timedelta(minutes=1),
+                     pnl="-0.5", fee="0.02")
+        with db.get_readonly_session() as s:
+            total = ground_truth.sum_realized(
+                s, RUN_ID, "LTCUSDT", ts - timedelta(hours=1),
+                ts + timedelta(hours=1),
+            )
+        assert total == Decimal("1.0")
+
+    def test_sum_commission(self, db, seeded_run_account, ts):
+        """SUM exec_fee over the window, symbol-scoped."""
+        _insert_exec(db, exec_id="e1", ts=ts, fee="0.01")
+        _insert_exec(db, exec_id="e2", ts=ts + timedelta(minutes=1), fee="0.02")
+        with db.get_readonly_session() as s:
+            total = ground_truth.sum_commission(
+                s, RUN_ID, "LTCUSDT", ts - timedelta(hours=1),
+                ts + timedelta(hours=1),
+            )
+        assert total == Decimal("0.03")
+
+    def test_sums_coalesce_empty_window_to_zero(self, db, seeded_run_account, ts):
+        """SUM over zero rows returns Decimal(0), not None."""
+        with db.get_readonly_session() as s:
+            assert ground_truth.sum_realized(
+                s, RUN_ID, "LTCUSDT", ts, ts + timedelta(hours=1)
+            ) == Decimal("0")
+            assert ground_truth.sum_commission(
+                s, RUN_ID, "LTCUSDT", ts, ts + timedelta(hours=1)
+            ) == Decimal("0")
+
+    def test_sums_coalesce_all_null_rows_to_zero(self, db, seeded_run_account, ts):
+        """SUM over all-NULL closed_pnl/exec_fee rows returns Decimal(0)."""
+        _insert_exec(db, exec_id="e1", ts=ts, pnl=None, fee=None)
+        with db.get_readonly_session() as s:
+            assert ground_truth.sum_realized(
+                s, RUN_ID, "LTCUSDT", ts - timedelta(hours=1),
+                ts + timedelta(hours=1),
+            ) == Decimal("0")
+            assert ground_truth.sum_commission(
+                s, RUN_ID, "LTCUSDT", ts - timedelta(hours=1),
+                ts + timedelta(hours=1),
+            ) == Decimal("0")
+
+    def test_multi_symbol_shared_run_isolation(self, db, seeded_run_account, ts):
+        """SOL sums EXCLUDE LTC execs under the SAME run_id (symbol-scoped)."""
+        _insert_exec(db, exec_id="sol1", ts=ts, symbol="SOLUSDT",
+                     pnl="2.0", fee="0.05")
+        _insert_exec(db, exec_id="ltc1", ts=ts, symbol="LTCUSDT",
+                     pnl="9.0", fee="0.90")
+        start, end = ts - timedelta(hours=1), ts + timedelta(hours=1)
+        with db.get_readonly_session() as s:
+            assert ground_truth.sum_realized(
+                s, RUN_ID, "SOLUSDT", start, end) == Decimal("2.0")
+            assert ground_truth.sum_commission(
+                s, RUN_ID, "SOLUSDT", start, end) == Decimal("0.05")
+            assert ground_truth.live_exec_count(
+                s, RUN_ID, "SOLUSDT", start, end) == 1
+
+
+class TestNetUnrealised:
+    def test_net_long_plus_short(self, db, seeded_run_account, ts):
+        """Long + short legs combine to one NET value per pair."""
+        acc = seeded_run_account.account_id
+        _insert_position(db, acc, ts=ts, side="Buy", unrealised="1.2")
+        _insert_position(db, acc, ts=ts, side="Sell", unrealised="-0.4")
+        with db.get_readonly_session() as s:
+            net = ground_truth.net_unrealised_per_pair(
+                s, RUN_ID, acc, "LTCUSDT", ts + timedelta(minutes=1)
+            )
+        assert net == Decimal("0.8")
+
+    def test_last_at_or_before_selection(self, db, seeded_run_account, ts):
+        """Takes the last snapshot at/before at_ts per side; later ones ignored."""
+        acc = seeded_run_account.account_id
+        _insert_position(db, acc, ts=ts, side="Buy", unrealised="1.0")
+        _insert_position(db, acc, ts=ts + timedelta(minutes=5), side="Buy",
+                         unrealised="2.0")
+        _insert_position(db, acc, ts=ts + timedelta(minutes=30), side="Buy",
+                         unrealised="99.0")
+        with db.get_readonly_session() as s:
+            net = ground_truth.net_unrealised_per_pair(
+                s, RUN_ID, acc, "LTCUSDT", ts + timedelta(minutes=10)
+            )
+        assert net == Decimal("2.0")
+
+    def test_null_unrealised_coerces_to_zero(self, db, seeded_run_account, ts):
+        """NULL unrealised_pnl on a leg counts as 0, not a crash."""
+        acc = seeded_run_account.account_id
+        _insert_position(db, acc, ts=ts, side="Buy", unrealised=None)
+        _insert_position(db, acc, ts=ts, side="Sell", unrealised="-0.3")
+        with db.get_readonly_session() as s:
+            net = ground_truth.net_unrealised_per_pair(
+                s, RUN_ID, acc, "LTCUSDT", ts + timedelta(minutes=1)
+            )
+        assert net == Decimal("-0.3")
+
+    def test_backtest_source_rows_excluded(self, db, seeded_run_account, ts):
+        """Only source='live' rows feed ground truth."""
+        acc = seeded_run_account.account_id
+        _insert_position(db, acc, ts=ts, side="Buy", unrealised="5.0",
+                         source="backtest")
+        with db.get_readonly_session() as s:
+            net = ground_truth.net_unrealised_per_pair(
+                s, RUN_ID, acc, "LTCUSDT", ts + timedelta(minutes=1)
+            )
+        assert net == Decimal("0")
+
+
+class TestProbes:
+    def test_latest_ticker_ts(self, db, seeded_run_account, ts):
+        """MAX exchange_ts per symbol."""
+        _insert_ticker(db, ts=ts)
+        _insert_ticker(db, ts=ts + timedelta(minutes=2))
+        with db.get_readonly_session() as s:
+            assert ground_truth.latest_ticker_ts(s, "LTCUSDT") == (
+                ts + timedelta(minutes=2)
+            )
+
+    def test_latest_ticker_ts_none_when_no_rows(self, db, seeded_run_account):
+        """No ticker rows for the symbol → None, not a crash."""
+        with db.get_readonly_session() as s:
+            assert ground_truth.latest_ticker_ts(s, "SOLUSDT") is None
+
+    def test_get_run_start(self, db, seeded_run_account, ts):
+        """Returns Run.start_ts for the guard."""
+        with db.get_readonly_session() as s:
+            assert ground_truth.get_run_start(s, RUN_ID) == ts - timedelta(days=1)
+
+    def test_get_run_start_unknown_run_raises(self, db, seeded_run_account):
+        """Unknown run_id is a hard error."""
+        with db.get_readonly_session() as s:
+            with pytest.raises(ValueError, match="not found"):
+                ground_truth.get_run_start(s, "nope")
+
+    def test_get_window_executions_raw_grain(self, db, seeded_run_account, ts):
+        """Raw rows, symbol-scoped, ordered (exchange_ts, exec_id)."""
+        _insert_exec(db, exec_id="b", ts=ts, link="L1")
+        _insert_exec(db, exec_id="a", ts=ts, link="L1")
+        _insert_exec(db, exec_id="sol", ts=ts, symbol="SOLUSDT")
+        with db.get_readonly_session() as s:
+            rows = ground_truth.get_window_executions(
+                s, RUN_ID, "LTCUSDT", ts - timedelta(hours=1),
+                ts + timedelta(hours=1),
+            )
+        assert [r.exec_id for r in rows] == ["a", "b"]
+        assert all(r.order_link_id == "L1" for r in rows)
+
+
+class TestCollect:
+    def test_collect_bundles_all_fields(self, db, seeded_run_account, ts):
+        """collect() gathers sums + net unrealised + count for one window."""
+        acc = seeded_run_account.account_id
+        _insert_exec(db, exec_id="e1", ts=ts, pnl="1.5", fee="0.01")
+        _insert_position(db, acc, ts=ts, side="Buy", unrealised="0.7")
+        window = Window(start=ts - timedelta(hours=1), end=ts + timedelta(hours=1))
+        with db.get_readonly_session() as s:
+            truth = ground_truth.collect(s, RUN_ID, acc, "LTCUSDT", window)
+        assert truth.sum_realized == Decimal("1.5")
+        assert truth.sum_commission == Decimal("0.01")
+        assert truth.net_unrealised == Decimal("0.7")
+        assert truth.live_exec_count == 1

--- a/apps/live_check/tests/test_guard.py
+++ b/apps/live_check/tests/test_guard.py
@@ -1,0 +1,37 @@
+"""Tests for the pre-0080 window guard (both floors)."""
+
+from datetime import datetime
+
+import pytest
+
+from live_check.window import POST_0080_CUTOFF, check_post_0080_floors
+
+
+class TestPost0080Guard:
+    def test_start_before_run_start_raises(self):
+        """Run floor: window.start < run.start_ts is a hard error."""
+        run_start = datetime(2026, 7, 3, 0, 0, 0)
+        with pytest.raises(ValueError, match="run's\\s+start_ts"):
+            check_post_0080_floors(datetime(2026, 7, 2, 0, 0, 0), run_start)
+
+    def test_start_before_absolute_cutoff_raises(self):
+        """Absolute floor fires even when start >= run.start_ts.
+
+        A --run-id pointed at a PRE-0080 recording passes the run floor but
+        must still be rejected (954→44 matching collapse).
+        """
+        run_start = datetime(2026, 6, 1, 0, 0, 0)  # pre-0080 recording
+        start = datetime(2026, 6, 10, 0, 0, 0)  # >= run_start, < cutoff
+        with pytest.raises(ValueError, match="0080"):
+            check_post_0080_floors(start, run_start)
+
+    def test_post_cutoff_post_run_start_passes(self):
+        """Both floors satisfied → no error."""
+        check_post_0080_floors(
+            datetime(2026, 7, 5, 0, 0, 0), datetime(2026, 7, 3, 0, 0, 0)
+        )
+
+    def test_cutoff_constant_value(self):
+        """Cutoff pins the 0080 merge moment 2026-06-17T23:07:00Z (naive UTC)."""
+        assert POST_0080_CUTOFF == datetime(2026, 6, 17, 23, 7, 0)
+        assert POST_0080_CUTOFF.tzinfo is None

--- a/apps/live_check/tests/test_naive_utc.py
+++ b/apps/live_check/tests/test_naive_utc.py
@@ -1,0 +1,68 @@
+"""Aware-vs-naive datetime regression tests (mandatory naive-UTC normalization).
+
+SQLite stores timestamps tz-stripped; an aware-vs-naive comparison or
+subtraction raises TypeError. Every window/cutoff/freshness code path must
+normalize to naive UTC first.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from live_check.window import (
+    check_post_0080_floors,
+    compute_window,
+    freshness_skip_reason,
+    staleness_threshold,
+    to_naive_utc,
+)
+
+_TZ_PLUS5 = timezone(timedelta(hours=5))
+
+
+class TestToNaiveUtc:
+    def test_aware_converted_to_utc_then_stripped(self):
+        """+05:00 input lands on the equivalent UTC wall time, naive."""
+        aware = datetime(2026, 7, 1, 17, 0, 0, tzinfo=_TZ_PLUS5)
+        naive = to_naive_utc(aware)
+        assert naive == datetime(2026, 7, 1, 12, 0, 0)
+        assert naive.tzinfo is None
+
+    def test_naive_passes_through(self):
+        """Naive input is assumed UTC and returned unchanged."""
+        dt = datetime(2026, 7, 1, 12, 0, 0)
+        assert to_naive_utc(dt) is dt
+
+
+class TestWindowMathWithAwareInputs:
+    def test_compute_window_with_aware_now(self):
+        """Aware now → naive-UTC bounds, no TypeError downstream."""
+        aware_now = datetime(2026, 7, 1, 12, 0, 0, tzinfo=timezone.utc)
+        w = compute_window(timedelta(hours=4), timedelta(minutes=2), now=aware_now)
+        assert w.start.tzinfo is None and w.end.tzinfo is None
+        assert w.end == datetime(2026, 7, 1, 11, 58, 0)
+        # Comparable against a SQLite-style naive timestamp without raising.
+        assert w.start < datetime(2026, 7, 1, 12, 0, 0)
+
+    def test_cutoff_guard_with_aware_inputs(self):
+        """Aware window start + aware run start compare cleanly vs the cutoff."""
+        start = datetime(2026, 7, 5, 0, 0, 0, tzinfo=timezone.utc)
+        run_start = datetime(2026, 7, 3, 0, 0, 0, tzinfo=_TZ_PLUS5)
+        check_post_0080_floors(start, run_start)  # no TypeError
+
+    def test_cutoff_guard_aware_still_fires(self):
+        """Normalization keeps the guard semantics — pre-cutoff aware start
+        (post-cutoff only via its +05:00 offset) is still rejected."""
+        start = datetime(2026, 6, 18, 3, 0, 0, tzinfo=_TZ_PLUS5)  # 06-17 22:00 UTC
+        run_start = datetime(2026, 6, 1, 0, 0, 0, tzinfo=timezone.utc)
+        with pytest.raises(ValueError, match="0080"):
+            check_post_0080_floors(start, run_start)
+
+    def test_freshness_subtraction_with_aware_inputs(self):
+        """Aware ticker ts and aware now subtract cleanly, no TypeError."""
+        now = datetime(2026, 7, 1, 12, 0, 0, tzinfo=timezone.utc)
+        latest = datetime(2026, 7, 1, 16, 57, 0, tzinfo=_TZ_PLUS5)  # 11:57 UTC
+        threshold = staleness_threshold(timedelta(minutes=2))
+        assert freshness_skip_reason(
+            latest, timedelta(minutes=2), threshold, now=now
+        ) is None

--- a/apps/live_check/tests/test_readonly.py
+++ b/apps/live_check/tests/test_readonly.py
@@ -1,0 +1,100 @@
+"""Tests for the grid_db read-only open (Phase 1B(a)).
+
+FILE-BACKED temp SQLite only — mode=ro is skipped for :memory: URLs, so an
+in-memory test would pass vacuously without exercising the read-only path.
+"""
+
+from datetime import datetime
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import func
+from sqlalchemy.exc import OperationalError
+
+from grid_db import DatabaseFactory, DatabaseSettings, TickerSnapshot
+
+
+def _insert_ticker(db, ts):
+    with db.get_session() as session:
+        session.add(TickerSnapshot(
+            symbol="LTCUSDT",
+            exchange_ts=ts,
+            local_ts=ts,
+            last_price=Decimal("80"),
+            mark_price=Decimal("80"),
+            bid1_price=Decimal("79.9"),
+            ask1_price=Decimal("80.1"),
+            funding_rate=Decimal("0.0001"),
+        ))
+
+
+def _count(session) -> int:
+    return session.query(func.count(TickerSnapshot.id)).scalar()
+
+
+@pytest.fixture
+def file_db(tmp_path):
+    """Writable file-backed DB with one ticker row."""
+    url = f"sqlite:///{tmp_path}/recorder.db"
+    db = DatabaseFactory(DatabaseSettings(database_url=url))
+    db.create_tables()
+    _insert_ticker(db, datetime(2026, 7, 1, 12, 0, 0))
+    return db, url
+
+
+class TestReadOnlyOpen:
+    def test_url_rewritten_to_mode_ro(self, file_db):
+        """read_only=True rewrites the engine URL to a mode=ro URI (no immutable)."""
+        _, url = file_db
+        ro = DatabaseFactory(DatabaseSettings(database_url=url, read_only=True))
+        rendered = str(ro.engine.url)
+        assert "mode=ro" in rendered
+        assert "uri=true" in rendered
+        assert "immutable" not in rendered
+
+    def test_select_succeeds(self, file_db):
+        """Reads work on the read-only open."""
+        _, url = file_db
+        ro = DatabaseFactory(DatabaseSettings(database_url=url, read_only=True))
+        with ro.get_readonly_session() as session:
+            assert _count(session) == 1
+
+    def test_write_raises_operational_error(self, file_db):
+        """INSERT via the read-only factory raises (readonly database)."""
+        _, url = file_db
+        ro = DatabaseFactory(DatabaseSettings(database_url=url, read_only=True))
+        with ro.get_readonly_session() as session:
+            _insert = TickerSnapshot(
+                symbol="LTCUSDT",
+                exchange_ts=datetime(2026, 7, 1, 13, 0, 0),
+                local_ts=datetime(2026, 7, 1, 13, 0, 0),
+                last_price=Decimal("81"),
+                mark_price=Decimal("81"),
+                bid1_price=Decimal("80.9"),
+                ask1_price=Decimal("81.1"),
+                funding_rate=Decimal("0.0001"),
+            )
+            session.add(_insert)
+            with pytest.raises(OperationalError):
+                session.flush()
+
+    def test_new_writer_rows_visible_after_ro_open(self, file_db):
+        """mode=ro (no immutable=1) sees rows committed AFTER the ro open.
+
+        This is the --watch/freshness regression guard: immutable=1 would
+        freeze the snapshot and hide the second row.
+        """
+        writer, url = file_db
+        ro = DatabaseFactory(DatabaseSettings(database_url=url, read_only=True))
+        with ro.get_readonly_session() as session:
+            assert _count(session) == 1  # ro connection now open
+        _insert_ticker(writer, datetime(2026, 7, 1, 12, 5, 0))
+        with ro.get_readonly_session() as session:
+            assert _count(session) == 2
+
+    def test_memory_url_not_rewritten(self):
+        """:memory: URLs skip the mode=ro rewrite (nothing to protect)."""
+        db = DatabaseFactory(
+            DatabaseSettings(db_type="sqlite", db_name=":memory:", read_only=True)
+        )
+        assert "mode=ro" not in str(db.engine.url)

--- a/apps/live_check/tests/test_readonly_run.py
+++ b/apps/live_check/tests/test_readonly_run.py
@@ -1,0 +1,178 @@
+"""Tests for ReplayEngine snapshot-emission disable under read-only (1B(b)).
+
+FILE-BACKED temp SQLite — mode=ro is skipped for :memory:, so only a file DB
+actually exercises the read-only open during a full engine run.
+"""
+
+from datetime import datetime, timedelta
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy import func
+
+from backtest.data_provider import InMemoryDataProvider
+from grid_db import DatabaseFactory, DatabaseSettings, PositionSnapshot
+from grid_db.models import BybitAccount, Run, Strategy, User
+from gridcore import EventType, TickerEvent
+
+from backtest.config import BacktestStrategyConfig
+from backtest.session import BacktestSession
+from replay.config import ReplayConfig, ReplayStrategyConfig
+from replay.engine import (
+    ReplayEngine,
+    _BatchPositionSnapshotWriter,
+    _NoopPositionSnapshotWriter,
+)
+
+RUN_ID = "test-run-id"
+TS = datetime(2026, 7, 1, 12, 0, 0)
+
+
+def _tick(price, ts):
+    return TickerEvent(
+        event_type=EventType.TICKER,
+        symbol="LTCUSDT",
+        exchange_ts=ts,
+        local_ts=ts,
+        last_price=price,
+        mark_price=price,
+        bid1_price=price - Decimal("0.1"),
+        ask1_price=price + Decimal("0.1"),
+        funding_rate=Decimal("0.0001"),
+    )
+
+
+def _seed_run(db) -> str:
+    with db.get_session() as session:
+        user = User(username="testuser", email="t@example.com")
+        session.add(user)
+        session.flush()
+        account = BybitAccount(
+            user_id=user.user_id,
+            account_name="test_account",
+            environment="testnet",
+        )
+        session.add(account)
+        session.flush()
+        account_id = str(account.account_id)
+        strategy = Strategy(
+            account_id=account.account_id,
+            strategy_type="GridStrategy",
+            symbol="LTCUSDT",
+            config_json={},
+        )
+        session.add(strategy)
+        session.flush()
+        session.add(Run(
+            run_id=RUN_ID,
+            user_id=user.user_id,
+            account_id=account_id,
+            strategy_id=strategy.strategy_id,
+            run_type="recording",
+            start_ts=TS - timedelta(hours=1),
+        ))
+        session.commit()
+    return account_id
+
+
+def _config() -> ReplayConfig:
+    return ReplayConfig(
+        database_url="sqlite:///:memory:",  # engine uses the db= factory
+        run_id=RUN_ID,
+        symbol="LTCUSDT",
+        start_ts=TS,
+        end_ts=TS + timedelta(minutes=10),
+        strategy=ReplayStrategyConfig(
+            tick_size=Decimal("0.1"),
+            grid_count=10,
+            grid_step=0.4,
+            amount="100",
+        ),
+        initial_balance=Decimal("10000"),
+        enable_funding=False,
+        output_dir="results/test_live_check",
+    )
+
+
+@pytest.fixture
+def mock_instrument():
+    with patch("replay.engine.InstrumentInfoProvider") as mock_provider_cls:
+        mock_info = MagicMock()
+        mock_info.qty_step = Decimal("0.01")
+        mock_info.tick_size = Decimal("0.1")
+        mock_info.round_qty = lambda q: q.quantize(Decimal("0.01"))
+        mock_provider_cls.return_value.get.return_value = mock_info
+        yield mock_provider_cls
+
+
+class TestNoopWriterWiring:
+    def test_disabled_emission_wires_noop_writer(self, mock_instrument):
+        """emit_backtest_snapshots=False wires ONLY the no-op writer."""
+        engine = ReplayEngine(
+            _config(),
+            db=MagicMock(),
+            emit_backtest_snapshots=False,
+        )
+        runner = engine._init_runner(
+            BacktestStrategyConfig(
+                strat_id="s", symbol="LTCUSDT", tick_size=Decimal("0.1")
+            ),
+            BacktestSession(initial_balance=Decimal("10000")),
+            run_id=RUN_ID,
+            account_id="acc1",
+        )
+        assert isinstance(runner._position_writer, _NoopPositionSnapshotWriter)
+        assert not isinstance(
+            runner._position_writer, _BatchPositionSnapshotWriter
+        )
+        assert runner._position_writer.flush() == 0
+        assert runner._position_writer.total_written == 0
+
+    def test_default_keeps_batch_writer(self, mock_instrument):
+        """Flag unset → existing callers keep the flushing batch writer."""
+        engine = ReplayEngine(_config(), db=MagicMock())
+        runner = engine._init_runner(
+            BacktestStrategyConfig(
+                strat_id="s", symbol="LTCUSDT", tick_size=Decimal("0.1")
+            ),
+            BacktestSession(initial_balance=Decimal("10000")),
+            run_id=RUN_ID,
+            account_id="acc1",
+        )
+        assert isinstance(runner._position_writer, _BatchPositionSnapshotWriter)
+
+
+class TestReadOnlyRun:
+    def test_run_completes_on_readonly_db_without_writes(
+        self, tmp_path, mock_instrument
+    ):
+        """Engine .run() with emission disabled never writes the ro live DB.
+
+        Completes without OperationalError and leaves the live DB's
+        source='backtest' PositionSnapshot rowcount at zero.
+        """
+        url = f"sqlite:///{tmp_path}/recorder.db"
+        writer_db = DatabaseFactory(DatabaseSettings(database_url=url))
+        writer_db.create_tables()
+        _seed_run(writer_db)
+
+        ro_db = DatabaseFactory(
+            DatabaseSettings(database_url=url, read_only=True)
+        )
+        engine = ReplayEngine(_config(), db=ro_db, emit_backtest_snapshots=False)
+        ticks = [
+            _tick(Decimal("80"), TS + timedelta(minutes=1)),
+            _tick(Decimal("80.4"), TS + timedelta(minutes=2)),
+            _tick(Decimal("79.6"), TS + timedelta(minutes=3)),
+        ]
+        result = engine.run(data_provider=InMemoryDataProvider(ticks))
+        assert result.run_id == RUN_ID
+
+        with writer_db.get_session() as session:
+            bt_rows = (
+                session.query(func.count(PositionSnapshot.id))
+                .filter(PositionSnapshot.source == "backtest")
+                .scalar()
+            )
+        assert bt_rows == 0

--- a/apps/live_check/tests/test_render.py
+++ b/apps/live_check/tests/test_render.py
@@ -1,0 +1,193 @@
+"""Smoke tests for the four live_check render modes."""
+
+from datetime import datetime
+from decimal import Decimal
+from types import SimpleNamespace
+
+from live_check.ground_truth import ExecRow
+from live_check.render import (
+    render_curve,
+    render_once,
+    render_per_fill,
+    render_watch_line,
+)
+from live_check.verdict import Verdict
+
+
+def _verdict(passed=True):
+    ok = passed
+    return Verdict(
+        live_only_count=0 if ok else 1,
+        backtest_only_count=0,
+        matched_count=2,
+        live_exec_count=3,
+        d_realized=Decimal("0.001"),
+        d_commission=Decimal("-0.002"),
+        d_unrealised=Decimal("0.1"),
+        matched_ok=ok,
+        realized_ok=True,
+        commission_ok=True,
+        unrealised_ok=True,
+        passed=ok,
+    )
+
+
+def _strat():
+    return SimpleNamespace(strat_id="ltcusdt_test", symbol="LTCUSDT")
+
+
+def _trade(link, price="80", qty="0.2", pnl="0.5", ts=None, order_id="O1"):
+    return SimpleNamespace(
+        client_order_id=link,
+        order_id=order_id,
+        price=Decimal(price),
+        qty=Decimal(qty),
+        realized_pnl=Decimal(pnl),
+        timestamp=ts or datetime(2026, 7, 1, 12, 0, 0),
+    )
+
+
+def _matched_pair(link, live_pnl, bt_pnl, ts):
+    return SimpleNamespace(
+        live=SimpleNamespace(
+            client_order_id=link,
+            realized_pnl=Decimal(live_pnl),
+            timestamp=ts,
+        ),
+        backtest=SimpleNamespace(realized_pnl=Decimal(bt_pnl)),
+    )
+
+
+def _result(trades=(), matched=()):
+    return SimpleNamespace(
+        session=SimpleNamespace(trades=list(trades)),
+        match_result=SimpleNamespace(matched=list(matched)),
+    )
+
+
+class TestRenderOnce:
+    def test_pass_block(self):
+        """Summary block carries strat, verdict, and all three deltas."""
+        out = render_once([(_strat(), _verdict(True), _result())])
+        assert "ltcusdt_test" in out
+        assert "PASS" in out
+        assert "Δrealized" in out
+        assert "Δcommission" in out
+        assert "Δunrealised" in out
+
+    def test_fail_block(self):
+        """FAIL verdict labelled FAIL."""
+        out = render_once([(_strat(), _verdict(False), _result())])
+        assert "FAIL" in out
+
+
+class TestRenderWatchLine:
+    def test_one_line_per_strat(self):
+        """Traffic-light line has matched count and the three deltas."""
+        out = render_watch_line([(_strat(), _verdict(True), _result())])
+        assert out.count("\n") == 0
+        assert "matched=2" in out
+        assert "Δr=" in out and "Δc=" in out and "Δu=" in out
+
+
+class TestRenderPerFill:
+    def test_partial_fills_pair_against_one_rollup_trade(self):
+        """Two partial execs pair with ONE aggregated bt trade and flag ✓.
+
+        event_follower flushes one BacktestTrade per order lifecycle (VWAP
+        price, summed qty/pnl) keyed (link prefix, order_id); the live
+        orderLinkId carries a -{millis} suffix that must be stripped for
+        the keys to meet. Sequential raw-link pairing would false-✗ here.
+        """
+        ts = datetime(2026, 7, 1, 12, 0, 0)
+        execs = [
+            ExecRow("exec-1", ts, "Buy", Decimal("80"), Decimal("0.1"),
+                    Decimal("0"), "L1-1751371200000", "O1"),
+            ExecRow("exec-2", ts, "Buy", Decimal("80"), Decimal("0.1"),
+                    Decimal("0"), "L1-1751371200000", "O1"),
+        ]
+        trades = [_trade("L1", qty="0.2", pnl="0", order_id="O1")]
+        out = render_per_fill(
+            [(_strat(), _verdict(True), _result(trades=trades), execs)]
+        )
+        assert "exec_id" in out  # header
+        assert "exec-1" in out and "exec-2" in out
+        assert "✗" not in out  # aggregate matches → every row ✓
+
+    def test_aggregate_mismatch_flags_group(self):
+        """Group qty sum ≠ bt trade qty → the group's rows flag ✗."""
+        ts = datetime(2026, 7, 1, 12, 0, 0)
+        execs = [
+            ExecRow("exec-1", ts, "Buy", Decimal("80"), Decimal("0.1"),
+                    Decimal("0"), "L1-1751371200000", "O1"),
+        ]
+        trades = [_trade("L1", qty="0.2", pnl="0", order_id="O1")]
+        out = render_per_fill(
+            [(_strat(), _verdict(False), _result(trades=trades), execs)]
+        )
+        assert "✗" in out
+
+    def test_multi_price_partials_match_vwap(self):
+        """Partials at DIFFERENT prices pair via the rollup's VWAP price."""
+        ts = datetime(2026, 7, 1, 12, 0, 0)
+        execs = [
+            ExecRow("exec-1", ts, "Buy", Decimal("80"), Decimal("0.1"),
+                    Decimal("0"), "L1-1751371200000", "O1"),
+            ExecRow("exec-2", ts, "Buy", Decimal("81"), Decimal("0.1"),
+                    Decimal("0"), "L1-1751371200000", "O1"),
+        ]
+        # rollup VWAP = (80*0.1 + 81*0.1) / 0.2 = 80.5
+        trades = [_trade("L1", price="80.5", qty="0.2", pnl="0", order_id="O1")]
+        out = render_per_fill(
+            [(_strat(), _verdict(True), _result(trades=trades), execs)]
+        )
+        assert "✗" not in out
+
+    def test_null_link_falls_back_to_order_id(self):
+        """NULL order_link_id pairs via order_id (no '' key collision)."""
+        ts = datetime(2026, 7, 1, 12, 0, 0)
+        execs = [
+            ExecRow("exec-1", ts, "Buy", Decimal("80"), Decimal("0.2"),
+                    Decimal("0"), None, "O9"),
+        ]
+        trades = [_trade("O9", qty="0.2", pnl="0", order_id="O9")]
+        out = render_per_fill(
+            [(_strat(), _verdict(True), _result(trades=trades), execs)]
+        )
+        assert "✗" not in out
+
+    def test_unmatched_exec_renders_dash_row(self):
+        """A live exec with no bt fill renders a placeholder row, no crash."""
+        ts = datetime(2026, 7, 1, 12, 0, 0)
+        execs = [ExecRow("exec-1", ts, "Sell", Decimal("81"), Decimal("0.2"),
+                         None, "orphan-123", "O2")]
+        out = render_per_fill(
+            [(_strat(), _verdict(False), _result(), execs)]
+        )
+        assert "exec-1" in out
+        assert "✗" in out
+
+
+class TestRenderCurve:
+    def test_matched_pair_grain_and_csv(self, tmp_path):
+        """Both series walk the same matched pairs; CSV exported per strat."""
+        t0 = datetime(2026, 7, 1, 12, 0, 0)
+        pairs = [
+            _matched_pair("L1", "0.5", "0.5", t0),
+            _matched_pair("L2", "-0.2", "-0.2", t0.replace(minute=5)),
+        ]
+        out = render_curve(
+            [(_strat(), _verdict(True), _result(matched=pairs))],
+            csv_dir=str(tmp_path),
+        )
+        assert "live" in out and "replay" in out
+        assert "2 matched pairs" in out
+        csv_file = tmp_path / "curve_ltcusdt_test.csv"
+        assert csv_file.exists()
+        content = csv_file.read_text()
+        assert "live_cum" in content and "replay_cum" in content
+
+    def test_empty_matched_no_crash(self):
+        """Zero matched pairs renders an empty-series marker."""
+        out = render_curve([(_strat(), _verdict(True), _result())])
+        assert "no data" in out

--- a/apps/live_check/tests/test_runner.py
+++ b/apps/live_check/tests/test_runner.py
@@ -1,0 +1,58 @@
+"""Tests for live_check.runner — per-strat ReplayConfig composition."""
+
+from datetime import datetime, timedelta
+from decimal import Decimal
+
+from live_check.runner import build_replay_config
+from live_check.window import Window
+
+
+class TestBuildReplayConfig:
+    def test_seed_and_follower_wiring(self, strat):
+        """Seeded event_follower config with strat_id salt and account_id."""
+        start = datetime(2026, 7, 1, 8, 0, 0)
+        window = Window(start=start, end=start + timedelta(hours=4))
+        config = build_replay_config(
+            strat=strat,
+            window=window,
+            run_id="test-run-id",
+            database_url="sqlite:///recorder.db",
+            account_id="acc-uuid",
+        )
+        assert config.fill_simulator.mode == "event_follower"
+        assert config.symbol == "LTCUSDT"
+        assert config.run_id == "test-run-id"
+        assert config.start_ts == window.start
+        assert config.end_ts == window.end
+        # 0080 salt + seed keyed to the window start.
+        assert config.strategy.strat_id == "ltcusdt_test"
+        assert config.seed.enabled is True
+        assert config.seed.at_ts == window.start
+        assert config.seed.strat_id == "ltcusdt_test"
+        assert config.seed.account_id == "acc-uuid"
+
+    def test_geometry_and_risk_mirror(self, strat):
+        """All five risk fields + geometry project into the strategy config."""
+        window = Window(
+            start=datetime(2026, 7, 1, 8, 0, 0),
+            end=datetime(2026, 7, 1, 12, 0, 0),
+        )
+        config = build_replay_config(
+            strat=strat,
+            window=window,
+            run_id="r",
+            database_url="sqlite:///x.db",
+            account_id="a",
+        )
+        s = config.strategy
+        assert s.tick_size == Decimal("0.1")
+        assert s.grid_count == 20
+        assert s.grid_step == 0.4
+        assert s.amount == "x0.0005"
+        assert s.max_margin == 5.0
+        assert s.min_liq_ratio == 0.8
+        assert s.max_liq_ratio == 1.2
+        assert s.min_total_margin == 3.0
+        assert s.increase_same_position_on_low_margin is True
+        assert s.leverage == 10
+        assert s.enable_risk_multipliers is True

--- a/apps/live_check/tests/test_verdict.py
+++ b/apps/live_check/tests/test_verdict.py
@@ -1,0 +1,126 @@
+"""Tests for live_check.verdict — the four threshold checks."""
+
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+
+from live_check.config import VerdictThresholds
+from live_check.ground_truth import GroundTruth
+from live_check.verdict import evaluate
+
+_ZERO = Decimal("0")
+
+
+def _truth(realized="0", commission="0", unrealised="0", count=3):
+    return GroundTruth(
+        sum_realized=Decimal(realized),
+        sum_commission=Decimal(commission),
+        net_unrealised=Decimal(unrealised),
+        live_exec_count=count,
+    )
+
+
+def _rr(realized="0", commission="0", unrealised="0",
+        matched=3, live_only=0, backtest_only=0, metrics_none=False):
+    """Synthetic ReplayResult stub.
+
+    ``replay_result.metrics`` (the comparator ValidationMetrics) deliberately
+    has NO total_unrealized_pnl attribute — evaluate must never read it.
+    ``session`` likewise has no top-level total_unrealized_pnl.
+    """
+    session_metrics = None if metrics_none else SimpleNamespace(
+        total_realized_pnl=Decimal(realized),
+        total_commission=Decimal(commission),
+        total_unrealized_pnl=Decimal(unrealised),
+    )
+    return SimpleNamespace(
+        session=SimpleNamespace(metrics=session_metrics),
+        metrics=SimpleNamespace(),  # ValidationMetrics stand-in, no pnl fields
+        match_result=SimpleNamespace(
+            matched=[object()] * matched,
+            live_only=[object()] * live_only,
+            backtest_only=[object()] * backtest_only,
+        ),
+    )
+
+
+class TestVerdictThresholds:
+    def test_all_pass(self):
+        """Exact parity on all four checks → PASS."""
+        v = evaluate(_rr(), _truth(), VerdictThresholds())
+        assert v.passed
+        assert v.matched_ok and v.realized_ok and v.commission_ok
+        assert v.unrealised_ok
+
+    @pytest.mark.parametrize("delta,ok", [("0.009", True), ("0.01", False)])
+    def test_realized_boundary(self, delta, ok):
+        """|Δrealized| strictly < 0.01 passes; == 0.01 fails."""
+        v = evaluate(_rr(realized=delta), _truth(), VerdictThresholds())
+        assert v.realized_ok is ok
+        assert v.passed is ok
+
+    @pytest.mark.parametrize("delta,ok", [("-0.009", True), ("-0.01", False)])
+    def test_commission_boundary(self, delta, ok):
+        """|Δcommission| strictly < 0.01 passes (abs of negative delta)."""
+        v = evaluate(_rr(commission=delta), _truth(), VerdictThresholds())
+        assert v.commission_ok is ok
+
+    @pytest.mark.parametrize("delta,ok", [("0.49", True), ("0.50", False)])
+    def test_unrealised_boundary(self, delta, ok):
+        """|Δunrealised| strictly < 0.50 passes."""
+        v = evaluate(_rr(unrealised=delta), _truth(), VerdictThresholds())
+        assert v.unrealised_ok is ok
+
+    def test_live_only_fails_matched_check(self):
+        """Any live_only trade fails the matched verdict."""
+        v = evaluate(_rr(live_only=1), _truth(), VerdictThresholds())
+        assert not v.matched_ok
+        assert not v.passed
+        assert v.live_only_count == 1
+
+    def test_backtest_only_fails_matched_check(self):
+        """Any backtest_only trade fails the matched verdict."""
+        v = evaluate(_rr(backtest_only=2), _truth(), VerdictThresholds())
+        assert not v.matched_ok
+        assert v.backtest_only_count == 2
+
+
+class TestMatchedGrain:
+    def test_partial_fill_aggregation_still_passes(self):
+        """Raw live_exec_count > matched_count must NOT fail a correct run.
+
+        Partial fills aggregate several raw execs into one NormalizedTrade,
+        so the gate is live_only/backtest_only == [], never
+        matched_count == live_exec_count.
+        """
+        v = evaluate(
+            _rr(matched=3, live_only=0, backtest_only=0),
+            _truth(count=5),
+            VerdictThresholds(),
+        )
+        assert v.live_exec_count == 5
+        assert v.matched_count == 3
+        assert v.passed
+
+    def test_live_exec_count_is_display_only(self):
+        """live_exec_count is carried on the Verdict but never gates it."""
+        v = evaluate(_rr(matched=1), _truth(count=100), VerdictThresholds())
+        assert v.passed
+
+
+class TestUnrealisedSource:
+    def test_reads_session_metrics_total_unrealized(self):
+        """d_unrealised comes from session.metrics.total_unrealized_pnl.
+
+        The stub's ReplayResult.metrics has no such field and session has no
+        top-level attribute — an implementation reading either would crash.
+        """
+        rr = _rr(unrealised="0.2")
+        v = evaluate(rr, _truth(unrealised="0.1"), VerdictThresholds())
+        assert v.d_unrealised == Decimal("0.1")
+
+    def test_metrics_none_raises_explicit_guard(self):
+        """session.metrics None → explicit ValueError, not AttributeError."""
+        with pytest.raises(ValueError, match="not.*finalized|finalize"):
+            evaluate(_rr(metrics_none=True), _truth(), VerdictThresholds())

--- a/apps/live_check/tests/test_watch.py
+++ b/apps/live_check/tests/test_watch.py
@@ -1,0 +1,128 @@
+"""Tests for --watch tick resilience (skip-on-seed-miss, no crash)."""
+
+from datetime import datetime, timedelta
+from decimal import Decimal
+
+from grid_db import PrivateExecution, TickerSnapshot
+from replay.snapshot_loader import SeedDataQualityError
+
+from live_check import main as lc_main
+from live_check.window import staleness_threshold
+
+_NOW = datetime(2026, 7, 1, 12, 0, 0)
+_LAG = timedelta(minutes=2)
+
+
+def _seed_window_data(db, ts):
+    """One exec + one fresh ticker so the tick reaches the seed path."""
+    with db.get_session() as session:
+        session.add(PrivateExecution(
+            run_id="test-run-id",
+            account_id="acc1",
+            symbol="LTCUSDT",
+            exec_id="e1",
+            order_id="o1",
+            order_link_id="L1",
+            exchange_ts=ts - timedelta(minutes=30),
+            side="Buy",
+            exec_price=Decimal("80"),
+            exec_qty=Decimal("0.2"),
+            exec_fee=Decimal("0.01"),
+            closed_pnl=Decimal("0"),
+        ))
+        session.add(TickerSnapshot(
+            symbol="LTCUSDT",
+            exchange_ts=ts - timedelta(minutes=3),
+            local_ts=ts - timedelta(minutes=3),
+            last_price=Decimal("80"),
+            mark_price=Decimal("80"),
+            bid1_price=Decimal("79.9"),
+            ask1_price=Decimal("80.1"),
+            funding_rate=Decimal("0.0001"),
+        ))
+
+
+class TestWatchSeedMiss:
+    def test_seed_miss_renders_skip_and_loop_continues(
+        self, db, seeded_run_account, strat, live_check_config, monkeypatch
+    ):
+        """SeedDataQualityError at window.start → SKIP line, no crash.
+
+        Two consecutive ticks both complete — proves the watch loop survives
+        a per-tick seed miss instead of dying on the exception.
+        """
+        _seed_window_data(db, _NOW)
+
+        def _raise_seed_miss(*args, **kwargs):
+            raise SeedDataQualityError("no grid state at window start")
+
+        monkeypatch.setattr(lc_main.runner, "run_strat", _raise_seed_miss)
+
+        threshold = staleness_threshold(_LAG)
+        for _ in range(2):  # loop continues across ticks
+            lines = lc_main.watch_tick(
+                live_check_config, db, seeded_run_account.run_id,
+                seeded_run_account.account_id, timedelta(hours=1), _LAG,
+                threshold, now=_NOW,
+            )
+            assert len(lines) == 1
+            assert "SKIP" in lines[0]
+            assert "seed miss" in lines[0]
+
+    def test_stale_data_renders_skip_line(
+        self, db, seeded_run_account, strat, live_check_config
+    ):
+        """Frozen recorder (stale ticker) → SKIP line, replay never invoked."""
+        with db.get_session() as session:
+            session.add(TickerSnapshot(
+                symbol="LTCUSDT",
+                exchange_ts=_NOW - timedelta(hours=3),
+                local_ts=_NOW - timedelta(hours=3),
+                last_price=Decimal("80"),
+                mark_price=Decimal("80"),
+                bid1_price=Decimal("79.9"),
+                ask1_price=Decimal("80.1"),
+                funding_rate=Decimal("0.0001"),
+            ))
+        threshold = staleness_threshold(_LAG)
+        lines = lc_main.watch_tick(
+            live_check_config, db, seeded_run_account.run_id,
+            seeded_run_account.account_id, timedelta(hours=1), _LAG,
+            threshold, now=_NOW,
+        )
+        assert len(lines) == 1
+        assert "SKIP" in lines[0]
+        assert "stale" in lines[0]
+
+
+class TestWatchWindowOverride:
+    def test_cli_last_reaches_reconcile_window(
+        self, db, seeded_run_account, strat, live_check_config, monkeypatch
+    ):
+        """The `last` passed into watch_tick sizes the window — a --last
+        override must NOT be silently replaced by config.last (4h default)."""
+        _seed_window_data(db, _NOW)
+        captured = {}
+
+        def _capture(strat_, window, *args, **kwargs):
+            captured["window"] = window
+            return ("skip", "captured")
+
+        monkeypatch.setattr(lc_main, "check_strat", _capture)
+        threshold = staleness_threshold(_LAG)
+        lc_main.watch_tick(
+            live_check_config, db, seeded_run_account.run_id,
+            seeded_run_account.account_id, timedelta(minutes=30), _LAG,
+            threshold, now=_NOW,
+        )
+        window = captured["window"]
+        assert window.end - window.start == timedelta(minutes=30)
+
+
+class TestExitCodes:
+    def test_fail_beats_skip_beats_pass(self):
+        """Exit priority: any FAIL → 1; else any SKIP → 2; else 0."""
+        assert lc_main._exit_code(["pass", "pass"]) == lc_main.EXIT_PASS
+        assert lc_main._exit_code(["pass", "skip"]) == lc_main.EXIT_SKIP
+        assert lc_main._exit_code(["skip", "fail"]) == lc_main.EXIT_FAIL
+        assert lc_main._exit_code(["skip"]) == lc_main.EXIT_SKIP

--- a/apps/live_check/tests/test_window.py
+++ b/apps/live_check/tests/test_window.py
@@ -1,0 +1,58 @@
+"""Tests for live_check.window — window/lag math and the empty-window guard."""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from live_check.main import check_strat
+from live_check.window import Window, compute_window, parse_duration
+
+
+class TestParseDuration:
+    @pytest.mark.parametrize("text,expected", [
+        ("30s", timedelta(seconds=30)),
+        ("2m", timedelta(minutes=2)),
+        ("10m", timedelta(minutes=10)),
+        ("4h", timedelta(hours=4)),
+        ("1d", timedelta(days=1)),
+    ])
+    def test_valid(self, text, expected):
+        """Parses count+unit forms."""
+        assert parse_duration(text) == expected
+
+    @pytest.mark.parametrize("text", ["", "4", "h", "4hours", "-2m", "1.5h"])
+    def test_invalid_raises(self, text):
+        """Unparseable durations are a hard error."""
+        with pytest.raises(ValueError, match="Invalid duration"):
+            parse_duration(text)
+
+
+class TestComputeWindow:
+    def test_end_is_now_minus_lag(self):
+        """end = now − lag; start = end − last."""
+        now = datetime(2026, 7, 1, 12, 0, 0)
+        w = compute_window(timedelta(hours=4), timedelta(minutes=2), now=now)
+        assert w.end == datetime(2026, 7, 1, 11, 58, 0)
+        assert w.start == datetime(2026, 7, 1, 7, 58, 0)
+
+    def test_rolling(self):
+        """A later now shifts both bounds by the same amount."""
+        last, lag = timedelta(hours=1), timedelta(minutes=2)
+        w1 = compute_window(last, lag, now=datetime(2026, 7, 1, 12, 0, 0))
+        w2 = compute_window(last, lag, now=datetime(2026, 7, 1, 12, 10, 0))
+        assert w2.start - w1.start == timedelta(minutes=10)
+        assert w2.end - w1.end == timedelta(minutes=10)
+
+
+class TestEmptyWindowGuard:
+    def test_zero_executions_reports_skip_never_pass(
+        self, db, seeded_run_account, ts, strat, live_check_config
+    ):
+        """A window with 0 live executions is SKIP with a reason, not PASS."""
+        window = Window(start=ts, end=ts + timedelta(hours=1))
+        outcome = check_strat(
+            strat, window, seeded_run_account.run_id,
+            seeded_run_account.account_id, db, live_check_config,
+        )
+        assert outcome[0] == "skip"
+        assert "no data in window" in outcome[1]

--- a/apps/replay/src/replay/engine.py
+++ b/apps/replay/src/replay/engine.py
@@ -273,6 +273,27 @@ class _BatchPositionSnapshotWriter:
         return self._total_written
 
 
+class _NoopPositionSnapshotWriter:
+    """Discards backtest position snapshots (feature 0088).
+
+    Wired instead of ``_BatchPositionSnapshotWriter`` when the engine is
+    constructed with ``emit_backtest_snapshots=False`` — live_check runs
+    against a READ-ONLY recorder DB where any ``source='backtest'`` insert
+    would raise, and its verdicts never consume ``position_pairs``.
+    """
+
+    def write(self, snapshot: PositionSnapshot) -> None:
+        """Discard the snapshot."""
+
+    def flush(self) -> int:
+        """Nothing buffered; returns 0."""
+        return 0
+
+    @property
+    def total_written(self) -> int:
+        return 0
+
+
 @dataclass
 class ReplayResult:
     """Result of a replay run."""
@@ -305,9 +326,23 @@ class ReplayEngine:
         self,
         config: ReplayConfig,
         db: DatabaseFactory,
+        emit_backtest_snapshots: bool = True,
     ):
+        """Initialize the replay engine.
+
+        Args:
+            config: Replay configuration.
+            db: Recorder database factory (reads; also snapshot writes
+                unless disabled below).
+            emit_backtest_snapshots: When False (feature 0088 live_check),
+                ``source='backtest'`` position snapshots are discarded via a
+                no-op writer instead of being inserted into ``db`` — required
+                when ``db`` is opened read-only. Default True keeps existing
+                callers byte-for-byte unchanged.
+        """
         self._config = config
         self._db = db
+        self._emit_backtest_snapshots = emit_backtest_snapshots
         self._instrument_provider = InstrumentInfoProvider()
 
     def run(
@@ -888,23 +923,29 @@ class ReplayEngine:
         # the recorder DB so the comparator can read both live and backtest
         # rows from the same table (filtered by `source`).
         if run_id is not None:
-            if account_id is None:
-                # Pre-0029 legacy data: Run.account_id is NULL. Don't
-                # silently fall back — surface the issue so the operator
-                # re-records with the current writer. A broken pre-0029
-                # run would otherwise look identical to a healthy empty
-                # data run (comparator would just see zero backtest rows).
-                raise ValueError(
-                    f"Run {run_id} has no account_id; cannot emit backtest "
-                    "position snapshots. Re-record after the 0029+0034 "
-                    "migrations to populate Run.account_id."
+            if not self._emit_backtest_snapshots:
+                # Feature 0088: live_check runs against a read-only recorder
+                # DB and never consumes position_pairs — discard snapshots
+                # instead of writing them.
+                position_writer = _NoopPositionSnapshotWriter()
+            else:
+                if account_id is None:
+                    # Pre-0029 legacy data: Run.account_id is NULL. Don't
+                    # silently fall back — surface the issue so the operator
+                    # re-records with the current writer. A broken pre-0029
+                    # run would otherwise look identical to a healthy empty
+                    # data run (comparator would just see zero backtest rows).
+                    raise ValueError(
+                        f"Run {run_id} has no account_id; cannot emit backtest "
+                        "position snapshots. Re-record after the 0029+0034 "
+                        "migrations to populate Run.account_id."
+                    )
+                position_writer = _BatchPositionSnapshotWriter(
+                    db=self._db,
+                    run_id=run_id,
+                    account_id=account_id,
+                    source="backtest",
                 )
-            position_writer = _BatchPositionSnapshotWriter(
-                db=self._db,
-                run_id=run_id,
-                account_id=account_id,
-                source="backtest",
-            )
             runner.position_snapshot_callback = position_writer.write
             # Stash on runner so the engine can call .flush() at end-of-run.
             runner._position_writer = position_writer  # type: ignore[attr-defined]

--- a/docs/features/0088_PLAN.md
+++ b/docs/features/0088_PLAN.md
@@ -1,0 +1,593 @@
+# Feature 0088 — `live_check` app
+
+## Context
+
+A convenience tool for the USER to visually verify that the backtest/replay
+matches live trading, on demand and continuously. This session verified the
+replay mechanism is trustworthy: Step 1 (`event_follower` reproduces live
+fills 1:1 — SOL 64/64, LTC 38/38, `live_only=0`, `backtest_only=0`) and Step 2
+(replay PnL breakdown reconciles to recorded ground truth to the cent) both
+PASS. This app packages that verification into a repeatable, user-facing tool
+that runs `event_follower` replay per strat over a rolling window and compares
+its output against recorded live ground truth.
+
+New app `apps/live_check`, CLI entry `live-check`. Wraps the existing
+`ReplayEngine` (fill mode `event_follower`, seeded) — no new fill logic,
+no `last_cross`. Ground truth is recorded rows ONLY (never live Bybit REST).
+
+## Reuse (do NOT reimplement)
+
+- `apps/replay/src/replay/config.py` — `ReplayConfig`, `ReplayStrategyConfig`
+  (incl. 0080 `strat_id` field), `SeedConfig`, `FillSimulatorConfig`.
+- `apps/replay/src/replay/engine.py` — `ReplayEngine(config, db)`, `.run()`
+  returns `ReplayResult` with: `session` (`BacktestSession`),
+  `metrics` (`ValidationMetrics`), `match_result` (`MatchResult` with
+  `matched`/`live_only`/`backtest_only` lists), `run_id`, `symbol`,
+  `start_ts`, `end_ts`, `fill_mode`, `position_pairs`.
+- `BacktestSession` (`apps/backtest/src/backtest/session.py`) — top-level
+  attrs `total_realized_pnl`, `total_commission`, `total_funding`, and
+  `get_summary()`. **Note:** `total_unrealized_pnl` is NOT a `BacktestSession`
+  attribute — it lives on `BacktestSession.metrics` (a `BacktestMetrics`,
+  `session.py:47`), populated only by `finalize()` (`session.py:537-545`).
+  `ReplayEngine.run()` calls `session.finalize(...)` (`engine.py:631`) before
+  returning, so on a returned `ReplayResult` the value is available as
+  `result.session.metrics.total_unrealized_pnl`.
+- **Do NOT confuse the two `metrics` objects.** `ReplayResult.metrics` is a
+  `comparator.ValidationMetrics` (`apps/comparator/src/comparator/metrics.py:33`)
+  — a match/parity object that has NO `total_unrealized_pnl` field.
+  `ReplayResult.session.metrics` is the `BacktestMetrics` that carries the
+  PnL totals. Unrealised MUST be read from
+  `ReplayResult.session.metrics.total_unrealized_pnl`.
+- `comparator.matcher` / `comparator.equity` (`EquityComparator`,
+  `load_backtest_from_session`, `resample`, `compute_metrics`, `export`) /
+  `comparator.reporter` — reuse where they fit the render modes.
+- `grid_db` (`shared/db`): `DatabaseFactory`, `DatabaseSettings`,
+  `PrivateExecution`, `PositionSnapshot`, `Run`, `RunRepository`,
+  `PrivateExecutionRepository.get_by_run_range(run_id, start_ts, end_ts)`,
+  `redact_db_url`.
+
+## Ground truth (recorded rows only)
+
+- realized: SUM `private_executions.closed_pnl` over window, **filtered by
+  `symbol`** (see per-symbol isolation note below).
+- commission: SUM `private_executions.exec_fee` over window, **filtered by
+  `symbol`**.
+- **NULL→0 coalesce (required).** Both `closed_pnl` and `exec_fee` are
+  `Optional` (nullable), and SQL `SUM` over zero rows or all-NULL rows returns
+  `NULL`/`None` → the verdict delta math crashes or diverges. Wrap both sums:
+  `func.coalesce(func.sum(col), 0)` at the SQL layer, and/or coerce
+  `None → Decimal(0)` in Python — matching how `event_follower` /
+  `LiveTradeLoader` coalesce these columns.
+- unrealised: `position_snapshots.unrealised_pnl` (British spelling), combine
+  long + short per pair — report NET per pair only (hedge mode). Take the last
+  snapshot at/before window end per (symbol, side).
+- NEVER use `apps/pnl_checker` (hits LIVE Bybit REST — wrong tool for
+  historical reconcile).
+
+**Per-symbol isolation (both strats share one `run_id` `580ca395` and one
+`database_url`).** `PrivateExecutionRepository.get_by_run_range(run_id, start,
+end)` (`shared/db/src/grid_db/repositories/execution.py:26`) filters ONLY by
+`run_id` + time — NO `symbol` filter — so SOL and LTC executions under
+`580ca395` are commingled. A per-strat realized/commission/count taken via that
+method would sum BOTH symbols and always mis-compare against a single-symbol
+replay → guaranteed FAIL. `PrivateExecution` HAS a `symbol` column. Therefore
+`ground_truth.sum_realized` / `sum_commission` / `live_exec_count` MUST add
+`PrivateExecution.symbol == symbol` to their filter (direct `func.sum` /
+`func.count` query scoped by `run_id` + `symbol` + time window), NOT rely on
+`get_by_run_range`. `net_unrealised_per_pair` is already symbol-scoped. This
+keeps per-strat verdicts comparing like symbol against like symbol.
+
+## Verdict thresholds
+
+- **matched verdict:** `match_result.live_only == []` AND
+  `match_result.backtest_only == []` (i.e. `live_only_count == 0` AND
+  `backtest_only_count == 0`), read from `ReplayResult.match_result`. Do NOT
+  gate on `matched == live_exec_count`: `matched` counts aggregated
+  `NormalizedTrade`s while `live_exec_count` (a `func.count` on
+  `PrivateExecution`) counts RAW execution rows — partial fills aggregate
+  several execs into one trade, so a correct run would false-FAIL. `live_exec_count`
+  is informational display ONLY, never the pass gate.
+- `|Δrealized| < $0.01` (replay `total_realized_pnl` vs SUM `closed_pnl`).
+- `|Δcommission| < $0.01` (replay `total_commission` vs SUM `exec_fee`).
+- `|Δunrealised| < $0.50` (replay unrealised vs recorded net-per-pair;
+  mark-price snapshot-timing jitter benign below this — established finding).
+  **Replay source (pinned):** use
+  `ReplayResult.session.metrics.total_unrealized_pnl`
+  (`BacktestMetrics.total_unrealized_pnl`, `session.py:47`), set from
+  `final_unrealized_pnl` inside `session.finalize()` (`session.py:537-545`).
+  `ReplayEngine.run()` calls `session.finalize(...)` (`engine.py:631`) before
+  building `ReplayResult`, so on the returned result `session.metrics` is
+  already populated — NOT a mid-run reading. Do NOT use
+  `ReplayResult.session.total_unrealized_pnl` (no such attribute — raises
+  `AttributeError`) and do NOT use `ReplayResult.metrics.total_unrealized_pnl`
+  (`ReplayResult.metrics` is a `comparator.ValidationMetrics`, which has no
+  such field). Each `live_check` engine run is single-strat / single-symbol,
+  so this session-total unrealised corresponds 1:1 with the recorded
+  net-per-pair sum for that one symbol; they are directly comparable.
+- All four must hold → PASS, else FAIL.
+
+## Constraints / pitfalls (plan must enforce)
+
+1. **POST-0080 data only.** Feature 0080 (merged 06-17) salts `orderLinkId`
+   hash by `strat_id`; `event_follower` matches by `link_id`, so replaying
+   PRE-0080 data collapses matching (954→44). TWO guards, both required:
+   - **run floor:** reject/hard-error when `window.start < run.start_ts` of the
+     configured run (current run `580ca395`, recorder restarted 2026-07-03).
+   - **absolute post-0080 floor:** reject/hard-error when `window.start` is
+     before the 0080 merge cutoff constant `2026-06-17T23:07:00Z` (when
+     orderLinkId salting landed). The run floor alone only floors to the chosen
+     run's start — pointing `--run-id` at a PRE-0080 recording would still allow
+     the 954→44 collapse within that run's range, so this absolute floor is
+     needed IN ADDITION to the run.start_ts check.
+   Clear error message on either, not a silent bad reconcile. Both floors
+   compare `window.start` against SQLite-stored / literal datetimes — normalize
+   `window.start`, `run.start_ts`, and the `2026-06-17T23:07:00Z` cutoff to
+   naive-UTC first (see Window/lag → Naive-UTC normalization) or the comparison
+   raises `TypeError`.
+2. **True read-only open — required, not free.** There is currently NO
+   read-only path: `DatabaseFactory._create_engine`
+   (`shared/db/src/grid_db/database.py:61`) builds the SQLite engine with no
+   `mode=ro`/`immutable`, and `get_session()` auto-commits
+   (`database.py:130`). Worse, `ReplayEngine.run()` actively WRITES
+   `source='backtest'` `PositionSnapshot` rows into whatever DB it is handed,
+   via `_BatchPositionSnapshotWriter.flush()` →
+   `PositionSnapshotRepository.bulk_insert` (`engine.py:224-269`). So pointing
+   `live_check` at the live recorder DB with today's code would mutate it.
+   Phase 1B (below) adds the read-only mechanism AND isolates replay's
+   backtest-snapshot writes. Open read-only with `mode=ro` ONLY (never
+   `immutable=1` — that freezes the snapshot and `--watch`/freshness would miss
+   new recorder writes). NO `VACUUM` / `.backup` against the live DB.
+3. **Freshness gate for `--watch`.** Recorder can silently freeze. Before each
+   watch tick, check `TickerSnapshot` max `exchange_ts` age PER SYMBOL, NOT
+   `PrivateExecution`. `TickerSnapshot` has NO `run_id` column (`models.py:245`;
+   only `symbol` + `exchange_ts`), so probe `MAX(TickerSnapshot.exchange_ts)
+   WHERE symbol=?`. `PrivateExecution` is fill-only, so it would false-trip the
+   gate during quiet-but-healthy periods (no fills, ticker still flowing). If
+   `now − lag − latest_ticker_ts(symbol)` exceeds the staleness threshold, warn /
+   skip the tick rather than comparing against frozen data.
+   **Staleness threshold default (pinned):** `staleness_threshold =
+   max(2 * lag, 5 minutes)` — overridable via config/CLI. Concrete default so
+   the gate has a defined trip point (parity with the pinned verdict deltas
+   `0.01`/`0.01`/`0.50`). `now − lag` and the
+   stored `exchange_ts` must both be naive-UTC before subtraction (see
+   Window/lag → Naive-UTC normalization) or it raises `TypeError`.
+   **None handling (required):** `latest_ticker_ts(symbol)` returns `None` when
+   the DB has NO ticker rows for that symbol; the subtraction would then
+   `TypeError` and crash `--watch`. If `latest_ticker_ts is None`, treat as
+   STALE → emit a SKIP line (reason `"no ticker data"`) for that tick, NEVER
+   crash. (Tested — see `test_freshness.py` None case.)
+4. **Seeded event_follower** needs a `grid_state_snapshots` row at/before
+   window start. gridbot writes these continuously under its own LIVE run_id
+   (separate from the recorder run_id). The seed loader is CROSS-RUN, keyed
+   `(account_id, strat_id, symbol, at_ts)` with NO recorder `run_id` predicate
+   (`snapshot_loader.py:348-365`) — filtering by recorder run_id is the 0052
+   zero-row bug, so run_id is deliberately absent from the key. Config must
+   supply `seed.strat_id` per strat, `seed.account_id`, and
+   `seed.at_ts = window.start`.
+5. **upnl net-per-pair only** — never quote long-leg vs short-leg unrealised
+   separately.
+6. `last_cross` is NOT used — `event_follower` fidelity only.
+
+## Window / lag computation
+
+- `--last <duration>` (default `4h`), `--lag <duration>` (default `2m`).
+- `end = now(UTC) − lag` (lets recorder writes settle, avoids racing
+  un-flushed data), `start = end − last`. Rolling.
+- Parse durations like `10m`, `4h`, `2m` (small helper; reuse
+  `replay.main.parse_datetime` style only if a helper already exists — else a
+  local `_parse_duration`).
+- **Naive-UTC normalization (required, applies everywhere).** SQLite stores
+  timestamps tz-stripped, and existing code guards against mixed aware/naive
+  comparisons (`apps/comparator/src/comparator/loader.py:26`,
+  `apps/replay/src/replay/engine.py:789`). ALL datetimes used in queries or
+  comparisons — window `start`/`end`, the `now()−lag`/`start=end−last`
+  computation, the absolute post-0080 cutoff `2026-06-17T23:07:00Z`, and the
+  `TickerSnapshot` freshness subtraction — MUST be normalized to naive-UTC
+  (compute in UTC, then drop tzinfo) BEFORE use, matching the stored column
+  semantics. An aware-vs-naive subtraction/comparison against a SQLite-stored
+  value raises `TypeError` and crashes. This normalization is referenced from
+  the pre-0080 guard (pitfall #1) and the freshness gate (pitfall #3).
+
+---
+
+## Phase 1 — Data layer: config + workspace registration
+
+### `apps/live_check/pyproject.toml`
+Mirror `apps/recorder/pyproject.toml`. `name = "live-check"`, deps:
+`replay`, `comparator`, `backtest`, `grid-db`, `gridbot`, `pyyaml`,
+`pydantic`; `[project.scripts]` → `live-check = "live_check.main:cli"`;
+`[tool.hatch.build.targets.wheel] packages = ["src/live_check"]`.
+
+### Root `pyproject.toml`
+Add `apps/live_check/src` to `[tool.pytest.ini_options].pythonpath` and
+`apps/live_check/tests` to `testpaths`. (Root has no `[project.scripts]`; the
+`live-check` script is registered in the app's own `pyproject.toml`, matching
+`recorder`. Workspace already globs `apps/*`.)
+
+### `apps/live_check/src/live_check/config.py`
+Pydantic `BaseModel`s (Google docstrings, `Decimal` for money):
+- `StratCheckConfig`: `strat_id`, `symbol`, `tick_size` (Decimal),
+  `grid_count`, `grid_step`, `amount` (**required** — live is `x0.0005` for
+  both sol+ltc per `conf/gridbot_test.yaml`; omitting it falls through to
+  `ReplayStrategyConfig` default `amount=x0.001` at `config.py:48-52` → wrong
+  placed qty → `event_follower` `live_only`/qty-excess divergence),
+  `min_liq_ratio` (0.8), `max_liq_ratio` (1.2), `min_total_margin`,
+  `increase_same_position_on_low_margin` (true), `leverage` (10),
+  `enable_risk_multipliers` (true), `max_margin` (mirrors live ltc 5.0 /
+  sol 3.0 per `conf/gridbot_test.yaml` — **NOTE: `max_margin` IS passed through
+  to `RiskConfig` by replay/backtest (`apps/replay/src/replay/engine.py:358`,
+  `apps/backtest/src/backtest/runner.py:203`) but is NOT consumed by gridcore's
+  risk-mgmt branches beyond being stored, so it does not affect
+  `event_follower` reconcile; included only to mirror live config
+  faithfully**). These mirror **live geometry+risk (some via engine
+  defaults, not the live yaml)** — `leverage`, `enable_risk_multipliers`,
+  `min_liq_ratio`, `max_liq_ratio` are ENGINE DEFAULTS not present in
+  `conf/gridbot_test.yaml`, so the "mirror" is geometry+risk parity, not a
+  1:1 copy of the yaml. Provides a `.to_replay_strategy_config()`/builder
+  consumed by the runner.
+- `LiveCheckConfig`: `database_url` (default sqlite
+  `recorder_ltcusdt_phase4.db`), `run_id` (default `580ca395`, discoverable/
+  overridable via CLI), `strats: list[StratCheckConfig]`, default window
+  (`last`/`lag`), freshness threshold, verdict thresholds (with the four
+  documented defaults). `load_config(path)` YAML loader mirroring
+  `replay.config.load_config` (env override + search paths).
+
+### `apps/live_check/conf/live_check.yaml`
+Two strats mirroring live:
+- `solusdt_test`: symbol SOLUSDT, grid_step 0.3, tick 0.01, grid_count 30,
+  min_total_margin 2.5, `amount: "x0.0005"`, `max_margin: 3.0`.
+- `ltcusdt_test`: symbol LTCUSDT, grid_step 0.4, tick 0.1, grid_count 20,
+  min_total_margin 3, `amount: "x0.0005"`, `max_margin: 5.0`.
+Both: `amount: "x0.0005"` (matches live — see StratCheckConfig note; omitting
+it defaults to `x0.001` → wrong qty → divergence), min_liq_ratio 0.8,
+max_liq_ratio 1.2, `increase_same_position_on_low_margin: true`, leverage 10,
+`enable_risk_multipliers: true`. `max_margin` mirrors live and IS passed
+through to `RiskConfig` but is not consumed by gridcore's risk-mgmt branches,
+so it does not affect `event_follower` reconcile. `database_url` sqlite
+`recorder_ltcusdt_phase4.db`, `run_id: 580ca395`. Fill mode `event_follower`,
+seed enabled (`at_ts` filled at runtime = window start, `strat_id` per strat).
+
+---
+
+## Phase 1B — Read-only DB open + replay write isolation (blocks all reads/runs)
+
+Two independent hazards, both must be fixed before `live_check` touches the
+live recorder DB.
+
+### (a) Read-only source open — for ground-truth queries
+`live_check.ground_truth.*` must read the live DB without ever locking or
+writing it.
+- Add an opt-in read-only mode to `grid_db`. In `DatabaseSettings`
+  (`shared/db/src/grid_db/settings.py`) add `read_only: bool = False`. In
+  `DatabaseFactory._create_engine` (`shared/db/src/grid_db/database.py:61`),
+  when `read_only` AND the URL is a file SQLite (not `:memory:`), rewrite it to
+  `sqlite:///file:<path>?mode=ro&uri=true` (SQLAlchemy passes `uri=true`
+  through to `sqlite3.connect`). **Use `mode=ro` ONLY — do NOT add
+  `immutable=1`.** `immutable=1` tells SQLite the file never changes, so it
+  would read a frozen snapshot and `--watch`/freshness would miss new recorder
+  writes. Plain `mode=ro` on a WAL DB lets readers see the writer's committed
+  rows without blocking. Skip the `PRAGMA foreign_keys=ON` write-cursor is
+  harmless but keep it; the `mode=ro` connection rejects any write.
+- Add a `get_readonly_session()` (or a `read_only` flag on the existing
+  contextmanager) that yields a session and DOES NOT call `session.commit()`.
+  On a `mode=ro` connection, reads and a no-op COMMIT typically succeed; only
+  WRITES raise. Skipping the auto-commit that `get_session()` performs
+  (`database.py:130`) is still the right thing — there is nothing to commit on a
+  read path, and it avoids any write attempt. `live_check` uses this
+  exclusively for ground-truth reads.
+- Test: assert opening the factory read-only and attempting an
+  `INSERT`/`session.add()+commit` raises `OperationalError` (readonly
+  database), that a `SELECT` succeeds, and that with `mode=ro` (no
+  `immutable=1`) a row inserted by a SEPARATE writable connection AFTER the
+  read-only session opened IS visible to a subsequent `SELECT` (proves the
+  snapshot is not frozen — the `--watch`/freshness regression is absent).
+
+### (b) Replay write isolation — backtest snapshots must NOT hit the live DB
+`ReplayEngine` writes `source='backtest'` `PositionSnapshot` rows during
+`.run()` via `_BatchPositionSnapshotWriter(db=self._db, ...)`
+(`engine.py:902-907`), gated by `if run_id is not None`. Every OTHER use of
+`self._db` in the engine is a READ (`engine.py:132,159,421,634,685,745,770,
+974` — executions, ticks, seed snapshots, `Run` row). Under the read-only
+source open in (a), those writes would RAISE, so the write path must be
+neutralised.
+
+**Why the prior "route writes to a scratch snapshot_db" is dropped.**
+`live_check`'s four verdicts (realized, commission, unrealised, matched) do
+NOT consume `ReplayResult.position_pairs`: realized/commission come from
+`session.metrics`; unrealised from recorded ground truth vs
+`session.metrics.total_unrealized_pnl`; matched from `match_result`. So the
+`source='backtest'` snapshots serve no purpose here. Routing only the WRITES
+to a scratch DB is also incomplete — `engine.py:685-701` READS
+`source='backtest'` snapshots from `self._db` during pairing
+(`load_position_snapshot_rows` source='backtest'), so a write-only reroute
+would leave `bt_snaps` empty on the read side anyway.
+
+**Pinned mechanism (single option — no implementer fork).** Add an optional
+flag/param to `ReplayEngine.__init__` (`engine.py:304-311`) that DISABLES
+backtest position-snapshot emission entirely (a no-op writer) for
+`live_check`, since `position_pairs` is unused. `self._db` (the read-only live
+factory) continues to serve every READ unchanged; with emission disabled there
+are no `source='backtest'` writes to raise. In `_init_runner`
+(`engine.py:796`) construct the no-op writer when the flag is set (else the
+existing `_BatchPositionSnapshotWriter(db=self._db, ...)`).
+
+**IF a future mode needs `position_pairs`, THEN** both the WRITE
+(`_BatchPositionSnapshotWriter`) and the pairing READ (`engine.py:685-701`,
+`load_position_snapshot_rows` source='backtest') must target the SAME scratch
+DB — a write-only reroute is not sufficient. That coupled-redirect is out of
+scope for `live_check`.
+
+Default (flag unset) keeps every existing `ReplayEngine` caller (replay app,
+tests) byte-for-byte unchanged (writer keeps targeting `self._db`).
+
+**Files MODIFIED by this feature (add to Phase 1 file list):**
+- `apps/replay/src/replay/engine.py` — add the disable-emission flag +
+  no-op writer wiring (`__init__` + `_init_runner`).
+
+**Rejected — writable-live-DB fallback.** Opening the live recorder DB
+writable and accepting `source='backtest'` rows into it is NOT permitted: it
+breaks the pitfall #2 read-only guarantee. There is no `--allow-writes`
+escape hatch for the live recorder DB. The disable-emission flag above is the
+only sanctioned path.
+
+**Test:** assert the live recorder DB `PositionSnapshot` rowcount for
+`source='backtest'` is unchanged after a `live_check` run (no snapshot rows
+are emitted).
+
+---
+
+## Phase 2 — Core modules (parallel after Phase 1)
+
+### 2A. `apps/live_check/src/live_check/runner.py`
+- `build_replay_config(strat, window, run_id, database_url, account_id) ->
+  ReplayConfig`: compose a per-strat `ReplayConfig` with `start_ts=window.start`,
+  `end_ts=window.end`, `strategy.strat_id = strat.strat_id` (0080 salt),
+  `fill_simulator.mode="event_follower"`, `seed.enabled=True`,
+  `seed.at_ts=window.start`, `seed.strat_id=strat.strat_id`,
+  `seed.account_id=account_id`. Populate all five risk fields.
+  **`account_id` MUST be passed in (not resolved later).**
+  `SeedConfig.require_seed_fields_when_enabled` (`config.py`) rejects
+  `enabled=True` without `account_id` at CONSTRUCTION time, but the engine only
+  resolves `Run.account_id` at `engine.py:770` — too late. So the app pre-queries
+  the `Run` row via `session.get(Run, run_id)` (the primary-key get, as
+  `ReplayEngine` already does at `engine.py:770`) to
+  obtain `Run.account_id`
+  BEFORE calling `build_replay_config` (option (a), primary). This is the
+  authoritative account_id source; do NOT rely on post-construction engine
+  resolution.
+- `run_strat(strat, window, run_id, db) -> ReplayResult`: instantiate
+  `ReplayEngine(config, db=db, <disable-snapshot-emission flag>).run()`, where
+  `db` is the read-only live factory and the disable flag suppresses
+  `source='backtest'` snapshot writes (Phase 1B(b)). One engine run per strat.
+
+### 2B. `apps/live_check/src/live_check/ground_truth.py`
+Recorded-row queries against a read-only session (frozen dataclass results,
+`Decimal`):
+- `sum_realized(session, run_id, symbol, start, end) -> Decimal` — SUM
+  `closed_pnl` via a direct `func.coalesce(func.sum(closed_pnl), 0)` query
+  filtered by `run_id` + `symbol` + `exchange_ts` window. `closed_pnl` is
+  nullable and `SUM` over zero/all-NULL rows returns `NULL`/`None` → COALESCE
+  NULL→0 (SQL layer and/or `None → Decimal(0)` in Python). MUST take `symbol`
+  (both strats share `run_id`; `get_by_run_range` has no symbol filter — see
+  per-symbol isolation note in Ground truth). Do NOT reuse `get_by_run_range`
+  for the sum.
+- `sum_commission(session, run_id, symbol, start, end) -> Decimal` — SUM
+  `exec_fee` with the SAME `func.coalesce(func.sum(exec_fee), 0)` NULL→0
+  guard, same `run_id` + `symbol` + window scoping.
+- `net_unrealised_per_pair(session, run_id, account_id, symbol, at_ts) ->
+  Decimal` — reuse the EXISTING
+  `PositionSnapshotRepository.get_latest_before(run_id, account_id, symbol,
+  side, at_ts, source='live')` (`shared/db/src/grid_db/repositories/
+  snapshots.py:95`) once per `side in {'Buy','Sell'}`, take each row's
+  `unrealised_pnl` (None → 0), sum the two. Do NOT hand-roll a group-by; the
+  repo method already gives the correct per-side last-at-or-before-`at_ts`
+  `source='live'` row, avoiding an accidental cross-side max collapse.
+- `live_exec_count(session, run_id, symbol, start, end) -> int` — `func.count`
+  scoped by `run_id` + `symbol` + window. **Informational display ONLY** — NOT
+  the matched-verdict gate (partial fills aggregate multiple RAW execs into one
+  `NormalizedTrade`, so this raw count ≠ `matched_count` on a correct run; the
+  matched verdict uses `match_result.live_only`/`backtest_only == []`). Kept
+  symbol-scoped for the same reason as the sums.
+- `latest_ticker_ts(session, symbol) -> datetime | None` — freshness probe.
+  `MAX(TickerSnapshot.exchange_ts) WHERE symbol=?`. Keyed by SYMBOL, NOT
+  `run_id` (`TickerSnapshot` has no `run_id` column — `models.py:245`). Do NOT
+  probe `PrivateExecution` (fill-only → false-trips on quiet-but-healthy
+  periods).
+- `get_run_start(session, run_id) -> datetime` — for the pre-0080 guard.
+
+### 2C. `apps/live_check/src/live_check/verdict.py`
+- Frozen `@dataclass Verdict`: `live_only_count`, `backtest_only_count`,
+  `matched_count`, `live_exec_count` (informational display only),
+  `d_realized`, `d_commission`, `d_unrealised`, `passed: bool`, per-check bool
+  flags.
+- `evaluate(replay_result, ground_truth, thresholds) -> Verdict`: apply the
+  four threshold checks. The matched check is
+  `len(replay_result.match_result.live_only) == 0 AND
+  len(replay_result.match_result.backtest_only) == 0` (NOT
+  `matched_count == live_exec_count` — see Verdict thresholds → matched
+  verdict). `live_exec_count` from `ground_truth` is carried for display only.
+  Pure function — the core of the test suite.
+  `d_unrealised = replay_result.session.metrics.total_unrealized_pnl −
+  ground_truth.net_unrealised` where the replay side is the finalized
+  `BacktestMetrics.total_unrealized_pnl` (see Verdict thresholds → pinned
+  source), compared against the single-symbol recorded net-per-pair sum. Both
+  sides are one symbol per run, so the comparison is like-for-like.
+  **Guard:** `evaluate` must assert `replay_result.session.metrics is not
+  None` before reading it (it is populated by `finalize()` inside `.run()`; a
+  `None` here means the result was built without finalize and the read would
+  otherwise crash with an opaque `AttributeError`).
+
+### 2D. `apps/live_check/src/live_check/render.py`
+Four render funcs, each takes `(list[(strat, Verdict, ReplayResult)])`:
+- `render_once(...)` — per-strat summary block: `matched N/N`, Δrealized,
+  Δcommission, Δunrealised, verdict PASS/FAIL.
+- `render_watch_line(...)` — one-line traffic-light per tick per strat:
+  matched count + ✓/✗ + the three deltas.
+- `render_per_fill(...)` — detailed table, one row per live EXECUTION vs its
+  matched replay fill: `exec_id`, time, side, `live_px`, `bt_px`, `dpx`,
+  `live_qty`, `bt_qty`, live `closed_pnl`, bt pnl, `ok` flag.
+  **Grain (pinned — raw-execution, NOT `match_result.matched`).** `--per-fill`
+  emits one row per live execution carrying `exec_id`, so it MUST source from
+  RAW `private_executions` rows on the live side (which carry `exec_id`,
+  `exec_price`, `exec_qty`, `closed_pnl`) compared against the replay engine's
+  PER-FILL records on the backtest side. Do NOT source from
+  `match_result.matched`: those are `NormalizedTrade`s that AGGREGATE partial
+  fills (partial execs merged) and carry NO `exec_id`
+  (`comparator/loader.py:40`), so a per-execution table cannot be built from
+  them. `--per-fill` (raw-execution grain) and `--curve` (aggregated/trade
+  grain, pinned to `match_result.matched`) INTENTIONALLY use different grains
+  for their different purposes — per-fill drills into individual executions,
+  curve compares cumulative trade-level realized. This is by design, not an
+  inconsistency.
+- `render_curve(...)` — builds its OWN two cumulative series directly.
+  **Grain match (required):** both series MUST be built from the SAME event set
+  at the SAME grain, or a PASS run's two sparklines diverge misleadingly
+  (raw-exec cumsum vs per-trade realized are DIFFERENT grains — partial fills
+  make the point count differ). Pin both sides to `match_result.matched` (the
+  paired live/bt `NormalizedTrade`s):
+  - **live** = running cumsum of each matched pair's live-side realized,
+    ordered by `NormalizedTrade.timestamp` (`comparator/loader.py:51`, NOT
+    `exchange_ts`).
+  - **replay** = running cumsum of each matched pair's bt-side realized, same
+    ordering.
+  Point-by-point comparable because both walk the same matched-pair sequence.
+  (If a raw-exec `cumsum(closed_pnl)` series is shown instead, it may ONLY be
+  reconciled to the replay total at window-end, NOT point-by-point — document
+  this explicitly if chosen. Default: matched-pair grain.)
+  Rendered as ASCII sparkline + CSV export for Excel. Do NOT reuse
+  `EquityComparator` for these series: `load_live` reads WALLET snapshots and
+  `load_backtest_from_session` builds a full `equity.py` equity curve — NEITHER
+  is the matched-pair cumulative-realized pair described here. Build the two
+  series inline in `render_curve`.
+
+---
+
+## Phase 3 — CLI + guards
+
+### `apps/live_check/src/live_check/main.py`
+`argparse` + `cli()` entry (mirror `recorder.main:cli`). Flags:
+- Modes (mutually exclusive-ish): `--once` (default), `--watch <interval>`,
+  `--per-fill`, `--curve`.
+- Window: `--last <dur>` (4h), `--lag <dur>` (2m).
+- `--config`, `--database-url`, `--run-id` (override config `580ca395`),
+  `--debug`.
+
+Dispatch flow:
+1. `load_config`, apply CLI overrides. Open the live recorder
+   `DatabaseFactory` **read-only** via the Phase 1B(a) mechanism
+   (`DatabaseSettings(read_only=True)` → `mode=ro` only, no `immutable=1`); use
+   `get_readonly_session()` for all ground-truth reads. Instantiate
+   `ReplayEngine(config, db=<read-only live>, <disable-snapshot-emission flag>)`
+   per Phase 1B(b) so `source='backtest'` snapshots are never emitted and never
+   touch the live DB.
+2. Resolve `run_id` (config/CLI/auto-discover via `RunRepository`), then
+   pre-query the `Run` row via `session.get(Run, run_id)` (primary-key get, as
+   `ReplayEngine` does at `engine.py:770`) to obtain
+   `Run.account_id`. This account_id is passed into `build_replay_config`
+   BEFORE the `ReplayConfig` is constructed — `SeedConfig` requires it at
+   construction time (see Phase 2A `build_replay_config`); the engine's own
+   `Run.account_id` resolution at `engine.py:770` is too late for `SeedConfig`
+   validation.
+3. Compute window (`_parse_duration` on `--last`/`--lag`; `end=now−lag`,
+   `start=end−last`).
+4. **Pre-0080 guard** (both floors): `start >= get_run_start(run_id)` AND
+   `start >= 2026-06-17T23:07:00Z` (the 0080 merge cutoff constant) else hard
+   error with the 954→44 explanation. The absolute cutoff catches a `--run-id`
+   pointed at a pre-0080 recording that the run floor alone would miss.
+5. `--watch` only: **freshness gate** — per strat/symbol,
+   `now − lag − latest_ticker_ts(symbol)` under the staleness threshold, else
+   warn/skip tick (uses `TickerSnapshot`, not `PrivateExecution`).
+6. Per strat: `runner.run_strat` → `ground_truth.*` → `verdict.evaluate` →
+   the mode's render func.
+   - **Empty-window guard:** if the window has 0 live executions (and/or 0
+     ticker rows) for the strat's symbol, report **N/A / SKIP** with a "no data
+     in window" reason — never PASS. A zero-data window yields `matched==0` and
+     zero deltas, which would otherwise be a false all-PASS.
+   - **Seed-miss handling:** a missing `grid_state` seed at `window.start`
+     raises `SeedDataQualityError` from the seed path. Under `--watch`, CATCH it
+     and render a SKIP/FAIL line for that tick (with reason) — do NOT crash the
+     watch loop. Under `--once`/`--per-fill`/`--curve`, surface it as a clear
+     error exit.
+7. `--watch`: loop every interval (recompute rolling window each tick,
+   one-line output; seed-miss and empty-window become SKIP lines, never a
+   crash). `--watch` NEVER exits on a per-tick SKIP or FAIL — it prints the tick
+   line and continues; it exits ONLY on a fatal (guard violation, unexpected
+   exception). `--once`/`--per-fill`/`--curve`: run once, then exit.
+
+**Exit-code semantics (pinned — so cron/automation distinguishes outcomes,
+never reports a false-green as success):**
+- `0` = all strats PASS.
+- `1` = any strat FAIL (verdict diverges) OR a config error.
+- `2` = SKIP / no-data / N/A — empty window (0 execs/ticks), seed miss, or
+  stale data — DISTINCT from PASS so a zero-data window is never mistaken for
+  success. Also used for unexpected exceptions.
+A `--once` run whose only outcome is SKIP returns `2`, not `0`.
+
+Return codes: `0` all-PASS, `1` FAIL/config error, `2` SKIP/no-data/N/A/
+unexpected.
+
+---
+
+## Phase 4 — Tests
+
+`apps/live_check/tests/` — hermetic, mock DB (no live Bybit, no network),
+`test_*.py`, `Test<Feature>`, one-line docstrings, gridcore-style rigor.
+- `test_ground_truth.py`: `closed_pnl`/`exec_fee`/`unrealised` sums correct
+  (net long+short per pair; last-at-or-before-end selection). **Multi-symbol
+  shared-`run_id` isolation regression:** seed SOL + LTC execs under the SAME
+  `run_id` and assert `sum_realized`/`sum_commission` for SOL EXCLUDE the LTC
+  execs (symbol-scoped query, not `get_by_run_range`).
+- `test_verdict.py`: threshold pass/fail boundaries for all four checks
+  (`0.01`/`0.01`/`0.50`). **Matched verdict** uses
+  `match_result.live_only`/`backtest_only == []`, NOT `matched_count ==
+  live_exec_count`: include a **partial-fill case** where multiple RAW execs
+  aggregate into one `NormalizedTrade` (raw `live_exec_count` > `matched_count`)
+  and assert the verdict still PASSES because `live_only`/`backtest_only` are
+  empty. Include one case that reads `d_unrealised` from a `ReplayResult` whose
+  `session.metrics` is populated (assert `evaluate` reads
+  `session.metrics.total_unrealized_pnl`, NOT `session.total_unrealized_pnl` /
+  `metrics.total_unrealized_pnl`), and one where `session.metrics is None`
+  asserting `evaluate` raises the explicit guard error (not a raw
+  `AttributeError`).
+- `test_window.py`: window+lag computation (`end=now−lag`, `start=end−last`),
+  duration parser. **Empty-window guard:** a window with 0 live executions
+  reports N/A / SKIP with "no data in window", never PASS.
+- `test_guard.py`: pre-0080 guard fires when `start < run.start_ts`, AND
+  separately when `start < 2026-06-17T23:07:00Z` even if `start >=
+  run.start_ts` (absolute post-0080 floor).
+- `test_render.py`: smoke each of the four modes with synthetic
+  `ReplayResult`/`Verdict` (no exceptions, expected columns/labels present).
+- `test_freshness.py`: watch freshness gate skips on stale
+  `latest_ticker_ts(symbol)` — staleness computed from `TickerSnapshot`
+  `exchange_ts`, NOT `PrivateExecution` (quiet-but-healthy period does NOT
+  trip the gate while ticker rows keep flowing). **None case:** when the DB has
+  NO ticker rows for the symbol (`latest_ticker_ts` returns `None`), the gate
+  emits a SKIP line (reason `"no ticker data"`) and does NOT crash / TypeError.
+- `test_watch.py`: `--watch` skip-on-seed-miss — a `SeedDataQualityError` at
+  the rolling `window.start` renders a SKIP line and the watch loop CONTINUES
+  (no crash).
+- `test_readonly.py`: `mode=ro` (no `immutable=1`) open still SEES new rows
+  inserted by another connection after the read-only session opened (proves the
+  frozen-snapshot regression is absent). **MUST use a FILE-BACKED temp SQLite
+  (`tmp_path`), NOT `:memory:`.** `mode=ro` is skipped for `:memory:` DBs
+  (Phase 1B(a) only rewrites the URL when it is a file SQLite), so a read-only
+  test on an in-memory DB passes VACUOUSLY — the `mode=ro` open and the
+  no-write assertions never exercise the read-only path.
+- `test_readonly_run.py`: a `ReplayEngine` constructed WITH the
+  disable-snapshot-emission flag AND a `mode=ro` (read-only) `DatabaseFactory`
+  completes a `.run()` WITHOUT raising `OperationalError` — i.e. the no-op
+  emission path attempts NO write against the read-only connection (assert no
+  flushing `_BatchPositionSnapshotWriter` is wired when emission is disabled;
+  only the no-op writer). Proves Phase 1B(b) neutralises the write path under
+  the read-only open. **MUST use a FILE-BACKED temp SQLite (`tmp_path`), NOT
+  `:memory:`** — same reason: `mode=ro` is skipped for `:memory:`, so the
+  read-only open would not actually be exercised.
+- `test_naive_utc.py`: aware-vs-naive regression. Feed tz-AWARE datetime inputs
+  to the window/cutoff/freshness datetime math (window `start`/`end`,
+  `now()−lag`, the `2026-06-17T23:07:00Z` cutoff compare, the `TickerSnapshot`
+  freshness subtraction) and assert they are normalized to naive-UTC and
+  compared/subtracted cleanly — does NOT raise the aware-vs-naive `TypeError`.
+  Locks in the mandatory naive-UTC normalization (Window/lag → Naive-UTC).
+Mock `ReplayEngine.run` in CLI/dispatch tests; unit-test `ground_truth`
+against an in-memory SQLite seeded with a few `PrivateExecution`/
+`PositionSnapshot`/`TickerSnapshot` rows.

--- a/docs/features/0088_REVIEW.md
+++ b/docs/features/0088_REVIEW.md
@@ -1,0 +1,38 @@
+# Feature 0088 — live_check: External Review Trail
+
+Plan: `docs/features/0088_PLAN.md` | Branch: `feature/0088-live-check`
+Engines: codex CLI + cursor agent CLI (read-only), 3 rounds, 2026-07-13.
+
+## Round 1 — 4 unique findings (2 engines overlapping)
+
+| # | Sev | Finding | Verdict | Action |
+|---|-----|---------|---------|--------|
+| 1 | P2 | `--watch --last` override ignored — `watch_tick` recomputed window from `config.last` while `run_watch` used `args.last` only for the floor guard (both engines) | ACCEPT | `watch_tick` now takes an explicit resolved `last` timedelta from `run_watch`; regression test `test_watch.py::TestWatchWindowOverride` |
+| 2 | P2 | `--per-fill` pairing broken on grain AND key: bt side is ONE `BacktestTrade` per order lifecycle (`_FillRollup`: VWAP/Σqty/Σpnl), and live `order_link_id` carries the `-{millis}` wire suffix that never equals the bt `client_order_id` prefix (both engines, verified at `runner.py:56-83,760-773`, `loader.py:113-125`) | ACCEPT | Rewritten: group live execs by `(extract_client_order_prefix(link) or order_id, order_id)`, compare group aggregates against the rollup trade; `ExecRow` gained `order_id`; tests: partial-fill ✓, multi-price VWAP ✓, aggregate mismatch ✗, NULL-link fallback |
+| 3 | P2 | `load_config` search paths omit `apps/live_check/conf/` (codex) | REJECT | Mirrors `replay`/`recorder` cwd-relative convention exactly; plan pinned "mirroring replay.config.load_config" |
+| 4 | P3 | `__pycache__`/`.pyc` artifacts under app dirs (codex) | REJECT | `git check-ignore` confirms ignored; not commit surface |
+
+Cursor P3s round 1: exit-code tests + `build_replay_config` tests → ADDED (`TestExitCodes`, `test_runner.py`); heterogeneous `check_strat` tuples → accepted gap (simplicity); `read_only` SQLite-only no-op on Postgres → accepted gap (documented); empty-link `""` cross-pairing → fixed by the finding-2 rewrite (order_id fallback key).
+
+## Round 2 — 1 valid P2 + P3s
+
+| # | Sev | Finding | Verdict | Action |
+|---|-----|---------|---------|--------|
+| 1 | P2 | `make test` (the CI gate, `ci.yml:47`) never runs `apps/live_check/tests` — all 0088 tests CI-invisible (cursor) | ACCEPT | Added `uv run pytest apps/live_check/tests --cov=live_check --cov-append -q` to `Makefile`; RULES.md test list updated |
+| 2 | P3 | Empty `strats: []` → `_exit_code([]) == 0` false-green (codex) | ACCEPT | `strats` now `min_length=1` (config error); `test_config.py` |
+| 3 | P3 | Per-fill `ok` uses exact `==`, no $0.01 band (cursor) | REJECT | event_follower applies recorded exec price/qty/pnl verbatim — exact equality is the correct expectation; a band would mask real drift |
+| 4 | P3 | `latest_ticker_ts` not window-scoped for `--once` (codex) | Accepted gap | Exec-present/no-tick window fails LOUDLY (live_only > 0 → FAIL), never false-green |
+| 5 | P3 | Per-exec rows show group-aggregate bt columns (cursor) | Accepted gap | Documented in `render_per_fill` docstring — by-design grain |
+| 6 | P3 | No CLI end-to-end `--once` exit-code test (cursor) | Accepted gap | `_exit_code` + `watch_tick` + `check_strat` covered at unit level |
+
+## Round 3 — confirmation
+
+- codex: `NO P1/P2 FINDINGS`, no P3s.
+- cursor: `NO P1/P2 FINDINGS`; 1 P3 (pydantic `ValidationError` not caught by `main()`) → REJECT: `ValidationError` subclasses `ValueError` (verified: `issubclass(ValidationError, ValueError) is True`; `except (FileNotFoundError, ValueError)` catches it → clean `EXIT_FAIL`).
+
+## Final status
+
+- Findings: raised 13 unique, accepted 5 (all fixed), rejected 4 (evidence above), accepted-gap P3s 4.
+- Tests: 84 live_check + full suite 2916 passed, 3 skipped.
+- Lint: `ruff check .` clean.
+- Result: SUCCESS (round 3 zero valid P1/P2).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,8 @@ gridbot = { workspace = true }
 pnl-checker = { workspace = true }
 
 [tool.pytest.ini_options]
-pythonpath = ["packages/gridcore/src", "packages/bybit_adapter/src", "shared/db/src", "apps/event_saver/src", "apps/gridbot/src", "apps/backtest/src", "apps/comparator/src", "apps/recorder/src", "apps/replay/src", "apps/pnl_checker/src", "tests/integration"]
-testpaths = ["packages/gridcore/tests", "packages/bybit_adapter/tests", "shared/db/tests", "apps/event_saver/tests", "apps/gridbot/tests", "apps/backtest/tests", "apps/comparator/tests", "apps/recorder/tests", "apps/replay/tests", "apps/pnl_checker/tests", "tests/integration"]
+pythonpath = ["packages/gridcore/src", "packages/bybit_adapter/src", "shared/db/src", "apps/event_saver/src", "apps/gridbot/src", "apps/backtest/src", "apps/comparator/src", "apps/recorder/src", "apps/replay/src", "apps/pnl_checker/src", "apps/live_check/src", "tests/integration"]
+testpaths = ["packages/gridcore/tests", "packages/bybit_adapter/tests", "shared/db/tests", "apps/event_saver/tests", "apps/gridbot/tests", "apps/backtest/tests", "apps/comparator/tests", "apps/recorder/tests", "apps/replay/tests", "apps/pnl_checker/tests", "apps/live_check/tests", "tests/integration"]
 asyncio_mode = "auto"
 addopts = ["--import-mode=importlib"]
 

--- a/shared/db/src/grid_db/database.py
+++ b/shared/db/src/grid_db/database.py
@@ -12,6 +12,18 @@ from grid_db.settings import DatabaseSettings
 from grid_db.models import Base
 
 
+def _readonly_sqlite_url(url: str) -> str:
+    """Rewrite a file-backed SQLite URL to a ``mode=ro`` URI open.
+
+    ``sqlite:///path/to.db`` → ``sqlite:///file:path/to.db?mode=ro&uri=true``.
+    SQLAlchemy passes ``uri=true`` through to ``sqlite3.connect``, which then
+    honours ``mode=ro``. ``mode=ro`` ONLY — ``immutable=1`` would freeze the
+    read snapshot and hide rows committed by a live writer after open.
+    """
+    scheme, _, path = url.partition(":///")
+    return f"{scheme}:///file:{path}?mode=ro&uri=true"
+
+
 class DatabaseFactory:
     """Factory for creating database connections supporting SQLite and PostgreSQL.
 
@@ -70,7 +82,12 @@ class DatabaseFactory:
             # Use StaticPool only for in-memory databases
             if ":memory:" in url:
                 poolclass = StaticPool
-            
+            elif self.settings.read_only:
+                # Feature 0088: file-backed SQLite opens read-only via URI.
+                # Skipped for :memory: (nothing to protect; URI form would
+                # create a new empty in-memory DB instead).
+                url = _readonly_sqlite_url(url)
+
             kwargs = {
                 "echo": self.settings.echo_sql,
                 "connect_args": connect_args,
@@ -131,6 +148,23 @@ class DatabaseFactory:
         except Exception:
             session.rollback()
             raise
+        finally:
+            session.close()
+
+    @contextmanager
+    def get_readonly_session(self) -> Generator[Session, None, None]:
+        """Context manager for read-only database sessions (feature 0088).
+
+        Unlike :meth:`get_session`, never calls ``session.commit()`` — there
+        is nothing to commit on a read path, and skipping it avoids any write
+        attempt against a ``mode=ro`` connection.
+
+        Yields:
+            SQLAlchemy Session instance.
+        """
+        session = self.session_factory()
+        try:
+            yield session
         finally:
             session.close()
 

--- a/shared/db/src/grid_db/settings.py
+++ b/shared/db/src/grid_db/settings.py
@@ -32,6 +32,12 @@ class DatabaseSettings(BaseSettings):
     pool_timeout: int = 30
     pool_recycle: int = 1800
 
+    # Read-only open (feature 0088). File-backed SQLite only: the engine URL
+    # is rewritten to mode=ro (URI open) so the connection rejects all writes.
+    # mode=ro ONLY — never immutable=1, which would freeze the snapshot and
+    # hide new writer rows from long-lived readers (live_check --watch).
+    read_only: bool = False
+
     # Debug
     echo_sql: bool = False
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,17 +1,18 @@
-# 0072 — Event-driven follower fill mode (issue #168)
+# Feature 0088 — live_check app
 
-Plan: docs/features/0072_PLAN.md  |  Branch: feature/0072-event-follower
+Plan: docs/features/0088_PLAN.md  |  Branch: feature/0088-live-check
 
-## Status: implementation + tests + docs COMPLETE (awaiting review)
-
-- [x] Step 1 — Foundations: repo secondary sort (exchange_ts, exec_id); FillMode.EVENT_FOLLOWER + _should_fill raise; config Literal + docstring
-- [x] Step 2 — RecordedExecution dataclass + EventFollower (drain/match, tz-normalized, initial_prev_ts boundary) + unit tests
-- [x] Step 3 — order_manager.apply_recorded_fill (placed-qty cap, pro-rated fee/pnl, partial/full) + unit tests
-- [x] Step 4 — session.py: shared _pnl_delta + set_pending_wallet/clear_pending_wallet (pending fold-in)
-- [x] Step 5 — runner.py: _event_follower attr, _prev_tick_ts, _dispatch_intents extraction (trigger-3 hook), iterative drain in process_fills, _FillRollup buffers + triggers 1-4, finalize_event_follower, EPS basis check
-- [x] Step 6 — replay engine.py wiring: load+materialize inside session, symbol filter, _init_runner kwarg + post-construction stash, finalize call after tick loop before wind-down
-- [x] Step 7 — reporter mode-aware relabel (backtest_only/live_only)
-- [x] Step 8 — tests: test_fill_simulator_event_follower.py (23 unit), test_engine_event_follower.py (4 integration incl. oracle round-trip: live_only=0, backtest_only=0, pnl delta 0, partial aggregation, same-window open→close, ETH symbol canary)
-- [x] Step 9 — RULES.md event_follower entry; regression: 830 passed (backtest+replay+comparator) + 155 (shared/db)
+- [x] Phase 1: apps/live_check pyproject + root pyproject registration + config.py + conf/live_check.yaml
+- [x] Phase 1B(a): grid_db read-only mode (settings.read_only, mode=ro URL rewrite, get_readonly_session) + tests
+- [x] Phase 1B(b): ReplayEngine disable-snapshot-emission flag + no-op writer + tests
+- [x] Phase 2A: runner.py (build_replay_config, run_strat)
+- [x] Phase 2B: ground_truth.py (sums, net unrealised, exec count, ticker freshness, run start)
+- [x] Phase 2C: verdict.py (Verdict dataclass, evaluate)
+- [x] Phase 2D: render.py (once, watch_line, per_fill, curve)
+- [x] Phase 3: main.py CLI (modes, window, guards, freshness, exit codes)
+- [x] Phase 4: full test suite green (2907 passed, 3 skipped; 75 new live_check tests)
+- [x] Lint clean (ruff)
+- [x] RULES.md live_check section
+- [x] ext-code-review (codex+cursor, 3 rounds): 5 accepted findings fixed — watch --last threading, per-fill rollup/prefix pairing, Makefile CI gate, strats min_length=1, extra tests; trail in docs/features/0088_REVIEW.md
 
 ## Not committed — awaiting user review/approval before any commit.

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,7 @@ members = [
     "grid-db",
     "gridbot",
     "gridcore",
+    "live-check",
     "pnl-checker",
     "recorder",
     "replay",
@@ -432,6 +433,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "live-check"
+version = "0.1.0"
+source = { editable = "apps/live_check" }
+dependencies = [
+    { name = "backtest" },
+    { name = "comparator" },
+    { name = "grid-db" },
+    { name = "gridbot" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "replay" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "backtest", editable = "apps/backtest" },
+    { name = "comparator", editable = "apps/comparator" },
+    { name = "grid-db", editable = "shared/db" },
+    { name = "gridbot", editable = "apps/gridbot" },
+    { name = "pydantic", specifier = ">=2.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
+    { name = "replay", editable = "apps/replay" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- New `apps/live_check` app: wraps `ReplayEngine` (seeded `event_follower`) per strat over a rolling window and reconciles against **recorded** ground truth only (never live Bybit REST)
- Four verdicts: matched (`live_only`/`backtest_only` empty — not raw exec count), |Δrealized| < \$0.01, |Δcommission| < \$0.01, |Δunrealised| < \$0.50 net per pair
- Modes: `--once` (default), `--watch <interval>`, `--per-fill`, `--curve` (+CSV); exit codes 0=PASS / 1=FAIL / 2=SKIP (zero-data window never reads as success)

## Infrastructure
- `grid_db`: `DatabaseSettings.read_only` rewrites file SQLite URLs to `mode=ro&uri=true` (never `immutable=1` — would freeze the snapshot for `--watch`), plus `get_readonly_session()` without auto-commit
- `ReplayEngine(emit_backtest_snapshots=False)`: no-op position-snapshot writer so live_check runs never write `source='backtest'` rows into the read-only live recorder DB; default path unchanged for all existing callers

## Guards
- Dual post-0080 floors: `window.start >= run.start_ts` AND `>= 2026-06-17T23:07:00Z` (pre-0080 data collapses link_id matching 954→44)
- Per-symbol scoped ground-truth sums (both strats share one run_id)
- `--watch` freshness gate on `MAX(TickerSnapshot.exchange_ts)` per symbol; seed-miss / empty-window / stale become SKIP lines, watch loop never dies per-tick
- Naive-UTC normalization on every stored-timestamp comparison

## Review
Plan `docs/features/0088_PLAN.md` (6 pre-implementation review rounds); external code review codex+cursor 3 rounds — trail in `docs/features/0088_REVIEW.md` (5 findings fixed incl. `--watch --last` threading, `--per-fill` rollup/prefix pairing, `make test` CI-gate coverage)

## Test plan
- [x] 84 live_check tests (ground truth, verdict boundaries, guards, freshness, watch resilience, read-only open, read-only engine run, naive-UTC, render smoke)
- [x] Full suite 2916 passed / 3 skipped; `ruff check .` clean
- [x] `make test` now covers `apps/live_check/tests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)