### PR TITLE
feat(replay): shared-wallet multi-strategy replay + validation (0094)

### DIFF
--- a/apps/live_check/src/live_check/config.py
+++ b/apps/live_check/src/live_check/config.py
@@ -50,7 +50,28 @@ class VerdictThresholds(BaseModel):
         ),
     )
 
-    @field_validator("realized", "commission", "unrealised", mode="before")
+    equity: Decimal = Field(
+        default=Decimal("0.50"),
+        description="Max replayed-vs-recorded account total_equity delta.",
+    )
+    total_margin_balance: Decimal = Field(
+        default=Decimal("5.00"),
+        description="Max replayed-vs-recorded account total_margin_balance delta.",
+    )
+    account_mm_rate: Decimal = Field(
+        default=Decimal("0.01"),
+        description="Max replayed-vs-recorded account_mm_rate ratio delta.",
+    )
+
+    @field_validator(
+        "realized",
+        "commission",
+        "unrealised",
+        "equity",
+        "total_margin_balance",
+        "account_mm_rate",
+        mode="before",
+    )
     @classmethod
     def parse_decimal_fields(cls, v):
         """Convert string/numeric to Decimal."""

--- a/apps/live_check/src/live_check/main.py
+++ b/apps/live_check/src/live_check/main.py
@@ -24,9 +24,13 @@ from typing import Optional
 from grid_db import DatabaseFactory, DatabaseSettings, Run, RunRepository, redact_db_url
 from replay.snapshot_loader import SeedDataQualityError
 
-from live_check import ground_truth, render, runner
+from live_check import ground_truth, render, runner, shared_wallet
 from live_check.config import LiveCheckConfig, StratCheckConfig, load_config
-from live_check.verdict import evaluate
+from live_check.verdict import (
+    evaluate,
+    evaluate_multi_strategy,
+    evaluate_shared_wallet,
+)
 from live_check.window import (
     Window,
     check_post_0080_floors,
@@ -178,6 +182,67 @@ def run_single(config: LiveCheckConfig, args, db: DatabaseFactory) -> int:
     return _exit_code(outcomes)
 
 
+def run_shared_single(config: LiveCheckConfig, args, db: DatabaseFactory) -> int:
+    """Run one shared-wallet replay and account-level reconciliation."""
+    run_id, account_id, run_start = _resolve_run(db, config.run_id)
+    window = compute_window(parse_duration(args.last), parse_duration(args.lag))
+    check_post_0080_floors(window.start, run_start)
+
+    with db.get_readonly_session() as session:
+        exec_counts = {
+            strat.symbol: ground_truth.live_exec_count(
+                session, run_id, strat.symbol, window.start, window.end
+            )
+            for strat in config.strats
+        }
+        missing_ticker = [
+            strat for strat in config.strats
+            if ground_truth.latest_ticker_ts(session, strat.symbol) is None
+        ]
+    if any(count == 0 for count in exec_counts.values()):
+        for strat in config.strats:
+            if exec_counts[strat.symbol] == 0:
+                print(f"{strat.strat_id} ({strat.symbol}) — SKIP: no data in window")
+        return EXIT_SKIP
+    if missing_ticker:
+        for strat in missing_ticker:
+            print(f"{strat.strat_id} ({strat.symbol}) — SKIP: no ticker data")
+        return EXIT_SKIP
+
+    result = runner.run_shared(config.strats, window, run_id, account_id, db)
+    per_strat = {}
+    rendered = []
+    with db.get_readonly_session() as session:
+        for strat in config.strats:
+            truth = ground_truth.collect(
+                session, run_id, account_id, strat.symbol, window
+            )
+            strategy_result = result.strategies[strat.symbol]
+            verdict = evaluate_multi_strategy(
+                strategy_result, truth, config.thresholds
+            )
+            per_strat[strat.strat_id] = verdict
+            rendered.append((strat, verdict, strategy_result))
+        recorded_curve = shared_wallet.load_wallet_curve(
+            session,
+            run_id,
+            account_id,
+            "USDT",
+            window,
+        )
+    wallet_diff = shared_wallet.reconcile_wallet_curve(
+        result.account_curve,
+        recorded_curve,
+    )
+    shared_verdict = evaluate_shared_wallet(
+        per_strat,
+        wallet_diff,
+        config.thresholds,
+    )
+    print(render.render_shared_wallet(rendered, shared_verdict))
+    return EXIT_PASS if shared_verdict.passed else EXIT_FAIL
+
+
 def watch_tick(
     config: LiveCheckConfig,
     db: DatabaseFactory,
@@ -274,6 +339,8 @@ def main(args) -> int:
     try:
         if args.watch:
             return run_watch(config, args, db)
+        if args.shared:
+            return run_shared_single(config, args, db)
         return run_single(config, args, db)
     except KeyboardInterrupt:
         # Ctrl-C out of the --watch sleep is a normal way to stop the loop —
@@ -314,6 +381,10 @@ def cli() -> None:
     mode.add_argument(
         "--curve", action="store_true",
         help="Cumulative realized sparklines + CSV export",
+    )
+    mode.add_argument(
+        "--shared", action="store_true",
+        help="Shared-wallet multi-strategy reconciliation",
     )
     parser.add_argument(
         "--last", type=str, default=None,

--- a/apps/live_check/src/live_check/render.py
+++ b/apps/live_check/src/live_check/render.py
@@ -58,6 +58,31 @@ def render_once(results) -> str:
     return "\n\n".join(blocks)
 
 
+def render_shared_wallet(strat_results, shared_verdict) -> str:
+    """Render per-strat rows plus shared account-level wallet gates."""
+    blocks = [render_once(strat_results)]
+    status = "PASS" if shared_verdict.passed else "FAIL"
+    diff = shared_verdict.wallet_diff
+    blocks.append(
+        "\n".join(
+            [
+                f"=== shared wallet — {status} ===",
+                f"  max Δequity          {_fmt(diff.max_equity_delta)} "
+                f"{_flag(shared_verdict.equity_ok)} "
+                f"({diff.equity_points} points)",
+                f"  final Δequity        {_fmt(diff.final_equity_delta)}",
+                f"  max Δmargin_balance  {_fmt(diff.max_margin_balance_delta)} "
+                f"{_flag(shared_verdict.total_margin_balance_ok)} "
+                f"({diff.margin_balance_points} points)",
+                f"  max Δaccount_mm_rate {_fmt(diff.max_account_mm_rate_delta)} "
+                f"{_flag(shared_verdict.account_mm_rate_ok)} "
+                f"({diff.account_mm_rate_points} points)",
+            ]
+        )
+    )
+    return "\n\n".join(blocks)
+
+
 def render_watch_line(results, tick_ts=None) -> str:
     """One-line traffic-light per strat for a watch tick.
 

--- a/apps/live_check/src/live_check/runner.py
+++ b/apps/live_check/src/live_check/runner.py
@@ -6,6 +6,8 @@ from grid_db import DatabaseFactory
 
 from replay.config import FillSimulatorConfig, ReplayConfig, SeedConfig
 from replay.engine import ReplayEngine, ReplayResult
+from replay.multi_config import MultiReplayConfig, MultiSeedConfig
+from replay.multi_engine import MultiReplayEngine, MultiReplayResult
 
 from live_check.config import StratCheckConfig
 from live_check.window import Window
@@ -78,5 +80,57 @@ def run_strat(
     logger.info(
         "%s: replaying %s window %s → %s (event_follower, seeded)",
         strat.strat_id, strat.symbol, window.start, window.end,
+    )
+    return engine.run()
+
+
+def build_multi_replay_config(
+    strats: list[StratCheckConfig],
+    window: Window,
+    run_id: str,
+    database_url: str,
+    account_id: str,
+) -> MultiReplayConfig:
+    """Compose one shared-wallet event_follower replay config."""
+    return MultiReplayConfig(
+        database_url=database_url,
+        run_id=run_id,
+        start_ts=window.start,
+        end_ts=window.end,
+        seed=MultiSeedConfig(
+            enabled=True,
+            at_ts=window.start,
+            account_id=account_id,
+        ),
+        fill_simulator=FillSimulatorConfig(mode="event_follower"),
+        strategies=[
+            strat.to_replay_strategy_config().model_dump() | {
+                "symbol": strat.symbol,
+                "strat_id": strat.strat_id,
+            }
+            for strat in strats
+        ],
+    )
+
+
+def run_shared(
+    strats: list[StratCheckConfig],
+    window: Window,
+    run_id: str,
+    account_id: str,
+    db: DatabaseFactory,
+) -> MultiReplayResult:
+    """Run one seeded shared-wallet replay for all configured strats."""
+    config = build_multi_replay_config(
+        strats=strats,
+        window=window,
+        run_id=run_id,
+        database_url=db.settings.get_database_url(),
+        account_id=account_id,
+    )
+    engine = MultiReplayEngine(config, db=db, emit_backtest_snapshots=False)
+    logger.info(
+        "shared: replaying %d strats window %s → %s (event_follower, seeded)",
+        len(strats), window.start, window.end,
     )
     return engine.run()

--- a/apps/live_check/src/live_check/shared_wallet.py
+++ b/apps/live_check/src/live_check/shared_wallet.py
@@ -88,17 +88,23 @@ def reconcile_wallet_curve(
 
     Recorded NULL fields are skipped per field, never coerced to zero. Replayed
     values are sampled nearest at-or-before the recorded timestamp.
+
+    Both timestamp streams are normalized to naive UTC before comparison so a
+    mixed tz-aware/tz-naive pair cannot raise a TypeError mid-walk (the prod
+    SQLite path is naive on both sides; this guards injected/aware inputs).
     """
-    replay = sorted(replay_curve, key=lambda p: p.exchange_ts)
+    replay = sorted(replay_curve, key=lambda p: to_naive_utc(p.exchange_ts))
+    replay_ts = [to_naive_utc(p.exchange_ts) for p in replay]
     equity_deltas: list[Decimal] = []
     margin_deltas: list[Decimal] = []
     mm_rate_deltas: list[Decimal] = []
     final_equity_delta = Decimal("0")
     idx = -1
     for point in recorded_curve:
+        point_ts = to_naive_utc(point.exchange_ts)
         while (
             idx + 1 < len(replay)
-            and replay[idx + 1].exchange_ts <= point.exchange_ts
+            and replay_ts[idx + 1] <= point_ts
         ):
             idx += 1
         if idx < 0:

--- a/apps/live_check/src/live_check/shared_wallet.py
+++ b/apps/live_check/src/live_check/shared_wallet.py
@@ -1,0 +1,128 @@
+"""Shared-wallet ground-truth reads and replayed-curve reconciliation."""
+
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from typing import Iterable, Optional
+
+from sqlalchemy.orm import Session
+
+from grid_db import WalletSnapshotRepository
+
+from live_check.window import Window, to_naive_utc
+
+
+@dataclass(frozen=True)
+class WalletCurvePoint:
+    """Materialized account-level wallet snapshot fields."""
+
+    exchange_ts: datetime
+    total_equity: Optional[Decimal]
+    total_margin_balance: Optional[Decimal]
+    account_mm_rate: Optional[Decimal]
+
+
+@dataclass(frozen=True)
+class SharedWalletDiff:
+    """Replay-vs-recorded shared wallet reconciliation metrics."""
+
+    max_equity_delta: Decimal
+    final_equity_delta: Decimal
+    max_margin_balance_delta: Decimal
+    max_account_mm_rate_delta: Decimal
+    equity_points: int
+    margin_balance_points: int
+    account_mm_rate_points: int
+
+
+def load_wallet_curve(
+    session: Session,
+    run_id: str,
+    account_id: str,
+    coin: str,
+    window: Window,
+) -> list[WalletCurvePoint]:
+    """Load account wallet snapshots, run-filtered and end-anchor de-duped.
+
+    ``WalletSnapshotRepository.get_by_account_range`` filters account, coin and
+    inclusive bounds but not run_id, so this function post-filters by run_id.
+    The at-window-end anchor comes from the run-scoped repository method and
+    supersedes any range row at the same ``exchange_ts``.
+    """
+    repo = WalletSnapshotRepository(session)
+    rows = [
+        row for row in repo.get_by_account_range(
+            account_id,
+            coin,
+            to_naive_utc(window.start),
+            to_naive_utc(window.end),
+        )
+        if row.run_id == run_id and row.coin == coin
+    ]
+    anchor = repo.get_latest_before(
+        run_id,
+        account_id,
+        coin,
+        to_naive_utc(window.end),
+    )
+    by_ts = {row.exchange_ts: row for row in rows}
+    if anchor is not None:
+        by_ts[anchor.exchange_ts] = anchor
+
+    return [
+        WalletCurvePoint(
+            exchange_ts=row.exchange_ts,
+            total_equity=row.total_equity,
+            total_margin_balance=row.total_margin_balance,
+            account_mm_rate=row.account_mm_rate,
+        )
+        for row in sorted(by_ts.values(), key=lambda r: r.exchange_ts)
+    ]
+
+
+def reconcile_wallet_curve(
+    replay_curve: Iterable,
+    recorded_curve: list[WalletCurvePoint],
+) -> SharedWalletDiff:
+    """Compare replayed account samples at recorded timestamps.
+
+    Recorded NULL fields are skipped per field, never coerced to zero. Replayed
+    values are sampled nearest at-or-before the recorded timestamp.
+    """
+    replay = sorted(replay_curve, key=lambda p: p.exchange_ts)
+    equity_deltas: list[Decimal] = []
+    margin_deltas: list[Decimal] = []
+    mm_rate_deltas: list[Decimal] = []
+    final_equity_delta = Decimal("0")
+    idx = -1
+    for point in recorded_curve:
+        while (
+            idx + 1 < len(replay)
+            and replay[idx + 1].exchange_ts <= point.exchange_ts
+        ):
+            idx += 1
+        if idx < 0:
+            continue
+        sample = replay[idx]
+        if point.total_equity is not None:
+            delta = sample.total_equity - point.total_equity
+            equity_deltas.append(abs(delta))
+            final_equity_delta = abs(delta)
+        if point.total_margin_balance is not None:
+            margin_deltas.append(
+                abs(sample.total_margin_balance - point.total_margin_balance)
+            )
+        if point.account_mm_rate is not None:
+            mm_rate_deltas.append(
+                abs(sample.account_mm_rate - point.account_mm_rate)
+            )
+
+    return SharedWalletDiff(
+        max_equity_delta=max(equity_deltas, default=Decimal("0")),
+        final_equity_delta=final_equity_delta,
+        max_margin_balance_delta=max(margin_deltas, default=Decimal("0")),
+        max_account_mm_rate_delta=max(mm_rate_deltas, default=Decimal("0")),
+        equity_points=len(equity_deltas),
+        margin_balance_points=len(margin_deltas),
+        account_mm_rate_points=len(mm_rate_deltas),
+    )

--- a/apps/live_check/src/live_check/verdict.py
+++ b/apps/live_check/src/live_check/verdict.py
@@ -8,6 +8,7 @@ from decimal import Decimal
 
 from live_check.config import VerdictThresholds
 from live_check.ground_truth import GroundTruth
+from live_check.shared_wallet import SharedWalletDiff
 
 
 @dataclass(frozen=True)
@@ -25,6 +26,18 @@ class Verdict:
     realized_ok: bool
     commission_ok: bool
     unrealised_ok: bool
+    passed: bool
+
+
+@dataclass(frozen=True)
+class SharedWalletVerdict:
+    """Outcome of the account-level shared-wallet gates."""
+
+    per_strat: dict[str, Verdict]
+    wallet_diff: SharedWalletDiff
+    equity_ok: bool
+    total_margin_balance_ok: bool
+    account_mm_rate_ok: bool
     passed: bool
 
 
@@ -95,4 +108,74 @@ def evaluate(
         commission_ok=commission_ok,
         unrealised_ok=unrealised_ok,
         passed=matched_ok and realized_ok and commission_ok and unrealised_ok,
+    )
+
+
+def evaluate_multi_strategy(
+    strategy_result,
+    ground_truth: GroundTruth,
+    thresholds: VerdictThresholds,
+) -> Verdict:
+    """Evaluate one symbol from a shared-session replay using per-symbol metrics."""
+    match_result = strategy_result.match_result
+    live_only_count = len(match_result.live_only)
+    backtest_only_count = len(match_result.backtest_only)
+    matched_ok = live_only_count == 0 and backtest_only_count == 0
+    metrics = strategy_result.metrics
+
+    d_realized = metrics.total_backtest_pnl - ground_truth.sum_realized
+    d_commission = metrics.total_backtest_fees - ground_truth.sum_commission
+    d_unrealised = strategy_result.final_unrealized - ground_truth.net_unrealised
+
+    realized_ok = abs(d_realized) < thresholds.realized
+    commission_ok = abs(d_commission) < thresholds.commission
+    unrealised_ok = abs(d_unrealised) < thresholds.unrealised
+
+    return Verdict(
+        live_only_count=live_only_count,
+        backtest_only_count=backtest_only_count,
+        matched_count=len(match_result.matched),
+        live_exec_count=ground_truth.live_exec_count,
+        d_realized=d_realized,
+        d_commission=d_commission,
+        d_unrealised=d_unrealised,
+        matched_ok=matched_ok,
+        realized_ok=realized_ok,
+        commission_ok=commission_ok,
+        unrealised_ok=unrealised_ok,
+        passed=matched_ok and realized_ok and commission_ok and unrealised_ok,
+    )
+
+
+def evaluate_shared_wallet(
+    per_strat: dict[str, Verdict],
+    wallet_diff: SharedWalletDiff,
+    thresholds: VerdictThresholds,
+) -> SharedWalletVerdict:
+    """AND per-strat event-follower checks with account wallet gates."""
+    equity_ok = (
+        wallet_diff.equity_points > 0
+        and wallet_diff.max_equity_delta < thresholds.equity
+    )
+    total_margin_balance_ok = (
+        wallet_diff.margin_balance_points > 0
+        and wallet_diff.max_margin_balance_delta < thresholds.total_margin_balance
+    )
+    account_mm_rate_ok = (
+        wallet_diff.account_mm_rate_points > 0
+        and wallet_diff.max_account_mm_rate_delta < thresholds.account_mm_rate
+    )
+    passed = (
+        all(v.passed for v in per_strat.values())
+        and equity_ok
+        and total_margin_balance_ok
+        and account_mm_rate_ok
+    )
+    return SharedWalletVerdict(
+        per_strat=per_strat,
+        wallet_diff=wallet_diff,
+        equity_ok=equity_ok,
+        total_margin_balance_ok=total_margin_balance_ok,
+        account_mm_rate_ok=account_mm_rate_ok,
+        passed=passed,
     )

--- a/apps/live_check/tests/test_shared_wallet.py
+++ b/apps/live_check/tests/test_shared_wallet.py
@@ -1,6 +1,6 @@
 """Tests for shared-wallet reconciliation helpers."""
 
-from datetime import timedelta
+from datetime import timedelta, timezone
 from decimal import Decimal
 
 from grid_db import WalletSnapshot
@@ -138,3 +138,28 @@ def test_reconcile_wallet_curve_skips_nulls_per_field(ts):
     assert diff.margin_balance_points == 1
     assert diff.max_account_mm_rate_delta == Decimal("0.001")
     assert diff.account_mm_rate_points == 1
+
+
+def test_reconcile_wallet_curve_mixed_tz_awareness(ts):
+    """Review P2: mixed tz-aware/naive timestamps normalize to naive UTC and
+    do not raise a TypeError mid-walk (recorded aware, replay naive here)."""
+    aware = ts.replace(tzinfo=timezone.utc)
+    recorded = [
+        WalletCurvePoint(
+            exchange_ts=aware,
+            total_equity=Decimal("100"),
+            total_margin_balance=None,
+            account_mm_rate=None,
+        )
+    ]
+    replay = [
+        AccountCurveSample(
+            exchange_ts=ts,  # naive — opposite awareness from recorded
+            total_equity=Decimal("100.4"),
+            total_margin_balance=Decimal("100.4"),
+            account_mm_rate=Decimal("0.01"),
+        )
+    ]
+    diff = reconcile_wallet_curve(replay, recorded)
+    assert diff.equity_points == 1
+    assert diff.max_equity_delta == Decimal("0.4")

--- a/apps/live_check/tests/test_shared_wallet.py
+++ b/apps/live_check/tests/test_shared_wallet.py
@@ -1,0 +1,140 @@
+"""Tests for shared-wallet reconciliation helpers."""
+
+from datetime import timedelta
+from decimal import Decimal
+
+from grid_db import WalletSnapshot
+from grid_db.models import Run
+
+from live_check.shared_wallet import (
+    WalletCurvePoint,
+    load_wallet_curve,
+    reconcile_wallet_curve,
+)
+from live_check.window import Window
+from replay.multi_engine import AccountCurveSample
+
+
+RUN_ID = "test-run-id"
+
+
+def _insert_wallet(
+    db,
+    account_id,
+    *,
+    run_id=RUN_ID,
+    ts,
+    equity=None,
+    margin=None,
+    mm_rate=None,
+    coin="USDT",
+):
+    with db.get_session() as session:
+        session.add(
+            WalletSnapshot(
+                run_id=run_id,
+                account_id=account_id,
+                exchange_ts=ts,
+                local_ts=ts,
+                coin=coin,
+                wallet_balance=Decimal("100"),
+                available_balance=Decimal("90"),
+                total_available_balance=Decimal("90"),
+                total_equity=Decimal(equity) if equity is not None else None,
+                total_margin_balance=(
+                    Decimal(margin) if margin is not None else None
+                ),
+                account_mm_rate=Decimal(mm_rate) if mm_rate is not None else None,
+            )
+        )
+
+
+def test_load_wallet_curve_run_filters_and_dedups_end_anchor(
+    db, seeded_run_account, ts
+):
+    """C6: range read is post-filtered by run_id and end anchor is de-duped."""
+    acc = seeded_run_account.account_id
+    # A second recording run on the SAME account — its wallet rows must be
+    # excluded by the run_id post-filter (C6). The FK to runs requires the
+    # run to exist, so mirror the seeded run's user/account/strategy refs.
+    with db.get_session() as session:
+        seeded = session.get(Run, RUN_ID)
+        session.add(
+            Run(
+                run_id="other-run",
+                user_id=seeded.user_id,
+                account_id=seeded.account_id,
+                strategy_id=seeded.strategy_id,
+                run_type="recording",
+                start_ts=seeded.start_ts,
+            )
+        )
+        session.commit()
+    _insert_wallet(db, acc, ts=ts, equity="100", margin="100", mm_rate="0.01")
+    _insert_wallet(
+        db,
+        acc,
+        run_id="other-run",
+        ts=ts + timedelta(minutes=1),
+        equity="999",
+        margin="999",
+        mm_rate="0.99",
+    )
+    _insert_wallet(
+        db,
+        acc,
+        ts=ts + timedelta(minutes=2),
+        equity="101",
+        margin="101",
+        mm_rate="0.02",
+    )
+    window = Window(start=ts, end=ts + timedelta(minutes=2))
+    with db.get_readonly_session() as session:
+        rows = load_wallet_curve(session, RUN_ID, acc, "USDT", window)
+    assert [row.exchange_ts for row in rows] == [
+        ts,
+        ts + timedelta(minutes=2),
+    ]
+    assert [row.total_equity for row in rows] == [
+        Decimal("100.00000000"),
+        Decimal("101.00000000"),
+    ]
+
+
+def test_reconcile_wallet_curve_skips_nulls_per_field(ts):
+    """C7: NULL recorded fields are skipped independently, never zero-filled."""
+    recorded = [
+        WalletCurvePoint(
+            exchange_ts=ts,
+            total_equity=Decimal("100"),
+            total_margin_balance=None,
+            account_mm_rate=Decimal("0.01"),
+        ),
+        WalletCurvePoint(
+            exchange_ts=ts + timedelta(seconds=1),
+            total_equity=None,
+            total_margin_balance=Decimal("101"),
+            account_mm_rate=None,
+        ),
+    ]
+    replay = [
+        AccountCurveSample(
+            exchange_ts=ts,
+            total_equity=Decimal("100.2"),
+            total_margin_balance=Decimal("100.2"),
+            account_mm_rate=Decimal("0.011"),
+        ),
+        AccountCurveSample(
+            exchange_ts=ts + timedelta(seconds=1),
+            total_equity=Decimal("100.3"),
+            total_margin_balance=Decimal("100.8"),
+            account_mm_rate=Decimal("0.012"),
+        ),
+    ]
+    diff = reconcile_wallet_curve(replay, recorded)
+    assert diff.max_equity_delta == Decimal("0.2")
+    assert diff.equity_points == 1
+    assert diff.max_margin_balance_delta == Decimal("0.2")
+    assert diff.margin_balance_points == 1
+    assert diff.max_account_mm_rate_delta == Decimal("0.001")
+    assert diff.account_mm_rate_points == 1

--- a/apps/live_check/tests/test_verdict.py
+++ b/apps/live_check/tests/test_verdict.py
@@ -7,7 +7,12 @@ import pytest
 
 from live_check.config import VerdictThresholds
 from live_check.ground_truth import GroundTruth
-from live_check.verdict import evaluate
+from live_check.shared_wallet import SharedWalletDiff
+from live_check.verdict import (
+    evaluate,
+    evaluate_multi_strategy,
+    evaluate_shared_wallet,
+)
 
 _ZERO = Decimal("0")
 
@@ -124,3 +129,56 @@ class TestUnrealisedSource:
         """session.metrics None → explicit ValueError, not AttributeError."""
         with pytest.raises(ValueError, match="not.*finalized|finalize"):
             evaluate(_rr(metrics_none=True), _truth(), VerdictThresholds())
+
+
+class TestSharedWalletVerdict:
+    def test_multi_strategy_uses_per_symbol_metrics_not_session_totals(self):
+        """C5: per-strat verdict fails even if shared session totals would pass."""
+        result = SimpleNamespace(
+            metrics=SimpleNamespace(
+                total_backtest_pnl=Decimal("10"),
+                total_backtest_fees=Decimal("1"),
+            ),
+            final_unrealized=Decimal("0"),
+            match_result=SimpleNamespace(matched=[], live_only=[], backtest_only=[]),
+        )
+        verdict = evaluate_multi_strategy(
+            result,
+            _truth(realized="0", commission="1", unrealised="0"),
+            VerdictThresholds(),
+        )
+        assert not verdict.realized_ok
+        assert not verdict.passed
+
+    def test_shared_wallet_ands_all_gate_groups(self):
+        """Shared verdict requires per-strat, equity and margin gates."""
+        per = {
+            "sol": evaluate(_rr(), _truth(), VerdictThresholds()),
+            "ltc": evaluate(_rr(), _truth(), VerdictThresholds()),
+        }
+        diff = SharedWalletDiff(
+            max_equity_delta=Decimal("0.1"),
+            final_equity_delta=Decimal("0.1"),
+            max_margin_balance_delta=Decimal("0.1"),
+            max_account_mm_rate_delta=Decimal("0.001"),
+            equity_points=2,
+            margin_balance_points=2,
+            account_mm_rate_points=2,
+        )
+        verdict = evaluate_shared_wallet(per, diff, VerdictThresholds())
+        assert verdict.passed
+
+    def test_shared_wallet_zero_points_fail(self):
+        """Zero wallet data is not a PASS."""
+        per = {"sol": evaluate(_rr(), _truth(), VerdictThresholds())}
+        diff = SharedWalletDiff(
+            max_equity_delta=Decimal("0"),
+            final_equity_delta=Decimal("0"),
+            max_margin_balance_delta=Decimal("0"),
+            max_account_mm_rate_delta=Decimal("0"),
+            equity_points=0,
+            margin_balance_points=0,
+            account_mm_rate_points=0,
+        )
+        verdict = evaluate_shared_wallet(per, diff, VerdictThresholds())
+        assert not verdict.passed

--- a/apps/replay/src/replay/__init__.py
+++ b/apps/replay/src/replay/__init__.py
@@ -7,6 +7,12 @@ simulated trades against real recorded executions.
 
 from replay.config import ReplayConfig, ReplayStrategyConfig, load_config
 from replay.engine import ReplayEngine, ReplayResult
+from replay.multi_config import (
+    MultiReplayConfig,
+    MultiReplayStrategyConfig,
+    load_multi_config,
+)
+from replay.multi_engine import MultiReplayEngine, MultiReplayResult
 
 __all__ = [
     "ReplayConfig",
@@ -14,4 +20,9 @@ __all__ = [
     "load_config",
     "ReplayEngine",
     "ReplayResult",
+    "MultiReplayConfig",
+    "MultiReplayStrategyConfig",
+    "load_multi_config",
+    "MultiReplayEngine",
+    "MultiReplayResult",
 ]

--- a/apps/replay/src/replay/multi_config.py
+++ b/apps/replay/src/replay/multi_config.py
@@ -1,0 +1,184 @@
+"""Configuration models for shared-wallet multi-strategy replay."""
+
+import os
+from datetime import datetime, timedelta
+from decimal import Decimal
+from pathlib import Path
+from typing import Optional
+
+import yaml
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from backtest.config import WindDownMode
+from replay.config import FillSimulatorConfig, ReplayStrategyConfig, _parse_decimal
+
+
+class MultiReplayStrategyConfig(ReplayStrategyConfig):
+    """One strategy entry for shared-wallet replay."""
+
+    strat_id: str = Field(
+        ...,
+        description="Live strategy id used for client_order_id namespace.",
+    )
+    symbol: str = Field(..., description="Trading symbol, e.g. SOLUSDT")
+
+
+class MultiSeedConfig(BaseModel):
+    """Account-level seed configuration for multi-strategy replay."""
+
+    enabled: bool = Field(default=False, description="Enable DB seed loading.")
+    at_ts: Optional[datetime] = Field(
+        default=None,
+        description="Account seed timestamp. Required when enabled.",
+    )
+    account_id: Optional[str] = Field(
+        default=None,
+        description="Account ID for account-level seed rows. Required when enabled.",
+    )
+    wallet_coin: str = Field(default="USDT", description="Wallet coin to seed.")
+    collateral_coins: list[str] = Field(default_factory=list)
+    collateral_symbol_map: dict[str, str] = Field(default_factory=dict)
+    collateral_value_ratios: dict[str, Decimal] = Field(default_factory=dict)
+    collateral_wallet_max_staleness: timedelta = Field(
+        default=timedelta(seconds=60)
+    )
+
+    @field_validator("collateral_coins")
+    @classmethod
+    def non_empty_collateral_coins(cls, v: list[str]) -> list[str]:
+        """Reject empty/whitespace coin names."""
+        if any(not s.strip() for s in v):
+            raise ValueError(
+                "collateral_coins must be non-empty, non-whitespace strings"
+            )
+        return v
+
+    @field_validator("collateral_value_ratios", mode="before")
+    @classmethod
+    def parse_collateral_value_ratios(cls, v):
+        """Coerce collateral value ratios to Decimal."""
+        if isinstance(v, dict):
+            return {k: _parse_decimal(val) for k, val in v.items()}
+        return v
+
+    @model_validator(mode="after")
+    def require_seed_fields_when_enabled(self):
+        """Require account seed identity fields when seeding is enabled."""
+        if self.enabled:
+            missing = [
+                name for name in ("at_ts", "account_id")
+                if getattr(self, name) is None
+            ]
+            if missing:
+                raise ValueError(
+                    f"seed.enabled=True requires fields: {', '.join(missing)}"
+                )
+        return self
+
+
+class MultiReplayConfig(BaseModel):
+    """Root config for shared-wallet multi-strategy replay."""
+
+    database_url: str = Field(default="sqlite:///recorder.db")
+    run_id: Optional[str] = Field(default=None)
+    start_ts: Optional[datetime] = Field(default=None)
+    end_ts: Optional[datetime] = Field(default=None)
+    seed: MultiSeedConfig = Field(default_factory=MultiSeedConfig)
+    fill_simulator: FillSimulatorConfig = Field(default_factory=FillSimulatorConfig)
+    strategies: list[MultiReplayStrategyConfig] = Field(..., min_length=1)
+    initial_balance: Decimal = Field(default=Decimal("10000"), gt=0)
+    enable_funding: bool = Field(default=True)
+    funding_rate: Decimal = Field(default=Decimal("0.0001"))
+    wind_down_mode: WindDownMode = Field(default=WindDownMode.LEAVE_OPEN)
+    output_dir: str = Field(default="results/replay_multi")
+    price_tolerance: Decimal = Field(default=Decimal("0"))
+    qty_tolerance: Decimal = Field(default=Decimal("0.001"))
+
+    @field_validator(
+        "initial_balance", "funding_rate", "price_tolerance", "qty_tolerance",
+        mode="before",
+    )
+    @classmethod
+    def parse_decimal_fields(cls, v):
+        """Convert string/numeric config values to Decimal."""
+        return _parse_decimal(v)
+
+    @model_validator(mode="after")
+    def reject_duplicate_strategies(self):
+        """Reject duplicate symbol / strat_id across strategies.
+
+        The engine keys bundles/runners/seed_data by symbol, so a duplicate
+        symbol would silently last-win and drop a strategy; duplicate strat_id
+        would collide the client_order_id namespace.
+        """
+        symbols = [s.symbol for s in self.strategies]
+        strat_ids = [s.strat_id for s in self.strategies]
+        dup_symbols = sorted({s for s in symbols if symbols.count(s) > 1})
+        dup_strats = sorted({s for s in strat_ids if strat_ids.count(s) > 1})
+        if dup_symbols:
+            raise ValueError(f"duplicate strategy symbol(s): {dup_symbols}")
+        if dup_strats:
+            raise ValueError(f"duplicate strategy strat_id(s): {dup_strats}")
+        return self
+
+    @model_validator(mode="after")
+    def reject_traded_symbol_as_collateral(self):
+        """Prevent double-counting traded base coins as spot collateral."""
+        traded_bases = {_base_coin(s.symbol) for s in self.strategies}
+        overlap = traded_bases & {coin.upper() for coin in self.seed.collateral_coins}
+        if overlap:
+            raise ValueError(
+                "seed.collateral_coins must not include traded base coins: "
+                f"{sorted(overlap)}"
+            )
+        return self
+
+
+def _base_coin(symbol: str) -> str:
+    """Return a simple linear-contract base coin for known quote suffixes."""
+    upper = symbol.upper()
+    for quote in ("USDT", "USDC", "USD"):
+        if upper.endswith(quote):
+            return upper[: -len(quote)]
+    return upper
+
+
+def load_multi_config(config_path: Optional[str] = None) -> MultiReplayConfig:
+    """Load shared-wallet replay config from YAML.
+
+    Args:
+        config_path: Explicit path. If None, checks
+            ``REPLAY_MULTI_CONFIG_PATH`` then ``conf/replay_multi.yaml``.
+
+    Returns:
+        Validated multi replay config.
+
+    Raises:
+        FileNotFoundError: If no config file exists.
+        ValueError: If the YAML is empty or invalid.
+    """
+    if config_path is None:
+        config_path = os.environ.get("REPLAY_MULTI_CONFIG_PATH")
+
+    if config_path is None:
+        path = Path("conf/replay_multi.yaml")
+        if path.exists():
+            config_path = str(path)
+
+    if config_path is None:
+        raise FileNotFoundError(
+            "No config file found. Set REPLAY_MULTI_CONFIG_PATH or create "
+            "conf/replay_multi.yaml"
+        )
+
+    path = Path(config_path)
+    if not path.exists():
+        raise FileNotFoundError(f"Config file not found: {config_path}")
+
+    with open(path) as f:
+        data = yaml.safe_load(f)
+
+    if data is None:
+        raise ValueError(f"Empty or invalid YAML file: {config_path}")
+
+    return MultiReplayConfig(**data)

--- a/apps/replay/src/replay/multi_engine.py
+++ b/apps/replay/src/replay/multi_engine.py
@@ -1,0 +1,810 @@
+"""Shared-wallet multi-strategy replay engine."""
+
+from __future__ import annotations
+
+import heapq
+import logging
+from contextlib import contextmanager
+from dataclasses import dataclass, field, replace
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Iterable, Iterator, Optional
+
+from sqlalchemy import desc
+
+from grid_db import (
+    DatabaseFactory,
+    PrivateExecutionRepository,
+    Run,
+    RunRepository,
+    TickerSnapshot,
+    redact_db_url,
+)
+
+from backtest.config import BacktestStrategyConfig, WindDownMode
+from backtest.data_provider import HistoricalDataProvider, InMemoryDataProvider
+from backtest.engine import FundingSimulator
+from backtest.fill_simulator import EventFollower, FillMode, RecordedExecution
+from backtest.runner import BacktestRunner
+from backtest.session import BacktestSession
+
+from comparator import (
+    BacktestTradeLoader,
+    LiveTradeLoader,
+    MatchResult,
+    TradeMatcher,
+    ValidationMetrics,
+    calculate_metrics,
+)
+
+from replay.engine import (
+    CollateralMarkFeed,
+    ReplayEngine,
+    _NoopPositionSnapshotWriter,
+)
+from replay.multi_config import MultiReplayConfig, MultiReplayStrategyConfig
+from replay.snapshot_loader import (
+    ActiveOrderSeed,
+    GridStateSeed,
+    PositionStateSeed,
+    SeedDataQualityError,
+    WalletSeed,
+    _strip_tz,
+    load_active_orders,
+    load_collateral_seed,
+    load_grid_state_from_active_snapshots,
+    load_grid_state_from_snapshots,
+    load_position_snapshots,
+    load_wallet_seed_full,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class AccountCurveSample:
+    """One replayed account-level reconciliation sample."""
+
+    exchange_ts: datetime
+    total_equity: Decimal
+    total_margin_balance: Decimal
+    account_mm_rate: Decimal
+
+
+@dataclass(frozen=True)
+class MultiStrategyReplayResult:
+    """Per-strategy replay comparison output under one shared session."""
+
+    strategy: MultiReplayStrategyConfig
+    runner: BacktestRunner
+    metrics: ValidationMetrics
+    match_result: MatchResult
+    final_unrealized: Decimal
+
+
+@dataclass(frozen=True)
+class MultiReplayResult:
+    """Result of a shared-wallet multi-strategy replay."""
+
+    session: BacktestSession
+    strategies: dict[str, MultiStrategyReplayResult]
+    run_id: str
+    account_id: Optional[str]
+    start_ts: datetime
+    end_ts: datetime
+    fill_mode: FillMode
+    account_curve: list[AccountCurveSample] = field(default_factory=list)
+
+    @property
+    def total_equity_curve(self) -> list[tuple[datetime, Decimal]]:
+        """Replayed ``total_equity`` series."""
+        return [(s.exchange_ts, s.total_equity) for s in self.account_curve]
+
+    @property
+    def total_margin_balance_curve(self) -> list[tuple[datetime, Decimal]]:
+        """Replayed ``total_margin_balance`` series."""
+        return [
+            (s.exchange_ts, s.total_margin_balance) for s in self.account_curve
+        ]
+
+    @property
+    def account_mm_rate_curve(self) -> list[tuple[datetime, Decimal]]:
+        """Replayed account maintenance-margin ratio series."""
+        return [(s.exchange_ts, s.account_mm_rate) for s in self.account_curve]
+
+
+@dataclass
+class _RunnerBundle:
+    config: MultiReplayStrategyConfig
+    runner: BacktestRunner
+    funding: Optional[FundingSimulator]
+
+
+class _SharedSessionCoordinator:
+    """Aggregate session-global refresh/pending values across runners."""
+
+    def __init__(
+        self,
+        session: BacktestSession,
+        runners: dict[str, BacktestRunner],
+        last_prices: dict[str, Decimal],
+    ):
+        self._session = session
+        self._runners = runners
+        self._last_prices = last_prices
+        self._pending: dict[str, tuple[Decimal, Decimal]] = {
+            symbol: (Decimal("0"), Decimal("0")) for symbol in runners
+        }
+        self._active_symbol: Optional[str] = None
+        self._orig_set_pending = session.set_pending_wallet
+        self._orig_clear_pending = session.clear_pending_wallet
+        self._orig_refresh = session.refresh_balances
+        session.set_pending_wallet = self.set_pending_wallet  # type: ignore[method-assign]
+        session.clear_pending_wallet = self.clear_pending_wallet  # type: ignore[method-assign]
+        session.refresh_balances = self.refresh_balances  # type: ignore[method-assign]
+
+    @contextmanager
+    def active(self, symbol: str):
+        """Route runner-owned session calls to the symbol's aggregate slot."""
+        previous = self._active_symbol
+        self._active_symbol = symbol
+        try:
+            yield
+        finally:
+            self._active_symbol = previous
+
+    def set_pending_wallet(
+        self,
+        pending_realized: Decimal,
+        pending_commission: Decimal,
+    ) -> None:
+        """Store active-symbol pending and publish the account-wide sum."""
+        if self._active_symbol is None:
+            self._orig_set_pending(pending_realized, pending_commission)
+            return
+        self._pending[self._active_symbol] = (pending_realized, pending_commission)
+        self._publish_pending()
+
+    def clear_pending_wallet(self) -> None:
+        """Clear the active symbol's pending state, or all state outside a runner."""
+        if self._active_symbol is None:
+            self._pending = {
+                symbol: (Decimal("0"), Decimal("0")) for symbol in self._runners
+            }
+        else:
+            self._pending[self._active_symbol] = (Decimal("0"), Decimal("0"))
+        self._publish_pending()
+
+    def refresh_balances(self, unrealized_pnl: Decimal) -> None:
+        """Refresh shared balances with Σ unrealized, not the caller's own leg."""
+        del unrealized_pnl
+        self._orig_refresh(self.total_unrealized())
+
+    def total_unrealized(self) -> Decimal:
+        """Return Σ unrealized across all runners at cached own-symbol marks."""
+        total = Decimal("0")
+        for symbol, runner in self._runners.items():
+            price = self._last_prices.get(symbol, Decimal("0"))
+            if price <= 0:
+                continue
+            total += runner.long_tracker.calculate_unrealized_pnl(price)
+            total += runner.short_tracker.calculate_unrealized_pnl(price)
+        return total
+
+    def total_im_mm(self) -> tuple[Decimal, Decimal]:
+        """Return account-level Σ initial and maintenance margin."""
+        total_im = Decimal("0")
+        total_mm = Decimal("0")
+        for symbol, runner in self._runners.items():
+            price = self._last_prices.get(symbol, Decimal("0"))
+            if price <= 0:
+                continue
+            im_long, mm_long, im_short, mm_short = runner._estimate_pair_im_mm(
+                runner.long_tracker.state,
+                runner.short_tracker.state,
+                price,
+            )
+            total_im += im_long + im_short
+            total_mm += mm_long + mm_short
+        return total_im, total_mm
+
+    def _publish_pending(self) -> None:
+        pending_realized = sum((v[0] for v in self._pending.values()), Decimal("0"))
+        pending_commission = sum((v[1] for v in self._pending.values()), Decimal("0"))
+        self._orig_set_pending(pending_realized, pending_commission)
+
+
+class MultiReplayEngine(ReplayEngine):
+    """Replay multiple strategies against one shared backtest wallet."""
+
+    def __init__(
+        self,
+        config: MultiReplayConfig,
+        db: DatabaseFactory,
+        emit_backtest_snapshots: bool = True,
+    ):
+        self._multi_config = config
+        self._db = db
+        self._emit_backtest_snapshots = emit_backtest_snapshots
+        from backtest.instrument_info import InstrumentInfoProvider
+
+        self._instrument_provider = InstrumentInfoProvider()
+
+    def run(
+        self,
+        data_providers: Optional[dict[str, InMemoryDataProvider]] = None,
+    ) -> MultiReplayResult:
+        """Run shared-wallet replay.
+
+        Args:
+            data_providers: Optional per-symbol in-memory providers for tests.
+
+        Returns:
+            Shared-wallet replay result with per-strategy comparisons.
+        """
+        config = self._multi_config
+        run_id, account_id, start_ts, end_ts = self._resolve_run_multi(config)
+        fill_mode = FillMode(config.fill_simulator.mode)
+        wallet_seed, seed_data = self._load_multi_seed(config, run_id)
+        session = self._build_shared_session(config, wallet_seed)
+
+        bundles: dict[str, _RunnerBundle] = {}
+        last_prices = self._startup_mark_cache(config, start_ts, data_providers)
+        for strat in config.strategies:
+            yaml_tick = strat.tick_size
+            instrument_info = self._instrument_provider.get(
+                strat.symbol, require_live=yaml_tick is None
+            )
+            from backtest.instrument_info import resolve_tick_size
+
+            strategy_config = self._strategy_config(
+                strat,
+                resolve_tick_size(yaml_tick, instrument_info.tick_size),
+            )
+            long_seed, short_seed, grid_seed, order_seeds = seed_data[strat.symbol]
+            event_follower = self._event_follower(
+                run_id, strat.symbol, start_ts, end_ts, fill_mode
+            )
+            runner = self._init_runner(
+                strategy_config,
+                session,
+                instrument_info=instrument_info,
+                long_seed=long_seed,
+                short_seed=short_seed,
+                grid_seed=grid_seed,
+                order_seeds=order_seeds,
+                fill_mode=fill_mode,
+                run_id=run_id,
+                account_id=account_id,
+                event_follower=event_follower,
+            )
+            if not self._emit_backtest_snapshots:
+                runner._position_writer = _NoopPositionSnapshotWriter()  # type: ignore[attr-defined]
+            bundles[strat.symbol] = _RunnerBundle(
+                config=strat,
+                runner=runner,
+                funding=(
+                    FundingSimulator(rate=config.funding_rate)
+                    if config.enable_funding else None
+                ),
+            )
+
+        runners = {symbol: bundle.runner for symbol, bundle in bundles.items()}
+        coordinator = _SharedSessionCoordinator(session, runners, last_prices)
+        providers = data_providers or {
+            strat.symbol: HistoricalDataProvider(
+                db=self._db,
+                symbol=strat.symbol,
+                start_ts=start_ts,
+                end_ts=end_ts,
+            )
+            for strat in config.strategies
+        }
+        collateral_feed = self._collateral_feed(
+            config, session, start_ts, end_ts, wallet_seed
+        )
+        collateral_marked: set[str] = set()
+        account_curve: list[AccountCurveSample] = []
+        tick_count = 0
+
+        for symbol, tick in self._merge_ticks(providers):
+            last_prices[symbol] = tick.last_price
+            if collateral_feed is not None:
+                for coin in session.collateral_balances:
+                    mark = collateral_feed.mark_at(coin, tick.exchange_ts)
+                    if mark is not None:
+                        session.update_collateral_mark(coin, mark)
+                        collateral_marked.add(coin)
+
+            bundle = bundles[symbol]
+            if (
+                bundle.funding is not None
+                and bundle.funding.should_apply_funding(tick.exchange_ts)
+            ):
+                funding = bundle.runner.apply_funding(
+                    bundle.funding.rate, tick.last_price
+                )
+                if funding != 0:
+                    logger.debug("%s funding payment: %s", symbol, funding)
+                bundle.funding.mark_funding_applied(tick.exchange_ts)
+
+            with coordinator.active(symbol):
+                bundle.runner.process_fills(tick)
+
+            unrealized = coordinator.total_unrealized()
+            total_im, total_mm = coordinator.total_im_mm()
+            session.update_equity(tick.exchange_ts, unrealized, total_im, total_mm)
+            account_curve.append(
+                self._account_sample(tick.exchange_ts, session, total_mm)
+            )
+
+            with coordinator.active(symbol):
+                bundle.runner.execute_tick(tick)
+
+            tick_count += 1
+            if tick_count % 10000 == 0:
+                logger.info("Processed %d merged ticks...", tick_count)
+
+        logger.info("Multi replay complete: %d merged ticks processed", tick_count)
+        self._warn_unmarked_collateral(session, collateral_feed, collateral_marked)
+
+        for symbol, bundle in bundles.items():
+            with coordinator.active(symbol):
+                bundle.runner.finalize_event_follower()
+
+        if config.wind_down_mode == WindDownMode.CLOSE_ALL:
+            for symbol, bundle in bundles.items():
+                price = last_prices.get(symbol, Decimal("0"))
+                if price > 0:
+                    self._wind_down(bundle.runner, session, price, end_ts)
+
+        for bundle in bundles.values():
+            writer = getattr(bundle.runner, "_position_writer", None)
+            if writer is not None:
+                writer.flush()
+
+        final_unrealized_by_symbol = {
+            symbol: self._runner_unrealized(bundle.runner, last_prices)
+            for symbol, bundle in bundles.items()
+        }
+        session.finalize(
+            sum(final_unrealized_by_symbol.values(), Decimal("0"))
+        )
+
+        per_strategy = {
+            symbol: self._compare_symbol(
+                bundle.config,
+                bundle.runner,
+                session,
+                run_id,
+                start_ts,
+                end_ts,
+                fill_mode,
+                final_unrealized_by_symbol[symbol],
+            )
+            for symbol, bundle in bundles.items()
+        }
+
+        return MultiReplayResult(
+            session=session,
+            strategies=per_strategy,
+            run_id=run_id,
+            account_id=account_id,
+            start_ts=start_ts,
+            end_ts=end_ts,
+            fill_mode=fill_mode,
+            account_curve=account_curve,
+        )
+
+    @staticmethod
+    def _merge_ticks(
+        providers: dict[str, Iterable],
+    ) -> Iterator[tuple[str, object]]:
+        """K-way merge provider ticks by ``(exchange_ts, symbol, sequence)``."""
+        heap: list[tuple[datetime, str, int, object, Iterator]] = []
+        for symbol in sorted(providers):
+            iterator = iter(providers[symbol])
+            try:
+                tick = next(iterator)
+            except StopIteration:
+                continue
+            heapq.heappush(heap, (tick.exchange_ts, symbol, 0, tick, iterator))
+
+        while heap:
+            _ts, symbol, seq, tick, iterator = heapq.heappop(heap)
+            yield symbol, tick
+            try:
+                nxt = next(iterator)
+            except StopIteration:
+                continue
+            heapq.heappush(heap, (nxt.exchange_ts, symbol, seq + 1, nxt, iterator))
+
+    def _resolve_run_multi(
+        self, config: MultiReplayConfig
+    ) -> tuple[str, Optional[str], datetime, datetime]:
+        """Resolve run_id/account_id/time range for a multi replay."""
+        run_id = config.run_id
+        with self._db.get_session() as session:
+            if run_id is None:
+                run = RunRepository(session).get_latest_by_type("recording")
+                if run is None:
+                    safe_url = redact_db_url(self._db.settings.get_database_url())
+                    raise ValueError(f"No recording runs found in database ({safe_url})")
+            else:
+                run = session.get(Run, run_id)
+                if run is None:
+                    raise ValueError(f"Run '{run_id}' not found in database")
+            resolved_run_id = run.run_id
+            account_id = run.account_id
+            start_ts = config.start_ts or run.start_ts
+            end_ts = config.end_ts or run.end_ts
+
+        if end_ts is None:
+            end_ts = datetime.now(timezone.utc)
+        if start_ts is None:
+            raise ValueError("start_ts could not be resolved")
+        if start_ts.replace(tzinfo=None) >= end_ts.replace(tzinfo=None):
+            raise ValueError(
+                f"Invalid time range: start_ts ({start_ts}) must be before "
+                f"end_ts ({end_ts})"
+            )
+        return resolved_run_id, account_id, start_ts, end_ts
+
+    def _load_multi_seed(
+        self,
+        config: MultiReplayConfig,
+        run_id: str,
+    ) -> tuple[
+        Optional[WalletSeed],
+        dict[
+            str,
+            tuple[
+                Optional[PositionStateSeed],
+                Optional[PositionStateSeed],
+                Optional[GridStateSeed],
+                Optional[list[ActiveOrderSeed]],
+            ],
+        ],
+    ]:
+        """Load account-level wallet seed and per-symbol position/grid/order seeds."""
+        seed = config.seed
+        empty = {
+            strat.symbol: (None, None, None, None) for strat in config.strategies
+        }
+        if not seed.enabled:
+            return None, empty
+        if seed.at_ts is None or seed.account_id is None:
+            raise ValueError("seed.enabled=True but at_ts/account_id are unset")
+
+        with self._db.get_session() as db_session:
+            self._seed_pre_check(db_session, run_id, seed.at_ts)
+            wallet_seed = load_wallet_seed_full(
+                db_session,
+                run_id,
+                seed.account_id,
+                seed.at_ts,
+                coin=seed.wallet_coin,
+            )
+            if seed.collateral_coins:
+                if wallet_seed is None:
+                    raise SeedDataQualityError(
+                        "seed.collateral_coins requires a valid wallet seed"
+                    )
+                (
+                    coin_balances,
+                    seed_marks,
+                    value_ratios,
+                    excluded_coins,
+                    missing_mark_coins,
+                    switch_off_coins,
+                ) = load_collateral_seed(
+                    db_session,
+                    run_id,
+                    seed.account_id,
+                    seed.at_ts,
+                    seed.wallet_coin,
+                    seed.collateral_coins,
+                    seed.collateral_symbol_map,
+                    seed.collateral_value_ratios,
+                    seed.collateral_wallet_max_staleness,
+                )
+                wallet_seed = replace(
+                    wallet_seed,
+                    coin_balances=coin_balances,
+                    seed_marks=seed_marks,
+                    collateral_value_ratios=value_ratios,
+                    collateral_excluded_coins=excluded_coins,
+                    collateral_missing_mark_coins=missing_mark_coins,
+                    collateral_switch_off_coins=switch_off_coins,
+                )
+
+            data = {}
+            for strat in config.strategies:
+                grid_seed = load_grid_state_from_snapshots(
+                    db_session,
+                    seed.account_id,
+                    strat.strat_id,
+                    strat.symbol,
+                    seed.at_ts,
+                    expected_step=strat.grid_step,
+                    expected_count=strat.grid_count,
+                )
+                if grid_seed is None:
+                    grid_seed = load_grid_state_from_active_snapshots(
+                        db_session,
+                        strat.strat_id,
+                        strat.symbol,
+                        seed.at_ts,
+                        expected_step=strat.grid_step,
+                        expected_count=strat.grid_count,
+                    )
+                if grid_seed is None:
+                    raise SeedDataQualityError(
+                        f"seed.enabled=True but no grid state found for "
+                        f"strat_id={strat.strat_id!r} symbol={strat.symbol!r}"
+                    )
+                long_seed, short_seed = load_position_snapshots(
+                    db_session,
+                    run_id,
+                    seed.account_id,
+                    strat.symbol,
+                    seed.at_ts,
+                )
+                order_seeds = load_active_orders(
+                    db_session,
+                    run_id,
+                    seed.account_id,
+                    strat.symbol,
+                    seed.at_ts,
+                )
+                data[strat.symbol] = (long_seed, short_seed, grid_seed, order_seeds)
+
+        if wallet_seed is None:
+            logger.warning("multi replay wallet seed missing, using initial_balance")
+        return wallet_seed, data
+
+    @staticmethod
+    def _build_shared_session(
+        config: MultiReplayConfig,
+        wallet_seed: Optional[WalletSeed],
+    ) -> BacktestSession:
+        """Build the one account-level BacktestSession."""
+        initial_balance = (
+            wallet_seed.total_available_balance
+            if wallet_seed is not None else config.initial_balance
+        )
+        initial_equity = (
+            wallet_seed.total_equity if wallet_seed is not None else initial_balance
+        )
+        return BacktestSession(
+            initial_balance=initial_balance,
+            initial_equity=initial_equity,
+            collateral_balances=(
+                wallet_seed.coin_balances if wallet_seed is not None else {}
+            ),
+            collateral_seed_marks=(
+                wallet_seed.seed_marks if wallet_seed is not None else {}
+            ),
+        )
+
+    @staticmethod
+    def _strategy_config(
+        strat: MultiReplayStrategyConfig,
+        tick_size: Decimal,
+    ) -> BacktestStrategyConfig:
+        """Project a multi strategy config into BacktestStrategyConfig."""
+        return BacktestStrategyConfig(
+            strat_id=strat.strat_id,
+            symbol=strat.symbol,
+            tick_size=tick_size,
+            grid_count=strat.grid_count,
+            grid_step=strat.grid_step,
+            amount=strat.amount,
+            max_margin=strat.max_margin,
+            early_imbalance_multiplier=strat.early_imbalance_multiplier,
+            commission_rate=strat.commission_rate,
+            enable_risk_multipliers=strat.enable_risk_multipliers,
+            min_liq_ratio=strat.min_liq_ratio,
+            max_liq_ratio=strat.max_liq_ratio,
+            min_total_margin=strat.min_total_margin,
+            increase_same_position_on_low_margin=(
+                strat.increase_same_position_on_low_margin
+            ),
+            leverage=strat.leverage,
+        )
+
+    def _event_follower(
+        self,
+        run_id: str,
+        symbol: str,
+        start_ts: datetime,
+        end_ts: datetime,
+        fill_mode: FillMode,
+    ) -> Optional[EventFollower]:
+        """Load a per-symbol EventFollower when requested."""
+        if fill_mode != FillMode.EVENT_FOLLOWER:
+            return None
+        recorded_execs: list[RecordedExecution] = []
+        skipped = 0
+        with self._db.get_session() as db_session:
+            repo = PrivateExecutionRepository(db_session)
+            for ex in repo.get_by_run_range(run_id, start_ts, end_ts):
+                if ex.symbol != symbol:
+                    skipped += 1
+                    continue
+                recorded_execs.append(
+                    RecordedExecution(
+                        exec_id=ex.exec_id,
+                        order_link_id=ex.order_link_id,
+                        order_id=ex.order_id,
+                        side=ex.side,
+                        exec_price=ex.exec_price,
+                        exec_qty=ex.exec_qty,
+                        exec_fee=ex.exec_fee if ex.exec_fee is not None else Decimal("0"),
+                        closed_pnl=(
+                            ex.closed_pnl if ex.closed_pnl is not None else Decimal("0")
+                        ),
+                        exchange_ts=_strip_tz(ex.exchange_ts),
+                    )
+                )
+        logger.info(
+            "event_follower: loaded %d recorded executions for %s "
+            "(%d other-symbol rows skipped)",
+            len(recorded_execs), symbol, skipped,
+        )
+        return EventFollower(recorded_execs, symbol=symbol, start_ts=_strip_tz(start_ts))
+
+    def _startup_mark_cache(
+        self,
+        config: MultiReplayConfig,
+        start_ts: datetime,
+        data_providers: Optional[dict[str, InMemoryDataProvider]],
+    ) -> dict[str, Decimal]:
+        """Seed last-price cache from at-or-before DB marks or in-memory first ticks."""
+        marks = {strat.symbol: Decimal("0") for strat in config.strategies}
+        if data_providers is not None:
+            for symbol, provider in data_providers.items():
+                events = getattr(provider, "_events", [])
+                before = [
+                    event for event in events
+                    if event.exchange_ts.replace(tzinfo=None)
+                    <= start_ts.replace(tzinfo=None)
+                ]
+                if before:
+                    marks[symbol] = before[-1].last_price
+                else:
+                    logger.warning(
+                        "%s: no at-or-before-start mark; idle-book unrealized/"
+                        "IM/MM carries 0 until its first own tick (O2)", symbol)
+            return marks
+
+        with self._db.get_session() as session:
+            for strat in config.strategies:
+                row = (
+                    session.query(TickerSnapshot.last_price)
+                    .filter(TickerSnapshot.symbol == strat.symbol)
+                    .filter(TickerSnapshot.exchange_ts <= _strip_tz(start_ts))
+                    .order_by(desc(TickerSnapshot.exchange_ts))
+                    .first()
+                )
+                if row is not None:
+                    marks[strat.symbol] = row[0]
+                else:
+                    logger.warning(
+                        "%s: no at-or-before-start ticker mark; idle-book "
+                        "unrealized/IM/MM carries 0 until its first own tick "
+                        "(O2)", strat.symbol)
+        return marks
+
+    def _collateral_feed(
+        self,
+        config: MultiReplayConfig,
+        session: BacktestSession,
+        start_ts: datetime,
+        end_ts: datetime,
+        wallet_seed: Optional[WalletSeed],
+    ) -> Optional[CollateralMarkFeed]:
+        """Build the account-level collateral mark feed when needed."""
+        if not session.collateral_balances:
+            return None
+        symbol_for = {
+            coin: config.seed.collateral_symbol_map.get(coin, f"{coin}USDT")
+            for coin in session.collateral_balances
+        }
+        return CollateralMarkFeed(
+            db=self._db,
+            symbol_for=symbol_for,
+            start_ts=start_ts,
+            end_ts=end_ts,
+            seed_at_ts=config.seed.at_ts if wallet_seed is not None else None,
+        )
+
+    @staticmethod
+    def _account_sample(
+        ts: datetime,
+        session: BacktestSession,
+        total_mm: Decimal,
+    ) -> AccountCurveSample:
+        """Build one emitted account-level reconcile sample."""
+        total_margin_balance = session.total_equity
+        account_mm_rate = (
+            total_mm / total_margin_balance
+            if total_margin_balance != 0 else Decimal("0")
+        )
+        return AccountCurveSample(
+            exchange_ts=ts,
+            total_equity=session.total_equity,
+            total_margin_balance=total_margin_balance,
+            account_mm_rate=account_mm_rate,
+        )
+
+    @staticmethod
+    def _runner_unrealized(
+        runner: BacktestRunner,
+        last_prices: dict[str, Decimal],
+    ) -> Decimal:
+        """Return one runner's final unrealized at its cached own-symbol price."""
+        price = last_prices.get(runner.symbol, Decimal("0"))
+        if price <= 0:
+            return Decimal("0")
+        return (
+            runner.long_tracker.calculate_unrealized_pnl(price)
+            + runner.short_tracker.calculate_unrealized_pnl(price)
+        )
+
+    def _compare_symbol(
+        self,
+        strat: MultiReplayStrategyConfig,
+        runner: BacktestRunner,
+        session: BacktestSession,
+        run_id: str,
+        start_ts: datetime,
+        end_ts: datetime,
+        fill_mode: FillMode,
+        final_unrealized: Decimal,
+    ) -> MultiStrategyReplayResult:
+        """Run per-symbol trade matching and metrics under a shared session."""
+        with self._db.get_session() as db_session:
+            live_loader = LiveTradeLoader(db_session)
+            recorded_trades = live_loader.load(
+                run_id=run_id,
+                start_ts=start_ts,
+                end_ts=end_ts,
+                symbol=strat.symbol,
+            )
+        bt_loader = BacktestTradeLoader()
+        simulated = [
+            trade for trade in bt_loader.load_from_session(session.trades)
+            if trade.symbol == strat.symbol
+        ]
+        matcher = TradeMatcher()
+        match_result = matcher.match(recorded_trades, simulated)
+        metrics = calculate_metrics(
+            match_result,
+            price_tolerance=self._multi_config.price_tolerance,
+            qty_tolerance=self._multi_config.qty_tolerance,
+        )
+        return MultiStrategyReplayResult(
+            strategy=strat,
+            runner=runner,
+            metrics=metrics,
+            match_result=match_result,
+            final_unrealized=final_unrealized,
+        )
+
+    @staticmethod
+    def _warn_unmarked_collateral(
+        session: BacktestSession,
+        collateral_feed: Optional[CollateralMarkFeed],
+        marked: set[str],
+    ) -> None:
+        """Warn for collateral coins that never received an in-window mark."""
+        if collateral_feed is None:
+            return
+        for coin in sorted(set(session.collateral_balances) - marked):
+            logger.warning(
+                "collateral coin %s had no ticker rows in the replay window; "
+                "used seed mark throughout",
+                coin,
+            )

--- a/apps/replay/tests/test_multi_config.py
+++ b/apps/replay/tests/test_multi_config.py
@@ -1,0 +1,77 @@
+"""Tests for shared-wallet replay config validation."""
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from replay.multi_config import MultiReplayConfig, MultiReplayStrategyConfig
+
+
+def _strategy(symbol: str = "SOLUSDT", strat_id: str = "solusdt_test"):
+    return {
+        "symbol": symbol,
+        "strat_id": strat_id,
+        "tick_size": "0.01",
+        "grid_count": 10,
+        "grid_step": 0.5,
+    }
+
+
+class TestMultiReplayConfig:
+    def test_rejects_empty_strategies(self):
+        """Empty strategy list is invalid and cannot false-green."""
+        with pytest.raises(ValidationError):
+            MultiReplayConfig(strategies=[])
+
+    def test_strategy_requires_symbol_and_strat_id(self):
+        """Each strategy has explicit replay identity."""
+        with pytest.raises(ValidationError):
+            MultiReplayStrategyConfig(symbol="SOLUSDT")
+        with pytest.raises(ValidationError):
+            MultiReplayStrategyConfig(strat_id="solusdt_test")
+
+    def test_seed_requires_account_fields_when_enabled(self):
+        """Account-level seed fields are required when seeding."""
+        with pytest.raises(ValidationError, match="at_ts|account_id"):
+            MultiReplayConfig(
+                strategies=[_strategy()],
+                seed={"enabled": True, "at_ts": datetime.now(timezone.utc)},
+            )
+
+    def test_rejects_duplicate_symbol(self):
+        """Duplicate symbol would silently last-win in the engine's per-symbol maps."""
+        with pytest.raises(ValidationError, match="duplicate strategy symbol"):
+            MultiReplayConfig(
+                strategies=[
+                    _strategy("SOLUSDT", "a"),
+                    _strategy("SOLUSDT", "b"),
+                ]
+            )
+
+    def test_rejects_duplicate_strat_id(self):
+        """Duplicate strat_id would collide the client_order_id namespace."""
+        with pytest.raises(ValidationError, match="duplicate strategy strat_id"):
+            MultiReplayConfig(
+                strategies=[
+                    _strategy("SOLUSDT", "dup"),
+                    _strategy("LTCUSDT", "dup"),
+                ]
+            )
+
+    def test_rejects_traded_base_as_collateral(self):
+        """A traded base coin cannot also be modelled as spot collateral."""
+        with pytest.raises(ValidationError, match="traded base"):
+            MultiReplayConfig(
+                strategies=[_strategy("SOLUSDT")],
+                seed={"collateral_coins": ["SOL"]},
+            )
+
+    def test_decimal_fields_parse_from_strings(self):
+        """Shared wallet numeric config keeps Decimal precision."""
+        config = MultiReplayConfig(
+            strategies=[_strategy()],
+            initial_balance="60.25",
+        )
+        assert config.initial_balance == Decimal("60.25")

--- a/apps/replay/tests/test_multi_engine.py
+++ b/apps/replay/tests/test_multi_engine.py
@@ -1,0 +1,280 @@
+"""Tests for shared-wallet multi replay orchestration helpers."""
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from gridcore import EventType, TickerEvent
+from grid_db.models import PrivateExecution
+
+from backtest.data_provider import InMemoryDataProvider
+from backtest.fill_simulator import FillMode
+from backtest.session import BacktestSession, BacktestTrade
+
+from replay.multi_config import MultiReplayConfig
+from replay.multi_engine import (
+    MultiReplayEngine,
+    _SharedSessionCoordinator,
+)
+
+
+TS = datetime(2026, 7, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _tick(symbol: str, price: str, offset_ms: int) -> TickerEvent:
+    ts = TS + timedelta(milliseconds=offset_ms)
+    px = Decimal(price)
+    return TickerEvent(
+        event_type=EventType.TICKER,
+        symbol=symbol,
+        exchange_ts=ts,
+        local_ts=ts,
+        last_price=px,
+        mark_price=px,
+        bid1_price=px - Decimal("0.1"),
+        ask1_price=px + Decimal("0.1"),
+        funding_rate=Decimal("0"),
+    )
+
+
+@dataclass
+class _Tracker:
+    unrealized: Decimal
+
+    @property
+    def state(self):
+        return SimpleNamespace(size=Decimal("1"), avg_entry_price=Decimal("1"))
+
+    def calculate_unrealized_pnl(self, price: Decimal) -> Decimal:
+        return self.unrealized + (price * Decimal("0"))
+
+
+class _Runner:
+    def __init__(self, long_upnl: str, short_upnl: str, mm: str = "0"):
+        self.long_tracker = _Tracker(Decimal(long_upnl))
+        self.short_tracker = _Tracker(Decimal(short_upnl))
+        self._mm = Decimal(mm)
+
+    def _estimate_pair_im_mm(self, _long, _short, _price):
+        return Decimal("1"), self._mm, Decimal("2"), self._mm
+
+
+def _trade(symbol: str, pnl: str, fee: str) -> BacktestTrade:
+    return BacktestTrade(
+        trade_id=f"{symbol}-{pnl}",
+        symbol=symbol,
+        side="Buy",
+        price=Decimal("10"),
+        qty=Decimal("1"),
+        direction="long",
+        timestamp=TS,
+        order_id=f"oid-{symbol}",
+        client_order_id=f"cid-{symbol}",
+        realized_pnl=Decimal(pnl),
+        commission=Decimal(fee),
+        strat_id=f"{symbol.lower()}_test",
+    )
+
+
+class TestTickMerge:
+    def test_k_way_merge_ascending_and_symbol_scoped(self):
+        """Merged stream is globally ascending with deterministic equal-ts ties."""
+        providers = {
+            "SOLUSDT": InMemoryDataProvider([
+                _tick("SOLUSDT", "100", 0),
+                _tick("SOLUSDT", "101", 2),
+            ]),
+            "LTCUSDT": InMemoryDataProvider([
+                _tick("LTCUSDT", "80", 1),
+                _tick("LTCUSDT", "81", 2),
+            ]),
+        }
+        merged = list(MultiReplayEngine._merge_ticks(providers))
+        assert [(symbol, tick.exchange_ts) for symbol, tick in merged] == [
+            ("SOLUSDT", TS),
+            ("LTCUSDT", TS + timedelta(milliseconds=1)),
+            ("LTCUSDT", TS + timedelta(milliseconds=2)),
+            ("SOLUSDT", TS + timedelta(milliseconds=2)),
+        ]
+        assert all(symbol == tick.symbol for symbol, tick in merged)
+
+
+class TestSharedSessionCoordinator:
+    def test_merged_pending_sums_across_runners(self):
+        """C1: concurrent pending rollups sum instead of last-writer clobber."""
+        session = BacktestSession(initial_balance=Decimal("100"))
+        runners = {"SOLUSDT": _Runner("0", "0"), "LTCUSDT": _Runner("0", "0")}
+        coord = _SharedSessionCoordinator(
+            session,
+            runners,
+            {"SOLUSDT": Decimal("100"), "LTCUSDT": Decimal("80")},
+        )
+        with coord.active("SOLUSDT"):
+            session.set_pending_wallet(Decimal("1.5"), Decimal("0.1"))
+        with coord.active("LTCUSDT"):
+            session.set_pending_wallet(Decimal("-0.5"), Decimal("0.2"))
+        assert session._pending_realized_pnl == Decimal("1.0")
+        assert session._pending_commission == Decimal("0.3")
+
+    def test_refresh_balances_intercepts_sum_unrealized(self):
+        """C2: in-method refresh/read sees account-wide unrealized."""
+        session = BacktestSession(initial_balance=Decimal("100"))
+        runners = {
+            "SOLUSDT": _Runner("5", "0"),
+            "LTCUSDT": _Runner("-2", "0"),
+        }
+        coord = _SharedSessionCoordinator(
+            session,
+            runners,
+            {"SOLUSDT": Decimal("100"), "LTCUSDT": Decimal("80")},
+        )
+        seen_wallet = None
+        with coord.active("SOLUSDT"):
+            session.refresh_balances(Decimal("5"))
+            seen_wallet = session.current_balance
+        assert seen_wallet == Decimal("103")
+        assert session.total_equity == Decimal("103")
+
+    def test_account_margin_series_units(self):
+        """C3/C4: emitted sample has equity, margin balance and ratio units."""
+        session = BacktestSession(initial_balance=Decimal("100"))
+        session.update_equity(TS, Decimal("10"), Decimal("4"), Decimal("2"))
+        sample = MultiReplayEngine._account_sample(TS, session, Decimal("2"))
+        assert sample.total_equity == Decimal("110")
+        assert sample.total_margin_balance == Decimal("110")
+        assert sample.account_mm_rate == Decimal("0.01818181818181818181818181818")
+
+    def test_finalize_uses_sum_unrealized(self):
+        """Final metrics retain both books' open unrealized."""
+        session = BacktestSession(initial_balance=Decimal("100"))
+        session.record_trade(_trade("SOLUSDT", "1", "0.1"))
+        metrics = session.finalize(Decimal("7"))
+        assert metrics.total_unrealized_pnl == Decimal("7")
+        assert metrics.net_pnl == Decimal("7.9")
+
+
+class TestSharedWalletCoupling:
+    def test_record_trade_accumulates_shared_wallet(self):
+        """One shared session accumulates realized PnL and fees across symbols."""
+        session = BacktestSession(initial_balance=Decimal("100"))
+        session.record_trade(_trade("SOLUSDT", "-5", "0.1"))
+        session.record_trade(_trade("LTCUSDT", "2", "0.2"))
+        session.refresh_balances(Decimal("0"))
+        assert session.current_balance == Decimal("96.7")
+
+    def test_o2_startup_mark_cache_from_in_memory_provider(self):
+        """O2 startup cache seeds idle-symbol marks before the first merge tick."""
+        config = MultiReplayConfig(
+            start_ts=TS,
+            end_ts=TS + timedelta(seconds=1),
+            strategies=[
+                {"symbol": "SOLUSDT", "strat_id": "sol", "tick_size": "0.01"},
+                {"symbol": "LTCUSDT", "strat_id": "ltc", "tick_size": "0.01"},
+            ],
+        )
+        engine = MultiReplayEngine.__new__(MultiReplayEngine)
+        providers = {
+            "SOLUSDT": InMemoryDataProvider([_tick("SOLUSDT", "100", 0)]),
+            "LTCUSDT": InMemoryDataProvider([_tick("LTCUSDT", "80", 0)]),
+        }
+        cache = engine._startup_mark_cache(config, TS, providers)
+        assert cache == {"SOLUSDT": Decimal("100"), "LTCUSDT": Decimal("80")}
+
+
+class TestEventFollowerLoading:
+    def test_event_follower_is_per_symbol(self, db, seeded_run_account):
+        """Synthetic RecordedExecution stream is scoped to one strategy symbol."""
+        with db.get_session() as session:
+            for symbol in ("SOLUSDT", "LTCUSDT"):
+                session.add(
+                    PrivateExecution(
+                        run_id="test-run-id",
+                        account_id=seeded_run_account.account_id,
+                        symbol=symbol,
+                        exec_id=f"{symbol}-exec",
+                        order_id=f"{symbol}-oid",
+                        order_link_id=f"{symbol}-link",
+                        exchange_ts=TS,
+                        side="Buy",
+                        exec_price=Decimal("10"),
+                        exec_qty=Decimal("1"),
+                        exec_fee=Decimal("0.01"),
+                        closed_pnl=Decimal("0"),
+                    )
+                )
+        engine = MultiReplayEngine.__new__(MultiReplayEngine)
+        engine._db = db
+        follower = engine._event_follower(
+            "test-run-id",
+            "SOLUSDT",
+            TS - timedelta(seconds=1),
+            TS + timedelta(seconds=1),
+            FillMode.EVENT_FOLLOWER,
+        )
+        rows = follower.drain(TS - timedelta(seconds=1), TS)
+        assert [row.exec_id for row in rows] == ["SOLUSDT-exec"]
+        assert rows[0].order_id == "SOLUSDT-oid"
+
+
+class TestMultiReplayRunEndToEnd:
+    """End-to-end MultiReplayEngine.run() over two in-memory providers —
+    exercises the wired merged-tick loop (merge → coordinator.active around
+    process_fills/execute_tick → Σ update_equity → account_curve append →
+    per-strat finalize), not just isolated helpers."""
+
+    @patch("backtest.instrument_info.InstrumentInfoProvider")
+    def test_run_emits_account_curve_and_shares_one_session(
+        self, mock_provider_cls, db, seeded_run_account
+    ):
+        """C3/coupling: one shared session drives BOTH symbols; the loop emits
+        an account_curve (total_equity/margin/mm-rate series) that is a
+        SEPARATE series from the available-baseline session.equity_curve."""
+        mock_info = MagicMock()
+        mock_info.qty_step = Decimal("0.001")
+        mock_info.tick_size = Decimal("0.01")
+        mock_info.round_qty = lambda q: max(
+            Decimal("0.001"), q.quantize(Decimal("0.001"))
+        )
+        mock_provider_cls.return_value.get.return_value = mock_info
+
+        config = MultiReplayConfig(
+            run_id="test-run-id",
+            start_ts=TS,
+            end_ts=TS + timedelta(seconds=1),
+            initial_balance=Decimal("1000"),
+            enable_funding=False,
+            fill_simulator={"mode": "last_cross"},
+            strategies=[
+                {"symbol": "SOLUSDT", "strat_id": "solusdt_test",
+                 "tick_size": "0.01", "grid_count": 10, "grid_step": 0.5},
+                {"symbol": "LTCUSDT", "strat_id": "ltcusdt_test",
+                 "tick_size": "0.01", "grid_count": 10, "grid_step": 0.5},
+            ],
+        )
+        providers = {
+            "SOLUSDT": InMemoryDataProvider(
+                [_tick("SOLUSDT", "100", 0), _tick("SOLUSDT", "101", 200)]
+            ),
+            "LTCUSDT": InMemoryDataProvider(
+                [_tick("LTCUSDT", "80", 100), _tick("LTCUSDT", "81", 300)]
+            ),
+        }
+        engine = MultiReplayEngine(config=config, db=db)
+        result = engine.run(data_providers=providers)
+
+        # Both symbols ran against ONE shared session.
+        assert set(result.strategies) == {"SOLUSDT", "LTCUSDT"}
+        assert result.session is not None
+        # C3/C4: one account sample per merged tick (2 + 2), three series.
+        assert len(result.account_curve) == 4
+        assert len(result.total_equity_curve) == 4
+        assert len(result.total_margin_balance_curve) == 4
+        assert len(result.account_mm_rate_curve) == 4
+        # The emitted total_equity curve is a SEPARATE object/series from the
+        # session's available-baseline equity_curve (C3 — distinct formula).
+        assert result.total_equity_curve is not result.session.equity_curve
+        # Samples are ascending by the merged timeline.
+        stamps = [ts for ts, _ in result.total_equity_curve]
+        assert stamps == sorted(stamps)

--- a/apps/replay/tests/test_multi_engine.py
+++ b/apps/replay/tests/test_multi_engine.py
@@ -137,6 +137,37 @@ class TestSharedSessionCoordinator:
         assert seen_wallet == Decimal("103")
         assert session.total_equity == Decimal("103")
 
+    def test_in_method_place_reads_account_wide_wallet_balance(self):
+        """C2 (review): the wallet_balance an in-method execute_place consumes
+        during execute_tick reflects the account-wide Σ unrealized (idle book
+        folded in), NOT the own-symbol value — the exact anti-pattern a
+        trailing refresh would leave stale."""
+        session = BacktestSession(initial_balance=Decimal("100"))
+        runners = {
+            "SOLUSDT": _Runner("5", "0"),   # active book: +5 own unrealized
+            "LTCUSDT": _Runner("-2", "0"),  # idle book: -2, must be folded in
+        }
+        coord = _SharedSessionCoordinator(
+            session,
+            runners,
+            {"SOLUSDT": Decimal("100"), "LTCUSDT": Decimal("80")},
+        )
+        captured = {}
+
+        def fake_execute_place():
+            # Mirrors runner.execute_place(wallet_balance=session.current_balance)
+            captured["wallet_balance"] = session.current_balance
+
+        # Simulate execute_tick internals: own-symbol refresh, then a place
+        # that reads session.current_balance in-method.
+        with coord.active("SOLUSDT"):
+            session.refresh_balances(Decimal("5"))
+            fake_execute_place()
+
+        # Σ = 100 + 5 + (-2) = 103, NOT the own-symbol 100 + 5 = 105.
+        assert captured["wallet_balance"] == Decimal("103")
+        assert captured["wallet_balance"] != Decimal("105")
+
     def test_account_margin_series_units(self):
         """C3/C4: emitted sample has equity, margin balance and ratio units."""
         session = BacktestSession(initial_balance=Decimal("100"))

--- a/docs/features/0094_PLAN.md
+++ b/docs/features/0094_PLAN.md
@@ -1,0 +1,572 @@
+# Feature 0094 — Shared-Wallet Multi-Strategy Replay + Validation
+
+## Context
+
+The replay/validation stack today runs ONE symbol per process: a single
+`ReplayConfig.symbol` (`apps/replay/src/replay/config.py:296`), a single
+`strategy: ReplayStrategyConfig` (`config.py:307`), one `BacktestSession`
+(wallet) built from one `initial_balance` config field plus a DERIVED
+`initial_equity` (`wallet_seed.total_equity` when seeded, else
+`initial_balance`; `engine.py:442-460` — there is no `initial_equity`
+config field, cf. `config.py:283-337`). All prior parametric work (H1–H8) therefore ran each
+symbol ISOLATED with its own ~$60 wallet.
+
+Live shares ONE Bybit UTA account across BOTH pairs (`solusdt_test` /
+`ltcusdt_test`). Cross-margin / cross-liquidation coupling — a SOL storm
+draining margin the LTC leg needs, or driving the whole account toward
+liquidation — is currently **unmodeled**. This feature steps BOTH strategies
+on a merged/interleaved tick timeline (SOL ~5.4 ticks/s, LTC ~2.4/s) against
+ONE shared wallet + ONE margin pool: per-symbol positions, shared collateral.
+
+Data feasibility is CONFIRMED in `data/recorder_ltcusdt_phase4.db`, run
+`580ca395-ce99-42a5-bf30-d8542ddaccb8`: both symbols' `private_executions`
+present (LTC 1045, SOL 2494); account-level `wallet_snapshots` present (11806
+USDT rows over 07-03→07-20) carrying `total_equity` / `total_margin_balance` /
+`account_mm_rate`. The reconciliation target — the recorded shared-wallet
+equity/margin curve — exists.
+
+The feature MUST be validatable against live to the cent, same pattern as the
+single-symbol `live_check` / `event_follower` stack (features 0088, 0072).
+**The validation-to-the-cent reconciliation gate is a hard, explicit
+acceptance criterion that must pass BEFORE any counterfactual A/B result is
+believed** (see Phase 4 gate).
+
+Constraints (RULES.md / `.claude/rules/code-style.md`): `Decimal` for money,
+never `float`; `gridcore` stays pure (no network/DB); frozen dataclasses for
+domain models; per-package tests hermetic (mock DB, no real Bybit); recorder
+WAL DB is read-only (recorder stays live); `tick_size` sourced from exchange
+(0090, `InstrumentInfoProvider`); keep the per-tick Position-update INFO
+heartbeat.
+
+## Key existing mechanics this feature reuses (do NOT duplicate)
+
+- **`BacktestSession` already couples the wallet by accumulation.**
+  `record_trade` (`session.py:225`) adds every trade's `realized_pnl` /
+  `commission` into `total_realized_pnl` / `total_commission`; `_pnl_delta`
+  (`session.py:260`) derives both baselines from those running sums. Two
+  runners calling `record_trade` on ONE session therefore share the wallet
+  with no new margin math. `current_balance` = UTA `totalAvailableBalance`
+  (margin gating, wallet-fraction qty, risk mult); `total_equity` = UTA
+  `totalEquity` (pair-liq pool input). Collateral re-mark term already lives
+  on `total_equity` only (`session.py:299-311`).
+- **Per-strat pair-liquidation is already pool-shaped, but subtracts ONLY
+  its own symbol's MM.** `BacktestRunner._estimate_pair_liq_prices(long,
+  short, total_equity)` (RULES entry 16) computes `pool = total_equity -
+  mm_total` (`runner.py:1456`), where `mm_total` is derived from
+  `combined_pv = L_pv + S_pv` of THAT runner's own long/short only
+  (`runner.py:1444-1453`). Under a shared session `total_equity` reflects
+  BOTH strats' PnL + shared collateral (equity coupling is real and for
+  free), BUT each runner's `pool` subtracts only its OWN pair-MM, ignoring
+  the other symbol's maintenance margin held against the same shared equity.
+  This UNDERSTATES joint liq risk (over-states free pool) — it is NOT a
+  true account-wide liq. **Open question O1** (below) states this explicitly
+  and scopes it: v1 models equity coupling only, ranks the A/B on
+  Net$/MaxDD$ from the shared equity curve, and does NOT claim per-symbol
+  liq-price fidelity under the shared pool.
+- **`event_follower` fill source** (`fill_simulator.py:380` `EventFollower`;
+  `runner.py:448` `_process_recorded_fills`): per-runner forward-only cursor
+  draining `(prev_tick_ts, tick_ts]` of that symbol's recorded executions.
+  Reused per strat; each runner keeps its OWN follower/cursor.
+- **`live_check` reconciliation shape** (`apps/live_check/`): seeded
+  `event_follower` replay per strat over a rolling window vs recorded ground
+  truth; per-check `Decimal` thresholds; exit codes 0/1/2; zero-data window is
+  never a PASS.
+- **Wallet snapshot reads**: `WalletSnapshotRepository.get_latest_before(run_id,
+  account_id, coin, at_ts)` (`snapshots.py:233`) and
+  `get_by_account_range(account_id, coin, start, end)` (`snapshots.py:179`) —
+  the account-level `total_equity` / `total_margin_balance` / `account_mm_rate`
+  curve for the reconciliation target.
+- **Seed loaders** (`replay/snapshot_loader.py`): `load_wallet_seed_full`
+  (account-level, coin='USDT'), `load_collateral_seed`, `load_position_snapshots`
+  (per symbol), `load_grid_state_from_snapshots` (per strat). Wallet + collateral
+  seeds are ACCOUNT-LEVEL (shared); positions + grid are PER-STRAT.
+
+## Files & functions to change / create
+
+### Phase 1 — Data layer: multi-strategy replay config
+
+**Create `apps/replay/src/replay/multi_config.py`**
+- `MultiReplayStrategyConfig(BaseModel)` — one entry per strat, carrying the
+  per-strat fields currently on `ReplayStrategyConfig` PLUS `symbol: str` and
+  `strat_id`. Reuse existing `ReplayStrategyConfig` field definitions (grid
+  geometry, risk-mgmt pass-through, `tick_size`, `commission_rate`,
+  `early_imbalance_multiplier`). Add per-strat `seed`-relevant identity
+  (`strat_id`, `symbol`).
+- `MultiReplayConfig(BaseModel)` — root wrapper mirroring `ReplayConfig`'s
+  ACCOUNT-LEVEL fields (`database_url`, `run_id`, `start_ts`, `end_ts`,
+  ONE account-level `seed` block: `at_ts` / `account_id` / `wallet_coin` /
+  `collateral_coins` / `collateral_symbol_map`, `fill_simulator.mode`,
+  `enable_funding`, `funding_rate`, `wind_down_mode`, `output_dir`,
+  tolerances) plus `strategies: list[MultiReplayStrategyConfig]`
+  (`min_length=1`; empty list is a false-green risk — mirror
+  `LiveCheckConfig.strats` `min_length=1`). ONE `initial_balance: Decimal`
+  (default 10000) for the shared wallet — the ONLY wallet-baseline config
+  field, mirroring `ReplayConfig` (`config.py:321`, which has NO
+  `initial_equity` field). `initial_equity` is DERIVED, never configured:
+  `wallet_seed.total_equity` when the account-level seed is present, else
+  the `initial_balance` fallback (exactly `engine.py:442-446`).
+- `load_multi_config(path)` — YAML loader mirroring `config.load_config`
+  (env-var `REPLAY_MULTI_CONFIG_PATH`, `conf/replay_multi.yaml` fallback).
+
+Decision (stated, not silent): a **new wrapper config** is chosen over
+extending `ReplayConfig.symbol`/`.strategy` to lists, so the single-symbol
+`ReplayConfig` + `ReplayEngine` path stays byte-for-byte unchanged (0088
+`live_check`, all H-series drivers, existing replay YAMLs depend on it). The
+multi path is additive.
+
+### Phase 2 — Multi-strategy engine: merged tick timeline + shared wallet
+
+**Create `apps/replay/src/replay/multi_engine.py` — `MultiReplayEngine`**
+Models on `ReplayEngine` but owns ONE `BacktestSession` and N `BacktestRunner`s.
+
+- **Shared session construction**: build ONE `BacktestSession` seeded from the
+  ACCOUNT-LEVEL wallet seed (`load_wallet_seed_full` with `coin='USDT'`, plus
+  `load_collateral_seed` when `seed.collateral_coins` set) — NOT per strat.
+  `initial_balance = wallet_seed.total_available_balance`,
+  `initial_equity = wallet_seed.total_equity`, collateral balances/marks from
+  the account seed — reproducing the un-shared derivation at
+  `engine.py:434-460`. Un-seeded fallback (no wallet seed): `initial_balance
+  = config.initial_balance` and `initial_equity = initial_balance` (config
+  has no `initial_equity`; the validation path is always seeded, so this
+  fallback is only exercised by hermetic tests). This is the single coupling
+  point.
+  **Traded-symbol-is-also-collateral de-dup (double-count guard):** the
+  collateral re-mark term (`_collateral_remark_delta`, `session.py:299`)
+  values a coin's balance × mark and adds it to `total_equity`; a runner's
+  position P&L for the SAME coin also flows into `total_equity`. If a traded
+  symbol's base coin (e.g. SOL) were ALSO listed in `seed.collateral_coins`,
+  SOL price moves would hit `total_equity` TWICE (position unrealized + spot
+  re-mark). Existing replay/live_check YAMLs configure NO `collateral_coins`
+  (grep of `conf/` + `apps/*/conf/`), and the 580ca395 A/B runs USDT-only
+  collateral, so this overlap is NOT triggered by the shipped configs. RULE
+  (validated at config load): a symbol traded by any `strategies[*]` entry
+  MUST NOT appear in `seed.collateral_coins` — reject with `ValueError` at
+  `MultiReplayConfig` validation. This keeps position-P&L and spot re-mark
+  mutually exclusive per coin (no de-dup arithmetic needed).
+- **Per-strat runner construction**: for each strategy, resolve its own
+  `strat_id`, `tick_size` (0090: `InstrumentInfoProvider.get(symbol,
+  require_live=yaml_tick is None)` + `resolve_tick_size`), position seed
+  (`load_position_snapshots` per symbol), grid seed
+  (`load_grid_state_from_snapshots` per strat), active-order seed
+  (`load_active_orders` per symbol), and per-strat `EventFollower` (recorded
+  executions for THAT symbol only — reuse the `engine.py:468-510`
+  materialization + other-symbol skip). Build each `BacktestRunner` via the
+  SAME `_init_runner` wiring but passing the SHARED session and disabling the
+  per-strat wallet seed (each runner's `record_trade` mutates the shared
+  session). Extract the runner-build body of `ReplayEngine._init_runner` into a
+  reusable helper OR call it per strat with the shared session.
+- **Merged tick timeline**: create one `HistoricalDataProvider` per symbol
+  (`backtest/data_provider.py`), then k-way merge their tick iterators by
+  `exchange_ts` (heap-merge; ties broken deterministically by symbol then a
+  stable key) into a single ascending stream. Each merged tick is dispatched to
+  the runner for ITS symbol only. This preserves each runner's monotonic
+  `exchange_ts` contract (`EventFollower.drain` and `CollateralMarkFeed.mark_at`
+  both raise on non-monotonic ts) — a runner only ever sees its own symbol's
+  ticks, in ascending order. Merge-ordering is LOAD-BEARING for two reasons:
+  (a) `BacktestSession.update_equity` has NO ts guard (`session.py:367`), so
+  the equity-curve correctness depends entirely on the merge feeding strictly
+  ascending ts; (b) equal `exchange_ts` across symbols is TOLERATED — both
+  guards use strict `<` (`fill_simulator.py:434`, `engine.py:205`), so equal
+  ts passes and the symbol-then-stable-key tie-break makes the order
+  deterministic. The idle-symbol carry-forward requires each runner to CACHE
+  its most-recent OWN-symbol `last_price` across ticks (see step 4d / O2):
+  feeding a foreign symbol's price into a runner's
+  `calculate_unrealized_pnl` / `_estimate_pair_im_mm` would be a correctness
+  bug.
+- **Per-tick loop** (mirrors `engine.py:593-634` two-phase processing, but
+  routed to the tick's symbol runner):
+  1. Refresh collateral marks at top of tick via ONE shared
+     `CollateralMarkFeed` (account-level; feeds the shared session's
+     `update_collateral_mark`). Feed ts must be non-decreasing across the
+     MERGED stream — satisfied because the merge is globally ascending.
+  2. Funding (per symbol; `FundingSimulator` — one per runner, keyed off the
+     symbol's own ticks).
+  3. `runner.process_fills(tick)` for the tick's symbol.
+  4. `session.update_equity(tick.exchange_ts, unrealized, total_im,
+     total_mm)` where `unrealized` is Σ over ALL runners' long+short
+     `calculate_unrealized_pnl` (the shared wallet's equity reflects both
+     books), and `total_im`/`total_mm` are Σ of each runner's own
+     `_estimate_pair_im_mm` across BOTH runners — so the session's
+     account-level `_peak_mmr_pct` / `account_mm_rate` proxy is fed the
+     SHARED margin, not one symbol's. (`update_equity` accepts `total_im`,
+     `total_mm` kwargs, defaulting to 0 — `session.py:367-372`; passing the
+     summed values is the account-level margin coupling for the Phase-3
+     `account_mm_rate` reconcile.) NOTE the equity term (`total_equity`) is
+     coupled but each runner's per-symbol `_estimate_pair_liq_prices` still
+     subtracts only its OWN pair-MM from the pool (O1) — the summed
+     `total_mm` fed HERE improves only the account-level margin-rate reconcile,
+     not per-symbol liq prices.
+     **Open question O2**: the non-active runner's unrealized (and IM/MM) is
+     evaluated at its last-seen OWN-symbol mark (carry-forward per runner),
+     never the current tick's foreign symbol price.
+  5. `runner.execute_tick(tick)` for the tick's symbol.
+  - **INTRA-TICK refresh caveat (C2)**: `process_fills` and `execute_tick`
+    internally call `self._session.refresh_balances(fresh_unrealized)`
+    (`runner.py:642`, `:792`, `:1043`) with the OWN symbol's unrealized only.
+    `refresh_balances` sets the shared `current_balance` / `total_equity` that
+    downstream qty-sizing, the margin gate, and `_estimate_pair_liq_prices`
+    read WITHIN the tick — so a naive reuse makes the shared pool reflect only
+    the refreshing symbol's unrealized, dropping the idle book mid-tick. The
+    multi-engine must pass the account-wide Σ unrealized (both runners' cached
+    marks, per O2) into every `refresh_balances` call by INTERCEPTING the
+    refresh at its source — wrap `session.refresh_balances`, or override the
+    runner's fresh-unrealized computation to add the sibling's cached
+    unrealized. Refreshing the shared session with the Σ AFTER `process_fills` /
+    `execute_tick` RETURNS is INSUFFICIENT: those methods READ the balance
+    in-method before returning — `execute_tick`'s place path calls
+    `execute_place(..., wallet_balance=self._session.current_balance)`
+    (`runner.py:~908`) for qty sizing, so a stale own-symbol-only
+    `current_balance` is already consumed by the order before any post-method
+    refresh could correct it. The end-of-tick `update_equity` Σ (step 4) alone
+    is likewise NOT sufficient: it fixes only the sampled equity point, not the
+    intra-tick balance the strategy sizes and gates against. New-logic (e) must
+    intercept EVERY `refresh_balances` call site (`runner.py:642`, `:792`,
+    `:1043`), not add a trailing refresh.
+- **End-of-run**: per runner `finalize_event_follower()`, then optional
+  per-runner `_wind_down`, then ONE `session.finalize(final_unrealized_pnl=Σ)`.
+  CAVEAT: `BacktestSession.finalize` defaults `final_unrealized_pnl=Decimal("0")`
+  (`session.py:450-453`), so calling it bare would DROP both books' open
+  unrealized from the final metrics / Net PnL. The multi-engine must pass the
+  account-wide Σ final unrealized — each runner's long+short
+  `calculate_unrealized_pnl` at its cached own-symbol mark (same Σ-at-cached-mark
+  rule as step 4d / O2). Position-snapshot
+  writers: gated by an `emit_backtest_snapshots` flag exactly like
+  `ReplayEngine.__init__` (`engine.py:333`, `_NoopPositionSnapshotWriter` for
+  read-only DB in the validation path).
+- **Result type**: `MultiReplayResult` (frozen dataclass) carrying the shared
+  `session`, per-strat `ReplayResult`-equivalents (match_result / metrics per
+  symbol, reusing `LiveTradeLoader` + `TradeMatcher` + `calculate_metrics` per
+  symbol as `engine.py:685-711` does), and the shared equity/margin curve
+  samples for Phase 3 reconciliation.
+
+**Reuse, do NOT reimplement**: `_estimate_pair_liq_prices`,
+`_estimate_pair_im_mm`, `refresh_balances`, `_pnl_delta`, collateral re-mark,
+`EventFollower`, `_process_recorded_fills`, `CollateralMarkFeed`.
+
+**New logic** (the shared `BacktestSession` was built single-runner — several
+of its state fields are session-global scalars that a naive N-runner reuse
+would CLOBBER; these must be aggregated explicitly, they do NOT couple "for
+free"):
+- (a) the k-way tick merge;
+- (b) one shared session across N runners for the ACCUMULATION fields only
+  (`total_realized_pnl` / `total_commission` via `record_trade` — these are
+  `+=`, so they genuinely couple for free);
+- (c) the account-level (not per-strat) seed wiring;
+- (d) **merged pending-wallet across runners** — `session.set_pending_wallet`
+  (`session.py`) OVERWRITES the single session-global `_pending_realized_pnl` /
+  `_pending_commission` (designed for one runner; `_set_session_pending`,
+  `runner.py:684`). Two runners each calling it would clobber the other's
+  in-flight event_follower partials. The multi-engine must sum each runner's
+  pending and call `set_pending_wallet` ONCE per tick with the account-wide
+  Σ (or track per-runner pending and re-sum before each `update_equity`);
+- (e) **Σ-unrealized into `refresh_balances`** — see step 4 below;
+- (f) **emitted reconcile series** — the engine must record per-tick
+  `(ts, total_equity)`, `(ts, total_margin_balance)`, `(ts, account_mm_rate)`
+  series for Phase 3. `session.equity_curve` is available-baseline
+  (`initial_balance + pnl_delta`; `session.py:388-396` + comment), NOT
+  `total_equity`, and the session keeps only PEAK IM/MM (`_peak_mm` /
+  `_peak_mmr_pct`), not a per-tick margin series — so NONE of the three gated
+  reconcile quantities exists as a curve today, and each needs a DEFINED
+  replay formula (the session computes none of them as a time series):
+  - `total_equity` = the scalar the session already derives at each
+    `update_equity` (`initial_equity + Σ realized + Σ unrealized + collateral
+    re-mark`); the fix is only to APPEND it to a curve, not recompute it.
+  - `total_margin_balance` — the session computes NO such value (grep: absent).
+    Define it explicitly to match Bybit UTA semantics: for a cross-margin USDT
+    account `marginBalance == total_equity` (walletBalance + unrealized), so the
+    replayed series can be defined as EQUAL to the emitted `total_equity` unless
+    a discrepancy against recorded data shows otherwise — state this assumption
+    so the implementer does not invent a second formula. If reconciliation
+    against recorded `total_margin_balance` diverges from `total_equity`, that
+    divergence itself is the signal to refine the formula (record it, don't
+    silently pass).
+  - `account_mm_rate` = `Σ total_mm / total_margin_balance` (Bybit's maintenance
+    -margin ratio = account MM ÷ margin balance), computed from the SAME summed
+    `total_mm` fed to `update_equity` (step 4d) — NOT `_peak_mmr_pct` (a
+    percent-of-available peak, wrong basis AND wrong reduction). See the Phase-3
+    scale caveat (C4).
+
+### Phase 3 — Shared-wallet reconciliation (extend live_check)
+
+**Create `apps/live_check/src/live_check/shared_wallet.py`** (ground-truth
+reads) + extend `verdict.py` / `render.py` / `main.py`, OR add a sibling
+`multi_runner.py` — keep the existing single-strat path intact.
+
+- **Ground truth (account-level)**: query the recorded shared-wallet curve from
+  `wallet_snapshots` via `WalletSnapshotRepository.get_by_account_range(...)`
+  plus `get_latest_before(...)` for the at-`window.end` anchor. CORRECTNESS
+  CAVEATS verified against `shared/db/src/grid_db/repositories/snapshots.py:179`
+  (C6): (1) `get_by_account_range` is NOT `run_id`-scoped (it filters only
+  `account_id` + ts range) — a multi-run account DB would contaminate the
+  curve, so the caller MUST post-filter by `run_id` (or a `run_id`-scoped
+  repo method must be added in Phase 1; `get_latest_before` IS run-scoped,
+  so the two anchors must use consistent scoping). (2) The range filter is
+  INCLUSIVE on BOTH ends (`exchange_ts >= start AND <= end`), NOT half-open;
+  the plan's earlier "half-open / matches live_check convention" was wrong
+  (single-symbol `live_check` exec sums are inclusive both ends too). To
+  avoid double-counting the `window.end` point across the range query and the
+  `get_latest_before(window.end)` anchor, de-dup on `exchange_ts` (the anchor
+  supersedes). (3) confirm whether the method filters `coin` — if not, the
+  caller filters `coin == 'USDT'`. Extract `total_equity`,
+  `total_margin_balance`, `account_mm_rate` (account-level, NOT per-symbol).
+  SKIP recorded rows where ANY of the reconciled field(s) is NULL —
+  `wallet_snapshots.total_equity`, `total_margin_balance`, AND `account_mm_rate`
+  are ALL `Optional[Decimal]` / nullable (`models.py:500-511`, feature 0042);
+  a NULL must be dropped for THAT field's diff, NOT coerced to 0 (a 0 blows
+  the max-diff and false-FAILs the gate). Skip is per-field: a row with a
+  non-NULL `total_equity` but NULL `account_mm_rate` still contributes to the
+  equity diff. Materialize to a frozen dataclass inside the read session
+  (DetachedInstanceError, cf. 0038) — mirror `ground_truth.ExecRow`.
+- **Replayed curves (must be EMITTED — they do not exist today, C3/C4)**: the
+  reconcile needs THREE replayed time series, none of which the session records
+  today. `session.equity_curve` is the AVAILABLE-baseline (`initial_balance +
+  pnl_delta`, `session.py:388-396`), NOT `total_equity`; `total_equity` is kept
+  only as the latest scalar; and margin is kept only as PEAKS (`_peak_mm`,
+  `_peak_mmr_pct`), not a per-tick series. So Phase 2's `MultiReplayEngine`
+  (New-logic (f)) MUST append, at each `update_equity`, `(ts, total_equity)`,
+  `(ts, total_margin_balance)`, `(ts, account_mm_rate)` to new curves carried on
+  `MultiReplayResult`. SCALE CAVEAT (C4): the session's `_peak_mmr_pct` is a
+  PERCENT-of-available figure, whereas Bybit's recorded `account_mm_rate` is a
+  DECIMAL RATIO — the emitted `account_mm_rate` series must be computed in the
+  SAME units as the recorded field (define the conversion, or reconcile
+  `total_margin_balance` in absolute USDT and treat `account_mm_rate` as the
+  derived check) before any Δ is taken; comparing % against ratio would
+  guarantee a spurious miss. Sample each replayed curve at each (non-NULL)
+  recorded `exchange_ts` (nearest at-or-before), so replayed-vs-recorded is
+  compared point-by-point at the SAME timestamps. BASIS NOTE: recorded `total_equity` is a MARK-price
+  snapshot; the replayed curve values unrealized at `last_price` — the
+  documented ~$0.20-0.50 last-vs-mark jitter (RULES pos_value / mark-jitter).
+  Under the shared wallet BOTH books' jitter sums into the single
+  `total_equity` diff, so the equity tolerance must absorb roughly the SUM of
+  two single-symbol bands (≈2× the 0.50 starting hypothesis) — the exact
+  floor is empirical (Phase 4).
+- **Reconciliation metrics** (all `Decimal`):
+  - PRIMARY (the A/B ranks on this): `max` absolute diff of replayed
+    `total_equity` vs recorded `total_equity` over the window (to the cent)
+    plus a final-point `|Δtotal_equity|` at `window.end`.
+  - MARGIN-COUPLING (GATED, not informational): `max |Δtotal_margin_balance|`
+    and `max |Δaccount_mm_rate|` over the window. Because a passing equity
+    gate does NOT exercise the shared MM/liq pool (O1), these are a SEPARATE
+    gated check with their OWN tolerances — the only signal that the summed
+    `total_im`/`total_mm` account-margin coupling (step 4d) tracks live. They
+    validate the account-level margin rate; they do NOT validate per-symbol
+    liq prices (out of scope, O1).
+  - Extend `VerdictThresholds` with `equity` (default matching the current
+    `unrealised` 0.50 mark-jitter band — see Phase 3 basis-jitter note; may
+    need ~2× for two books), `total_margin_balance`, and `account_mm_rate`
+    fields. Exact tolerances are set in Phase 4 after measuring; the
+    account-margin tolerances start LOOSE (the own-MM-only pool is a known
+    approximation) and are ratcheted, but a wild `account_mm_rate` miss must
+    still FAIL the gate rather than pass silently.
+- **Verdict**: extend `evaluate` (`verdict.py:31`) OR add a
+  `evaluate_shared_wallet` that ANDs THREE gate groups: (1) the existing
+  per-strat event_follower checks (`live_only==[] AND backtest_only==[]`,
+  |Δrealized|<0.01, |Δcommission|<0.01, |Δunrealised|<0.50, per symbol) —
+  the trade-level trust gate. CAVEAT (C5): the current `evaluate` reads
+  `session.metrics.total_realized_pnl` / `.total_commission` /
+  `.total_unrealized_pnl` (`verdict.py:62-83`), which under the SHARED session
+  are ACCOUNT-WIDE totals mixing both symbols — they CANNOT be diffed against a
+  per-symbol `ground_truth`. Group (1) must be fed PER-SYMBOL metrics: reuse
+  the per-symbol `calculate_metrics` / `TradeMatcher` outputs already carried
+  on `MultiReplayResult` (the per-strat `ReplayResult`-equivalents,
+  `engine.py:685-711`), one `evaluate` call per symbol, NOT the shared
+  `session.metrics`. UNREALISED SOURCE: `ValidationMetrics` (per-symbol
+  `calculate_metrics`) carries realized/commission but NO final-unrealized
+  field, so the per-symbol `|Δunrealised|` must be taken from each runner's OWN
+  trackers — `long_tracker.calculate_unrealized_pnl + short_tracker.
+  calculate_unrealized_pnl` at that runner's cached own-symbol mark (the same
+  per-symbol unrealized the multi-engine already computes for step 4d / finalize)
+  — diffed against that symbol's recorded `ground_truth.net_unrealised`, NOT the
+  account-wide `session.metrics.total_unrealized_pnl`. (2)
+  `max |Δtotal_equity| < equity_threshold` —
+  the equity-coupling trust gate (the quantity the A/B ranks on); (3)
+  `max |Δtotal_margin_balance| < margin_threshold` AND `max |Δaccount_mm_rate|
+  < mm_rate_threshold` — the account-margin-coupling gate (validates the
+  summed IM/MM, loose but not silent). Each group can independently FAIL.
+- **CLI**: a `--shared` (or a distinct `multi-live-check` entry) mode in
+  `main.py` that resolves `(run_id, account_id, run_start)` once
+  (`_resolve_run`, `main.py:111`), runs the multi-engine over the window, and
+  renders per-strat rows PLUS the shared equity reconcile line. Keep exit-code
+  semantics (`_exit_code`, `main.py:132`): FAIL(1) > SKIP(2) > PASS(0); zero
+  live-exec window → SKIP, never PASS.
+
+### Phase 4 — Reconciliation gate, THEN counterfactual A/B
+
+**Gate (hard acceptance criterion, blocks Phase-4b):**
+> The combined replayed shared-wallet `total_equity` must reconcile against the
+> recorded account-level `wallet_snapshots.total_equity` within a stated
+> tolerance over a multi-day window (target: the full `580ca395` window or a
+> ≥3-day slice). Concretely, ALL THREE must hold: (1) BOTH per-strat
+> event_follower checks PASS for SOL and LTC (`live_only==[]`,
+> `backtest_only==[]`, |Δrealized|<0.01, |Δcommission|<0.01, AND
+> |Δunrealised|<0.50 per symbol — same three checks as Phase-3 verdict
+> group (1), fed PER-SYMBOL metrics not the shared `session.metrics`, C5); (2)
+> `max |replayed total_equity − recorded total_equity|` over the window is ≤
+> the equity tolerance fixed here (start at 0.50 USDT — but see the Phase-3
+> basis-jitter note: two books' last-vs-mark jitter can add, so ~2× may be
+> the achievable floor; ratchet down to the tightest value the data supports
+> and record the achieved max-abs diff); (3) `max |Δtotal_margin_balance|`
+> and `max |Δaccount_mm_rate|` are ≤ their (initially loose) tolerances —
+> the account-margin-coupling check, gated so a gross MM miss FAILS rather
+> than passing on the equity curve alone. This gate validates equity + the
+> account-level margin RATE; it does NOT validate per-symbol liq prices
+> (out of scope, O1 — the pool subtracts own-MM only). Until this gate
+> passes, NO A/B result under the shared wallet is believed.
+
+**Phase 4b — Counterfactual A/B driver (only after the gate passes):**
+- Gitignored `conf/_*.py` driver (H-series pattern, e.g. `apps/replay/conf/`),
+  NOT tracked source. Sweeps `grid_step` for both symbols under the shared
+  wallet on the month window using the `last_cross` fill mode
+  (counterfactual — `event_follower` cannot model fills the strategy never
+  placed; RULES `event_follower` entry). The A/B uses the SAME
+  `MultiReplayEngine` + shared session so coupling is active; only
+  `fill_simulator.mode` flips to `last_cross` and grid_step varies.
+- Rank on Net$ / MaxDD$ per the fresh-grid recipe; report whether coupling
+  reinforces "go wider" (expected gs≈0.6, but MEASURED not assumed).
+
+## Algorithm — k-way merged tick loop (Phase 2 core)
+
+1. Open one `HistoricalDataProvider` per symbol over `[start_ts, end_ts]`.
+2. Wrap each as an iterator yielding `(exchange_ts, symbol, tick)`.
+3. Heap-merge the N iterators into a single stream ascending by
+   `(exchange_ts, symbol)` (deterministic tie-break; symbol order fixed).
+4. For each merged `(ts, symbol, tick)`:
+   a. Shared `CollateralMarkFeed.mark_at(coin, ts)` for each collateral coin →
+      `session.update_collateral_mark` (ts globally non-decreasing ⇒ the feed's
+      monotonic cursor is satisfied).
+   b. Funding for `symbol` (its `FundingSimulator`).
+   c. `runners[symbol].process_fills(tick)` (drains only `symbol`'s recorded
+      execs; its follower cursor advances monotonically because it only sees
+      `symbol`'s ticks).
+   d. `unrealized = Σ_runner (long.calc_unrealized + short.calc_unrealized)`
+      at each runner's last OWN-symbol mark (idle runner uses its cached
+      last own-symbol `last_price`, never the foreign tick's price);
+      `total_im, total_mm = Σ_runner _estimate_pair_im_mm(...)` (also at each
+      runner's cached own-symbol mark) → `session.update_equity(ts,
+      unrealized, total_im, total_mm)`.
+   e. `runners[symbol].execute_tick(tick)`.
+5. After the stream: per runner `finalize_event_follower()`; optional
+   `_wind_down`; `session.finalize`.
+
+The shared session's `total_realized_pnl` / `total_commission` accumulate
+across BOTH runners' `record_trade` calls (`+=`), so the REALIZED component of
+`current_balance` / `total_equity` couples for free from the existing
+accumulation model. The UNREALIZED and pending components do NOT couple for
+free: `refresh_balances` / `set_pending_wallet` are fed per-runner own-symbol
+values and overwrite session-global scalars (see New-logic (d)/(e) and the
+step-5 intra-tick caveat) — the multi-engine must pass account-wide Σ
+unrealized and Σ pending into those calls, or the shared pool the LTC runner's
+pair-liq reads is missing SOL's unrealized/pending within the tick.
+
+## Testing (hermetic, mock DB, no real Bybit)
+
+- **Phase 1**: `MultiReplayConfig` validation — reject empty `strategies`
+  (`min_length=1`); per-strat `symbol`/`strat_id` required; account-level seed
+  fields required when seeding (mirror `SeedConfig.require_seed_fields`);
+  reject a `seed.collateral_coins` entry whose coin is the base of any traded
+  `strategies[*].symbol` (double-count guard — expect `ValueError`).
+- **Phase 2**: k-way merge is globally ascending and each runner sees only its
+  symbol's ticks in order (feed a two-symbol `InMemoryDataProvider`); ONE
+  shared session, two runners recording trades → `current_balance` reflects
+  BOTH; a SOL loss reduces the pool `total_equity` the LTC runner's pair-liq
+  reads (the coupling assertion); `event_follower` per strat yields
+  `backtest_only==[]`. Plus the multi-runner-aggregation regressions that the
+  New-logic (d)/(e)/(f) fixes target: (i) **merged pending** — both symbols
+  with concurrent UNFLUSHED event_follower rollups; assert the shared
+  `_pending_realized_pnl` / `_pending_commission` equals the SUM, not the
+  last-writer's value (C1); (ii) **Σ-unrealized refresh** — an idle book with
+  open unrealized; assert the shared `total_equity` / pair-liq pool read
+  DURING the active symbol's tick includes the idle book's cached unrealized
+  (C2), not own-symbol only; (iii) **emitted series** — assert the engine
+  appends `(ts, total_equity)` / `(ts, total_margin_balance)` /
+  `(ts, account_mm_rate)` curves distinct from `equity_curve` (C3/C4);
+  (iv) **in-method refresh→read** (interception, not trailing-refresh): a tick
+  where the active runner refreshes own-symbol balance then, IN THE SAME
+  `execute_tick`, places via `execute_place(wallet_balance=
+  session.current_balance)` (`runner.py:~908`) — assert the `wallet_balance`
+  seen by the place reflects the account-wide Σ unrealized, not own-symbol
+  only; the concrete sequence is a cancel-flush (`runner.py:920-922`) followed
+  by a place intent. Reuse `InMemoryDataProvider` and synthetic
+  `RecordedExecution` streams.
+- **Phase 3/4**: shared-equity reconcile diff computed against a synthetic
+  recorded `wallet_snapshots` curve; verdict ANDs per-strat + shared checks;
+  zero-data window → SKIP; exit-code precedence preserved. Plus reconcile-layer
+  regressions: (a) per-strat verdict fed PER-SYMBOL metrics, not account-wide
+  `session.metrics` (C5) — a two-symbol session where account totals would
+  PASS but one symbol individually FAILS must FAIL; (b) `run_id` post-filter on
+  `get_by_account_range` — a multi-run `wallet_snapshots` fixture must not
+  contaminate the curve (C6); (c) inclusive-both-ends range + `get_latest_before`
+  anchor de-dup at `window.end` (no double-count, C6); (d) per-field NULL skip
+  for `total_equity` AND `total_margin_balance` AND `account_mm_rate` (C7);
+  (e) `account_mm_rate` unit conversion (ratio vs percent, C4) — a matching
+  live/replay pair must reconcile only after the scale is applied.
+
+## Open questions / decisions (stated, not silently resolved)
+
+- **O1 — per-symbol pair-liq vs true account cross-liq; the MM asymmetry.**
+  Each runner computes its own symbol's `_estimate_pair_liq_prices(long,
+  short, total_equity)` off the SHARED `total_equity` pool, then subtracts
+  `pool = total_equity - mm_total` where `mm_total` covers ONLY that runner's
+  own long/short (`runner.py:1444-1456`). So the EQUITY term is coupled
+  across both books but the MM term is NOT: the LTC runner's liq pool ignores
+  SOL's maintenance margin held against the same equity, over-stating LTC's
+  free pool and under-stating joint liq risk. This is deliberately OUT OF
+  SCOPE for v1: the shared-wallet model captures margin/collateral coupling
+  through `total_equity` (a SOL drawdown shrinks the pool LTC reads) and the
+  A/B ranks ONLY on Net$/MaxDD$ derived from the shared EQUITY curve — NOT on
+  per-symbol liq-price accuracy or joint-liq-event counts, which the
+  own-MM-only pool cannot get right. A genuine account-level MM aggregation
+  (feed each runner a shared `total_mm`/`total_im` summed across BOTH runners
+  into `refresh_balances`/`_estimate_pair_liq_prices`, and thence
+  `account_mm_rate`) is a named FOLLOW-UP, not v1. Flag for confirmation
+  before Phase 2. The Phase-4 gate reconciles the EQUITY curve (the quantity
+  the A/B actually ranks on); the account-margin fields
+  (`account_mm_rate` / `total_margin_balance`) are a SEPARATE gated check
+  (see Phase 3 reconciliation metric + Phase 4 gate) precisely because a
+  passing equity gate does NOT exercise the MM/liq pool — a green equity
+  curve must not be read as validating the (out-of-scope) liq coupling.
+- **O2 — non-active runner's unrealized on a foreign-symbol tick (idle-price
+  cache).** The shared `update_equity` needs Σ unrealized (and Σ IM/MM)
+  across both books at every tick, but only the tick's symbol has a fresh
+  mark. RESOLUTION (crux, spelled out): each runner CACHES its most-recent
+  OWN-symbol `last_price` — updated only when a tick for THAT symbol is
+  dispatched. On a foreign-symbol tick the idle runner's unrealized /
+  `_estimate_pair_im_mm` is recomputed at its CACHED own-symbol price, NEVER
+  the foreign tick's `last_price` (feeding SOL's price into LTC's
+  `calculate_unrealized_pnl` would be a correctness bug). This is a per-tick
+  carry-forward approximation; its error is bounded by inter-tick mark drift
+  of the idle symbol and is measured by the reconciliation gate. Confirm
+  acceptable, or interleave a mark-only update for the idle symbol (extra
+  provider read per tick).
+  **STARTUP INIT (required):** `PositionStateSeed` carries NO mark/last_price
+  (`snapshot_loader.py:144-149` — only direction/size/entry/liq/cum/cur), so the
+  per-runner mark cache has nothing to carry forward on the FIRST ticks before
+  each symbol's first own tick. A seeded position on the idle symbol would then
+  contribute wrong/zero unrealized + IM/MM to the shared `update_equity` /
+  `refresh_balances` / `finalize` until its first own tick lands. Before the
+  merge loop, seed each runner's mark cache with an at-or-before-`start_ts`
+  mark per symbol (a `get_latest_before(start_ts)` on `ticker_snapshots`, or the
+  seed-window last mark the engine already reads, cf. `engine.py:148-155`), so
+  both books have a valid mark from tick 0.
+- **Timestamp handling (merge is load-bearing).** `update_equity` has NO ts
+  monotonicity guard (`session.py:367`); equity-curve correctness depends on
+  the k-way merge feeding strictly ascending ts. Equal `exchange_ts` across
+  symbols is acceptable — both drain/mark-feed guards use strict `<`
+  (`fill_simulator.py:434`, `engine.py:205`), so equal ts passes; the
+  symbol-then-stable-key tie-break keeps ordering deterministic.
+- **O3 — `funding` per symbol under one wallet.** Each runner keeps its own
+  `FundingSimulator`; funding fires ONLY on that symbol's own ticks (step 4b),
+  so `apply_funding(rate, current_price)` (`runner.py:1671`) ALWAYS has a
+  fresh own-symbol `last_price` — the idle-symbol price-cache concern (O2 /
+  F-1-3) does NOT apply to funding, and no idle-symbol funding update is
+  needed. Both symbols' funding folds into the shared session's
+  `total_funding` via `record_funding` (`session.py:277`), which the shared
+  `_pnl_delta` already feeds into `total_equity`. Bybit funding is a fixed
+  8h wall-clock schedule; a tick-gap straddling a boundary lands the two
+  symbols' applications at slightly different ts on the shared wallet —
+  acceptable, both accrue into the same reconciled `total_equity`. RECONCILE
+  NOTE: recorded funding is already embedded in the recorded
+  `wallet_snapshots.total_equity` ground truth — there is NO separate funding
+  reconcile line; funding faithfulness is validated transitively by the
+  equity gate. Confirm per-position per-symbol accrual into one wallet matches
+  how recorded funding hit the shared account.

--- a/docs/features/0094_REVIEW.md
+++ b/docs/features/0094_REVIEW.md
@@ -1,0 +1,36 @@
+# 0094 — External code review trail
+
+Feature: shared-wallet multi-strategy replay + validation (plan `0094_PLAN.md`).
+Reviewed: staged implementation on branch `feature/0094-shared-wallet-replay`.
+Engines: OpenAI codex + Cursor agent (both, read-only). Triage + fixes: main session.
+
+## Round 1
+
+**codex** — 1 P1, 2 P3:
+- P1 `multi_engine.py:721` `total_margin_balance` emitted as `total_equity`, `account_mm_rate` divided by it → "mm-rate gate systematically wrong". **REJECTED.** `reconcile_wallet_curve` (`shared_wallet.py:111-118`) diffs replayed values against the REAL recorded `point.total_margin_balance` / `point.account_mm_rate` fields, not `total_equity` — the documented cross-margin-UTA assumption (plan New-logic f: `marginBalance == total_equity`) is SELF-CHECKING; divergence surfaces as a margin/mm-rate delta the gate flags. Loose initial tolerances by design (O1). Not a silent bug.
+- P3 signed `final_equity_delta` vs plan `|Δ|`. **ACCEPTED** → `abs()`.
+- P3 test asserts `total_margin_balance == total_equity`. Covered by the reject rationale + new e2e test.
+
+**cursor** — verification log (all C1–C7 / New-logic MATCH), 3 P2 + 5 P3:
+- P2 startup mark-cache leaves `Decimal("0")` silently when no at-or-before mark. **ACCEPTED** → `logger.warning` in both branches of `_startup_mark_cache`.
+- P2 missing e2e `MultiReplayEngine.run()` test (coupling + `account_curve` vs `equity_curve`). **ACCEPTED** → added `TestMultiReplayRunEndToEnd`.
+- P2 missing C2 in-method `execute_place` interception regression. **PARTIAL** — the e2e run() test exercises the wired `coordinator.active` interception loop; the unit `test_refresh_balances_intercepts_sum_unrealized` covers the mechanism. A dedicated wallet_balance-capture assertion recorded as an accepted non-blocking gap.
+- P3 shared gates `<=` vs per-strat strict `<`. **ACCEPTED** → strict `<`.
+- P3 (×4) C5 mask-scenario test, C3 sample distinctness, 800-line module smell, monkey-patch style. **Accepted non-blocking gaps.**
+
+Fixes verified: `uv run pytest apps/replay apps/live_check` = 251 passed; `make lint` clean.
+
+## Round 2 (convergence check)
+
+Both engines: **NO P1/P2 FINDINGS.** cursor re-verified all round-1 fixes MATCH and confirmed the rejected P1 is self-checking.
+
+Shared P3 (both engines): no unique-`symbol` validator — duplicate `strategies[*].symbol` silently last-wins in the engine's per-symbol maps. **ACCEPTED** (cheap, real footgun) → `reject_duplicate_strategies` validator on `MultiReplayConfig` (symbol + strat_id) + 2 tests.
+Other P3s (ts-normalize both sides in `reconcile_wallet_curve` — prod path is SQLite-naive/safe; `final_equity_delta` not separately gated — `max_equity_delta` over the window already includes the final point): accepted non-blocking gaps.
+
+Final: `uv run pytest apps/replay apps/live_check` = 253 passed; `make lint` clean.
+
+## Trace
+
+- iterations: 2
+- findings: raised 8+8, accepted 6 (fixed 6), rejected 1 (self-checking margin assumption), P3-ignored several
+- result: SUCCESS (zero valid P1/P2, tests+lint green)


### PR DESCRIPTION
## What

Run both live pairs (**SOLUSDT + LTCUSDT**) concurrently against **ONE shared account wallet** on a k-way merged tick timeline, so cross-margin / cross-liquidation coupling is modeled the way live actually works — then reconcile the combined equity/margin against the recorded account `wallet_snapshots` to the cent before any counterfactual A/B is believed.

Motivation: all prior parametric work (H1–H8) ran each symbol **isolated** with its own wallet; live shares one account. This models what that couldn't.

## Changes

- **`replay.multi_config`** — `MultiReplayConfig` / `MultiReplayStrategyConfig` (additive wrapper; single-symbol `ReplayConfig`/`ReplayEngine` untouched by design). Validators reject empty strategies, missing seed fields, traded-base-as-collateral, and duplicate symbol/strat_id.
- **`replay.multi_engine`** — `MultiReplayEngine` + `_SharedSessionCoordinator`: one shared `BacktestSession` across N runners; aggregates pending-wallet across runners (C1), intercepts `refresh_balances` at source with account-wide Σ unrealized (C2), emits per-tick `total_equity` / `total_margin_balance` / `account_mm_rate` series (C3/C4), passes Σ final unrealized to `finalize`, seeds a startup mark cache before the merge loop (O2).
- **`live_check.shared_wallet`** + `evaluate_multi_strategy` / `evaluate_shared_wallet` + `run_shared`: per-symbol event_follower checks AND account-level equity/margin reconciliation gate; per-symbol verdict metrics from runner trackers not account-wide `session.metrics` (C5); `run_id` post-filter + inclusive-end de-dup on the wallet curve (C6); per-field NULL skip (C7).

Scope note: MM/liq-**pool** coupling is deliberately out for v1 (each runner subtracts only its own MM; the A/B ranks on Net$/MaxDD$ from the shared **equity** curve; Σ-account-MM is a follow-up). Phase-4b gitignored A/B driver not included.

## Process

- Plan `docs/features/0094_PLAN.md` — plan-debate (2 iters) + ext-plan-review (codex+cursor, 4 rounds, ~14 findings all fixed).
- Implemented by codex, then **ext-code-review** (codex+cursor, 2 rounds → SUCCESS). Trail: `docs/features/0094_REVIEW.md`. 1 of 16 findings rejected with evidence (self-checking margin-basis assumption).

## Verification

- `uv run pytest apps/replay apps/live_check` → **253 passed**
- `make lint` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)