### PR TITLE
fix(live_check): working default config (data/ path + run_id auto-discover)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,12 +34,10 @@ clear-log:
 
 # Reconcile replay vs live over the rolling window (feature 0088).
 # Read-only against the live recorder DB; exit 0=PASS 1=FAIL 2=SKIP/no-data.
-# Config run_id default is a short prefix — the DB stores the full UUID,
-# and database_url needs the data/ prefix, hence both overrides here.
+# Defaults live in the yaml (data/ db path + run_id: null auto-discovers the
+# latest recording run); override with --run-id to reconcile a historical run.
 live-check:
 	uv run --package live-check live-check \
 		-c apps/live_check/conf/live_check.yaml \
-		--database-url "sqlite:///data/recorder_ltcusdt_phase4.db" \
-		--run-id "580ca395-ce99-42a5-bf30-d8542ddaccb8" \
 		--once
 

--- a/apps/live_check/conf/live_check.yaml
+++ b/apps/live_check/conf/live_check.yaml
@@ -5,8 +5,13 @@
 # max_margin mirrors live and IS passed through to RiskConfig but is not
 # consumed by gridcore's risk-mgmt branches (does not affect reconcile).
 
-database_url: "sqlite:///recorder_ltcusdt_phase4.db"
-run_id: "580ca395"
+# Paths are relative to the project root (run via `make live-check` or
+# `uv run live-check` from the repo root); the recorder DB lives under data/.
+database_url: "sqlite:///data/recorder_ltcusdt_phase4.db"
+# null → auto-discover the latest recording run (survives recorder restarts,
+# which mint a fresh run_id each time). Pin a full 36-char UUID or pass
+# --run-id only to reconcile a specific historical run.
+run_id: null
 
 last: "4h"
 lag: "2m"


### PR DESCRIPTION
## Problem
The shipped `apps/live_check/conf/live_check.yaml` only worked through `make live-check`'s CLI overrides. Running `uv run live-check` directly hit two traps:
- **`database_url`** lacked the `data/` prefix → relative path failed (`unable to open database file`).
- **`run_id`** was a short 8-char prefix (`"580ca395"`), but resolution is exact-PK `session.get(Run, run_id)` → `"Run not found"` → exit 1, not a real reconcile.

## Fix
Make the defaults work with zero overrides:
- `database_url` → `sqlite:///data/recorder_ltcusdt_phase4.db`
- `run_id` → `null` → auto-discover the latest recording run (`get_latest_by_type("recording")`). Survives recorder restarts (each mints a fresh `run_id`); override with `--run-id` for a specific historical run.
- Drop the now-redundant `--database-url`/`--run-id` overrides from the Makefile target — the pinned UUID would go stale on the next recorder restart.

## Verification
- `uv run live-check --once` with the default config and **zero overrides** → both strats **PASS** (Δrealized/Δcommission = 0.0000), exit 0.
- `make live-check` (simplified recipe) → PASS, exit 0.
- 85 `live_check` tests pass; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)