### PR TITLE
fix(gridbot): execute duplicate-healing cancels while SAME ORDER latch is active

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -927,7 +927,12 @@ ticker (feature 0087, issue #220): `engine.py:_place_grid_orders` groups
 limits into round-8 price buckets, keeps one survivor per price (preference:
 grid-side match > fill history > first-in-list) and cancels the shadowed
 extras with `CancelIntent(reason='duplicate')` — the proactive complement
-to the reactive 0031/0046 post-fill layer. Mid-run order sync keeps
+to the reactive 0031/0046 post-fill layer. While the SAME ORDER soft-block is
+latched (`runner._same_order_error`), only healing `CancelIntent(reason=
+'duplicate')`s still execute via `_execute_generated_intents` (otherwise 0087
+cleanup is a no-op during the latch); placements AND other-reason cancels
+(rebuild/side_mismatch/outside_grid) stay suppressed — cancelling grid orders
+without their paired placements would thin the grid. Mid-run order sync keeps
 warn-and-retry semantics (stopping a bot managing a live grid is riskier);
 sync failures now also alert (`order_sync_<strat_id>`, both `result.errors`
 and exception paths). Repro/regression: `test_issue_206_startup_reconcile_race.py`,

--- a/apps/gridbot/src/gridbot/runner.py
+++ b/apps/gridbot/src/gridbot/runner.py
@@ -736,7 +736,8 @@ class StrategyRunner:
             limit_orders = self.get_limit_orders()
             intents = self._engine.on_event(event, limit_orders)
 
-            # Only execute intents if no same-order error.
+            # Placement is suppressed while SAME ORDER is latched, but healing
+            # CancelIntents (feature 0087 duplicate cleanup) still execute.
             # WARNING is throttled (feature 0046 / issue #94): loud-first,
             # then suppress within _SAME_ORDER_WARN_THROTTLE_SEC, then a
             # single heartbeat re-emit with `(suppressed N since last)`.
@@ -758,10 +759,8 @@ class StrategyRunner:
                         self._same_order_warn_suppressed = 0
                     else:
                         self._same_order_warn_suppressed += 1
-                return intents
 
-            if intents:
-                self._execute_intents(intents, limit_orders)
+            self._execute_generated_intents(intents, limit_orders)
 
             return intents
         except Exception as e:
@@ -854,10 +853,9 @@ class StrategyRunner:
             # Pass to engine (update grid state regardless of error)
             intents = self._engine.on_event(event)
 
-            # Only execute intents if no same-order error.
-            if intents and not self._same_order_error:
+            if intents:
                 limit_orders = self.get_limit_orders()
-                self._execute_intents(intents, limit_orders)
+                self._execute_generated_intents(intents, limit_orders)
 
             return intents
         except Exception as e:
@@ -905,10 +903,9 @@ class StrategyRunner:
             # Pass to engine (update state regardless of error)
             intents = self._engine.on_event(event)
 
-            # Only execute intents if no same-order error
-            if intents and not self._same_order_error:
+            if intents:
                 limit_orders = self.get_limit_orders()
-                self._execute_intents(intents, limit_orders)
+                self._execute_generated_intents(intents, limit_orders)
 
             return intents
         except Exception as e:
@@ -1211,6 +1208,32 @@ class StrategyRunner:
             cum_realized_pnl=Decimal(str(cum_realized_pnl)),
             cur_realized_pnl=Decimal(str(cur_realized_pnl)),
         )
+
+    def _execute_generated_intents(
+        self,
+        intents: list[PlaceLimitIntent | CancelIntent],
+        limits: dict[str, list[dict]],
+    ) -> None:
+        """Execute engine intents, suppressing all but duplicate-healing cancels
+        when SAME ORDER is latched.
+
+        Feature 0087 duplicate-healing emits CancelIntent(reason='duplicate') on
+        the tick path; those must still reach the exchange while the soft-block
+        is active. Everything else (placements AND other-reason cancels such as
+        rebuild/side_mismatch/outside_grid) stays suppressed — a non-duplicate
+        cancel executed without its paired placement would thin out the grid
+        while the latch state is already suspect.
+        """
+        if not intents:
+            return
+        if self._same_order_error:
+            intents = [
+                i for i in intents
+                if isinstance(i, CancelIntent) and i.reason == "duplicate"
+            ]
+            if not intents:
+                return
+        self._execute_intents(intents, limits)
 
     def _execute_intents(
         self,

--- a/apps/gridbot/tests/test_runner.py
+++ b/apps/gridbot/tests/test_runner.py
@@ -2401,9 +2401,144 @@ class TestSameOrderDetection:
         assert "SAME ORDER ERROR" in call_args[0][0]
         assert "50000.0" in call_args[0][0]
 
-    def test_on_order_update_skips_intents_when_same_order_error(self, runner):
-        """Test on_order_update does not execute intents when same-order error active."""
+    def test_execute_generated_intents_suppresses_places_not_cancels(self, runner):
+        """SAME ORDER latch blocks placements only; duplicate-healing cancels run."""
         runner._same_order_error = True
+        cancel = CancelIntent(
+            symbol="BTCUSDT", order_id="dup-2", reason="duplicate",
+        )
+        place = PlaceLimitIntent.create(
+            symbol="BTCUSDT",
+            side="Buy",
+            price=Decimal("49000.0"),
+            qty=Decimal("0.001"),
+            grid_level=5,
+            direction="long",
+            strat_id="btcusdt_test",
+        )
+
+        executed: list[PlaceLimitIntent | CancelIntent] = []
+        runner._execute_intents = lambda intents, limits: executed.extend(intents)
+
+        runner._execute_generated_intents([cancel, place], EMPTY_LIMITS)
+
+        assert executed == [cancel]
+
+    def test_execute_generated_intents_suppresses_non_duplicate_cancels(self, runner):
+        """SAME ORDER latch suppresses cancels with reasons other than 'duplicate'.
+
+        A rebuild/side_mismatch/outside_grid cancel executed without its paired
+        placement would thin the grid while state is suspect.
+        """
+        runner._same_order_error = True
+        rebuild_cancel = CancelIntent(
+            symbol="BTCUSDT", order_id="old-1", reason="rebuild",
+        )
+        duplicate_cancel = CancelIntent(
+            symbol="BTCUSDT", order_id="dup-2", reason="duplicate",
+        )
+
+        executed: list[PlaceLimitIntent | CancelIntent] = []
+        runner._execute_intents = lambda intents, limits: executed.extend(intents)
+
+        runner._execute_generated_intents(
+            [rebuild_cancel, duplicate_cancel], EMPTY_LIMITS,
+        )
+
+        assert executed == [duplicate_cancel]
+
+    def test_execute_generated_intents_no_latch_passes_all(self, runner):
+        """Without the latch, all intents pass through unchanged."""
+        cancel = CancelIntent(
+            symbol="BTCUSDT", order_id="old-1", reason="rebuild",
+        )
+        place = PlaceLimitIntent.create(
+            symbol="BTCUSDT",
+            side="Buy",
+            price=Decimal("49000.0"),
+            qty=Decimal("0.001"),
+            grid_level=5,
+            direction="long",
+            strat_id="btcusdt_test",
+        )
+
+        executed: list[PlaceLimitIntent | CancelIntent] = []
+        runner._execute_intents = lambda intents, limits: executed.extend(intents)
+
+        runner._execute_generated_intents([cancel, place], EMPTY_LIMITS)
+
+        assert executed == [cancel, place]
+
+    def test_on_ticker_duplicate_healing_cancels_under_same_order_error(
+        self, runner, mock_executor,
+    ):
+        """Feature 0087 duplicate CancelIntents must execute while SAME ORDER latched."""
+        ticker = TickerEvent(
+            event_type=EventType.TICKER,
+            symbol="BTCUSDT",
+            exchange_ts=datetime.now(UTC),
+            local_ts=datetime.now(UTC),
+            last_price=Decimal("50000.0"),
+            mark_price=Decimal("50000.0"),
+            bid1_price=Decimal("49999.0"),
+            ask1_price=Decimal("50001.0"),
+            funding_rate=Decimal("0.0001"),
+        )
+        runner.on_ticker(ticker)
+        buy_level = next(
+            g for g in runner._engine.grid.grid if g["side"] == "Buy"
+        )
+        runner.inject_open_orders([
+            {
+                "orderId": "dup-survivor",
+                "price": str(buy_level["price"]),
+                "qty": "0.001",
+                "side": "Buy",
+                "reduceOnly": False,
+            },
+            {
+                "orderId": "dup-shadow",
+                "price": str(buy_level["price"]),
+                "qty": "0.001",
+                "side": "Buy",
+                "reduceOnly": False,
+            },
+        ])
+        runner._same_order_error = True
+        mock_executor.execute_cancel.reset_mock()
+        mock_executor.execute_place.reset_mock()
+
+        runner.on_ticker(ticker)
+
+        duplicate_cancels = [
+            c for c in mock_executor.execute_cancel.call_args_list
+            if c.args[0].reason == "duplicate"
+        ]
+        cancelled_ids = {c.args[0].order_id for c in duplicate_cancels}
+        assert "dup-shadow" in cancelled_ids
+        assert mock_executor.execute_place.call_count == 0
+
+    def test_on_order_update_skips_placements_not_cancels_when_same_order_error(
+        self, runner,
+    ):
+        """on_order_update still forwards CancelIntents while SAME ORDER latched."""
+        runner._same_order_error = True
+        cancel = CancelIntent(
+            symbol="BTCUSDT", order_id="dup-2", reason="duplicate",
+        )
+        place = PlaceLimitIntent.create(
+            symbol="BTCUSDT",
+            side="Buy",
+            price=Decimal("49000.0"),
+            qty=Decimal("0.001"),
+            grid_level=5,
+            direction="long",
+            strat_id="btcusdt_test",
+        )
+        runner._engine.on_event = Mock(return_value=[cancel, place])
+
+        executed: list[PlaceLimitIntent | CancelIntent] = []
+        runner._execute_intents = lambda intents, limits: executed.extend(intents)
 
         order_event = OrderUpdateEvent(
             event_type=EventType.ORDER_UPDATE,
@@ -2418,21 +2553,10 @@ class TestSameOrderDetection:
             qty=Decimal("0.1"),
             leaves_qty=Decimal("0"),
         )
-
-        execute_called = False
-        original_execute = runner._execute_intents
-
-        def mock_execute(intents, limits):
-            nonlocal execute_called
-            execute_called = True
-            original_execute(intents)
-
-        runner._execute_intents = mock_execute
-
         runner.on_order_update(order_event)
 
         assert runner.same_order_error is True
-        assert execute_called is False
+        assert executed == [cancel]
 
     def test_partial_fill_skipped_from_buffer(self, runner):
         """Test partial fills (leavesQty != 0) are not added to buffer.


### PR DESCRIPTION
## Bug and impact

The SAME ORDER soft-block (`runner._same_order_error`) gated **all** intent execution in `on_ticker`, `on_execution`, and `on_order_update`. Feature 0087 (#220) emits healing `CancelIntent(reason='duplicate')` on the tick path, but while the latch was active those cancels were silently dropped (`on_ticker` returned before `_execute_intents`; the other two handlers gated on `not _same_order_error`). Result: duplicate resting orders at other price levels kept 2x exposure for the whole latch window — until the next successful order sync cleared the flag.

## Root cause

The latch was designed to suppress **placements** after a duplicate-fill incident, but the gates made no distinction between `PlaceLimitIntent` and `CancelIntent`, so 0087 cleanup was a no-op during the latch.

## Fix

- New `RunnerCore._execute_generated_intents()`: forwards all intents normally; while the latch is active, filters to `CancelIntent(reason='duplicate')` **only**.
- `on_ticker` / `on_execution` / `on_order_update` wired through the helper; throttled WARNING behavior on tick unchanged.
- Deliberately narrower than the bot-authored fix: other-reason cancels (`rebuild`/`side_mismatch`/`outside_grid`) stay suppressed under the latch — executing them without their paired placements would thin the grid while state is already suspect.
- RULES.md updated to document the latch-time semantics.

## Validation

- Red/green proven: with the source fix reverted to `origin/main`, the 5 new/updated tests FAIL (including the tick-path integration test where `dup-shadow` is never cancelled); with the fix, all pass.
- `uv run pytest apps/gridbot/tests/ packages/gridcore/tests/` — 1247 passed, 1 skipped.
- `make lint` — clean.

Supersedes #225 and #223 (byte-identical bot-authored duplicates; bug and fix independently verified against main and re-implemented with the narrower filter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)