### PR TITLE
feat(lint): cover operational check_tier_drift.py (feature 0091)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,11 @@ test:
 test-integration:
 	uv run pytest tests/integration/ -v
 
-# Run ruff linter
+# Run ruff linter. check_tier_drift.py is passed explicitly: it is an
+# operational script (weekly risk-tier-monitor CI) inside the otherwise
+# ruff-excluded scripts/ dir (issue #215).
 lint:
-	uv run ruff check .
+	uv run ruff check . scripts/check_tier_drift.py
 
 # Truncate /tmp/gridbot.log before a fresh run
 clear-log:

--- a/RULES.md
+++ b/RULES.md
@@ -127,10 +127,10 @@ Phase-0 rollout while the repo is red:
 
 ### Lint / Ruff (Feature 0078, issue #181)
 
-`make lint` = `uv run ruff check .`. Root config lives in `pyproject.toml` `[tool.ruff]` (ruff defaults; only an additive `exclude` list). Excluded trees, each with a rationale comment in the config:
+`make lint` = `uv run ruff check . scripts/check_tier_drift.py`. Root config lives in `pyproject.toml` `[tool.ruff]` (ruff defaults; only an additive `exclude` list). Excluded trees, each with a rationale comment in the config:
 - `apps/backtest/debug_walkthrough.py` — interactive debug walkthrough; not app code.
 - `bbu_reference` — vendored bbu2 reference; not maintained, has its own nested `ruff.toml` (line-length 140).
-- `scripts` — one-off research/migration tooling; disposable, not imported by apps.
+- `scripts` — one-off research/migration tooling; disposable, not imported by apps. Carve-out: `scripts/check_tier_drift.py` is operational and linted via the explicit path in the `make lint` recipe (issue #215 / feature 0091) — an explicit positional file arg overrides the directory exclude (no `--force-exclude` set).
 
 Maintained code is NOT excluded. When a maintained file has an intentional lint error, prefer a targeted `# noqa: <code>` over excluding it — e.g. `tests/integration/conftest.py:16` carries `# noqa: E402` on the `gridcore.config` import that must follow the `sys.path.insert` block.
 
@@ -1414,7 +1414,7 @@ Per-symbol maintenance-margin tiers are now fetched from Bybit's `/v5/market/ris
 - `packages/bybit_adapter/src/bybit_adapter/rest_client.py` — `get_risk_limit()` API call (`_unwrap_risk_limit_response` raises `ValueError` on unexpected structure)
 - `apps/pnl_checker/src/pnl_checker/calculator.py` — Uses tiers for IM/MM calculation
 - `apps/pnl_checker/src/pnl_checker/fetcher.py` — Fetches risk limits per symbol
-- `scripts/check_tier_drift.py` — Compares hardcoded tiers against live API (weekly CI via `.github/workflows/risk-tier-monitor.yml`)
+- `scripts/check_tier_drift.py` — Compares hardcoded tiers against live API (weekly CI via `.github/workflows/risk-tier-monitor.yml`). Lint-covered via `make lint`'s explicit path despite the `scripts/` ruff exclude (issue #215 / feature 0091).
 
 ### Caching Strategy (3-Tier Fallback)
 1. **Cache** — Local JSON file, default TTL 24 hours. Stale cache is still used when API fails.

--- a/docs/features/0091_PLAN.md
+++ b/docs/features/0091_PLAN.md
@@ -1,0 +1,141 @@
+# Feature 0091 — Include operational scripts in Ruff lint checks
+
+**Issue:** #215 | **Severity:** Low/Medium | **Area:** Code quality / operational scripts
+
+## Context
+
+Ruff excludes the entire `scripts/` directory
+(`pyproject.toml` `[tool.ruff] exclude` list, rationale comment:
+*"one-off research/migration scripts; disposable, not imported by apps"*).
+That blanket exclusion also swallows `scripts/check_tier_drift.py`, which is
+**operational**, not disposable: the scheduled `risk-tier-monitor` workflow
+runs it weekly and can open GitHub issues on drift
+(`.github/workflows/risk-tier-monitor.yml:30`):
+
+```
+uv run python scripts/check_tier_drift.py --threshold 0.05
+```
+
+So production-adjacent code has zero lint coverage while `make lint` stays green.
+
+**Chosen approach — Option B** (issue author's assessment: smallest change
+consistent with the existing exclusion rationale): keep the `scripts/`
+blanket exclusion, but explicitly lint the one operational script so CI
+fails on Ruff errors in it. Options A (narrow the exclude) and C (move to a
+package) are rejected as larger changes not warranted here.
+
+## Current state (verified)
+
+- `pyproject.toml` `[tool.ruff]` `exclude` lists `"scripts"` with the
+  disposable-scripts rationale comment. There is no `per-file` include
+  mechanism in play; ruff has no "exclude all except X" via the `exclude`
+  list alone.
+- `make lint` target = `uv run ruff check .` (Makefile). CI `lint` job runs
+  `make lint` (`.github/workflows/ci.yml`).
+- `scripts/check_tier_drift.py` currently passes ruff clean
+  (`uv run ruff check scripts/check_tier_drift.py` → "All checks passed!"),
+  so this change is **preventive**: it wires the file into CI so *future*
+  edits are caught. No code fixes to the script are expected.
+- **Optional AC (unit tests) is ALREADY satisfied**:
+  `apps/backtest/tests/test_check_tier_drift.py` exists and tests
+  `compare_tiers`, `_rate_drift_pct`, `_fetch_live_tiers`, and `main` with
+  mocked Bybit responses (imports the script by injecting `scripts/` onto
+  `sys.path`). No new tests are required by this feature.
+
+## Changes
+
+### 1. `pyproject.toml` — update the `scripts` exclude rationale comment only
+
+**Verified fact:** an explicit positional file path passed to `ruff check`
+overrides the directory `exclude` list. Confirmed on ruff 0.14.10 (this
+repo's version) by injecting an unused import into
+`scripts/check_tier_drift.py` and running
+`uv run ruff check scripts/check_tier_drift.py` → E402 + F401, exit=1. Since
+`--force-exclude` is **not** set anywhere in the config, the explicit path is
+honored with no extra flags. No config-side include mechanism is needed (and
+none exists: a file under an excluded directory cannot be re-included via the
+`exclude` list alone).
+
+The only `pyproject.toml` change:
+
+- Keep `"scripts"` in `[tool.ruff] exclude` (blanket disposable-scripts rule
+  unchanged).
+- Update the rationale comment on the `exclude` entry to note that
+  `check_tier_drift.py` is operational and linted explicitly via the
+  Makefile/CI (issue #215), so a future reader does not "fix" the exclusion by
+  deleting the whole entry or assume the operational script is unlinted.
+
+Enforcement itself lives in the lint entry point (step 2), not in config.
+
+### 2. `Makefile` — extend the `lint` target to include the operational script
+
+Current:
+
+```
+lint:
+	uv run ruff check .
+```
+
+Change the `lint` recipe to a **single combined invocation** that lints the
+whole tree plus the operational script in one pass:
+
+```
+uv run ruff check . scripts/check_tier_drift.py
+```
+
+Verified (ruff 0.14.10): with both a directory arg and an explicit file arg,
+ruff honors the `scripts` exclude for `.` while still linting the explicitly
+passed `scripts/check_tier_drift.py` in the same run — unified output, single
+`uv run` startup, one non-zero exit fails `make lint`.
+
+Chosen over two separate recipe lines (`ruff check .` then
+`ruff check scripts/check_tier_drift.py`) because the combined form is simpler
+and avoids the double `uv run` startup cost. (Both forms are correct; the
+plan picks the combined form explicitly.)
+
+Add a short comment above the recipe explaining why the explicit path is
+appended (operational script inside the otherwise-excluded `scripts/` dir;
+issue #215).
+
+### 3. `.github/workflows/ci.yml` — no change required
+
+The CI `lint` job runs `make lint`. Extending the Makefile recipe (step 2)
+automatically brings the operational script under CI lint coverage. Do **not**
+add a separate CI step (keep enforcement in one place: the Makefile).
+
+### 4. `RULES.md` — update BOTH affected entries
+
+Two places in `RULES.md` document the current lint contract and must be
+amended together:
+
+- **"Lint / Ruff (Feature 0078, issue #181)" section (~lines 128–134):**
+  states `make lint` = `uv run ruff check .` and lists the `scripts`
+  exclusion with the rationale *"one-off research/migration tooling;
+  disposable, not imported by apps."* Update the `make lint` definition to
+  the new combined invocation from step 2, and amend the `scripts` bullet
+  to note the carve-out: `check_tier_drift.py` is operational and linted
+  explicitly via the Makefile (issue #215 / feature 0091). Otherwise the
+  documented lint gate no longer matches the Makefile and invites "fixing"
+  the recipe back.
+- **"Dynamic Risk Limit Tiers" section (header at ~line 1384; the
+  `check_tier_drift.py` bullet to amend is line ~1417):** add one line
+  noting the script is lint-covered via `make lint` (issue #215 / feature
+  0091) despite the `scripts/` directory being ruff-excluded, so the
+  exclusion is not mistaken for "this file is unlinted."
+
+## Verification
+
+- `uv run ruff check scripts/check_tier_drift.py` → passes (baseline).
+- `make lint` → passes and now includes the script; introduce a temporary
+  lint error in the script locally to confirm `make lint` turns red, then
+  revert.
+- No changes to test suite behavior; `apps/backtest/tests/test_check_tier_drift.py`
+  continues to pass unchanged.
+
+## Out of scope
+
+- The other files under `scripts/` (research/migration one-offs) stay
+  ruff-excluded — no lint coverage added for them (matches the existing
+  disposable-scripts rationale).
+- No refactor of the script into a package (Option C rejected).
+- No new unit tests (optional AC already met by the existing test file).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,5 +37,7 @@ markers = [
 exclude = [
     "apps/backtest/debug_walkthrough.py",  # interactive debug walkthrough; not app code
     "bbu_reference",                        # vendored bbu2 reference; not maintained, has its own ruff config
-    "scripts",                              # one-off research/migration scripts; disposable, not imported by apps
+    "scripts",                              # one-off research/migration scripts; disposable, not imported by apps.
+                                            # Exception: scripts/check_tier_drift.py is operational (weekly CI) and
+                                            # linted explicitly via the Makefile lint target (issue #215).
 ]


### PR DESCRIPTION
## Summary
- Keep the blanket `scripts/` ruff exclude, but explicitly lint the one operational script: `make lint` = `uv run ruff check . scripts/check_tier_drift.py` (explicit positional path overrides the directory exclude; no `--force-exclude` set).
- Update the `pyproject.toml` exclude rationale comment and both affected `RULES.md` sections so docs match the new lint contract.
- CI needs no change — the `lint` job runs `make lint` and inherits coverage.
- Plan: `docs/features/0091_PLAN.md` (Option B from issue #215; plan-debated + dual external review).

## Verification
- `make lint` → green baseline.
- Canary: injected an unused import into `scripts/check_tier_drift.py` → `make lint` exits 1; reverted → green. Enforcement proven.
- `apps/backtest/tests/test_check_tier_drift.py` → 23 passed unchanged.
- 5-category review loop (quality/security/perf/testing/docs) → zero findings.

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)