### PR TITLE
feat(importer): trad_save_history import adapter (feature 0093)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ test:
 	uv run pytest apps/backtest/tests --cov=backtest --cov-append -q
 	uv run pytest apps/pnl_checker/tests --cov=pnl_checker --cov-append -q
 	uv run pytest apps/live_check/tests --cov=live_check --cov-append -q
+	uv run pytest apps/importer/tests --cov=importer --cov-append -q
 	uv run pytest tests/integration/ --cov-append --cov-report=term-missing -v
 	uv run coverage report --fail-under=88
 

--- a/apps/importer/conf/smoke_replay.yaml
+++ b/apps/importer/conf/smoke_replay.yaml
@@ -1,0 +1,24 @@
+# Smoke-replay template for the importer's --validate check (feature 0093).
+# validate.py renders this to a temp file, overriding database_url, symbol,
+# start_ts/end_ts (one 4h window) and strategy.tick_size (pinned per-symbol
+# EXCHANGE tick — without it replay's instrument-info path would require a
+# live exchange fetch and the smoke check would fail offline).
+database_url: "OVERRIDDEN"
+run_id: null  # auto-discover the synthetic recording run
+symbol: "OVERRIDDEN"
+start_ts: "OVERRIDDEN"
+end_ts: "OVERRIDDEN"
+
+strategy:
+  tick_size: "OVERRIDDEN"
+  grid_count: 50
+  grid_step: 0.5
+  amount: "x0.001"
+
+seed:
+  enabled: false  # fresh grid from market price
+
+fill_simulator:
+  mode: last_cross
+
+output_dir: "OVERRIDDEN"

--- a/apps/importer/pyproject.toml
+++ b/apps/importer/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "importer"
+version = "0.1.0"
+description = "One-way import adapter: trad_save_history ticker_data -> replay-compatible SQLite (feature 0093)"
+requires-python = ">=3.11"
+dependencies = [
+    "grid-db",
+    "replay",
+    "sqlalchemy>=2.0",
+    "requests>=2.31",
+    "pyyaml>=6.0",
+]
+
+[tool.uv.sources]
+grid-db = { workspace = true }
+replay = { workspace = true }
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/importer"]

--- a/apps/importer/src/importer/__init__.py
+++ b/apps/importer/src/importer/__init__.py
@@ -1,0 +1,6 @@
+"""One-way import adapter: trad_save_history -> replay-compatible SQLite.
+
+Feature 0093. Imported DBs are for counterfactual A/B / relative ranking
+only — the source has no private-stream data, so live-fidelity tooling
+(event_follower / live_check) stays on recorder DBs.
+"""

--- a/apps/importer/src/importer/config.py
+++ b/apps/importer/src/importer/config.py
@@ -1,0 +1,159 @@
+"""CLI argument parsing and datetime discipline for the importer (feature 0093).
+
+Every datetime entering the pipeline is normalized to naive UTC (convert to
+UTC, strip tzinfo). SQLite returns naive datetimes, so any aware value that
+survives into a comparison against a stored cursor raises ``TypeError`` —
+the same guard replay applies before comparing timestamps.
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+
+
+def to_naive_utc(dt: datetime) -> datetime:
+    """Convert to UTC and strip tzinfo; naive input passes through unchanged.
+
+    Naive datetimes are assumed UTC already (owner-confirmed source
+    semantics).
+    """
+    if dt.tzinfo is not None:
+        dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+    return dt
+
+
+def parse_utc(value: str) -> datetime:
+    """Parse an ISO-8601 datetime string and return it as naive UTC.
+
+    Accepts the trailing-``Z`` shorthand and explicit offsets
+    (``+05:00``); aware input is converted to UTC before tzinfo is
+    stripped.
+    """
+    normalized = value.replace("Z", "+00:00") if value.endswith("Z") else value
+    try:
+        dt = datetime.fromisoformat(normalized)
+    except ValueError as e:
+        raise argparse.ArgumentTypeError(
+            f"invalid ISO-8601 datetime: {value!r}"
+        ) from e
+    return to_naive_utc(dt)
+
+
+def positive_int(value: str) -> int:
+    """argparse type: strictly positive integer (LIMIT 0/-1 are footguns)."""
+    number = int(value)
+    if number <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return number
+
+
+def unit_fraction(value: str) -> float:
+    """argparse type: float in (0, 1] (0 would disable the OHLC value gate)."""
+    number = float(value)
+    if not 0 < number <= 1:
+        raise argparse.ArgumentTypeError("must be in (0, 1]")
+    return number
+
+
+def parse_symbols(value: str) -> list[str]:
+    """Split a comma-separated symbol list; rejects an empty list."""
+    symbols = [s.strip().upper() for s in value.split(",") if s.strip()]
+    if not symbols:
+        raise argparse.ArgumentTypeError("--symbols must name at least one symbol")
+    return symbols
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the importer CLI parser (invoked via ``python -m importer.main``)."""
+    parser = argparse.ArgumentParser(
+        prog="python -m importer.main",
+        description=(
+            "One-way import: trad_save_history ticker_data -> per-symbol "
+            "replay-compatible SQLite DBs (feature 0093). Imported DBs are "
+            "for counterfactual A/B / relative ranking only."
+        ),
+    )
+    parser.add_argument(
+        "--source",
+        required=True,
+        choices=("db", "http"),
+        help="Source transport: direct SQLAlchemy URL (db) or HTTP API (http).",
+    )
+    parser.add_argument(
+        "--source-url",
+        required=True,
+        help=(
+            "Transport A: SQLAlchemy URL (postgresql://... or sqlite:///path). "
+            "Transport B: HTTP API base URL."
+        ),
+    )
+    parser.add_argument(
+        "--symbols",
+        required=True,
+        type=parse_symbols,
+        help="Comma-separated symbols to import (e.g. BTCUSDT,ETHUSDT).",
+    )
+    parser.add_argument(
+        "--start",
+        type=parse_utc,
+        default=None,
+        help=(
+            "ISO-8601 UTC start (inclusive). Default: source MIN(timestamp) "
+            "probe (transport A only; http requires explicit bounds)."
+        ),
+    )
+    parser.add_argument(
+        "--end",
+        type=parse_utc,
+        default=None,
+        help=(
+            "ISO-8601 UTC end (inclusive). Default: source MAX(timestamp) "
+            "probe (transport A only; http requires explicit bounds)."
+        ),
+    )
+    parser.add_argument(
+        "--out-dir",
+        default="data",
+        help="Output directory for imported_<symbol>[_<tag>].db files.",
+    )
+    parser.add_argument(
+        "--tag",
+        default=None,
+        help=(
+            "Optional filename tag for an isolated fresh import "
+            "(imported_<symbol>_<tag>.db), e.g. while a sweep reads the "
+            "default file."
+        ),
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=positive_int,
+        default=10000,
+        help="Source fetch batch size (default 10000).",
+    )
+    parser.add_argument(
+        "--validate",
+        action="store_true",
+        help="Run post-import validation (OHLC cross-check, smoke replay, "
+        "recorder overlap probe).",
+    )
+    parser.add_argument(
+        "--ohlc-threshold",
+        type=unit_fraction,
+        default=0.99,
+        help="Fraction of exactly-matching OHLC buckets required to pass "
+        "(default 0.99).",
+    )
+    parser.add_argument(
+        "--recorder-db",
+        default=None,
+        help="Recorder SQLite path/URL for the --validate overlap probe "
+        "(skipped with a NOTICE when omitted or no overlap).",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable debug logging.",
+    )
+    return parser

--- a/apps/importer/src/importer/density.py
+++ b/apps/importer/src/importer/density.py
@@ -1,0 +1,138 @@
+"""Per-day density report: tick counts, >60 s gaps, LOW-DENSITY flag.
+
+Feature 0093. The source writes only on lastPrice change, so imported data
+is sparser than the recorder's ~4-5 ticks/s. last_cross overfill
+sensitivity rises with sparsity — LOW-DENSITY days carry a WARNING so
+sweeps on that data are qualified.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import date, datetime, time as dt_time, timedelta
+from typing import Iterator, List, Optional
+
+from grid_db.database import DatabaseFactory
+from grid_db.models import TickerSnapshot
+
+logger = logging.getLogger(__name__)
+
+GAP_THRESHOLD_S = 60.0
+LOW_DENSITY_TICKS_PER_S = 0.5
+_PAGE_SIZE = 50000
+
+
+@dataclass
+class DayDensity:
+    """Density stats for one UTC day."""
+
+    day: date
+    tick_count: int = 0
+    gaps: List[tuple[datetime, datetime]] = field(default_factory=list)
+    covered_seconds: float = 0.0
+
+    @property
+    def ticks_per_second(self) -> float:
+        if self.covered_seconds <= 0:
+            return 0.0
+        return self.tick_count / self.covered_seconds
+
+    @property
+    def low_density(self) -> bool:
+        return self.ticks_per_second < LOW_DENSITY_TICKS_PER_S
+
+
+def _iter_exchange_ts(db: DatabaseFactory, symbol: str) -> Iterator[datetime]:
+    """Stream exchange_ts ascending, keyset-paginated (unique per symbol)."""
+    with db.get_session() as session:
+        cursor: Optional[datetime] = None
+        while True:
+            query = session.query(TickerSnapshot.exchange_ts).filter(
+                TickerSnapshot.symbol == symbol
+            )
+            if cursor is not None:
+                query = query.filter(TickerSnapshot.exchange_ts > cursor)
+            rows = (
+                query.order_by(TickerSnapshot.exchange_ts)
+                .limit(_PAGE_SIZE)
+                .all()
+            )
+            if not rows:
+                return
+            for (ts,) in rows:
+                yield ts
+            cursor = rows[-1][0]
+
+
+def compute_density(db: DatabaseFactory, symbol: str) -> List[DayDensity]:
+    """Per-UTC-day tick counts, >60 s gaps (keyed to the gap's start day)."""
+    days: dict[date, DayDensity] = {}
+    prev: Optional[datetime] = None
+    first: Optional[datetime] = None
+    last: Optional[datetime] = None
+
+    for ts in _iter_exchange_ts(db, symbol):
+        if first is None:
+            first = ts
+        last = ts
+        day = ts.date()
+        entry = days.get(day)
+        if entry is None:
+            entry = days[day] = DayDensity(day=day)
+        entry.tick_count += 1
+        if prev is not None and (ts - prev).total_seconds() > GAP_THRESHOLD_S:
+            days.setdefault(prev.date(), DayDensity(day=prev.date())).gaps.append(
+                (prev, ts)
+            )
+        prev = ts
+
+    if first is None:
+        return []
+
+    # Partial first/last days: rate denominator is the covered span within
+    # the day, not a full 86400 s.
+    for entry in days.values():
+        day_start = datetime.combine(entry.day, dt_time.min)
+        day_end = day_start + timedelta(days=1)
+        span_start = max(day_start, first)
+        span_end = min(day_end, last)
+        entry.covered_seconds = max((span_end - span_start).total_seconds(), 0.0)
+
+    return [days[d] for d in sorted(days)]
+
+
+def log_density_report(symbol: str, days: List[DayDensity]) -> bool:
+    """Log the per-day report; returns True when any day is LOW-DENSITY."""
+    any_low = False
+    for entry in days:
+        flag = " LOW-DENSITY" if entry.low_density else ""
+        logger.info(
+            "%s %s: %d ticks, %.2f ticks/s, %d gaps >%.0fs%s",
+            symbol,
+            entry.day.isoformat(),
+            entry.tick_count,
+            entry.ticks_per_second,
+            len(entry.gaps),
+            GAP_THRESHOLD_S,
+            flag,
+        )
+        for gap_start, gap_end in entry.gaps:
+            logger.info(
+                "  gap %.0fs: %s -> %s",
+                (gap_end - gap_start).total_seconds(),
+                gap_start,
+                gap_end,
+            )
+        if entry.low_density:
+            any_low = True
+    if any_low:
+        logger.warning(
+            "%s has LOW-DENSITY days (< %.1f ticks/s): last_cross overfill "
+            "sensitivity rises with sparsity — qualify any sweep on this "
+            "data. Never resume-append into this DB while a sweep reads it "
+            "(use --tag for an isolated file).",
+            symbol,
+            LOW_DENSITY_TICKS_PER_S,
+        )
+    return any_low

--- a/apps/importer/src/importer/fetch_source_db.py
+++ b/apps/importer/src/importer/fetch_source_db.py
@@ -1,0 +1,135 @@
+"""Transport A: direct SQLAlchemy read-only access to ``ticker_data``.
+
+Feature 0093. Streams the source table keyset-paginated on the composite
+cursor ``(timestamp, id)``: a bare ``timestamp >= cursor`` with LIMIT would
+loop forever, and a bare strict ``>`` on timestamp alone could skip rows
+sharing the cursor timestamp across a page boundary; the ``id`` tiebreaker
+fixes both (same pattern as the source project's own reader).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Iterator, Optional
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    Float,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    and_,
+    func,
+    or_,
+    select,
+)
+
+from grid_db.database import DatabaseFactory
+from grid_db.settings import DatabaseSettings
+
+from importer.config import to_naive_utc
+
+logger = logging.getLogger(__name__)
+
+# Lightweight Core mapping of the source table — typed binds and result
+# conversion work on both SQLite (str <-> datetime) and Postgres. Source
+# columns not needed by the mapping (sizes, 24h stats) are not selected.
+_metadata = MetaData()
+ticker_data = Table(
+    "ticker_data",
+    _metadata,
+    Column("id", Integer, primary_key=True),
+    Column("symbol", String),
+    Column("timestamp", DateTime),
+    Column("last_price", Float),
+    Column("mark_price", Float),
+    Column("bid1_price", Float),
+    Column("ask1_price", Float),
+    Column("funding_rate", Float),
+)
+
+
+def aware_utc(dt: datetime) -> datetime:
+    """Bind window bounds as aware UTC.
+
+    A naive bind against a Postgres ``timestamptz`` column is interpreted
+    in the SESSION timezone, silently shifting the import window on
+    non-UTC servers. An aware bind pins the absolute instant; SQLite's
+    bind formatter ignores tzinfo and writes the same UTC wall-clock, so
+    this is safe on both dialects.
+    """
+    return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
+
+
+class DbSource:
+    """Keyset-paginated read-only reader over the source ``ticker_data`` table."""
+
+    def __init__(self, url: str, batch_size: int = 10000):
+        # read_only rewrites file-backed SQLite URLs to mode=ro; the flag is
+        # inert for Postgres (reads happen via get_readonly_session either way).
+        self._db = DatabaseFactory(
+            DatabaseSettings(database_url=url, read_only=True)
+        )
+        self._batch_size = batch_size
+
+    def fetch_batches(
+        self, symbol: str, start: datetime, end: datetime
+    ) -> Iterator[list[dict]]:
+        """Yield 10k-row batches ordered by (timestamp, id), both bounds inclusive."""
+        t = ticker_data
+        start_bind, end_bind = aware_utc(start), aware_utc(end)
+        with self._db.get_readonly_session() as session:
+            cursor: Optional[tuple[datetime, int]] = None
+            while True:
+                query = select(
+                    t.c.id,
+                    t.c.symbol,
+                    t.c.timestamp,
+                    t.c.last_price,
+                    t.c.mark_price,
+                    t.c.bid1_price,
+                    t.c.ask1_price,
+                    t.c.funding_rate,
+                ).where(t.c.symbol == symbol, t.c.timestamp <= end_bind)
+                if cursor is None:
+                    query = query.where(t.c.timestamp >= start_bind)
+                else:
+                    cts, cid = cursor
+                    # Expanded row-value form of (timestamp, id) > (cts, cid).
+                    query = query.where(
+                        or_(
+                            t.c.timestamp > cts,
+                            and_(t.c.timestamp == cts, t.c.id > cid),
+                        )
+                    )
+                query = query.order_by(t.c.timestamp, t.c.id).limit(
+                    self._batch_size
+                )
+                rows = session.execute(query).all()
+                if not rows:
+                    return
+                # Cursor uses the DB-native (pre-normalization) timestamp so
+                # the next page's comparison matches stored values.
+                cursor = (rows[-1]._mapping["timestamp"], rows[-1]._mapping["id"])
+                batch = []
+                for row in rows:
+                    mapped = dict(row._mapping)
+                    mapped["timestamp"] = to_naive_utc(mapped["timestamp"])
+                    batch.append(mapped)
+                yield batch
+
+    def probe_range(self, symbol: str) -> Optional[tuple[datetime, datetime]]:
+        """MIN/MAX ``timestamp`` for a symbol; None when the source has no rows."""
+        t = ticker_data
+        with self._db.get_readonly_session() as session:
+            min_ts, max_ts = session.execute(
+                select(func.min(t.c.timestamp), func.max(t.c.timestamp)).where(
+                    t.c.symbol == symbol
+                )
+            ).one()
+        if min_ts is None or max_ts is None:
+            return None
+        return to_naive_utc(min_ts), to_naive_utc(max_ts)

--- a/apps/importer/src/importer/fetch_source_http.py
+++ b/apps/importer/src/importer/fetch_source_http.py
@@ -1,0 +1,145 @@
+"""Transport B: HTTP API client for trad_save_history (feature 0093).
+
+Client side of the plan's HTTP contract:
+``GET {base_url}/ticker_data?symbol&start&end&limit&cursor`` returning
+``{"rows": [...], "next_cursor": <opaque or null>}`` in stable
+``(timestamp, id)`` ascending order, both bounds inclusive.
+
+Robustness for long multi-hour pulls: 30 s per-request timeout; retry on
+connection errors / HTTP 429 / 5xx with exponential backoff re-requesting
+the SAME cursor (idempotent GET, so a retried page cannot skip rows); any
+other 4xx aborts with the response body logged.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from datetime import datetime, timezone
+from typing import Iterator, Optional
+
+import requests
+
+from importer.config import to_naive_utc
+
+logger = logging.getLogger(__name__)
+
+_TIMEOUT_S = 30
+_MAX_ATTEMPTS = 5
+_BACKOFF_BASE_S = 1.0
+_BACKOFF_FACTOR = 2.0
+_BACKOFF_CAP_S = 30.0
+
+
+class HttpSourceError(Exception):
+    """Non-recoverable HTTP source failure (aborts the import)."""
+
+
+def iso_utc(dt: datetime) -> str:
+    """Format a naive-UTC datetime as ISO-8601 with the ``Z`` suffix."""
+    return dt.replace(tzinfo=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+class HttpSource:
+    """Cursor-paginated reader against the trad_save_history HTTP API."""
+
+    def __init__(
+        self,
+        base_url: str,
+        batch_size: int = 10000,
+        session: Optional[requests.Session] = None,
+    ):
+        self._base_url = base_url.rstrip("/")
+        self._batch_size = batch_size
+        self._session = session or requests.Session()
+
+    def fetch_batches(
+        self, symbol: str, start: datetime, end: datetime
+    ) -> Iterator[list[dict]]:
+        """Yield batches following ``next_cursor`` to exhaustion."""
+        cursor: Optional[str] = None
+        while True:
+            params: dict = {
+                "symbol": symbol,
+                "start": iso_utc(start),
+                "end": iso_utc(end),
+                "limit": self._batch_size,
+            }
+            if cursor is not None:
+                params["cursor"] = cursor
+            payload = self._get_with_retry(params)
+            rows = payload.get("rows") or []
+            cursor = payload.get("next_cursor")
+            if not rows:
+                # A page with no rows cannot make progress — treat as
+                # exhausted even if the server sent a cursor (a buggy
+                # truthy cursor would otherwise spin forever).
+                if cursor:
+                    logger.warning(
+                        "HTTP source sent next_cursor with an empty rows "
+                        "page — treating as exhausted"
+                    )
+                return
+            yield [self._normalize_row(r) for r in rows]
+            # Contract says null when exhausted; treat any falsy cursor
+            # (e.g. "") as exhausted too — re-sending it would spin forever.
+            if not cursor:
+                return
+
+    def probe_range(self, symbol: str) -> Optional[tuple[datetime, datetime]]:
+        """The HTTP contract exposes no MIN/MAX probe — always None.
+
+        The caller requires explicit ``--start``/``--end`` for this
+        transport.
+        """
+        return None
+
+    def _get_with_retry(self, params: dict) -> dict:
+        """GET with exponential backoff; retried pages re-request the same cursor."""
+        url = f"{self._base_url}/ticker_data"
+        delay = _BACKOFF_BASE_S
+        for attempt in range(1, _MAX_ATTEMPTS + 1):
+            failure: str
+            try:
+                response = self._session.get(url, params=params, timeout=_TIMEOUT_S)
+            except requests.RequestException as e:
+                failure = f"connection error: {e}"
+            else:
+                if response.status_code == 200:
+                    return response.json()
+                if response.status_code == 429 or response.status_code >= 500:
+                    failure = f"HTTP {response.status_code}"
+                else:
+                    logger.error(
+                        "HTTP source returned %d: %s",
+                        response.status_code,
+                        response.text,
+                    )
+                    raise HttpSourceError(
+                        f"non-retryable HTTP {response.status_code} from {url}"
+                    )
+            if attempt == _MAX_ATTEMPTS:
+                raise HttpSourceError(
+                    f"{failure} after {_MAX_ATTEMPTS} attempts against {url}"
+                )
+            logger.warning(
+                "HTTP source %s (attempt %d/%d), retrying same cursor in %.0fs",
+                failure,
+                attempt,
+                _MAX_ATTEMPTS,
+                delay,
+            )
+            time.sleep(delay)
+            delay = min(delay * _BACKOFF_FACTOR, _BACKOFF_CAP_S)
+        raise HttpSourceError("unreachable")  # pragma: no cover
+
+    @staticmethod
+    def _normalize_row(row: dict) -> dict:
+        """Parse the ISO-8601 timestamp to naive UTC at the transport boundary."""
+        out = dict(row)
+        ts = out["timestamp"]
+        if isinstance(ts, str):
+            normalized = ts.replace("Z", "+00:00") if ts.endswith("Z") else ts
+            ts = datetime.fromisoformat(normalized)
+        out["timestamp"] = to_naive_utc(ts)
+        return out

--- a/apps/importer/src/importer/main.py
+++ b/apps/importer/src/importer/main.py
@@ -1,0 +1,217 @@
+"""Importer CLI entry point (feature 0093).
+
+Usage:
+    python -m importer.main --source db --source-url sqlite:///ticker.db \
+        --symbols BTCUSDT,ETHUSDT [--start ...] [--end ...] [--validate]
+
+Per symbol: acquire the .importlock sidecar, open/create the per-symbol
+output DB, resume-append new source rows (per-batch commit), refresh the
+single synthetic recording run row, print the density report, optionally
+validate. Symbols fail independently; the process exit code is non-zero if
+ANY symbol failed (aggregate, not fail-fast).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from datetime import datetime
+from typing import Optional
+
+from importer.config import build_parser
+from importer.density import compute_density, log_density_report
+from importer.mapping import FallbackCounters, map_row
+from importer.output_db import (
+    ImportLockHeldError,
+    acquire_lock,
+    ensure_parents,
+    ensure_run_row,
+    get_min_ts,
+    get_resume_ts,
+    insert_batch,
+    open_output_db,
+    output_db_path,
+    release_lock,
+)
+from importer.source import SourceTransport, make_source
+from importer.validate import run_validation
+
+logger = logging.getLogger(__name__)
+
+
+def setup_logging(debug: bool = False) -> None:
+    """Set up logging with console output."""
+    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler.setLevel(logging.DEBUG if debug else logging.INFO)
+    console_formatter = logging.Formatter(
+        "%(asctime)s %(levelname)-8s %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    console_handler.setFormatter(console_formatter)
+
+    root_logger = logging.getLogger()
+    root_logger.handlers.clear()
+    root_logger.setLevel(logging.DEBUG if debug else logging.INFO)
+    root_logger.addHandler(console_handler)
+
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
+
+
+def _resolve_window(
+    args: argparse.Namespace, source: SourceTransport, symbol: str
+) -> Optional[tuple[datetime, datetime]]:
+    """Resolve the [start, end] import window (both inclusive).
+
+    Missing bounds default to the source MIN/MAX probe. The HTTP transport
+    cannot probe — explicit ``--start``/``--end`` are required there.
+    """
+    start, end = args.start, args.end
+    if start is None or end is None:
+        probed = source.probe_range(symbol)
+        if probed is None:
+            logger.error(
+                "%s: cannot default --start/--end (source probe unavailable "
+                "or empty) — pass explicit bounds",
+                symbol,
+            )
+            return None
+        start = start if start is not None else probed[0]
+        end = end if end is not None else probed[1]
+    if start > end:
+        logger.error("%s: --start %s is after --end %s", symbol, start, end)
+        return None
+    return start, end
+
+
+def import_symbol(
+    args: argparse.Namespace, source: SourceTransport, symbol: str
+) -> bool:
+    """Import one symbol into its output DB; returns success."""
+    db_path = output_db_path(args.out_dir, symbol, args.tag)
+    lock = acquire_lock(db_path)
+    try:
+        db = open_output_db(db_path)
+        ensure_parents(db, symbol)
+
+        window = _resolve_window(args, source, symbol)
+        if window is None:
+            return False
+        start, end = window
+
+        # Prefix guard: resume is append-only. A resolved start earlier than
+        # the DB's existing MIN can never be filled by this path — abort
+        # rather than silently report coverage that was never imported.
+        existing_min = get_min_ts(db, symbol)
+        if existing_min is not None and start < existing_min:
+            logger.error(
+                "%s: resolved start %s predates existing MIN(exchange_ts) %s "
+                "in %s — resume is append-only. Use --tag for a separate "
+                "full-range file (or delete the DB) instead.",
+                symbol,
+                start,
+                existing_min,
+                db_path,
+            )
+            return False
+
+        resume_from = get_resume_ts(db, symbol)
+        # First import has no resume cursor — a literal max(start, None)
+        # would raise.
+        lower = start if resume_from is None else max(start, resume_from)
+
+        counters = FallbackCounters()
+        total_inserted = 0
+        last_logged_day = None
+        for batch in source.fetch_batches(symbol, lower, end):
+            snapshots = []
+            for row in batch:
+                # Resume skip BEFORE mapping (naive-vs-naive comparison —
+                # transports already normalized timestamps to naive UTC).
+                if resume_from is not None and row["timestamp"] <= resume_from:
+                    continue
+                snapshot = map_row(row, counters)
+                if snapshot is not None:
+                    snapshots.append(snapshot)
+            total_inserted += insert_batch(db, snapshots)
+            day = batch[-1]["timestamp"].date()
+            if day != last_logged_day:
+                logger.info(
+                    "%s: imported through %s (%d rows total)",
+                    symbol,
+                    day,
+                    total_inserted,
+                )
+                last_logged_day = day
+
+        fallback_counts = counters.as_dict()
+        if any(fallback_counts.values()):
+            logger.warning("%s NULL-fallback/skip counts: %s", symbol, fallback_counts)
+
+        run_id = ensure_run_row(
+            db, symbol, source_desc=f"{args.source}:{args.source_url}"
+        )
+        if run_id is None:
+            # Zero-row rule: empty range or every row skipped for NULL
+            # last_price — no run row (replay would abort on an invalid
+            # range), symbol counts as failed.
+            logger.error(
+                "%s: output DB has no ticker rows — no run row created", symbol
+            )
+            return False
+        logger.info(
+            "%s: %d new rows this session; run row %s refreshed from DB-wide "
+            "MIN/MAX",
+            symbol,
+            total_inserted,
+            run_id,
+        )
+
+        days = compute_density(db, symbol)
+        log_density_report(symbol, days)
+
+        if args.validate:
+            bounds = (get_min_ts(db, symbol), get_resume_ts(db, symbol))
+            return run_validation(
+                db,
+                db_path,
+                symbol,
+                args.source,
+                args.source_url,
+                bounds,
+                args.ohlc_threshold,
+                args.recorder_db,
+            )
+        return True
+    finally:
+        release_lock(lock)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    """Entry point; returns non-zero when ANY symbol failed."""
+    args = build_parser().parse_args(argv)
+    setup_logging(debug=args.debug)
+
+    source = make_source(args.source, args.source_url, args.batch_size)
+
+    failed: list[str] = []
+    for symbol in args.symbols:
+        try:
+            ok = import_symbol(args, source, symbol)
+        except ImportLockHeldError as e:
+            logger.error("%s: %s", symbol, e)
+            ok = False
+        except Exception:
+            logger.error("%s: import failed", symbol, exc_info=True)
+            ok = False
+        if not ok:
+            failed.append(symbol)
+
+    if failed:
+        logger.error("FAILED symbols: %s", ", ".join(failed))
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/apps/importer/src/importer/mapping.py
+++ b/apps/importer/src/importer/mapping.py
@@ -1,0 +1,91 @@
+"""Pure source-row -> TickerSnapshot mapping with NULL fallbacks (feature 0093).
+
+Hermetic, no I/O. Every numeric crosses the boundary as
+``Decimal(str(x))`` quantized to 8dp — never a raw float bind (project
+precision rule). All target price columns are ``nullable=False``, so the
+NULL fallbacks are mandatory to satisfy the schema.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from decimal import Decimal
+from typing import Optional
+
+from grid_db.models import TickerSnapshot
+
+_EIGHT_DP = Decimal("0.00000001")
+
+
+@dataclass
+class FallbackCounters:
+    """Per-field NULL-fallback / skip counters, logged after import."""
+
+    skipped_null_last_price: int = 0
+    mark_price_fallback: int = 0
+    bid1_price_fallback: int = 0
+    ask1_price_fallback: int = 0
+    funding_rate_fallback: int = 0
+
+    def as_dict(self) -> dict[str, int]:
+        return asdict(self)
+
+
+def _to_decimal(value: float | int | str) -> Decimal:
+    return Decimal(str(value)).quantize(_EIGHT_DP)
+
+
+def map_row(row: dict, counters: FallbackCounters) -> Optional[TickerSnapshot]:
+    """Map one source row dict to a TickerSnapshot ORM instance.
+
+    Returns None (and counts the skip) when ``last_price`` is NULL — there
+    is no fallback source and the target column is ``nullable=False``.
+    NULL mark/bid1/ask1 fall back to ``last_price``; NULL funding_rate
+    falls back to 0. Each fallback increments its counter.
+    """
+    last = row.get("last_price")
+    if last is None:
+        counters.skipped_null_last_price += 1
+        return None
+    last_price = _to_decimal(last)
+
+    mark = row.get("mark_price")
+    if mark is None:
+        counters.mark_price_fallback += 1
+        mark_price = last_price
+    else:
+        mark_price = _to_decimal(mark)
+
+    bid1 = row.get("bid1_price")
+    if bid1 is None:
+        counters.bid1_price_fallback += 1
+        bid1_price = last_price
+    else:
+        bid1_price = _to_decimal(bid1)
+
+    ask1 = row.get("ask1_price")
+    if ask1 is None:
+        counters.ask1_price_fallback += 1
+        ask1_price = last_price
+    else:
+        ask1_price = _to_decimal(ask1)
+
+    funding = row.get("funding_rate")
+    if funding is None:
+        counters.funding_rate_fallback += 1
+        funding_rate = Decimal("0")
+    else:
+        funding_rate = _to_decimal(funding)
+
+    return TickerSnapshot(
+        symbol=row["symbol"],
+        exchange_ts=row["timestamp"],
+        # No recv-ts on the source; local_ts mirrors exchange_ts.
+        local_ts=row["timestamp"],
+        last_price=last_price,
+        mark_price=mark_price,
+        bid1_price=bid1_price,
+        ask1_price=ask1_price,
+        funding_rate=funding_rate,
+        raw_json=None,
+    )

--- a/apps/importer/src/importer/output_db.py
+++ b/apps/importer/src/importer/output_db.py
@@ -1,0 +1,248 @@
+"""Output DB lifecycle for the importer (feature 0093).
+
+Open/create the per-symbol output DB (recorder schema + WAL), maintain the
+synthetic parent chain and the single ``recording`` run row, provide the
+per-batch-commit insert wrapper and resume cursor reads, and manage the
+``.importlock`` sidecar (O_EXCL, PID + start time, stale-PID reclaim).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Optional
+from uuid import uuid4
+
+from sqlalchemy import func
+
+from grid_db.database import DatabaseFactory
+from grid_db.identity import account_id_for, strategy_id_for, user_id_for
+from grid_db.models import BybitAccount, Run, Strategy, TickerSnapshot, User
+from grid_db.repositories.identity import RunRepository
+from grid_db.repositories.market_data import TickerSnapshotRepository
+from grid_db.settings import DatabaseSettings
+
+logger = logging.getLogger(__name__)
+
+# Pinned deterministic identity (recorder-style uuid5): reruns session.get
+# the same parent rows instead of inserting duplicates. The run row's
+# account_id must be non-null — replay's snapshot writer raises on NULL.
+_IMPORTER_NAME = "importer"
+IMPORTER_USER_ID = user_id_for(_IMPORTER_NAME)
+IMPORTER_ACCOUNT_ID = account_id_for(_IMPORTER_NAME)
+
+
+class ImportLockHeldError(Exception):
+    """The ``.importlock`` sidecar is held (or unreadable) — do not write."""
+
+
+def output_db_path(out_dir: str, symbol: str, tag: Optional[str] = None) -> Path:
+    """``{out_dir}/imported_<symbol>[_<tag>].db`` — stable default path.
+
+    The filename deliberately does NOT embed start/end: the default
+    ``--end`` resolves to a live MAX(timestamp) probe, so a range-encoded
+    name would defeat incremental resume.
+    """
+    suffix = f"_{tag}" if tag else ""
+    return Path(out_dir) / f"imported_{symbol}{suffix}.db"
+
+
+def lock_path(db_path: Path) -> Path:
+    """Sidecar lock path next to the output DB."""
+    return db_path.with_name(db_path.name + ".importlock")
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Exists but owned by another user — treat as alive.
+        return True
+    return True
+
+
+def _reclaim_or_abort(path: Path) -> None:
+    """Reclaim a stale (dead-PID) lock with a WARNING, else abort."""
+    try:
+        content = path.read_text()
+        pid = int(
+            next(
+                line.split("=", 1)[1]
+                for line in content.splitlines()
+                if line.startswith("pid=")
+            )
+        )
+    except (OSError, StopIteration, ValueError) as e:
+        raise ImportLockHeldError(
+            f"unreadable import lock {path}; inspect and rm it manually"
+        ) from e
+    if _pid_alive(pid):
+        # PID-reuse edge (recycled pid of a dead importer) is accepted:
+        # recovery is a documented manual rm; the stored start time aids
+        # diagnosis but is not used for automatic reclaim.
+        raise ImportLockHeldError(
+            f"import lock {path} held by live pid {pid}; wait for it or, "
+            "if the pid was recycled, rm the lock manually"
+        )
+    logger.warning("stale import lock %s (dead pid %d) — reclaiming", path, pid)
+    path.unlink()
+
+
+def acquire_lock(db_path: Path) -> Path:
+    """Acquire the O_EXCL ``.importlock`` sidecar; returns the lock path.
+
+    Excludes concurrent importers only — it cannot detect an in-flight
+    replay, which takes no lock (sweep separation is an operational rule).
+    """
+    path = lock_path(db_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+    except FileExistsError:
+        _reclaim_or_abort(path)
+        try:
+            fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        except FileExistsError as e:
+            # A concurrent importer won the post-reclaim race.
+            raise ImportLockHeldError(
+                f"import lock {path} was re-acquired by a concurrent importer"
+            ) from e
+    with os.fdopen(fd, "w") as f:
+        f.write(
+            f"pid={os.getpid()}\n"
+            f"start={datetime.now(timezone.utc).isoformat()}\n"
+        )
+    return path
+
+
+def release_lock(path: Path) -> None:
+    """Remove the sidecar lock (idempotent)."""
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def open_output_db(db_path: Path) -> DatabaseFactory:
+    """Create/open the output DB with full recorder schema and WAL."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    db = DatabaseFactory(DatabaseSettings(database_url=f"sqlite:///{db_path}"))
+    db.create_tables()
+    # DatabaseFactory's connect listener sets only PRAGMA foreign_keys —
+    # WAL must be issued explicitly (persistent per file; idempotent).
+    with db.engine.connect() as conn:
+        conn.exec_driver_sql("PRAGMA journal_mode=WAL")
+    return db
+
+
+def ensure_parents(db: DatabaseFactory, symbol: str) -> str:
+    """Insert-if-missing synthetic User/BybitAccount/Strategy; returns strategy_id."""
+    strategy_id = strategy_id_for(f"{_IMPORTER_NAME}_{symbol.lower()}")
+    with db.get_session() as session:
+        if session.get(User, IMPORTER_USER_ID) is None:
+            session.add(User(user_id=IMPORTER_USER_ID, username=_IMPORTER_NAME))
+        if session.get(BybitAccount, IMPORTER_ACCOUNT_ID) is None:
+            session.add(
+                BybitAccount(
+                    account_id=IMPORTER_ACCOUNT_ID,
+                    user_id=IMPORTER_USER_ID,
+                    account_name=_IMPORTER_NAME,
+                    environment="mainnet",
+                )
+            )
+        if session.get(Strategy, strategy_id) is None:
+            session.add(
+                Strategy(
+                    strategy_id=strategy_id,
+                    account_id=IMPORTER_ACCOUNT_ID,
+                    strategy_type="GridStrategy",
+                    symbol=symbol,
+                    config_json={"note": "synthetic importer stub"},
+                )
+            )
+    return strategy_id
+
+
+def get_resume_ts(db: DatabaseFactory, symbol: str) -> Optional[datetime]:
+    """Resume cursor: MAX(exchange_ts) already in the output DB."""
+    with db.get_session() as session:
+        return TickerSnapshotRepository(session).get_last_ticker_ts(symbol)
+
+
+def get_min_ts(db: DatabaseFactory, symbol: str) -> Optional[datetime]:
+    """MIN(exchange_ts) in the output DB (prefix-guard input)."""
+    with db.get_session() as session:
+        return (
+            session.query(func.min(TickerSnapshot.exchange_ts))
+            .filter(TickerSnapshot.symbol == symbol)
+            .scalar()
+        )
+
+
+def insert_batch(db: DatabaseFactory, snapshots: List[TickerSnapshot]) -> int:
+    """Insert one batch inside its own session — one commit per batch.
+
+    ``bulk_insert`` only flushes; the commit happens at ``get_session()``
+    exit. A single long session would lose ALL batches on a crash and make
+    the ``get_last_ticker_ts`` resume cursor a lie; per-batch commit bounds
+    crash loss to one uncommitted batch.
+    """
+    with db.get_session() as session:
+        return TickerSnapshotRepository(session).bulk_insert(snapshots)
+
+
+def ensure_run_row(
+    db: DatabaseFactory, symbol: str, source_desc: str
+) -> Optional[str]:
+    """Create-or-update the single synthetic ``recording`` run row.
+
+    ``start_ts``/``end_ts`` always come from the DB-wide
+    MIN/MAX(exchange_ts) — never the session's own min/max, which on
+    append would silently shrink the auto-discovered replay window. Runs
+    unconditionally when the DB holds >= 1 ticker row, healing a run row
+    left truncated by a crash between a committed batch and this step.
+
+    Returns the run_id, or None under the zero-row rule (no ticker rows:
+    ``Run.start_ts`` is nullable=False and replay aborts on an invalid
+    range, so no run row is created).
+    """
+    with db.get_session() as session:
+        min_ts, max_ts = (
+            session.query(
+                func.min(TickerSnapshot.exchange_ts),
+                func.max(TickerSnapshot.exchange_ts),
+            )
+            .filter(TickerSnapshot.symbol == symbol)
+            .one()
+        )
+        if min_ts is None:
+            return None
+        # Never insert a second recording row: get_latest_by_type orders by
+        # start_ts DESC only, so two rows with equal start_ts would make
+        # replay auto-discovery nondeterministic.
+        run = RunRepository(session).get_latest_by_type("recording")
+        if run is None:
+            run = Run(
+                run_id=str(uuid4()),
+                user_id=IMPORTER_USER_ID,
+                account_id=IMPORTER_ACCOUNT_ID,
+                strategy_id=strategy_id_for(f"{_IMPORTER_NAME}_{symbol.lower()}"),
+                run_type="recording",
+                config_snapshot={
+                    "note": "imported from trad_save_history",
+                    "symbol": symbol,
+                    "source": source_desc,
+                },
+                start_ts=min_ts,
+                end_ts=max_ts,
+                status="completed",
+            )
+            session.add(run)
+        else:
+            run.start_ts = min_ts
+            run.end_ts = max_ts
+        return run.run_id

--- a/apps/importer/src/importer/source.py
+++ b/apps/importer/src/importer/source.py
@@ -1,0 +1,48 @@
+"""Source transport protocol + factory (feature 0093)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterator, Optional, Protocol
+
+
+class SourceTransport(Protocol):
+    """Read-only access to the trad_save_history ``ticker_data`` stream.
+
+    ``fetch_batches`` yields bounded batches of row dicts with keys
+    ``id, symbol, timestamp, last_price, mark_price, bid1_price,
+    ask1_price, funding_rate``. Row ``timestamp`` values are ALREADY naive
+    UTC — normalization happens at the transport boundary because the
+    resume skip compares them against a naive SQLite cursor BEFORE the
+    mapping layer runs. ``start``/``end`` bounds are both inclusive
+    (replay's window filter is inclusive, and the default ``--end``
+    resolves to the source MAX probe).
+    """
+
+    def fetch_batches(
+        self, symbol: str, start: datetime, end: datetime
+    ) -> Iterator[list[dict]]:
+        """Yield bounded batches of source rows ordered by (timestamp, id)."""
+        ...
+
+    def probe_range(self, symbol: str) -> Optional[tuple[datetime, datetime]]:
+        """(MIN, MAX) source timestamp for a symbol.
+
+        Returns None when the source is empty for the symbol, or when the
+        transport cannot probe (HTTP contract has no MIN/MAX endpoint —
+        the caller must then require explicit ``--start``/``--end``).
+        """
+        ...
+
+
+def make_source(kind: str, url: str, batch_size: int = 10000) -> SourceTransport:
+    """Construct the transport named by ``--source``."""
+    if kind == "db":
+        from importer.fetch_source_db import DbSource
+
+        return DbSource(url, batch_size=batch_size)
+    if kind == "http":
+        from importer.fetch_source_http import HttpSource
+
+        return HttpSource(url, batch_size=batch_size)
+    raise ValueError(f"unknown source kind: {kind!r}")

--- a/apps/importer/src/importer/validate.py
+++ b/apps/importer/src/importer/validate.py
@@ -1,0 +1,531 @@
+"""Post-import ``--validate`` checks (feature 0093).
+
+1. OHLC cross-check — rebuild 1-minute OHLC from imported ticks for a
+   sampled day and diff vs the source ``klines`` (1m). Buckets are keyed by
+   absolute UTC epoch-minute, so a constant whole-hour tz offset produces
+   imported bucket keys OUTSIDE the kline day (hard key-set fail),
+   independent of any value drift. Minutes with no imported ticks are
+   legitimate (the source writes only on lastPrice change).
+2. Smoke replay — one 4 h window, gs0.5, fresh grid, last_cross against the
+   imported DB via ``python -m replay.main``; metrics must parse non-NaN.
+3. Recorder overlap probe — cross-check overlapping last_price series
+   against a recorder DB when one is supplied and coverage overlaps
+   (informational; skipped with a NOTICE otherwise).
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import re
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from datetime import datetime, time as dt_time, timedelta, timezone
+from decimal import Decimal
+from pathlib import Path
+from typing import List, Optional
+
+import yaml
+from sqlalchemy import DateTime as SaDateTime
+from sqlalchemy import MetaData, Table, func, select
+
+from grid_db.database import DatabaseFactory
+from grid_db.models import TickerSnapshot
+from grid_db.settings import DatabaseSettings
+
+from importer.config import to_naive_utc
+from importer.fetch_source_db import aware_utc
+from importer.fetch_source_http import iso_utc
+
+logger = logging.getLogger(__name__)
+
+# Pinned per-symbol EXCHANGE tick sizes (plan 0093: seed from exchange
+# instrument specs, NOT existing YAMLs — the old LTC YAML 0.1 diverged from
+# the exchange 0.01 and caused the 0090 startup abort).
+TICK_SIZE = {
+    "BTCUSDT": Decimal("0.1"),
+    "ETHUSDT": Decimal("0.01"),
+    "SOLUSDT": Decimal("0.01"),
+    "LTCUSDT": Decimal("0.01"),
+}
+
+_SMOKE_WINDOW = timedelta(hours=4)
+_OVERLAP_WINDOW = timedelta(hours=1)
+_EIGHT_DP = Decimal("0.00000001")
+
+
+def _epoch_minute(ts: datetime) -> int:
+    """Absolute UTC minute key for a naive-UTC timestamp."""
+    return int(ts.replace(tzinfo=timezone.utc).timestamp()) // 60
+
+
+@dataclass
+class OhlcBucket:
+    """One 1-minute OHLC bucket."""
+
+    open: Decimal
+    high: Decimal
+    low: Decimal
+    close: Decimal
+
+
+@dataclass
+class OhlcCheckResult:
+    """Outcome of the OHLC cross-check."""
+
+    passed: bool
+    extra_keys: List[int] = field(default_factory=list)
+    compared: int = 0
+    matched: int = 0
+    mismatched_keys: List[int] = field(default_factory=list)
+
+
+def rebuild_ohlc(
+    ticks: "list[tuple[datetime, Decimal]]",
+) -> dict[int, OhlcBucket]:
+    """Rebuild per-minute OHLC buckets keyed by absolute UTC epoch-minute.
+
+    ``ticks`` must already be ordered by timestamp ascending (open = first
+    tick of the minute, close = last) — ``_load_ticks`` guarantees this.
+    """
+    buckets: dict[int, OhlcBucket] = {}
+    for ts, price in ticks:
+        key = _epoch_minute(ts)
+        bucket = buckets.get(key)
+        if bucket is None:
+            buckets[key] = OhlcBucket(open=price, high=price, low=price, close=price)
+        else:
+            bucket.high = max(bucket.high, price)
+            bucket.low = min(bucket.low, price)
+            bucket.close = price
+    return buckets
+
+
+def compare_ohlc(
+    imported: dict[int, OhlcBucket],
+    klines: dict[int, OhlcBucket],
+    tick_size: Decimal,
+    threshold: float,
+) -> OhlcCheckResult:
+    """Diff imported buckets against source klines.
+
+    Hard-fail (tz detector): any imported bucket key absent from the kline
+    key set — a whole-hour offset shifts imported keys outside the kline
+    range. Kline minutes with no imported bucket are legitimate sparsity.
+
+    Value check, for keys present in both: open/close by exact Decimal
+    equality, high/low within 1 tick_size (intra-minute extremes can be
+    dropped by source batching). Passes when the matching fraction reaches
+    ``threshold``.
+    """
+    extra = sorted(set(imported) - set(klines))
+    if extra:
+        return OhlcCheckResult(passed=False, extra_keys=extra)
+
+    common = sorted(set(imported) & set(klines))
+    matched = 0
+    mismatched: List[int] = []
+    for key in common:
+        imp, ref = imported[key], klines[key]
+        ok = (
+            imp.open == ref.open
+            and imp.close == ref.close
+            and abs(imp.high - ref.high) <= tick_size
+            and abs(imp.low - ref.low) <= tick_size
+        )
+        if ok:
+            matched += 1
+        else:
+            mismatched.append(key)
+    fraction = matched / len(common) if common else 1.0
+    return OhlcCheckResult(
+        passed=fraction >= threshold,
+        compared=len(common),
+        matched=matched,
+        mismatched_keys=mismatched,
+    )
+
+
+def _coerce_kline_ts(value) -> datetime:
+    """Coerce a source kline start value (datetime / ISO string / epoch) to naive UTC."""
+    if isinstance(value, datetime):
+        return to_naive_utc(value)
+    if isinstance(value, str):
+        normalized = value.replace("Z", "+00:00") if value.endswith("Z") else value
+        return to_naive_utc(datetime.fromisoformat(normalized))
+    if isinstance(value, (int, float)):
+        seconds = value / 1000 if value > 1e12 else value
+        return datetime.fromtimestamp(seconds, tz=timezone.utc).replace(tzinfo=None)
+    raise ValueError(f"unsupported kline timestamp type: {type(value)!r}")
+
+
+def _fetch_klines_db(
+    source_url: str, symbol: str, start: datetime, end: datetime
+) -> dict[int, OhlcBucket]:
+    """Fetch 1m klines from the source DB (transport A).
+
+    Reflects the ``klines`` table (issue #232 source schema); expects
+    ``symbol``, a start-time column, and open/high/low/close. Filters an
+    ``interval`` column to 1m values when present.
+    """
+    db = DatabaseFactory(DatabaseSettings(database_url=source_url, read_only=True))
+    with db.get_readonly_session() as session:
+        table = Table("klines", MetaData(), autoload_with=db.engine)
+        cols = table.c
+        ts_col = next(
+            (cols[name] for name in ("start_time", "timestamp", "open_time")
+             if name in cols),
+            None,
+        )
+        if ts_col is None:
+            raise ValueError("klines table has no recognizable start-time column")
+        query = select(
+            ts_col, cols["open"], cols["high"], cols["low"], cols["close"]
+        ).where(cols["symbol"] == symbol)
+        if "interval" in cols:
+            query = query.where(cols["interval"].in_(("1", "1m")))
+        # Push the day window into SQL when the start-time column is a real
+        # datetime — fetching a symbol's full kline history for one sampled
+        # day is needlessly heavy. Epoch-integer columns fall back to the
+        # Python-side range filter below.
+        if isinstance(ts_col.type, SaDateTime):
+            query = query.where(
+                ts_col >= aware_utc(start), ts_col <= aware_utc(end)
+            )
+        rows = session.execute(query).all()
+
+    result: dict[int, OhlcBucket] = {}
+    for ts_value, o, h, lo, c in rows:
+        ts = _coerce_kline_ts(ts_value)
+        if not (start <= ts <= end):
+            continue
+        result[_epoch_minute(ts)] = OhlcBucket(
+            open=Decimal(str(o)).quantize(_EIGHT_DP),
+            high=Decimal(str(h)).quantize(_EIGHT_DP),
+            low=Decimal(str(lo)).quantize(_EIGHT_DP),
+            close=Decimal(str(c)).quantize(_EIGHT_DP),
+        )
+    return result
+
+
+def _fetch_klines_http(
+    base_url: str, symbol: str, start: datetime, end: datetime
+) -> dict[int, OhlcBucket]:
+    """Fetch 1m klines via ``GET {base}/klines?symbol&start&end`` (transport B)."""
+    import requests
+
+    response = requests.get(
+        f"{base_url.rstrip('/')}/klines",
+        params={
+            # Same Z-suffixed ISO format the ticker transport sends.
+            "symbol": symbol,
+            "start": iso_utc(start),
+            "end": iso_utc(end),
+        },
+        timeout=30,
+    )
+    response.raise_for_status()
+    result: dict[int, OhlcBucket] = {}
+    for row in response.json().get("rows") or []:
+        ts = _coerce_kline_ts(row["start_time"])
+        if not (start <= ts <= end):
+            continue
+        result[_epoch_minute(ts)] = OhlcBucket(
+            open=Decimal(str(row["open"])).quantize(_EIGHT_DP),
+            high=Decimal(str(row["high"])).quantize(_EIGHT_DP),
+            low=Decimal(str(row["low"])).quantize(_EIGHT_DP),
+            close=Decimal(str(row["close"])).quantize(_EIGHT_DP),
+        )
+    return result
+
+
+def _pick_sample_day(db: DatabaseFactory, symbol: str, midpoint: datetime):
+    """Pick the tick-bearing UTC day nearest the range midpoint.
+
+    The midpoint calendar day itself can be empty (collector outage) —
+    sampling the nearest NON-EMPTY day keeps ``--validate`` meaningful
+    instead of hard-failing on a gap. Returns None when the symbol has no
+    ticks at all.
+    """
+    with db.get_session() as session:
+        day_rows = (
+            session.query(func.date(TickerSnapshot.exchange_ts))
+            .filter(TickerSnapshot.symbol == symbol)
+            .distinct()
+            .all()
+        )
+    days = sorted(
+        datetime.strptime(value, "%Y-%m-%d").date() for (value,) in day_rows
+    )
+    if not days:
+        return None
+    target = midpoint.date()
+    return min(days, key=lambda d: abs(d - target))
+
+
+def _load_ticks(
+    db: DatabaseFactory, symbol: str, start: datetime, end: datetime
+) -> List[tuple[datetime, Decimal]]:
+    """Load (exchange_ts, last_price) ticks in [start, end] ordered by ts."""
+    with db.get_session() as session:
+        rows = (
+            session.query(TickerSnapshot.exchange_ts, TickerSnapshot.last_price)
+            .filter(
+                TickerSnapshot.symbol == symbol,
+                TickerSnapshot.exchange_ts >= start,
+                TickerSnapshot.exchange_ts <= end,
+            )
+            .order_by(TickerSnapshot.exchange_ts)
+            .all()
+        )
+    return [(ts, Decimal(str(price)).quantize(_EIGHT_DP)) for ts, price in rows]
+
+
+def check_ohlc(
+    db: DatabaseFactory,
+    symbol: str,
+    source_kind: str,
+    source_url: str,
+    bounds: tuple[datetime, datetime],
+    threshold: float,
+) -> bool:
+    """OHLC cross-check on a sampled day (the middle day of the import)."""
+    tick_size = TICK_SIZE.get(symbol)
+    if tick_size is None:
+        logger.error(
+            "no pinned tick_size for %s — extend importer.validate.TICK_SIZE "
+            "from the EXCHANGE instrument spec",
+            symbol,
+        )
+        return False
+
+    min_ts, max_ts = bounds
+    sample_day = _pick_sample_day(db, symbol, min_ts + (max_ts - min_ts) / 2)
+    if sample_day is None:
+        logger.error("OHLC check: no imported ticks for %s", symbol)
+        return False
+    day_start = datetime.combine(sample_day, dt_time.min)
+    day_end = day_start + timedelta(days=1) - timedelta(microseconds=1)
+
+    ticks = _load_ticks(db, symbol, day_start, day_end)
+    if not ticks:
+        logger.error("OHLC check: no imported ticks on sampled day %s", sample_day)
+        return False
+    imported = rebuild_ohlc(ticks)
+
+    try:
+        if source_kind == "db":
+            klines = _fetch_klines_db(source_url, symbol, day_start, day_end)
+        else:
+            klines = _fetch_klines_http(source_url, symbol, day_start, day_end)
+    except Exception as e:
+        logger.error("OHLC check: failed to fetch source klines: %s", e)
+        return False
+    if not klines:
+        logger.error(
+            "OHLC check: source has no 1m klines for %s on %s", symbol, sample_day
+        )
+        return False
+
+    result = compare_ohlc(imported, klines, tick_size, threshold)
+    if result.extra_keys:
+        logger.error(
+            "OHLC check FAILED (key-set mismatch — likely tz offset): %d "
+            "imported bucket keys absent from source klines, e.g. %s",
+            len(result.extra_keys),
+            result.extra_keys[:5],
+        )
+        return False
+    logger.info(
+        "OHLC check %s: %d/%d buckets exact on %s (threshold %.2f)",
+        "PASSED" if result.passed else "FAILED",
+        result.matched,
+        result.compared,
+        sample_day,
+        threshold,
+    )
+    if result.mismatched_keys:
+        logger.info("  mismatching buckets: %s", result.mismatched_keys[:20])
+    return result.passed
+
+
+def smoke_replay(
+    db_path: Path, symbol: str, bounds: tuple[datetime, datetime]
+) -> bool:
+    """One 4 h fresh-grid last_cross replay against the imported DB.
+
+    Replay exposes no console script — invoked via ``python -m
+    replay.main``. The rendered config pins the per-symbol exchange
+    tick_size so replay's instrument-info path needs no live fetch.
+    """
+    tick_size = TICK_SIZE.get(symbol)
+    if tick_size is None:
+        logger.error("no pinned tick_size for %s — smoke replay skipped", symbol)
+        return False
+
+    min_ts, max_ts = bounds
+    window_start = max(min_ts, max_ts - _SMOKE_WINDOW)
+    template_path = Path(__file__).resolve().parents[2] / "conf" / "smoke_replay.yaml"
+    with open(template_path) as f:
+        config = yaml.safe_load(f)
+
+    config["database_url"] = f"sqlite:///{db_path}"
+    config["symbol"] = symbol
+    config["start_ts"] = window_start.isoformat()
+    config["end_ts"] = max_ts.isoformat()
+    config["strategy"]["tick_size"] = str(tick_size)
+
+    with tempfile.TemporaryDirectory(prefix="importer_smoke_") as tmp_dir:
+        config["output_dir"] = str(Path(tmp_dir) / "results")
+        rendered = Path(tmp_dir) / "smoke_replay.yaml"
+        rendered.write_text(yaml.safe_dump(config))
+        proc = subprocess.run(
+            [sys.executable, "-m", "replay.main", "--config", str(rendered)],
+            capture_output=True,
+            text=True,
+        )
+    if proc.returncode != 0:
+        logger.error(
+            "smoke replay FAILED (exit %d):\n%s",
+            proc.returncode,
+            (proc.stderr or proc.stdout)[-2000:],
+        )
+        return False
+    # "Metrics parse and are non-NaN": a zero exit alone is not enough —
+    # require the summary's Net PnL line to exist and parse to a finite
+    # float, plus a blanket NaN scan over the remaining metrics.
+    match = re.search(r"Net PnL:\s*(\S+)", proc.stdout)
+    if match is None:
+        logger.error("smoke replay FAILED: no 'Net PnL' metric in replay output")
+        return False
+    try:
+        net_pnl = float(match.group(1))
+    except ValueError:
+        logger.error(
+            "smoke replay FAILED: unparsable Net PnL %r", match.group(1)
+        )
+        return False
+    if not math.isfinite(net_pnl) or "nan" in proc.stdout.lower():
+        logger.error("smoke replay FAILED: non-finite metric in replay summary")
+        return False
+    logger.info(
+        "smoke replay PASSED (%s -> %s, Net PnL %.2f)",
+        window_start,
+        max_ts,
+        net_pnl,
+    )
+    return True
+
+
+def recorder_overlap_probe(
+    db: DatabaseFactory,
+    symbol: str,
+    bounds: tuple[datetime, datetime],
+    recorder_db: Optional[str],
+) -> bool:
+    """Cross-check 1 h of overlapping last_price series vs a recorder DB.
+
+    Informational fidelity probe of the collector itself: reports max abs
+    diff (imported tick vs recorder last_price at-or-before it) and row
+    counts. Skipped with a NOTICE when no recorder DB is supplied or
+    coverage does not overlap. Never gates the import.
+    """
+    if recorder_db is None:
+        logger.info(
+            "NOTICE: recorder overlap probe skipped (no --recorder-db supplied)"
+        )
+        return True
+    url = (
+        recorder_db
+        if recorder_db.startswith(("sqlite:", "postgresql:"))
+        else f"sqlite:///{recorder_db}"
+    )
+    rec = DatabaseFactory(DatabaseSettings(database_url=url, read_only=True))
+    with rec.get_readonly_session() as session:
+        rec_min = (
+            session.query(TickerSnapshot.exchange_ts)
+            .filter(TickerSnapshot.symbol == symbol)
+            .order_by(TickerSnapshot.exchange_ts)
+            .first()
+        )
+        rec_max = (
+            session.query(TickerSnapshot.exchange_ts)
+            .filter(TickerSnapshot.symbol == symbol)
+            .order_by(TickerSnapshot.exchange_ts.desc())
+            .first()
+        )
+        if rec_min is None or rec_max is None:
+            logger.info(
+                "NOTICE: recorder overlap probe skipped (recorder has no %s)",
+                symbol,
+            )
+            return True
+        overlap_start = max(bounds[0], rec_min[0])
+        overlap_end = min(bounds[1], rec_max[0])
+        if overlap_start >= overlap_end:
+            logger.info("NOTICE: recorder overlap probe skipped (no overlap)")
+            return True
+        window_start = max(overlap_start, overlap_end - _OVERLAP_WINDOW)
+        rec_rows = (
+            session.query(TickerSnapshot.exchange_ts, TickerSnapshot.last_price)
+            .filter(
+                TickerSnapshot.symbol == symbol,
+                TickerSnapshot.exchange_ts >= window_start,
+                TickerSnapshot.exchange_ts <= overlap_end,
+            )
+            .order_by(TickerSnapshot.exchange_ts)
+            .all()
+        )
+
+    imported_rows = _load_ticks(db, symbol, window_start, overlap_end)
+    if not rec_rows or not imported_rows:
+        logger.info("NOTICE: recorder overlap probe skipped (empty window)")
+        return True
+
+    max_diff = Decimal("0")
+    idx = -1
+    for ts, price in imported_rows:
+        while idx + 1 < len(rec_rows) and rec_rows[idx + 1][0] <= ts:
+            idx += 1
+        if idx < 0:
+            continue
+        diff = abs(price - Decimal(str(rec_rows[idx][1])))
+        max_diff = max(max_diff, diff)
+    logger.info(
+        "recorder overlap probe (%s -> %s): max abs last_price diff %s, "
+        "imported rows %d vs recorder rows %d",
+        window_start,
+        overlap_end,
+        max_diff,
+        len(imported_rows),
+        len(rec_rows),
+    )
+    return True
+
+
+def run_validation(
+    db: DatabaseFactory,
+    db_path: Path,
+    symbol: str,
+    source_kind: str,
+    source_url: str,
+    bounds: tuple[datetime, datetime],
+    ohlc_threshold: float,
+    recorder_db: Optional[str],
+) -> bool:
+    """Run the three ``--validate`` checks for one imported symbol.
+
+    The OHLC cross-check and smoke replay gate the result; the recorder
+    overlap probe is informational only.
+
+    Returns:
+        True only when both gating checks pass.
+    """
+    ohlc_ok = check_ohlc(
+        db, symbol, source_kind, source_url, bounds, ohlc_threshold
+    )
+    smoke_ok = smoke_replay(db_path, symbol, bounds)
+    recorder_overlap_probe(db, symbol, bounds, recorder_db)
+    return ohlc_ok and smoke_ok

--- a/apps/importer/tests/conftest.py
+++ b/apps/importer/tests/conftest.py
@@ -1,0 +1,60 @@
+"""Shared fixtures for importer tests (hermetic — no network, no real Bybit).
+
+Helpers are exposed as fixtures returning callables — pytest runs with
+``--import-mode=importlib``, so ``from conftest import ...`` is not
+available (matches the repo-wide convention).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+
+from importer.fetch_source_db import ticker_data
+
+
+def _src_row(
+    row_id: int,
+    ts: datetime,
+    symbol: str = "BTCUSDT",
+    last_price: float | None = 100.0,
+    **overrides,
+) -> dict:
+    """Build one synthetic source ticker_data row."""
+    row = {
+        "id": row_id,
+        "symbol": symbol,
+        "timestamp": ts,
+        "last_price": last_price,
+        "mark_price": last_price,
+        "bid1_price": last_price,
+        "ask1_price": last_price,
+        "funding_rate": 0.0001,
+    }
+    row.update(overrides)
+    return row
+
+
+def _seed_source_db(path: Path, rows: list[dict]) -> None:
+    """Create/extend a synthetic sqlite source DB with ticker_data rows."""
+    engine = create_engine(f"sqlite:///{path}")
+    ticker_data.metadata.create_all(engine)
+    if rows:
+        with engine.begin() as conn:
+            conn.execute(ticker_data.insert(), rows)
+    engine.dispose()
+
+
+@pytest.fixture
+def src_row():
+    """Row-builder callable for synthetic source rows."""
+    return _src_row
+
+
+@pytest.fixture
+def seed_source_db():
+    """Callable that seeds a synthetic sqlite source DB file."""
+    return _seed_source_db

--- a/apps/importer/tests/test_config.py
+++ b/apps/importer/tests/test_config.py
@@ -1,0 +1,81 @@
+"""Tests for importer CLI parsing and datetime discipline (feature 0093)."""
+
+from datetime import datetime
+
+import pytest
+
+from importer.config import build_parser, parse_utc, to_naive_utc
+
+_BASE_ARGS = [
+    "--source", "db",
+    "--source-url", "sqlite:///src.db",
+]
+
+
+class TestConfig:
+    def test_symbols_required(self):
+        """Parser rejects an invocation without --symbols."""
+        with pytest.raises(SystemExit):
+            build_parser().parse_args(_BASE_ARGS)
+
+    def test_symbols_parsed_and_uppercased(self):
+        """Comma-separated symbols are split, stripped and uppercased."""
+        args = build_parser().parse_args(
+            _BASE_ARGS + ["--symbols", "btcusdt, ethusdt"]
+        )
+        assert args.symbols == ["BTCUSDT", "ETHUSDT"]
+
+    def test_source_choice_validated(self):
+        """--source outside {db,http} is rejected."""
+        with pytest.raises(SystemExit):
+            build_parser().parse_args(
+                ["--source", "ftp", "--source-url", "x", "--symbols", "BTCUSDT"]
+            )
+
+    def test_naive_iso_parsed_as_utc(self):
+        """Naive ISO input is taken as UTC unchanged."""
+        assert parse_utc("2026-07-01T12:30:00") == datetime(2026, 7, 1, 12, 30)
+
+    def test_z_suffix_converted_to_naive(self):
+        """Aware ...Z input is converted to UTC and returned naive."""
+        result = parse_utc("2026-07-01T12:30:00Z")
+        assert result == datetime(2026, 7, 1, 12, 30)
+        assert result.tzinfo is None
+
+    def test_offset_converted_to_naive_utc(self):
+        """+05:00 input shifts to UTC and strips tzinfo (TypeError hazard)."""
+        result = parse_utc("2026-07-01T12:30:00+05:00")
+        assert result == datetime(2026, 7, 1, 7, 30)
+        assert result.tzinfo is None
+
+    def test_invalid_datetime_rejected(self):
+        """Garbage datetime input fails argparse validation."""
+        with pytest.raises(SystemExit):
+            build_parser().parse_args(
+                _BASE_ARGS + ["--symbols", "BTCUSDT", "--start", "not-a-date"]
+            )
+
+    def test_to_naive_utc_passthrough(self):
+        """Naive datetimes pass through to_naive_utc unchanged."""
+        dt = datetime(2026, 7, 1, 12, 0)
+        assert to_naive_utc(dt) is dt
+
+    def test_batch_size_must_be_positive(self):
+        """--batch-size 0 / negative are rejected (LIMIT 0/-1 footguns)."""
+        for bad in ("0", "-1"):
+            with pytest.raises(SystemExit):
+                build_parser().parse_args(
+                    _BASE_ARGS + ["--symbols", "BTCUSDT", "--batch-size", bad]
+                )
+
+    def test_ohlc_threshold_must_be_unit_fraction(self):
+        """--ohlc-threshold outside (0, 1] is rejected."""
+        for bad in ("0", "-0.5", "1.5"):
+            with pytest.raises(SystemExit):
+                build_parser().parse_args(
+                    _BASE_ARGS + ["--symbols", "BTCUSDT", "--ohlc-threshold", bad]
+                )
+        args = build_parser().parse_args(
+            _BASE_ARGS + ["--symbols", "BTCUSDT", "--ohlc-threshold", "0.9"]
+        )
+        assert args.ohlc_threshold == 0.9

--- a/apps/importer/tests/test_density.py
+++ b/apps/importer/tests/test_density.py
@@ -1,0 +1,90 @@
+"""Tests for the per-day density report — feature 0093."""
+
+from datetime import datetime, timedelta
+from decimal import Decimal
+
+from grid_db.models import TickerSnapshot
+
+from importer.density import compute_density, log_density_report
+from importer.output_db import insert_batch, open_output_db
+
+_T0 = datetime(2026, 7, 1, 0, 0, 0)
+
+
+def _snapshot(ts: datetime) -> TickerSnapshot:
+    price = Decimal("100.00000000")
+    return TickerSnapshot(
+        symbol="BTCUSDT",
+        exchange_ts=ts,
+        local_ts=ts,
+        last_price=price,
+        mark_price=price,
+        bid1_price=price,
+        ask1_price=price,
+        funding_rate=Decimal("0"),
+    )
+
+
+def _seed(tmp_path, timestamps):
+    db = open_output_db(tmp_path / "out.db")
+    insert_batch(db, [_snapshot(ts) for ts in timestamps])
+    return db
+
+
+class TestDensity:
+    def test_per_day_counts(self, tmp_path):
+        """Ticks are counted per UTC day."""
+        db = _seed(
+            tmp_path,
+            [_T0, _T0 + timedelta(seconds=1), _T0 + timedelta(days=1)],
+        )
+        days = compute_density(db, "BTCUSDT")
+        assert [(d.day.isoformat(), d.tick_count) for d in days] == [
+            ("2026-07-01", 2),
+            ("2026-07-02", 1),
+        ]
+
+    def test_gap_detection_over_60s(self, tmp_path):
+        """Consecutive deltas > 60 s are reported as gaps; <= 60 s are not."""
+        db = _seed(
+            tmp_path,
+            [
+                _T0,
+                _T0 + timedelta(seconds=60),  # exactly 60 -> not a gap
+                _T0 + timedelta(seconds=121),  # 61 s -> gap
+            ],
+        )
+        (day,) = compute_density(db, "BTCUSDT")
+        assert day.gaps == [
+            (_T0 + timedelta(seconds=60), _T0 + timedelta(seconds=121))
+        ]
+
+    def test_low_density_flag(self, tmp_path):
+        """A day under 0.5 ticks/s over its covered span is LOW-DENSITY."""
+        sparse = _seed(tmp_path, [_T0, _T0 + timedelta(seconds=1000)])
+        (day,) = compute_density(sparse, "BTCUSDT")
+        assert day.ticks_per_second < 0.5
+        assert day.low_density
+
+    def test_dense_day_not_flagged(self, tmp_path):
+        """A day at >= 0.5 ticks/s is not flagged."""
+        ticks = [_T0 + timedelta(seconds=i) for i in range(100)]
+        db = _seed(tmp_path, ticks)
+        (day,) = compute_density(db, "BTCUSDT")
+        assert day.ticks_per_second >= 0.5
+        assert not day.low_density
+
+    def test_report_returns_low_density_presence(self, tmp_path, caplog):
+        """log_density_report returns True and warns when a low day exists."""
+        import logging
+
+        db = _seed(tmp_path, [_T0, _T0 + timedelta(seconds=1000)])
+        days = compute_density(db, "BTCUSDT")
+        with caplog.at_level(logging.INFO):
+            assert log_density_report("BTCUSDT", days) is True
+        assert any("LOW-DENSITY" in r.message for r in caplog.records)
+
+    def test_empty_db(self, tmp_path):
+        """No rows -> empty report."""
+        db = open_output_db(tmp_path / "out.db")
+        assert compute_density(db, "BTCUSDT") == []

--- a/apps/importer/tests/test_fetch_db.py
+++ b/apps/importer/tests/test_fetch_db.py
@@ -1,0 +1,131 @@
+"""Tests for transport A (direct-DB keyset pagination) — feature 0093."""
+
+from datetime import datetime, timedelta, timezone
+
+from importer.fetch_source_db import DbSource, aware_utc
+
+_T0 = datetime(2026, 7, 1, 0, 0, 0)
+
+# NOTE on the plan's "tz-aware source timestamps yielded naive UTC" case:
+# SQLite cannot round-trip aware datetimes (the bind formatter drops
+# tzinfo), so the Postgres timestamptz->naive path cannot be exercised
+# against a sqlite fixture. The conversion itself (to_naive_utc) is
+# unit-tested in test_config.py, the HTTP transport's aware path in
+# test_fetch_http.py, and the window-bind side in TestAwareUtcBinds below.
+
+
+class TestDbSource:
+    def test_composite_keyset_pagination(self, tmp_path, seed_source_db, src_row):
+        """Duplicate timestamps straddling a page boundary neither loop nor drop rows."""
+        path = tmp_path / "source.db"
+        # ids 1..5; ids 2,3,4 share one timestamp; batch_size=2 forces a
+        # page boundary inside the duplicate group.
+        rows = [
+            src_row(1, _T0),
+            src_row(2, _T0 + timedelta(seconds=1), last_price=101.0),
+            src_row(3, _T0 + timedelta(seconds=1), last_price=102.0),
+            src_row(4, _T0 + timedelta(seconds=1), last_price=103.0),
+            src_row(5, _T0 + timedelta(seconds=2)),
+        ]
+        seed_source_db(path, rows)
+        source = DbSource(f"sqlite:///{path}", batch_size=2)
+        fetched = [
+            r
+            for batch in source.fetch_batches(
+                "BTCUSDT", _T0, _T0 + timedelta(minutes=1)
+            )
+            for r in batch
+        ]
+        assert [r["id"] for r in fetched] == [1, 2, 3, 4, 5]
+
+    def test_bounds_inclusive(self, tmp_path, seed_source_db, src_row):
+        """Both start and end bounds are inclusive."""
+        path = tmp_path / "source.db"
+        rows = [src_row(i, _T0 + timedelta(seconds=i)) for i in range(5)]
+        seed_source_db(path, rows)
+        source = DbSource(f"sqlite:///{path}", batch_size=10)
+        fetched = [
+            r
+            for batch in source.fetch_batches(
+                "BTCUSDT", _T0 + timedelta(seconds=1), _T0 + timedelta(seconds=3)
+            )
+            for r in batch
+        ]
+        assert [r["id"] for r in fetched] == [1, 2, 3]
+
+    def test_timestamps_yielded_naive(self, tmp_path, seed_source_db, src_row):
+        """Yielded row timestamps are naive UTC (transport-boundary rule)."""
+        path = tmp_path / "source.db"
+        seed_source_db(path, [src_row(1, _T0)])
+        source = DbSource(f"sqlite:///{path}")
+        (batch,) = list(
+            source.fetch_batches("BTCUSDT", _T0, _T0 + timedelta(minutes=1))
+        )
+        assert batch[0]["timestamp"] == _T0
+        assert batch[0]["timestamp"].tzinfo is None
+
+    def test_symbol_filter(self, tmp_path, seed_source_db, src_row):
+        """Only rows for the requested symbol are yielded."""
+        path = tmp_path / "source.db"
+        seed_source_db(
+            path,
+            [src_row(1, _T0), src_row(2, _T0, symbol="ETHUSDT")],
+        )
+        source = DbSource(f"sqlite:///{path}")
+        fetched = [
+            r
+            for batch in source.fetch_batches(
+                "ETHUSDT", _T0, _T0 + timedelta(minutes=1)
+            )
+            for r in batch
+        ]
+        assert [r["id"] for r in fetched] == [2]
+
+    def test_probe_range(self, tmp_path, seed_source_db, src_row):
+        """probe_range returns naive (MIN, MAX); None for an absent symbol."""
+        path = tmp_path / "source.db"
+        rows = [src_row(i, _T0 + timedelta(minutes=i)) for i in range(3)]
+        seed_source_db(path, rows)
+        source = DbSource(f"sqlite:///{path}")
+        probed = source.probe_range("BTCUSDT")
+        assert probed == (_T0, _T0 + timedelta(minutes=2))
+        assert probed[0].tzinfo is None and probed[1].tzinfo is None
+        assert source.probe_range("ETHUSDT") is None
+
+    def test_resume_comparison_no_typeerror(self, tmp_path, seed_source_db, src_row):
+        """Yielded timestamps compare cleanly against a naive SQLite cursor."""
+        path = tmp_path / "source.db"
+        seed_source_db(
+            path, [src_row(1, _T0), src_row(2, _T0 + timedelta(seconds=5))]
+        )
+        source = DbSource(f"sqlite:///{path}")
+        resume_from = _T0  # what get_last_ticker_ts returns: naive
+        kept = [
+            r
+            for batch in source.fetch_batches(
+                "BTCUSDT", _T0, _T0 + timedelta(minutes=1)
+            )
+            for r in batch
+            if r["timestamp"] > resume_from
+        ]
+        assert [r["id"] for r in kept] == [2]
+
+    def test_source_opened_read_only(self, tmp_path, seed_source_db):
+        """The source engine settings request read-only mode for SQLite."""
+        path = tmp_path / "source.db"
+        seed_source_db(path, [])
+        source = DbSource(f"sqlite:///{path}")
+        assert source._db.settings.read_only is True
+
+
+class TestAwareUtcBinds:
+    def test_naive_bound_becomes_aware_utc(self):
+        """Window bounds bind aware UTC (session-tz hazard on timestamptz)."""
+        bound = aware_utc(_T0)
+        assert bound.tzinfo == timezone.utc
+        assert bound.replace(tzinfo=None) == _T0
+
+    def test_aware_bound_passthrough(self):
+        """Already-aware bounds pass through unchanged."""
+        aware = _T0.replace(tzinfo=timezone.utc)
+        assert aware_utc(aware) is aware

--- a/apps/importer/tests/test_fetch_http.py
+++ b/apps/importer/tests/test_fetch_http.py
@@ -1,0 +1,180 @@
+"""Tests for transport B (HTTP cursor pagination, retry/backoff) — feature 0093."""
+
+from datetime import datetime
+
+import pytest
+import requests
+
+from importer.fetch_source_http import HttpSource, HttpSourceError
+
+_T0 = datetime(2026, 7, 1, 0, 0, 0)
+_T1 = datetime(2026, 7, 1, 1, 0, 0)
+
+
+def _http_row(row_id: int, ts_iso: str, price: float = 100.0) -> dict:
+    return {
+        "id": row_id,
+        "symbol": "BTCUSDT",
+        "timestamp": ts_iso,
+        "last_price": price,
+        "mark_price": price,
+        "bid1_price": price,
+        "ask1_price": price,
+        "funding_rate": 0.0001,
+    }
+
+
+class FakeResponse:
+    def __init__(self, status_code: int, payload: dict | None = None, text: str = ""):
+        self.status_code = status_code
+        self._payload = payload or {}
+        self.text = text
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class FakeSession:
+    """Scripted requests.Session stand-in; records every call's params."""
+
+    def __init__(self, script: list):
+        self._script = list(script)
+        self.calls: list[dict] = []
+
+    def get(self, url, params=None, timeout=None):
+        self.calls.append(dict(params))
+        item = self._script.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+
+@pytest.fixture(autouse=True)
+def no_sleep(monkeypatch):
+    """Backoff sleeps are a no-op in tests."""
+    monkeypatch.setattr("importer.fetch_source_http.time.sleep", lambda s: None)
+
+
+class TestHttpSource:
+    def test_pagination_follows_next_cursor(self):
+        """Batches follow next_cursor to exhaustion."""
+        session = FakeSession(
+            [
+                FakeResponse(
+                    200,
+                    {
+                        "rows": [_http_row(1, "2026-07-01T00:00:00Z")],
+                        "next_cursor": "c1",
+                    },
+                ),
+                FakeResponse(
+                    200,
+                    {
+                        "rows": [_http_row(2, "2026-07-01T00:00:01Z")],
+                        "next_cursor": None,
+                    },
+                ),
+            ]
+        )
+        source = HttpSource("http://src", session=session)
+        batches = list(source.fetch_batches("BTCUSDT", _T0, _T1))
+        assert [r["id"] for b in batches for r in b] == [1, 2]
+        assert "cursor" not in session.calls[0]
+        assert session.calls[1]["cursor"] == "c1"
+
+    def test_timestamps_yielded_naive_utc(self):
+        """ISO-8601 Z timestamps are converted to naive UTC at the boundary."""
+        session = FakeSession(
+            [
+                FakeResponse(
+                    200,
+                    {
+                        "rows": [_http_row(1, "2026-07-01T00:00:00Z")],
+                        "next_cursor": None,
+                    },
+                )
+            ]
+        )
+        source = HttpSource("http://src", session=session)
+        (batch,) = list(source.fetch_batches("BTCUSDT", _T0, _T1))
+        assert batch[0]["timestamp"] == _T0
+        assert batch[0]["timestamp"].tzinfo is None
+
+    def test_retry_on_429_re_requests_same_cursor(self):
+        """429 retries re-request the identical cursor (no skipped rows)."""
+        ok = FakeResponse(
+            200,
+            {"rows": [_http_row(1, "2026-07-01T00:00:00Z")], "next_cursor": None},
+        )
+        session = FakeSession([FakeResponse(429), ok])
+        source = HttpSource("http://src", session=session)
+        batches = list(source.fetch_batches("BTCUSDT", _T0, _T1))
+        assert len(batches) == 1
+        assert session.calls[0] == session.calls[1]
+
+    def test_retry_on_5xx_and_connection_error(self):
+        """503 and connection errors are retried with the same params."""
+        ok = FakeResponse(200, {"rows": [], "next_cursor": None})
+        session = FakeSession(
+            [FakeResponse(503), requests.ConnectionError("boom"), ok]
+        )
+        source = HttpSource("http://src", session=session)
+        assert list(source.fetch_batches("BTCUSDT", _T0, _T1)) == []
+        assert session.calls[0] == session.calls[1] == session.calls[2]
+
+    def test_non_retryable_4xx_aborts(self):
+        """A 404 aborts immediately with the body logged."""
+        session = FakeSession([FakeResponse(404, text="not found")])
+        source = HttpSource("http://src", session=session)
+        with pytest.raises(HttpSourceError, match="non-retryable HTTP 404"):
+            list(source.fetch_batches("BTCUSDT", _T0, _T1))
+        assert len(session.calls) == 1
+
+    def test_exhausted_retries_abort(self):
+        """Five consecutive retryable failures give up with an error."""
+        session = FakeSession([FakeResponse(500)] * 5)
+        source = HttpSource("http://src", session=session)
+        with pytest.raises(HttpSourceError, match="after 5 attempts"):
+            list(source.fetch_batches("BTCUSDT", _T0, _T1))
+        assert len(session.calls) == 5
+
+    def test_empty_rows_with_truthy_cursor_terminates(self):
+        """An empty rows page ends pagination even with a (buggy) cursor."""
+        session = FakeSession(
+            [FakeResponse(200, {"rows": [], "next_cursor": "c-loop"})]
+        )
+        source = HttpSource("http://src", session=session)
+        assert list(source.fetch_batches("BTCUSDT", _T0, _T1)) == []
+        assert len(session.calls) == 1
+
+    def test_empty_string_cursor_terminates(self):
+        """A falsy (empty-string) next_cursor ends pagination instead of spinning."""
+        session = FakeSession(
+            [
+                FakeResponse(
+                    200,
+                    {
+                        "rows": [_http_row(1, "2026-07-01T00:00:00Z")],
+                        "next_cursor": "",
+                    },
+                )
+            ]
+        )
+        source = HttpSource("http://src", session=session)
+        batches = list(source.fetch_batches("BTCUSDT", _T0, _T1))
+        assert len(batches) == 1
+        assert len(session.calls) == 1
+
+    def test_probe_range_unsupported(self):
+        """The HTTP contract has no MIN/MAX probe."""
+        assert HttpSource("http://src", session=FakeSession([])).probe_range(
+            "BTCUSDT"
+        ) is None
+
+    def test_request_window_is_iso_z(self):
+        """start/end are sent as ISO-8601 UTC with Z suffix."""
+        session = FakeSession([FakeResponse(200, {"rows": [], "next_cursor": None})])
+        source = HttpSource("http://src", session=session)
+        list(source.fetch_batches("BTCUSDT", _T0, _T1))
+        assert session.calls[0]["start"] == "2026-07-01T00:00:00Z"
+        assert session.calls[0]["end"] == "2026-07-01T01:00:00Z"

--- a/apps/importer/tests/test_mapping.py
+++ b/apps/importer/tests/test_mapping.py
@@ -1,0 +1,78 @@
+"""Tests for source-row -> TickerSnapshot mapping (feature 0093)."""
+
+from datetime import datetime
+from decimal import Decimal
+
+from importer.mapping import FallbackCounters, map_row
+
+_TS = datetime(2026, 7, 1, 12, 0, 0)
+
+
+def _row(**overrides) -> dict:
+    row = {
+        "id": 1,
+        "symbol": "BTCUSDT",
+        "timestamp": _TS,
+        "last_price": 65000.1,
+        "mark_price": 65000.2,
+        "bid1_price": 65000.0,
+        "ask1_price": 65000.3,
+        "funding_rate": 0.0001,
+    }
+    row.update(overrides)
+    return row
+
+
+class TestMapping:
+    def test_float_to_decimal_8dp(self):
+        """Floats cross the boundary as Decimal(str(x)) quantized to 8dp."""
+        counters = FallbackCounters()
+        snap = map_row(_row(last_price=0.1), counters)
+        assert snap.last_price == Decimal("0.10000000")
+        assert snap.funding_rate == Decimal("0.00010000")
+        assert counters.as_dict() == {
+            "skipped_null_last_price": 0,
+            "mark_price_fallback": 0,
+            "bid1_price_fallback": 0,
+            "ask1_price_fallback": 0,
+            "funding_rate_fallback": 0,
+        }
+
+    def test_local_ts_mirrors_exchange_ts(self):
+        """No recv-ts on source: local_ts equals exchange_ts."""
+        snap = map_row(_row(), FallbackCounters())
+        assert snap.exchange_ts == _TS
+        assert snap.local_ts == _TS
+
+    def test_null_mark_falls_back_to_last(self):
+        """NULL mark_price -> last_price fallback + counter increment."""
+        counters = FallbackCounters()
+        snap = map_row(_row(mark_price=None), counters)
+        assert snap.mark_price == snap.last_price
+        assert counters.mark_price_fallback == 1
+
+    def test_null_bid_ask_fall_back_to_last(self):
+        """NULL bid1/ask1 -> last_price fallback + counter increments."""
+        counters = FallbackCounters()
+        snap = map_row(_row(bid1_price=None, ask1_price=None), counters)
+        assert snap.bid1_price == snap.last_price
+        assert snap.ask1_price == snap.last_price
+        assert counters.bid1_price_fallback == 1
+        assert counters.ask1_price_fallback == 1
+
+    def test_null_funding_falls_back_to_zero(self):
+        """NULL funding_rate -> 0 + counter increment."""
+        counters = FallbackCounters()
+        snap = map_row(_row(funding_rate=None), counters)
+        assert snap.funding_rate == Decimal("0")
+        assert counters.funding_rate_fallback == 1
+
+    def test_null_last_price_row_skipped(self):
+        """NULL last_price row is skipped (never inserted) and counted."""
+        counters = FallbackCounters()
+        assert map_row(_row(last_price=None), counters) is None
+        assert counters.skipped_null_last_price == 1
+
+    def test_raw_json_is_null(self):
+        """No audit payload on source: raw_json stays NULL."""
+        assert map_row(_row(), FallbackCounters()).raw_json is None

--- a/apps/importer/tests/test_output_db.py
+++ b/apps/importer/tests/test_output_db.py
@@ -1,0 +1,157 @@
+"""Tests for output DB lifecycle: WAL, run row, importlock — feature 0093."""
+
+import logging
+import subprocess
+from datetime import datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from grid_db.models import Run, TickerSnapshot
+from grid_db.repositories.identity import RunRepository
+
+from importer.output_db import (
+    ImportLockHeldError,
+    acquire_lock,
+    ensure_parents,
+    ensure_run_row,
+    insert_batch,
+    lock_path,
+    open_output_db,
+    output_db_path,
+    release_lock,
+)
+
+_T0 = datetime(2026, 7, 1, 0, 0, 0)
+
+
+def _snapshot(ts: datetime, symbol: str = "BTCUSDT") -> TickerSnapshot:
+    price = Decimal("100.00000000")
+    return TickerSnapshot(
+        symbol=symbol,
+        exchange_ts=ts,
+        local_ts=ts,
+        last_price=price,
+        mark_price=price,
+        bid1_price=price,
+        ask1_price=price,
+        funding_rate=Decimal("0"),
+    )
+
+
+class TestOutputDbPath:
+    def test_default_and_tagged_paths(self, tmp_path):
+        """Stable default path; --tag appends a suffix before .db."""
+        assert output_db_path(str(tmp_path), "BTCUSDT").name == "imported_BTCUSDT.db"
+        assert (
+            output_db_path(str(tmp_path), "BTCUSDT", "fresh").name
+            == "imported_BTCUSDT_fresh.db"
+        )
+
+
+class TestOutputDb:
+    def test_wal_enabled(self, tmp_path):
+        """The output DB is opened in WAL journal mode."""
+        db = open_output_db(tmp_path / "out.db")
+        with db.engine.connect() as conn:
+            mode = conn.exec_driver_sql("PRAGMA journal_mode").scalar()
+        assert mode == "wal"
+
+    def test_run_row_discoverable_by_replay(self, tmp_path):
+        """ensure_run_row creates a recording run replay auto-discovery finds."""
+        db = open_output_db(tmp_path / "out.db")
+        ensure_parents(db, "BTCUSDT")
+        insert_batch(db, [_snapshot(_T0), _snapshot(_T0 + timedelta(minutes=5))])
+        run_id = ensure_run_row(db, "BTCUSDT", "db:sqlite:///src.db")
+        assert run_id is not None
+        with db.get_session() as session:
+            run = RunRepository(session).get_latest_by_type("recording")
+            assert run is not None
+            assert run.run_id == run_id
+            assert run.account_id is not None  # replay snapshot writer needs it
+            assert run.start_ts == _T0
+            assert run.end_ts == _T0 + timedelta(minutes=5)
+            assert run.status == "completed"
+
+    def test_run_row_zero_row_rule(self, tmp_path):
+        """No ticker rows -> no run row (Run.start_ts is nullable=False)."""
+        db = open_output_db(tmp_path / "out.db")
+        ensure_parents(db, "BTCUSDT")
+        assert ensure_run_row(db, "BTCUSDT", "src") is None
+        with db.get_session() as session:
+            assert session.query(Run).count() == 0
+
+    def test_run_row_updated_not_duplicated(self, tmp_path):
+        """Resume-append updates the single run row from DB-wide MIN/MAX."""
+        db = open_output_db(tmp_path / "out.db")
+        ensure_parents(db, "BTCUSDT")
+        insert_batch(db, [_snapshot(_T0)])
+        first_run_id = ensure_run_row(db, "BTCUSDT", "src")
+        insert_batch(db, [_snapshot(_T0 + timedelta(hours=1))])
+        second_run_id = ensure_run_row(db, "BTCUSDT", "src")
+        assert second_run_id == first_run_id
+        with db.get_session() as session:
+            runs = session.query(Run).filter(Run.run_type == "recording").all()
+            assert len(runs) == 1
+            assert runs[0].start_ts == _T0  # unchanged on append
+            assert runs[0].end_ts == _T0 + timedelta(hours=1)
+
+    def test_parents_idempotent(self, tmp_path):
+        """ensure_parents reruns session.get the same pinned rows."""
+        db = open_output_db(tmp_path / "out.db")
+        first = ensure_parents(db, "BTCUSDT")
+        second = ensure_parents(db, "BTCUSDT")
+        assert first == second
+
+
+class TestImportLock:
+    def test_second_importer_blocked(self, tmp_path):
+        """A live lock (our own pid) blocks a second acquire."""
+        db_path = tmp_path / "out.db"
+        lock = acquire_lock(db_path)
+        try:
+            with pytest.raises(ImportLockHeldError, match="held by live pid"):
+                acquire_lock(db_path)
+        finally:
+            release_lock(lock)
+
+    def test_released_on_clean_exit(self, tmp_path):
+        """After release the lock file is gone and re-acquire succeeds."""
+        db_path = tmp_path / "out.db"
+        lock = acquire_lock(db_path)
+        release_lock(lock)
+        assert not lock_path(db_path).exists()
+        release_lock(lock)  # idempotent
+        lock = acquire_lock(db_path)
+        release_lock(lock)
+
+    def test_stale_lock_reclaimed(self, tmp_path, caplog):
+        """A dead-PID lock is reclaimed with a WARNING."""
+        db_path = tmp_path / "out.db"
+        proc = subprocess.Popen(["true"])
+        proc.wait()  # guaranteed-dead pid
+        lock_path(db_path).parent.mkdir(parents=True, exist_ok=True)
+        lock_path(db_path).write_text(f"pid={proc.pid}\nstart=2026-07-01T00:00:00\n")
+        with caplog.at_level(logging.WARNING):
+            lock = acquire_lock(db_path)
+        release_lock(lock)
+        assert any("stale import lock" in r.message for r in caplog.records)
+
+    def test_unreadable_lock_aborts(self, tmp_path):
+        """A garbage lock file aborts with a manual-removal hint."""
+        db_path = tmp_path / "out.db"
+        lock_path(db_path).write_text("garbage\n")
+        with pytest.raises(ImportLockHeldError, match="unreadable"):
+            acquire_lock(db_path)
+
+    def test_post_reclaim_race_maps_to_lock_error(self, tmp_path, monkeypatch):
+        """Losing the post-reclaim O_EXCL race raises ImportLockHeldError."""
+        db_path = tmp_path / "out.db"
+        lock_path(db_path).write_text("pid=999999\nstart=x\n")
+        # Simulate a concurrent importer re-creating the lock between
+        # reclaim and re-open: reclaim becomes a no-op, file stays.
+        monkeypatch.setattr(
+            "importer.output_db._reclaim_or_abort", lambda path: None
+        )
+        with pytest.raises(ImportLockHeldError, match="concurrent importer"):
+            acquire_lock(db_path)

--- a/apps/importer/tests/test_resume.py
+++ b/apps/importer/tests/test_resume.py
@@ -1,0 +1,210 @@
+"""End-to-end resume/idempotency tests through the importer CLI — feature 0093."""
+
+from datetime import datetime, timedelta
+
+from sqlalchemy import create_engine, text
+
+from grid_db.models import Run, TickerSnapshot
+
+import importer.main as importer_main
+from importer.output_db import open_output_db, output_db_path
+
+_T0 = datetime(2026, 7, 1, 0, 0, 0)
+
+
+def _run_import(source_path, out_dir, symbols="BTCUSDT", extra=None) -> int:
+    argv = [
+        "--source", "db",
+        "--source-url", f"sqlite:///{source_path}",
+        "--symbols", symbols,
+        "--out-dir", str(out_dir),
+    ] + (extra or [])
+    return importer_main.main(argv)
+
+
+def _rows(out_dir, symbol="BTCUSDT"):
+    db = open_output_db(output_db_path(str(out_dir), symbol))
+    with db.get_session() as session:
+        return (
+            session.query(TickerSnapshot.exchange_ts, TickerSnapshot.last_price)
+            .filter(TickerSnapshot.symbol == symbol)
+            .order_by(TickerSnapshot.exchange_ts)
+            .all()
+        )
+
+
+def _recording_runs(out_dir, symbol="BTCUSDT"):
+    db = open_output_db(output_db_path(str(out_dir), symbol))
+    with db.get_session() as session:
+        return [
+            (r.start_ts, r.end_ts)
+            for r in session.query(Run).filter(Run.run_type == "recording").all()
+        ]
+
+
+class TestResume:
+    def test_rerun_is_idempotent(self, tmp_path, seed_source_db, src_row):
+        """Overlapping rerun inserts no duplicates (resume skip + OR IGNORE)."""
+        source = tmp_path / "source.db"
+        out = tmp_path / "out"
+        seed_source_db(
+            source, [src_row(i, _T0 + timedelta(minutes=i)) for i in range(10)]
+        )
+        assert _run_import(source, out) == 0
+        # Extend the source with 5 later rows; window overlaps fully.
+        seed_source_db(
+            source,
+            [src_row(10 + i, _T0 + timedelta(minutes=10 + i)) for i in range(5)],
+        )
+        assert _run_import(source, out) == 0
+        rows = _rows(out)
+        assert len(rows) == 15
+        assert len({ts for ts, _ in rows}) == 15
+
+    def test_end_bound_inclusive(self, tmp_path, seed_source_db, src_row):
+        """A row with exchange_ts == --end is imported."""
+        source = tmp_path / "source.db"
+        out = tmp_path / "out"
+        seed_source_db(
+            source, [src_row(i, _T0 + timedelta(minutes=i)) for i in range(3)]
+        )
+        end = (_T0 + timedelta(minutes=2)).isoformat()
+        assert _run_import(source, out, extra=["--end", end]) == 0
+        assert len(_rows(out)) == 3
+
+    def test_crash_resume_survives_committed_batches(
+        self, tmp_path, seed_source_db, src_row, monkeypatch
+    ):
+        """Per-batch commits survive a mid-import crash; rerun resumes and heals."""
+        source = tmp_path / "source.db"
+        out = tmp_path / "out"
+        seed_source_db(
+            source, [src_row(i, _T0 + timedelta(minutes=i)) for i in range(9)]
+        )
+
+        calls = {"n": 0}
+        real_insert = importer_main.insert_batch
+
+        def flaky_insert(db, snapshots):
+            calls["n"] += 1
+            if calls["n"] > 2:
+                raise RuntimeError("simulated crash mid-import")
+            return real_insert(db, snapshots)
+
+        monkeypatch.setattr(importer_main, "insert_batch", flaky_insert)
+        assert _run_import(source, out, extra=["--batch-size", "3"]) == 1
+        monkeypatch.setattr(importer_main, "insert_batch", real_insert)
+
+        # 2 batches x 3 rows committed; no run row yet (crash before step 4).
+        assert len(_rows(out)) == 6
+        assert _recording_runs(out) == []
+
+        # Rerun resumes from the last committed row and heals the run row.
+        assert _run_import(source, out, extra=["--batch-size", "3"]) == 0
+        assert len(_rows(out)) == 9
+        runs = _recording_runs(out)
+        assert runs == [(_T0, _T0 + timedelta(minutes=8))]
+
+    def test_single_run_row_across_appends(self, tmp_path, seed_source_db, src_row):
+        """Append rerun keeps ONE recording row: start_ts fixed, end_ts advanced."""
+        source = tmp_path / "source.db"
+        out = tmp_path / "out"
+        seed_source_db(
+            source, [src_row(i, _T0 + timedelta(minutes=i)) for i in range(3)]
+        )
+        assert _run_import(source, out) == 0
+        seed_source_db(
+            source, [src_row(3, _T0 + timedelta(hours=2))]
+        )
+        assert _run_import(source, out) == 0
+        runs = _recording_runs(out)
+        assert runs == [(_T0, _T0 + timedelta(hours=2))]
+
+    def test_prefix_guard_aborts_with_tag_hint(
+        self, tmp_path, seed_source_db, src_row, capsys
+    ):
+        """Default-start rerun after a mid-range first import aborts (append-only)."""
+        source = tmp_path / "source.db"
+        out = tmp_path / "out"
+        seed_source_db(
+            source, [src_row(i, _T0 + timedelta(minutes=i)) for i in range(10)]
+        )
+        mid = (_T0 + timedelta(minutes=5)).isoformat()
+        assert _run_import(source, out, extra=["--start", mid]) == 0
+        assert len(_rows(out)) == 5
+        # Plain rerun resolves start = source MIN < existing MIN -> abort.
+        # setup_logging clears root handlers (caplog's included), so assert
+        # on the stdout log stream instead.
+        assert _run_import(source, out) == 1
+        assert "--tag" in capsys.readouterr().out
+        assert len(_rows(out)) == 5  # prefix was not silently skipped-over
+
+    def test_zero_row_symbol_fails_others_continue(
+        self, tmp_path, seed_source_db, src_row
+    ):
+        """All-NULL symbol creates no run row + non-zero exit; others import."""
+        source = tmp_path / "source.db"
+        out = tmp_path / "out"
+        seed_source_db(
+            source,
+            [src_row(1, _T0), src_row(2, _T0, symbol="ETHUSDT", last_price=None)],
+        )
+        assert _run_import(source, out, symbols="ETHUSDT,BTCUSDT") == 1
+        assert len(_rows(out, "BTCUSDT")) == 1
+        assert _recording_runs(out, "BTCUSDT") != []
+        assert _rows(out, "ETHUSDT") == []
+        assert _recording_runs(out, "ETHUSDT") == []
+
+    def test_duplicate_source_timestamps_collapse_first_by_id(
+        self, tmp_path, seed_source_db, src_row
+    ):
+        """Rows sharing (symbol, timestamp) collapse to the first by id."""
+        source = tmp_path / "source.db"
+        out = tmp_path / "out"
+        dup_ts = _T0 + timedelta(seconds=1)
+        seed_source_db(
+            source,
+            [
+                src_row(1, _T0),
+                src_row(2, dup_ts, last_price=101.0),
+                src_row(3, dup_ts, last_price=102.0),
+                src_row(4, dup_ts, last_price=103.0),
+                src_row(5, _T0 + timedelta(seconds=2)),
+            ],
+        )
+        # batch-size 2 puts the page boundary inside the duplicate group.
+        assert _run_import(source, out, extra=["--batch-size", "2"]) == 0
+        rows = _rows(out)
+        assert len(rows) == 3  # distinct timestamps only
+        by_ts = {ts: price for ts, price in rows}
+        assert str(by_ts[dup_ts]) == "101.00000000"  # first by id survived
+
+    def test_http_source_requires_explicit_bounds(self, tmp_path, capsys):
+        """--source http without --start/--end fails per symbol (no probe)."""
+        argv = [
+            "--source", "http",
+            "--source-url", "http://unreachable.invalid",
+            "--symbols", "BTCUSDT",
+            "--out-dir", str(tmp_path / "out"),
+        ]
+        assert importer_main.main(argv) == 1  # fails before any HTTP call
+        assert "pass explicit bounds" in capsys.readouterr().out
+
+    def test_tagged_import_is_isolated(self, tmp_path, seed_source_db, src_row):
+        """--tag writes a distinct file, leaving the default DB untouched."""
+        source = tmp_path / "source.db"
+        out = tmp_path / "out"
+        seed_source_db(source, [src_row(1, _T0)])
+        assert _run_import(source, out) == 0
+        assert _run_import(source, out, extra=["--tag", "fresh"]) == 0
+        assert output_db_path(str(out), "BTCUSDT", "fresh").exists()
+        # Both DBs independently complete.
+        engine = create_engine(
+            f"sqlite:///{output_db_path(str(out), 'BTCUSDT', 'fresh')}"
+        )
+        with engine.connect() as conn:
+            count = conn.execute(
+                text("SELECT COUNT(*) FROM ticker_snapshots")
+            ).scalar()
+        engine.dispose()
+        assert count == 1

--- a/apps/importer/tests/test_validate_ohlc.py
+++ b/apps/importer/tests/test_validate_ohlc.py
@@ -1,0 +1,340 @@
+"""Tests for the OHLC cross-check core (rebuild + compare) — feature 0093."""
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import create_engine, text
+
+from grid_db.models import TickerSnapshot
+
+from importer.output_db import insert_batch, open_output_db
+from importer.validate import (
+    OhlcBucket,
+    _coerce_kline_ts,
+    check_ohlc,
+    compare_ohlc,
+    rebuild_ohlc,
+    recorder_overlap_probe,
+    smoke_replay,
+)
+
+_T0 = datetime(2026, 7, 1, 10, 0, 0)
+_TICK = Decimal("0.1")
+
+
+def _ticks_two_minutes():
+    """Two minutes of ticks: minute A 100->102 (H 103, L 99), minute B flat 105."""
+    return [
+        (_T0 + timedelta(seconds=1), Decimal("100.00000000")),
+        (_T0 + timedelta(seconds=20), Decimal("103.00000000")),
+        (_T0 + timedelta(seconds=40), Decimal("99.00000000")),
+        (_T0 + timedelta(seconds=59), Decimal("102.00000000")),
+        (_T0 + timedelta(seconds=61), Decimal("105.00000000")),
+    ]
+
+
+def _matching_klines(buckets):
+    """Klines identical to the rebuilt buckets."""
+    return {
+        key: OhlcBucket(open=b.open, high=b.high, low=b.low, close=b.close)
+        for key, b in buckets.items()
+    }
+
+
+class TestRebuildOhlc:
+    def test_buckets_by_absolute_utc_minute(self):
+        """Ticks bucket by epoch-minute with correct OHLC per bucket."""
+        buckets = rebuild_ohlc(_ticks_two_minutes())
+        assert len(buckets) == 2
+        key_a = min(buckets)
+        bucket_a = buckets[key_a]
+        assert bucket_a.open == Decimal("100.00000000")
+        assert bucket_a.high == Decimal("103.00000000")
+        assert bucket_a.low == Decimal("99.00000000")
+        assert bucket_a.close == Decimal("102.00000000")
+        bucket_b = buckets[max(buckets)]
+        assert bucket_b.open == bucket_b.close == Decimal("105.00000000")
+        assert max(buckets) - key_a == 1  # consecutive minutes
+
+
+class TestCompareOhlc:
+    def test_exact_match_passes(self):
+        """Identical buckets pass at threshold 0.99."""
+        buckets = rebuild_ohlc(_ticks_two_minutes())
+        result = compare_ohlc(buckets, _matching_klines(buckets), _TICK, 0.99)
+        assert result.passed
+        assert result.matched == result.compared == 2
+        assert result.extra_keys == []
+
+    def test_high_low_within_one_tick_tolerated(self):
+        """High/low within 1 tick_size of the kline still count as matching."""
+        buckets = rebuild_ohlc(_ticks_two_minutes())
+        klines = _matching_klines(buckets)
+        key = min(klines)
+        klines[key].high += _TICK  # intra-minute extreme dropped by batching
+        klines[key].low -= _TICK
+        result = compare_ohlc(buckets, klines, _TICK, 0.99)
+        assert result.passed
+
+    def test_high_beyond_one_tick_mismatches(self):
+        """High/low beyond 1 tick_size makes the bucket mismatch."""
+        buckets = rebuild_ohlc(_ticks_two_minutes())
+        klines = _matching_klines(buckets)
+        key = min(klines)
+        klines[key].high += _TICK * 2
+        result = compare_ohlc(buckets, klines, _TICK, 0.99)
+        assert not result.passed
+        assert result.mismatched_keys == [key]
+
+    def test_open_close_must_match_exactly(self):
+        """Open/close use exact Decimal equality — below threshold fails."""
+        buckets = rebuild_ohlc(_ticks_two_minutes())
+        klines = _matching_klines(buckets)
+        klines[min(klines)].open += Decimal("0.00000001")
+        assert not compare_ohlc(buckets, klines, _TICK, 0.99).passed
+        # A permissive threshold accepts the same data (1/2 matched).
+        assert compare_ohlc(buckets, klines, _TICK, 0.5).passed
+
+    def test_whole_hour_shift_fails_on_key_set(self):
+        """An hour-shifted tick set fails on bucket-KEY-set mismatch, not values."""
+        ticks = _ticks_two_minutes()
+        klines = _matching_klines(rebuild_ohlc(ticks))
+        shifted = [(ts + timedelta(hours=1), price) for ts, price in ticks]
+        result = compare_ohlc(rebuild_ohlc(shifted), klines, _TICK, 0.0)
+        assert not result.passed  # even with a zero value-threshold
+        assert len(result.extra_keys) == 2  # every bucket outside kline keys
+        assert result.compared == 0
+
+    def test_sparse_minutes_are_legitimate(self):
+        """Kline minutes without imported ticks do NOT fail the key-set check."""
+        buckets = rebuild_ohlc(_ticks_two_minutes())
+        klines = _matching_klines(buckets)
+        # Source klines cover extra minutes the sparse import never ticked.
+        extra_key = max(klines) + 1
+        klines[extra_key] = OhlcBucket(
+            open=Decimal("1"), high=Decimal("1"), low=Decimal("1"), close=Decimal("1")
+        )
+        assert compare_ohlc(buckets, klines, _TICK, 0.99).passed
+
+
+class TestCoerceKlineTs:
+    def test_aware_datetime_to_naive_utc(self):
+        """Aware datetimes are converted to naive UTC."""
+        aware = datetime(2026, 7, 1, 10, 0, tzinfo=timezone.utc)
+        assert _coerce_kline_ts(aware) == datetime(2026, 7, 1, 10, 0)
+
+    def test_iso_z_string(self):
+        """ISO-8601 Z strings parse to naive UTC."""
+        assert _coerce_kline_ts("2026-07-01T10:00:00Z") == datetime(2026, 7, 1, 10, 0)
+
+    def test_epoch_seconds_and_millis(self):
+        """Numeric epochs: > 1e12 treated as milliseconds, else seconds."""
+        expected = datetime(2026, 7, 1, 10, 0)
+        epoch_s = int(expected.replace(tzinfo=timezone.utc).timestamp())
+        assert _coerce_kline_ts(epoch_s) == expected
+        assert _coerce_kline_ts(epoch_s * 1000) == expected
+
+    def test_unsupported_type_raises(self):
+        """Unknown timestamp types are rejected."""
+        with pytest.raises(ValueError, match="unsupported kline timestamp"):
+            _coerce_kline_ts(object())
+
+
+def _seed_output_ticks(tmp_path, ticks, symbol="BTCUSDT"):
+    db_path = tmp_path / "imported.db"
+    db = open_output_db(db_path)
+    insert_batch(
+        db,
+        [
+            TickerSnapshot(
+                symbol=symbol,
+                exchange_ts=ts,
+                local_ts=ts,
+                last_price=price,
+                mark_price=price,
+                bid1_price=price,
+                ask1_price=price,
+                funding_rate=Decimal("0"),
+            )
+            for ts, price in ticks
+        ],
+    )
+    return db, db_path
+
+
+def _seed_klines_db(path, buckets):
+    """Write a synthetic source klines table matching the given buckets."""
+    engine = create_engine(f"sqlite:///{path}")
+    with engine.begin() as conn:
+        conn.exec_driver_sql(
+            "CREATE TABLE IF NOT EXISTS klines ("
+            "id INTEGER PRIMARY KEY, symbol TEXT, interval TEXT, "
+            "start_time DATETIME, open REAL, high REAL, low REAL, close REAL)"
+        )
+        for key, bucket in buckets.items():
+            start = datetime.fromtimestamp(key * 60, tz=timezone.utc).replace(
+                tzinfo=None
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO klines (symbol, interval, start_time, open, "
+                    "high, low, close) VALUES (:s, '1', :t, :o, :h, :l, :c)"
+                ),
+                {
+                    "s": "BTCUSDT",
+                    "t": start.isoformat(sep=" "),
+                    "o": float(bucket.open),
+                    "h": float(bucket.high),
+                    "l": float(bucket.low),
+                    "c": float(bucket.close),
+                },
+            )
+    engine.dispose()
+
+
+class TestCheckOhlc:
+    def test_end_to_end_pass_against_source_klines(self, tmp_path):
+        """check_ohlc passes when source klines match the imported ticks."""
+        ticks = _ticks_two_minutes()
+        db, _ = _seed_output_ticks(tmp_path, ticks)
+        source = tmp_path / "source.db"
+        _seed_klines_db(source, rebuild_ohlc(ticks))
+        bounds = (ticks[0][0], ticks[-1][0])
+        assert check_ohlc(
+            db, "BTCUSDT", "db", f"sqlite:///{source}", bounds, 0.99
+        )
+
+    def test_unknown_symbol_fails(self, tmp_path):
+        """A symbol without a pinned exchange tick_size fails closed."""
+        db, _ = _seed_output_ticks(tmp_path, _ticks_two_minutes(), symbol="XXXUSDT")
+        bounds = (_T0, _T0 + timedelta(minutes=2))
+        assert not check_ohlc(db, "XXXUSDT", "db", "sqlite:///none.db", bounds, 0.99)
+
+    def test_no_ticks_on_sampled_day_fails(self, tmp_path):
+        """An empty imported window fails the check."""
+        db = open_output_db(tmp_path / "imported.db")
+        bounds = (_T0, _T0 + timedelta(minutes=2))
+        assert not check_ohlc(db, "BTCUSDT", "db", "sqlite:///none.db", bounds, 0.99)
+
+    def test_empty_midpoint_day_falls_back_to_nearest(self, tmp_path):
+        """A collector-outage day at the midpoint samples the nearest tick day."""
+        # Ticks only on day 1 and day 5; midpoint (day 3) is empty.
+        day1 = _ticks_two_minutes()
+        day5 = [(ts + timedelta(days=4), price) for ts, price in day1]
+        db, _ = _seed_output_ticks(tmp_path, day1 + day5)
+        source = tmp_path / "source.db"
+        _seed_klines_db(source, rebuild_ohlc(day1 + day5))
+        bounds = (day1[0][0], day5[-1][0])
+        assert check_ohlc(
+            db, "BTCUSDT", "db", f"sqlite:///{source}", bounds, 0.99
+        )
+
+
+class TestSmokeReplayGuards:
+    def test_unknown_symbol_fails_without_subprocess(self, tmp_path):
+        """No pinned tick_size -> smoke replay fails closed, no replay spawned."""
+        bounds = (_T0, _T0 + timedelta(hours=5))
+        assert not smoke_replay(tmp_path / "imported.db", "XXXUSDT", bounds)
+
+
+class TestSmokeReplayMocked:
+    """Contract of the rendered config + result parsing (mocked subprocess)."""
+
+    @staticmethod
+    def _fake_run(captured, returncode=0, stdout="Net PnL:    1.23"):
+        import yaml
+
+        def fake_run(cmd, capture_output, text):
+            captured["cmd"] = cmd
+            with open(cmd[-1]) as f:
+                captured["config"] = yaml.safe_load(f)
+            return SimpleNamespace(
+                returncode=returncode, stdout=stdout, stderr=""
+            )
+
+        return fake_run
+
+    def test_renders_config_and_passes(self, tmp_path, monkeypatch):
+        """Rendered YAML pins db URL, symbol, 4h window, tick_size, run_id null."""
+        captured = {}
+        monkeypatch.setattr(
+            "importer.validate.subprocess.run", self._fake_run(captured)
+        )
+        db_path = tmp_path / "imported_BTCUSDT.db"
+        bounds = (_T0, _T0 + timedelta(hours=6))
+        assert smoke_replay(db_path, "BTCUSDT", bounds) is True
+        config = captured["config"]
+        assert config["database_url"] == f"sqlite:///{db_path}"
+        assert config["symbol"] == "BTCUSDT"
+        assert config["run_id"] is None
+        assert config["strategy"]["tick_size"] == "0.1"
+        assert config["fill_simulator"]["mode"] == "last_cross"
+        assert config["seed"]["enabled"] is False
+        # 4h window anchored at the data's end.
+        assert config["start_ts"] == (_T0 + timedelta(hours=2)).isoformat()
+        assert config["end_ts"] == (_T0 + timedelta(hours=6)).isoformat()
+        assert captured["cmd"][1:3] == ["-m", "replay.main"]
+
+    def test_nan_metric_fails(self, tmp_path, monkeypatch):
+        """A NaN in the replay summary fails the smoke check."""
+        monkeypatch.setattr(
+            "importer.validate.subprocess.run",
+            self._fake_run({}, stdout="Net PnL:    nan"),
+        )
+        bounds = (_T0, _T0 + timedelta(hours=6))
+        assert smoke_replay(tmp_path / "x.db", "BTCUSDT", bounds) is False
+
+    def test_infinite_metric_fails(self, tmp_path, monkeypatch):
+        """An inf Net PnL fails the smoke check (finite required)."""
+        monkeypatch.setattr(
+            "importer.validate.subprocess.run",
+            self._fake_run({}, stdout="Net PnL:    inf"),
+        )
+        bounds = (_T0, _T0 + timedelta(hours=6))
+        assert smoke_replay(tmp_path / "x.db", "BTCUSDT", bounds) is False
+
+    def test_missing_metric_fails(self, tmp_path, monkeypatch):
+        """A zero-exit run WITHOUT a parsable Net PnL metric fails."""
+        monkeypatch.setattr(
+            "importer.validate.subprocess.run",
+            self._fake_run({}, stdout="replay finished\n"),
+        )
+        bounds = (_T0, _T0 + timedelta(hours=6))
+        assert smoke_replay(tmp_path / "x.db", "BTCUSDT", bounds) is False
+
+    def test_nonzero_exit_fails(self, tmp_path, monkeypatch):
+        """A replay crash (non-zero exit) fails the smoke check."""
+        monkeypatch.setattr(
+            "importer.validate.subprocess.run",
+            self._fake_run({}, returncode=2),
+        )
+        bounds = (_T0, _T0 + timedelta(hours=6))
+        assert smoke_replay(tmp_path / "x.db", "BTCUSDT", bounds) is False
+
+
+class TestRecorderOverlapProbe:
+    def test_skipped_without_recorder_db(self, tmp_path):
+        """No --recorder-db -> NOTICE skip, never gates."""
+        db, _ = _seed_output_ticks(tmp_path, _ticks_two_minutes())
+        bounds = (_T0, _T0 + timedelta(minutes=2))
+        assert recorder_overlap_probe(db, "BTCUSDT", bounds, None) is True
+
+    def test_skipped_when_no_overlap(self, tmp_path):
+        """Disjoint recorder coverage -> NOTICE skip."""
+        db, _ = _seed_output_ticks(tmp_path, _ticks_two_minutes())
+        rec_ticks = [
+            (_T0 + timedelta(days=30), Decimal("100.00000000")),
+        ]
+        _, rec_path = _seed_output_ticks(tmp_path / "rec", rec_ticks)
+        bounds = (_T0, _T0 + timedelta(minutes=2))
+        assert recorder_overlap_probe(db, "BTCUSDT", bounds, str(rec_path)) is True
+
+    def test_reports_on_overlap(self, tmp_path):
+        """Overlapping coverage runs the diff and returns True (informational)."""
+        ticks = _ticks_two_minutes()
+        db, _ = _seed_output_ticks(tmp_path, ticks)
+        _, rec_path = _seed_output_ticks(tmp_path / "rec", ticks)
+        bounds = (ticks[0][0], ticks[-1][0])
+        assert recorder_overlap_probe(db, "BTCUSDT", bounds, str(rec_path)) is True

--- a/docs/features/0093_PLAN.md
+++ b/docs/features/0093_PLAN.md
@@ -1,0 +1,475 @@
+# Feature 0093 — `apps/importer`: trad_save_history → replay-compatible SQLite
+
+## Context
+
+`trad_save_history` (neighbor project) runs a Bybit public-WS collector on a
+remote server. Its `ticker_data` table (last/mark/bid1/ask1 + sizes,
+funding_rate, 24h stats; written on lastPrice change, batched ×100) covers
+BTCUSDT, ETHUSDT, LTCUSDT, SOLUSDT.
+
+We want to run the existing **last_cross parameter sweeps** (the H-series
+harness in `apps/replay/conf/_h1*.py … _h7*.py` + scorer `_rank_hypotheses.py`)
+against that data — new symbols (BTC/ETH) and longer/independent periods —
+**without touching the replay engine**.
+
+Replay/backtest consume ONLY public ticker data via `shared/db` models:
+`ticker_snapshots` (`symbol, exchange_ts, local_ts, last_price, mark_price,
+bid1_price, ask1_price, funding_rate, raw_json`) plus a `runs` row that
+`ReplayEngine._resolve_run` looks up (or auto-discovers via
+`RunRepository.get_latest_by_type("recording")`). So a **one-way import
+adapter** producing standalone SQLite DBs in recorder schema is sufficient —
+each becomes a `database_url` in a replay config.
+
+**Scope guard (public-only source):** imported DBs are for **counterfactual
+A/B / RELATIVE ranking only**. NOT usable for live-fidelity — `event_follower`
+/ `live_check` need `private_executions`, which the source does not have.
+Recorder stays the only source for live-parity. Trust in the replay mechanism
+was established separately (0072/0088); imported data inherits it for relative
+ranking only.
+
+This is a full uv-workspace app **`apps/importer`** (supersedes issue #232's
+`scripts/import_trad_history.py` path).
+
+## Relevant existing code (reuse, do not modify)
+
+- `shared/db/src/grid_db/models.py` — `TickerSnapshot` (target schema:
+  `Numeric(20,8)` price cols all `nullable=False`; `raw_json` nullable;
+  `UniqueConstraint("symbol","exchange_ts", name="uq_ticker_symbol_ts")`) and
+  `Run` (`run_id` PK uuid, `run_type` — replay auto-discovery filters on
+  `"recording"`; requires FKs `user_id`/`account_id`/`strategy_id`).
+- `shared/db/src/grid_db/repositories/market_data.py` —
+  `TickerSnapshotRepository`: `bulk_insert()` already does dialect-specific
+  `on_conflict_do_nothing` (= INSERT OR IGNORE on `uq_ticker_symbol_ts`),
+  and `get_last_ticker_ts(symbol)` (resume cursor). **Reuse both.**
+- `shared/db/src/grid_db/database.py` — `DatabaseFactory(DatabaseSettings(
+  database_url=...))`; `.create_tables()` (`Base.metadata.create_all`),
+  `.get_session()`, `.get_readonly_session()`, `_readonly_sqlite_url()`.
+  NOTE: the SQLite `connect` listener sets only `PRAGMA foreign_keys=ON` — it
+  does **not** set WAL. The importer must issue `PRAGMA journal_mode=WAL`
+  explicitly on the output DB (see Phase 3).
+- `apps/recorder/src/recorder/prepare_session.py` — **actual precedent** for
+  creating the `users`/`bybit_accounts`/`strategies` parent rows (session.get-
+  guarded `add` of `User`/`BybitAccount`/`Strategy`). `apps/recorder/src/
+  recorder/recorder.py::_seed_db_records` (line ~752; the `Run` insert with
+  `run_type="recording"` is at ~line 824) — precedent for the synthetic `Run`
+  insert. Note:
+  `apps/recorder/src/recorder/shared_db_parents.py` is **verify-only**
+  (`verify_shared_db_parents()` — existence/metadata checks, forbids mutation,
+  "consumer, never co-writer") and its checks assume the gridbot
+  environment/symbol/strategy_type — do NOT reuse it against the importer's
+  synthetic stubs; it is cited only to clarify it is NOT the creation code.
+  `shared/db/src/grid_db/repositories/identity.py` — identity repo helpers.
+  The importer needs the same minimal synthetic parent chain.
+- `apps/replay/src/replay/engine.py::ReplayEngine._resolve_run` (lines ~786–846)
+  — confirms what a usable output DB needs: a `Run` row of type `recording`
+  (for `run_id=None` auto-discovery) OR any `Run` whose `run_id` is named in
+  the replay config, plus `ticker_snapshots` in `[start_ts, end_ts]`.
+- `apps/replay/src/replay/config.py` — `database_url` / `run_id` fields.
+- `apps/pnl_checker` — app-layout pattern to mirror (`pyproject.toml` with
+  `[tool.hatch.build.targets.wheel] packages=["src/importer"]`, `src/importer/
+  main.py` with `argparse` + `setup_logging`, `conf/`, `tests/`).
+
+## Field mapping (`ticker_data` → `ticker_snapshots`)
+
+| target | source | transform |
+|---|---|---|
+| `symbol` | `symbol` | as-is |
+| `exchange_ts` | `timestamp` | UTC as-is (owner confirmed naive datetimes are UTC) |
+| `local_ts` | `timestamp` | same value (no recv-ts on source) |
+| `last_price` | `last_price` | `Decimal(str(x))`, quantize 8dp; if NULL → **skip row** + WARNING count (no fallback source; col is `nullable=False`) |
+| `mark_price` | `mark_price` | same; if NULL → fall back to `last_price` + WARNING count |
+| `bid1_price` | `bid1_price` | same; if NULL → `last_price` fallback + WARNING count |
+| `ask1_price` | `ask1_price` | same; if NULL → `last_price` fallback + WARNING count |
+| `funding_rate` | `funding_rate` | `Decimal(str(x))` 8dp; if NULL → `0` + WARNING count |
+| `raw_json` | — | `NULL` (no audit payload on source; acceptable for A/B) |
+
+**Precision rule (project):** every price/qty crosses the boundary via
+`Decimal(str(float_value))` — never bind a raw `float`. All target price cols
+are `nullable=False`, so the NULL fallbacks above are mandatory to satisfy the
+schema.
+
+## Output DB layout
+
+**Per-symbol DB files** with a **stable default path**:
+`{out_dir}/imported_<symbol>.db` (`--out-dir`, default `data/`; one file per
+`--symbols` entry; each replay config points at its own file). All path
+formulas below — including the `.importlock` sidecar — resolve against
+`--out-dir`, never a hardcoded `data/`. The filename deliberately does NOT embed
+`start`/`end`: the default `--end` resolves to a live `MAX(timestamp)` probe,
+so a range-encoded name would resolve to a **new path on every rerun** and the
+incremental resume would never find the prior DB. An optional `--tag <t>`
+appends `_<t>` (→ `{out_dir}/imported_<symbol>_<t>.db`) when the operator wants an
+isolated fresh import (e.g. while a sweep reads the default file — see
+Concurrency). The covered time range lives in the `runs` row
+(`start_ts`/`end_ts`), not the filename.
+
+Each per-symbol DB gets:
+- Full recorder schema via `DatabaseFactory.create_tables()`.
+- `PRAGMA journal_mode=WAL`.
+- A minimal synthetic parent chain (`users` → `bybit_accounts` →
+  `strategies`) + **exactly ONE synthetic `runs` row per DB, ever**:
+  created on first import with `run_id=uuid4()`, `run_type="recording"` (so
+  replay `run_id=None` auto-discovery finds it), `config_snapshot={"note":
+  "imported from trad_save_history", "symbol": ..., "source": ...}`,
+  `start_ts=min(exchange_ts)`, `end_ts=max(exchange_ts)`, `status="completed"`.
+  On resume-append the importer looks up the existing `run_type="recording"`
+  row in the output DB and **UPDATEs its `start_ts`/`end_ts` from the DB-wide
+  `MIN(exchange_ts)`/`MAX(exchange_ts)` of `ticker_snapshots`** (never the
+  session's own min/max — a session-min on append would advance `start_ts`
+  and silently shrink the auto-discovered replay window,
+  `engine.py:814-815`; in practice `start_ts` never moves on append and only
+  `end_ts` advances). It must never insert a second `recording` row:
+  `RunRepository.get_latest_by_type` orders by `start_ts DESC` only
+  (`shared/db/src/grid_db/repositories/identity.py:347`), so two rows with
+  equal `start_ts` would make auto-discovery nondeterministic.
+  **Zero-row rule:** if after the import the output DB contains no
+  `ticker_snapshots` rows for the symbol (empty range, or every source row
+  skipped for NULL `last_price`), create **no** run row — `Run.start_ts` is
+  `nullable=False` and replay aborts on an invalid range — log an ERROR for
+  that symbol, **continue with the remaining `--symbols`**, and make the
+  process exit code non-zero if ANY symbol ended empty/failed (aggregate,
+  not fail-fast).
+  **Parent-row identity:** the synthetic `users`/`bybit_accounts`/`strategies`
+  rows use pinned module-level constant UUIDs (recorder-style), so reruns
+  `session.get` the same rows instead of inserting duplicates; the run row's
+  `account_id` must be non-null (replay's snapshot writer raises on a NULL
+  `account_id`, `engine.py:952-962`).
+  `ticker_snapshots` has no `run_id` FK, so the run row exists purely to
+  satisfy replay's lookup/auto-discovery.
+
+## Source transport abstraction (`--source {db,http}`)
+
+Both transports implemented now, behind a single interface so A/B differ in one
+module:
+
+```
+fetch_batches(symbol, start, end) -> Iterator[list[row]]
+```
+where each `row` is a dict with keys mirroring `ticker_data` columns
+(`symbol, timestamp, last_price, mark_price, bid1_price, ask1_price,
+funding_rate`). Bounded batches of **10 000 rows**; read-only; no writes/deletes.
+
+- **A. Direct DB** (`fetch_source_db.py`): a SQLAlchemy URL
+  (`postgresql://…` or `sqlite:///path` for a copied/tunneled file), opened
+  read-only (for sqlite reuse `_readonly_sqlite_url` AND read via
+  `get_readonly_session()` (`database.py:155-160`), never the auto-committing
+  `get_session()`). Streams
+  `SELECT … FROM ticker_data WHERE symbol=:s AND timestamp>=:start AND
+  timestamp<=:end ORDER BY timestamp, id` keyset-paginated in 10k chunks on
+  the **composite cursor `(timestamp, id)`** — first page bounded by
+  `timestamp >= :start`, subsequent pages by `(timestamp, id) > (:cts, :cid)`
+  (row-value comparison or its expanded OR form). A bare `timestamp >= cursor`
+  with LIMIT would loop forever, and a bare strict `>` on timestamp alone
+  could skip rows sharing the cursor timestamp across a page boundary; the
+  `id` tiebreaker fixes both (same pattern as the source project's own
+  reader). **Both bounds inclusive** — replay's window filter is inclusive
+  (`exchange_ts <= end_ts`, `apps/backtest/src/backtest/data_provider.py:85`)
+  and the default `--end` resolves to the source `MAX(timestamp)` probe, so an
+  exclusive upper bound would silently drop the last tick. May also run
+  `COUNT/MIN/MAX` probes (see Density/probe).
+- **B. HTTP API** (`fetch_source_http.py`): client codes against the contract
+  below; the server side is implemented separately in `trad_save_history`.
+
+### HTTP API contract (documented here; server implemented in trad_save_history)
+
+- `GET {base_url}/ticker_data?symbol=<S>&start=<ISO8601 UTC>&end=<ISO8601 UTC>&limit=<n>&cursor=<opaque>`
+- Response JSON:
+  ```json
+  { "rows": [ { "id": 123456, "symbol": "...",
+                "timestamp": "2026-07-01T00:00:00Z",
+                "last_price": 0.0, "mark_price": 0.0, "bid1_price": 0.0,
+                "ask1_price": 0.0, "funding_rate": 0.0 }, ... ],
+    "next_cursor": "<opaque or null>" }
+  ```
+- `rows` in a **stable total order `(timestamp, id)` ascending** (the server
+  paginates on the same composite key as transport A, so duplicate-timestamp
+  collapse is deterministically first-by-`id` on BOTH transports and cursors
+  are stable across retries); `next_cursor` null when exhausted.
+  Client passes it back verbatim; `limit` defaults to 10 000. `start`/`end` are
+  **both inclusive** (same rationale as transport A). Numeric fields
+  arrive as JSON numbers (float) or null → same `Decimal(str(x))` / NULL-fallback
+  path as transport A. Timestamps are ISO-8601 UTC.
+- **Client robustness (long multi-hour pulls):** per-request timeout 30 s;
+  retry on connection errors / HTTP 429 / 5xx with exponential backoff
+  (5 attempts, 1 s base, ×2, cap 30 s) re-requesting the **same cursor**
+  (idempotent GET, so a retried page cannot skip rows); any other 4xx aborts
+  the import with the response body logged. Retry/backoff behavior is unit
+  tested against a mocked HTTP client (see `test_fetch_http.py`).
+
+## Import algorithm (default, no `--validate`)
+
+CLI (`python -m importer.main`): `--source {db,http}`, `--source-url`,
+`--symbols S[,S…]` (**required**, no hardcoded coverage), `--start`, `--end`
+(ISO-8601 UTC, **inclusive**; optional — default to full source range via
+MIN/MAX probe), `--out-dir data/`, `--tag`, `--batch-size 10000`, `--debug`.
+
+**Datetime discipline:** every datetime entering the pipeline is normalized
+to **naive UTC** (convert to UTC, strip tzinfo) — CLI args immediately after
+parsing, AND every source row timestamp **at the transport boundary**: each
+`fetch_batches` implementation yields rows whose `timestamp` is already naive
+UTC (transport A: a Postgres `timestamptz` column arrives tz-aware;
+transport B: ISO-8601 `Z` strings parse tz-aware). Normalizing inside the
+transports — not later in `mapping.py` — matters because the step-2 resume
+skip compares `exchange_ts <= resume_from` BEFORE mapping runs; an aware
+source timestamp there against the naive SQLite cursor would raise
+`TypeError` on every resume. Rationale: SQLite returns naive datetimes, so
+`get_last_ticker_ts` yields naive values — `max(start, resume_from)` or any
+aware-vs-naive comparison raises `TypeError`. Same guard replay already
+applies (`apps/replay/src/replay/engine.py:840-841` strips tzinfo before
+comparing).
+
+Per symbol:
+1. **Acquire the `.importlock` sidecar first** (O_EXCL, stale-PID reclaim —
+   see Concurrency; released in a `finally` on exit), then build output path
+   `{out_dir}/imported_<symbol>[_<tag>].db`; open `DatabaseFactory`,
+   `create_tables()`, set WAL, ensure synthetic parent chain exists.
+2. **Resume**: read `TickerSnapshotRepository.get_last_ticker_ts(symbol)` on
+   the *output* DB → `resume_from`. Skip source rows with
+   `exchange_ts <= resume_from` (same dedup key as recorder; `bulk_insert`'s
+   INSERT-OR-IGNORE is the belt-and-suspenders backstop). Reruns are idempotent.
+   **Prefix guard:** resume is append-only — if the **resolved** start
+   (explicit `--start` OR the default source-MIN probe) is earlier than the
+   output DB's existing `MIN(exchange_ts)`, the requested prefix can never be
+   filled by this path; abort with an ERROR telling the operator to use
+   `--tag` for a separate full-range file (or delete the DB) rather than
+   silently reporting coverage that was never imported. (The default-start
+   case is the sneaky one: a mid-range first import followed by a plain rerun
+   resolves start=source-MIN and would otherwise skip the prefix silently.)
+3. Stream `fetch_batches(symbol, lower, end)` where `lower = start if
+   resume_from is None else max(start, resume_from)` (first import has no
+   resume cursor — a literal `max(start, None)` would raise); for each 10k
+   batch: map rows → `TickerSnapshot` ORM instances (Decimal + NULL fallbacks,
+   incrementing per-field WARNING counters; a row with NULL `last_price` is
+   **skipped** and counted — no value to fall back to, and `last_price` is
+   `nullable=False`), then `bulk_insert` **inside its own
+   `with db.get_session():` block — one commit per batch**. `bulk_insert`
+   only `flush()`es (`market_data.py:226`); the commit happens at
+   `get_session()` exit (`database.py:147`), so a single long session would
+   lose ALL batches on a crash and make the `get_last_ticker_ts` resume
+   cursor a lie. Per-batch commit bounds crash loss to one uncommitted batch
+   (precedent: recorder's per-call `with get_session()` usage). Progress log
+   per day boundary (rows imported, running total).
+4. **Always when the output DB holds ≥ 1 `ticker_snapshots` row** (even if
+   THIS fetch returned zero new rows — e.g. everything ≤ `resume_from`; the
+   zero-row rule in Output DB layout governs a DB with no rows at all):
+   create-or-**update** the single synthetic `runs` row
+   (see Output DB layout) from the DB-wide `MIN/MAX(exchange_ts)`, and log the
+   per-field NULL-fallback/skip counts. Running this unconditionally heals a
+   `runs` row left truncated by a crash between a committed batch and step 4
+   of a previous run — otherwise auto-discovery under-reports the window until
+   new source rows happen to arrive.
+
+## Concurrency with running sweeps
+
+Replay/backtest stream `ticker_snapshots` via cursor pagination while an
+import may be resume-appending to the same DB file.
+
+- **WAL enables concurrent readers during import writes** — the importer sets
+  `PRAGMA journal_mode=WAL` on the output DB, so a running sweep is not blocked
+  by (nor blocks) the importer's writes.
+- **Within one iterator the sweep IS snapshot-stable.** The ticker iterator
+  holds a single `get_session()` for its entire cursor loop
+  (`apps/backtest/src/backtest/data_provider.py:77` — one session, never
+  committed mid-loop → one read transaction → frozen WAL snapshot), so
+  mid-import appends do NOT leak into an in-flight iterator.
+- **The residual hazard is cross-session skew.** The engine opens *separate*
+  sessions at different times (e.g. the mark-price iterator,
+  `apps/replay/src/replay/engine.py:163`, and run resolution). Sessions opened
+  before vs after an append see **different snapshots** of the same window —
+  e.g. marks could include ticks the main iterator never saw. Subtle, silent,
+  and enough to keep imports and sweeps separated.
+- **Sweeps are not pure readers.** The replay CLI constructs
+  `ReplayEngine(..., emit_backtest_snapshots=True)` by default
+  (`engine.py:333`) and writes `source='backtest'` `position_snapshots` rows
+  into the DB it runs against (`engine.py:942-969`). On an imported DB this is
+  **accepted and benign** for the A/B use case — a separate table,
+  `ticker_snapshots` untouched, relative ranking unaffected — but it makes a
+  concurrent sweep a WRITER: importer appends + sweep snapshot flushes can
+  contend (SQLITE_BUSY), one more reason for the lock + operational rule.
+  (Requires the synthetic run row's non-null `account_id` — see Output DB
+  layout — or the engine raises at startup.)
+- **Mechanism: an importer-exclusion lock.** Before writing, the importer
+  acquires an advisory sidecar lock file
+  `{out_dir}/imported_<symbol>[_<tag>].db.importlock` (created O_EXCL, holding PID +
+  start time, removed on clean exit). If it exists: read the PID; if that
+  process is dead (`os.kill(pid, 0)` raises) the lock is **stale** — log a
+  WARNING and reclaim (replace) it; if alive, abort with an ERROR naming the
+  holder. (PID-reuse edge — dead importer's PID recycled by an unrelated
+  process — is accepted: the lock then wrongly looks live and recovery is a
+  documented manual `rm` of the sidecar; the stored start time aids that
+  diagnosis but is not used for automatic reclaim.) This excludes concurrent importers only — it CANNOT detect an
+  in-flight replay, which takes no lock; sweep separation rests on the
+  operational rule below.
+- **Operational rule (documented, enforced by convention): never start a
+  resume-append import against a DB while a sweep on it is running.** For a
+  guaranteed-isolated import while the default file is under sweep, use
+  `--tag` to write a distinct new file. The density/import summary restates
+  this so the operator qualifies any overlapping run.
+
+Covered by tests: lock blocks a second importer, released on clean exit, and
+a stale lock (dead PID) is reclaimed (see `test_output_db.py`).
+
+## Density report (always printed after import)
+
+Per symbol, per UTC day: tick count + list of **gaps > 60 s** (consecutive
+`exchange_ts` deltas). Source writes only on lastPrice change → sparser than
+recorder's ~4–5/s. Flag any day with **< 0.5 ticks/s** as `LOW-DENSITY` and
+emit a carry-forward WARNING (last_cross overfill sensitivity rises with
+sparsity — the warning must be visible so sweeps on that data are qualified).
+
+## `--validate` (opt-in; import stays plain/fast without it)
+
+After a successful import, run three checks:
+
+1. **OHLC cross-check** — rebuild 1-minute OHLC from the imported ticks for a
+   sampled day and diff vs the source `klines` (1m) table/endpoint.
+   **Bucket anchoring (this is what makes the tz check bite):** each imported
+   tick is bucketed by `floor(exchange_ts → whole minute)` treating the naive
+   `exchange_ts` as UTC; buckets are keyed by their **absolute UTC minute**
+   (epoch-minute integer). Source klines are keyed on the **same absolute UTC
+   minute** (kline `start` truncated to minute). The check first diffs the
+   **bucket key sets**: a constant whole-hour tz offset shifts every imported
+   bucket by that offset, producing missing/extra bucket keys at the day
+   boundary (the imported day is short/long by N minutes vs klines) — so the
+   check fails on **key-set mismatch**, independent of any value drift.
+   Then, for keys present in both: **open/close compared by exact Decimal
+   equality per bucket, with a pass threshold of exactly-matching buckets**
+   (`--ohlc-threshold`, default 0.99) — the source writes ticker rows only on
+   `lastPrice` change and batches ×100, so a legitimate import can miss the
+   true first/last trade of some minutes (kline open = first *trade* of the
+   minute; the first lastPrice *change* can lag it, so open skews more than
+   close — calibrate the threshold on the first real import if 0.99 proves
+   too strict; `tick_size` comes from the same pinned per-symbol map the
+   smoke template uses — seed that map from EXCHANGE tick sizes at
+   implementation time (LTC exchange tick is 0.01; the old repo YAML `0.1`
+   was wrong and caused the 0090 startup abort — do not copy YAML values); a tz shift or float mangling corrupts essentially ALL buckets,
+   so the threshold separates the two (mismatching buckets are listed in the
+   report). Source `klines` (1m) availability is per issue #232's source
+   schema (`ticker_data`, `klines`, `trades`, `orderbooks`). **High/low within `1 tick_size` of the kline
+   high/low** (intra-minute extremes can be dropped by batching — `tick_size`
+   from the symbol, e.g. LTC 0.01). The bucket **key-set check above stays
+   hard-fail** (tz detector); the value checks fail only below the threshold.
+   Requires the source to expose `klines` (transport A: table; transport B: an
+   analogous `GET /klines` — out of client scope to define beyond symbol/start/end).
+2. **Smoke replay** — invoke the existing replay entry against the imported DB
+   for one 4 h window, `gs0.5`, fresh grid, last_cross; assert metrics parse
+   and are non-NaN. Replay exposes **no** `[project.scripts]` console script
+   (verified), so invoke it via `python -m replay.main` (or import and call the
+   replay main function directly) — NOT `uv run replay`. No engine changes.
+   **Config fixture:** `load_config` requires a YAML file and `strategy` is a
+   mandatory section (`apps/replay/src/replay/config.py`), so `validate.py`
+   ships a template `apps/importer/conf/smoke_replay.yaml` (seed.enabled=false,
+   fill_mode last_cross, gs0.5, `run_id: null` auto-discovery) and renders it
+   to a temp file with the imported DB's `database_url`, symbol, the chosen
+   4 h window, **and a pinned per-symbol `strategy.tick_size`** — without it
+   replay's instrument-info path requires a live exchange fetch
+   (`require_live=True`) and the smoke check would fail offline/no-cache.
+   Existing H-series YAMLs are NOT reused (e.g. `ab_gs_05.yaml` pins
+   seed.enabled=true, SOLUSDT + its tick, a fixed `run_id`).
+3. **Recorder overlap probe** (only if the source also collected LTCUSDT/
+   SOLUSDT during our recorder's coverage, post 2026-07-03): cross-check 1 h of
+   overlapping `last_price` series between imported and recorder DBs
+   (max abs diff, row-count mismatch) — a direct fidelity probe of the
+   collector itself. Skipped with a NOTICE when no overlap.
+
+## Module layout (`apps/importer/src/importer/`)
+
+- `main.py` — argparse CLI, `setup_logging`, orchestration loop. Invoked via
+  `python -m importer.main` (mirrors `apps/pnl_checker`, which has NO
+  `[project.scripts]`). If a `uv run importer` console script is wanted later
+  it can add a `[project.scripts]` table, but that is a NEW convention not
+  inherited from the pnl_checker precedent — the base plan does not require it.
+- `config.py` — (thin) arg/param validation; symbol/date parsing to **naive
+  UTC** (aware input converted then tzinfo stripped — see Datetime discipline).
+- `source.py` — `fetch_batches` protocol + `make_source(kind, url)` factory.
+- `fetch_source_db.py` — transport A (SQLAlchemy read-only, keyset pagination,
+  COUNT/MIN/MAX probes).
+- `fetch_source_http.py` — transport B (cursor pagination against the
+  contract; 30 s timeout + exponential-backoff retry per the contract's client
+  robustness rules).
+- `mapping.py` — pure `row_dict → TickerSnapshot` (Decimal, NULL fallbacks,
+  fallback counters). Hermetic, no I/O.
+- `output_db.py` — open/create output DB, WAL pragma, synthetic parent+run
+  rows (create-or-update single `recording` row), per-batch-commit
+  `bulk_insert` wrapper, resume cursor read, import lock-file
+  acquire/release (O_EXCL sidecar `.importlock`, PID + start time, removed on
+  clean exit, stale-PID reclaim).
+- `density.py` — per-day tick counts + >60 s gaps + LOW-DENSITY flag.
+- `validate.py` — the three `--validate` checks.
+
+## Tests (`apps/importer/tests/`, hermetic — no network, no real Bybit/server)
+
+- `test_mapping.py` — float→Decimal precision (8dp); each NULL fallback
+  (mark/bid1/ask1 → last_price, funding_rate → 0) and its counter increment;
+  NULL `last_price` row is skipped and counted (never inserted).
+- `test_resume.py` — pre-seed an output DB, import overlapping synthetic rows,
+  assert rows ≤ `get_last_ticker_ts` are skipped and no duplicates
+  (INSERT-OR-IGNORE holds under rerun); **end bound inclusive** (row with
+  `exchange_ts == end` is imported); **crash-resume**: simulate a failure
+  mid-import after N committed batches, assert the committed batches survive
+  (per-batch commit) and a rerun resumes from the last committed row;
+  **single run row**: after initial import + resume-append, the output DB
+  holds exactly one `run_type="recording"` row with advanced `end_ts` and
+  **unchanged `start_ts`** (DB-wide MIN/MAX semantics); **prefix guard**:
+  explicit `--start` earlier than existing `MIN(exchange_ts)` aborts with the
+  `--tag` hint; **zero-row rule**: an empty/all-skipped import creates no run
+  row and exits non-zero for that symbol; **keyset pagination**: synthetic
+  source rows with duplicate timestamps straddling a page boundary neither
+  loop forever nor drop any *distinct* timestamp; rows sharing
+  `(symbol, timestamp)` deterministically collapse to the **first by `id`**
+  (insertion is ordered by `(timestamp, id)` and the target's
+  `UNIQUE(symbol, exchange_ts)` + ON CONFLICT DO NOTHING keeps the first
+  inserted row) — they cannot "all survive" in the target schema.
+- `test_fetch_http.py` — mocked HTTP client: retry/backoff on 429/5xx and
+  connection errors re-requests the same cursor; non-retryable 4xx aborts;
+  pagination follows `next_cursor` to exhaustion; **yielded row `timestamp`s
+  are naive UTC** (ISO-8601 `Z` input → tzinfo stripped at the transport
+  boundary).
+- `test_fetch_db.py` — transport A against a synthetic sqlite source:
+  composite `(timestamp, id)` keyset pagination; **tz-aware source timestamps
+  yielded naive UTC**; resume path with a pre-seeded output DB runs the
+  `exchange_ts <= resume_from` skip without `TypeError` (locks in the
+  transport-boundary normalization).
+- `test_density.py` — synthetic ticks → correct per-day counts, >60 s gap
+  detection, LOW-DENSITY threshold at 0.5 ticks/s.
+- `test_validate_ohlc.py` — synthetic ticks + matching synthetic `klines` →
+  OHLC rebuild matches (open/close exact, high/low within 1 tick_size); a
+  set shifted by a whole hour fails on **bucket-key-set mismatch** (missing/
+  extra epoch-minute keys at the day boundary), proving the anchoring catches a
+  real tz offset rather than only value drift.
+- `test_output_db.py` — created DB has WAL, the synthetic `recording` run row,
+  and is discoverable by `RunRepository.get_latest_by_type("recording")`; a
+  second importer against a locked DB aborts; the lock file is released on
+  clean exit; a stale lock (dead PID) is reclaimed with a WARNING.
+- `test_config.py` — required `--symbols`, ISO-8601 UTC parsing, `--source`
+  validation; aware input (`…Z` / `+05:00`) is converted to UTC and returned
+  **naive** (the `TypeError` hazard from Datetime discipline).
+
+## Workspace wiring
+
+- `apps/importer/pyproject.toml` (`name="importer"`, deps: `grid-db`,
+  `sqlalchemy`, `requests` for transport B (already present in the workspace;
+  `httpx` is not — do not introduce it), **`replay`** (the `--validate` smoke
+  invokes `python -m replay.main` / imports replay; needs BOTH `"replay"` in
+  `[project] dependencies` AND `replay = { workspace = true }` under
+  `[tool.uv.sources]` — precedent: `apps/live_check/pyproject.toml:7,17`),
+  `pyyaml` if a conf file is
+  added; `[tool.uv.sources] grid-db = { workspace = true }` per the
+  `event_saver`/`recorder` precedent (`pnl_checker` has no `grid-db` dep);
+  hatchling wheel
+  `packages=["src/importer"]`).
+- Root `pyproject.toml`: add `apps/importer/src` to `[tool.pytest.ini_options]`
+  `pythonpath` + `apps/importer/tests` to `testpaths`; register the app in the
+  `uv` workspace (already globbed by `apps/*`).
+- `Makefile` `test` target: add
+  `uv run pytest apps/importer/tests --cov=importer --cov-append -q`
+  alongside the other per-app lines (before the integration run) — `make test`
+  enumerates each app explicitly, so without this line the importer tests
+  never run under the project's standard gate.
+
+## Not in scope
+
+- Private-stream data; `live_check` / `event_follower` on imported DBs.
+- Continuous sync daemon (one-shot + incremental rerun is enough).
+- Backfilling recorder DBs — imported data lives in separate DB files only.
+- Any change to the replay engine, gridcore, or `shared/db` models.

--- a/docs/features/0093_REVIEW.md
+++ b/docs/features/0093_REVIEW.md
@@ -1,0 +1,79 @@
+# Feature 0093 — apps/importer: review trail
+
+Branch `feature/0093-importer`. Plan: `docs/features/0093_PLAN.md`.
+
+## Internal review (/review-fix-loop-staged)
+
+5 parallel category reviewers (quality/security/performance/testing/docs),
+1 iteration, **0 criticals**. Applied: 2 missing type hints, 2 docstring
+tightenings, validate.py unit tests (34% → 74%: `_coerce_kline_ts`,
+`check_ohlc` end-to-end vs synthetic klines + error paths, probe skip
+paths). Rejected with evidence: "O(n²) overlap loop" (two-pointer merge,
+O(n+m)); "batch[-1] IndexError" (transports never yield empty batches);
+path-traversal guards on operator CLI args (path choice is the feature;
+no speculative validation per project constraints); engine/session
+dispose (matches recorder/pnl_checker process-lifetime pattern).
+
+## External review trail (/ext-code-review)
+
+Engines: codex (`codex exec --sandbox read-only`) + cursor
+(`agent --mode ask`), both per round. Rounds: 4. Criteria:
+`commands/code_review.md`.
+
+### Findings raised → verdicts
+
+Round 1 (cursor 6 P2 + 5 P3; codex 1 P2 + 3 P3, overlap deduped):
+- ACCEPT+fixed: klines fetch pushed day window into SQL (datetime cols;
+  Python filter stays as epoch fallback); post-stale-reclaim O_EXCL race
+  → `ImportLockHeldError`; kline HTTP params aligned on shared Z-suffix
+  `iso_utc`; empty-string `next_cursor` terminates; window bounds bind
+  aware-UTC (naive binds vs Postgres `timestamptz` shift with SESSION
+  timezone); `--batch-size` rejects ≤ 0. P3s fixed as trivially cheap:
+  mocked-subprocess `smoke_replay` contract tests; http-no-bounds e2e test.
+- REJECT: density last-day `covered_seconds` "bug" — coverage of the last
+  day of a continuous window genuinely starts at midnight; tz-aware sqlite
+  fixture — sqlite bind formatter drops tzinfo, cannot round-trip aware
+  datetimes (conversion unit-tested at function level; documented in
+  test_fetch_db.py).
+- Accepted gaps (P3): response-shape guards for camelCase/nested payloads
+  (contract documented; unknown shapes fail closed); interval spellings
+  beyond ("1","1m"); validate.py module size.
+
+Round 2 (codex NO P1/P2 + 1 P3; cursor 2 P2 + 4 P3):
+- ACCEPT+fixed: OHLC sample day falls back to nearest tick-bearing day
+  when the midpoint day is empty (collector outage); empty-rows page with
+  truthy cursor terminates (progress guarantee); importer added to root
+  dev-group so bare `uv run python -m importer.main` works; tz helpers
+  promoted to public `aware_utc`/`iso_utc`.
+- Accepted gaps (P3): single long read session on a Postgres source
+  (resume heals a timeout abort); kline-HTTP retry/column-alias asymmetry
+  (kline endpoint explicitly out of client scope beyond symbol/start/end).
+
+Round 3 (codex 1 P2; cursor NO P1/P2 + 4 P3):
+- ACCEPT+fixed: `smoke_replay` now requires a parsable `Net PnL` metric
+  (missing/unparsable fails) + regression tests; `--ohlc-threshold`
+  validated to (0, 1].
+- Accepted gaps (P3): `run_validation` runs smoke even after OHLC failure
+  (deliberate — full diagnostics per run); no HTTP happy-path e2e through
+  main (transport fully unit-tested).
+
+Round 4 — confirmation (codex 1 P2-labeled nit; cursor NO P1/P2 + 3 P3):
+- ACCEPT+fixed: `math.isfinite` instead of `isnan` (inf rejected) + test;
+  kline HTTP `.get("rows") or []` (null-rows symmetry with ticker path).
+- Accepted gap (P3): multi-day batch emits one progress log per batch
+  boundary, not per day crossed (cosmetic).
+
+### Final status
+
+86 importer tests green; `make lint` clean; full `make test` exit 0,
+TOTAL coverage 91% (gate ≥ 88), importer package ~91%.
+
+```
+ext-code-review trace
+  scope: 26 files
+  engines: both (codex + cursor)
+  iterations: 4/10
+  findings: raised 31, accepted 14 (fixed 14), rejected 4, P3-ignored 13
+  verification: make test exit 0 (TOTAL 91%), lint clean
+  result: SUCCESS
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,15 +16,17 @@ dev = [
     "ruff>=0.1.0",
     "gridbot",
     "pnl-checker",
+    "importer",
 ]
 
 [tool.uv.sources]
 gridbot = { workspace = true }
 pnl-checker = { workspace = true }
+importer = { workspace = true }
 
 [tool.pytest.ini_options]
-pythonpath = ["packages/gridcore/src", "packages/bybit_adapter/src", "shared/db/src", "apps/event_saver/src", "apps/gridbot/src", "apps/backtest/src", "apps/comparator/src", "apps/recorder/src", "apps/replay/src", "apps/pnl_checker/src", "apps/live_check/src", "tests/integration"]
-testpaths = ["packages/gridcore/tests", "packages/bybit_adapter/tests", "shared/db/tests", "apps/event_saver/tests", "apps/gridbot/tests", "apps/backtest/tests", "apps/comparator/tests", "apps/recorder/tests", "apps/replay/tests", "apps/pnl_checker/tests", "apps/live_check/tests", "tests/integration"]
+pythonpath = ["packages/gridcore/src", "packages/bybit_adapter/src", "shared/db/src", "apps/event_saver/src", "apps/gridbot/src", "apps/backtest/src", "apps/comparator/src", "apps/recorder/src", "apps/replay/src", "apps/pnl_checker/src", "apps/live_check/src", "apps/importer/src", "tests/integration"]
+testpaths = ["packages/gridcore/tests", "packages/bybit_adapter/tests", "shared/db/tests", "apps/event_saver/tests", "apps/gridbot/tests", "apps/backtest/tests", "apps/comparator/tests", "apps/recorder/tests", "apps/replay/tests", "apps/pnl_checker/tests", "apps/live_check/tests", "apps/importer/tests", "tests/integration"]
 asyncio_mode = "auto"
 addopts = ["--import-mode=importlib"]
 markers = [

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,12 +1,30 @@
-# Feature 0090 — Source tick_size from exchange instead of hand-maintained YAML
+# Feature 0093 — apps/importer (trad_save_history → replay-compatible SQLite)
 
-Plan: docs/features/0090_PLAN.md  |  Branch: feature/0090-exchange-tick-size
+Plan: docs/features/0093_PLAN.md  |  Branch: feature/0093-importer
 
-- [x] Task 1 / Phase 1: move InstrumentInfoProvider → bybit_adapter, require_live flag, backtest re-export + pyproject dep, gridcore from_bybit_response missing-key fix + tests
-- [x] Task 2 / Phase 2: gridbot — optional YAML tick_size, fail-closed _fetch_instrument_info w/ retries, mismatch cross-check (raise), runner tick resolution fallback + tests
-- [x] Task 3 / Phase 3: replay + backtest — optional YAML tick_size, provider-sourced tick w/ dynamic require_live, warn-and-use-YAML mismatch + tests
-- [x] Task 4: conf YAMLs mark tick_size deprecated; RULES.md updates (lines 175, 1115)
-- [x] Full suite green (post-fix: all packages 0 failures) + lint clean
-- [x] Final whole-branch review — READY TO MERGE (0 Critical/Important); 2 test-hygiene nits folded in
+- [x] apps/importer package skeleton (pyproject, __init__)
+- [x] config.py — CLI parsing, naive-UTC datetime discipline
+- [x] source.py — fetch_batches protocol + factory
+- [x] fetch_source_db.py — transport A (keyset pagination, read-only)
+- [x] fetch_source_http.py — transport B (cursor pagination, retry/backoff)
+- [x] mapping.py — row → TickerSnapshot (Decimal, NULL fallbacks)
+- [x] output_db.py — WAL, parents, run row, per-batch commit, importlock
+- [x] density.py — per-day counts, >60s gaps, LOW-DENSITY
+- [x] validate.py — OHLC cross-check, smoke replay, recorder overlap probe
+- [x] main.py — orchestration loop, aggregate exit code
+- [x] conf/smoke_replay.yaml template
+- [x] tests (8 files, 61 tests, all green)
+- [x] workspace wiring: root pyproject pythonpath/testpaths, Makefile test line
+- [x] make test (exit 0, TOTAL 90% ≥ 88 gate) + make lint green
+- [x] /review-fix-loop-staged — 0 criticals; type hints/docstrings/validate tests folded in
+- [x] /ext-code-review — 4 rounds codex+cursor, SUCCESS (trail: docs/features/0093_REVIEW.md); 86 tests, make test 91%, lint clean
+
+## Plan deviations (documented)
+- HTTP transport cannot probe MIN/MAX (contract has no endpoint) → explicit
+  --start/--end required for --source http; clear ERROR otherwise.
+- Added --recorder-db CLI arg for the --validate overlap probe (plan named the
+  check but no arg); omitted → NOTICE skip.
+- OHLC key-set check = imported-keys ⊆ kline-keys (extra imported keys hard-fail).
+  Missing kline minutes are legitimate source sparsity.
 
 ## Not committed — awaiting user review/approval before any commit.

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,7 @@ members = [
     "grid-db",
     "gridbot",
     "gridcore",
+    "importer",
     "live-check",
     "pnl-checker",
     "recorder",
@@ -338,6 +339,7 @@ source = { virtual = "." }
 [package.dev-dependencies]
 dev = [
     { name = "gridbot" },
+    { name = "importer" },
     { name = "pnl-checker" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -350,6 +352,7 @@ dev = [
 [package.metadata.requires-dev]
 dev = [
     { name = "gridbot", editable = "apps/gridbot" },
+    { name = "importer", editable = "apps/importer" },
     { name = "pnl-checker", editable = "apps/pnl_checker" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
@@ -426,6 +429,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "importer"
+version = "0.1.0"
+source = { editable = "apps/importer" }
+dependencies = [
+    { name = "grid-db" },
+    { name = "pyyaml" },
+    { name = "replay" },
+    { name = "requests" },
+    { name = "sqlalchemy" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "grid-db", editable = "shared/db" },
+    { name = "pyyaml", specifier = ">=6.0" },
+    { name = "replay", editable = "apps/replay" },
+    { name = "requests", specifier = ">=2.31" },
+    { name = "sqlalchemy", specifier = ">=2.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- New uv-workspace app `apps/importer` (feature 0093, closes #232): one-way import of the trad_save_history collector's `ticker_data` into per-symbol replay-compatible SQLite DBs, so H-series last_cross sweeps can run on BTC/ETH and longer independent windows without touching the replay engine.
- Scope guard: public-only source → counterfactual A/B / relative ranking only; recorder stays the only live-fidelity source.
- Dual transports behind one `fetch_batches` interface: direct DB (composite `(timestamp,id)` keyset, read-only, aware-UTC window binds) and HTTP (cursor pagination, 30s timeout, exponential backoff re-requesting the same cursor).
- Resume-append with prefix guard + per-batch commits + `.importlock` sidecar (stale-PID reclaim); single self-healing `recording` run row from DB-wide MIN/MAX for replay auto-discovery; per-day density report with LOW-DENSITY warnings; opt-in `--validate` (OHLC epoch-minute tz detector vs source klines, smoke replay gated on finite Net PnL, recorder overlap probe).
- Wiring: Makefile test line, root pyproject pythonpath/testpaths/dev-group.

## Review
- Internal staged review loop: 0 criticals.
- External review: 4 rounds codex + cursor, SUCCESS — 31 findings raised, 14 fixed, 4 rejected with evidence. Full trail in `docs/features/0093_REVIEW.md`.
- Documented plan deviations: `--source http` requires explicit `--start/--end` (contract has no MIN/MAX probe); `--recorder-db` CLI arg feeds the validate overlap probe; OHLC key-set check = imported keys ⊆ kline keys.

## Test plan
- [x] 86 importer tests green (`uv run pytest apps/importer/tests`)
- [x] Full `make test` exit 0, TOTAL coverage 91% (gate ≥ 88)
- [x] `make lint` clean
- [ ] First real import against the trad_save_history source + `--ohlc-threshold` calibration (post-merge, needs server access)

🤖 Generated with [Claude Code](https://claude.com/claude-code)