### PR TITLE
feat(ci): enforce uv lockfile consistency (0097)

### DIFF
--- a/.claude/rules/core-invariants.md
+++ b/.claude/rules/core-invariants.md
@@ -69,6 +69,13 @@ make test-integration
 
 The merge gate (feature 0073, issue #176). Two parallel jobs — `test` (`make test`) and `lint` (`make lint`) — run on every PR and on push to `main`; both fail the workflow on any non-zero exit. **CI green is the source of truth for repo health.**
 
+### Dependency / lockfile discipline (Feature 0097, issue #212)
+
+- **Local install:** plain `uv sync` is the day-to-day command (resolves freely).
+- **After editing any workspace `pyproject.toml`** (root or member under `packages/`, `shared/`, `apps/`) or dependency metadata: run `uv lock` at repo root and commit the manifest change together with the updated `uv.lock`.
+- **CI / scheduled / release workflows:** must use `uv sync --locked` (not plain `uv sync`). Any new workflow that installs deps must follow this — today: `.github/workflows/ci.yml` and `.github/workflows/risk-tier-monitor.yml`.
+- **Pre-commit:** `uv lock --check` runs via the local `uv-lock-check` hook in `.pre-commit-config.yaml` when a matching workspace manifest changes. Install hooks once per clone (or after pulling this change): `uv run pre-commit install`. (`bbu_reference/**` is out of scope.)
+
 Phase-0 rollout while the repo is red:
 - **Step A (current)** — real failing jobs, no `continue-on-error`; the check is NOT required in branch protection, so it doesn't block the fix PRs for #177–#180.
 - **Step A′** — advisory green via `continue-on-error: true` on `lint` ONLY (never `test`); opt-in scaffolding, avoid unless explicitly requested.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --locked
 
       - name: Run tests
         run: make test
@@ -60,7 +60,7 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --locked
 
       - name: Run lint
         run: make lint

--- a/.github/workflows/risk-tier-monitor.yml
+++ b/.github/workflows/risk-tier-monitor.yml
@@ -21,7 +21,7 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --locked
 
       - name: Check tier drift
         id: drift-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+# Feature 0097 / issue #212 — lockfile consistency gate.
+# Install once per clone: uv run pre-commit install
+repos:
+  - repo: local
+    hooks:
+      - id: uv-lock-check
+        name: check uv.lock is up to date
+        entry: uv lock --check
+        language: system
+        pass_filenames: false
+        files: ^(pyproject\.toml|(packages|shared|apps)/[^/]+/pyproject\.toml)$

--- a/RULES.md
+++ b/RULES.md
@@ -16,7 +16,7 @@ every ~10 features, sweep the rule files and prune entries that no longer apply.
 | Rule file | Loads | Contents |
 |---|---|---|
 | `.claude/rules/code-style.md` | always | Coding principles, conventions, safety rules |
-| `.claude/rules/core-invariants.md` | always | Project overview, Constraints (do-not), running tests, CI, logging levels, cross-package testing + pitfalls, margin-ratio vs positionIM distinction, Common Pitfalls (cross-cutting) |
+| `.claude/rules/core-invariants.md` | always | Project overview, Constraints (do-not), running tests, CI, Dependency / lockfile (`uv sync` local vs `uv sync --locked` in CI, `uv lock` after manifest edits, pre-commit `uv lock --check`), logging levels, cross-package testing + pitfalls, margin-ratio vs positionIM distinction, Common Pitfalls (cross-cutting) |
 | `.claude/rules/gridcore.md` | `packages/gridcore/**` | Strategy engine: grid/engine/position modules, 110017 self-heal (0064), state-divergence detector (0069), 110007 preflight + chase-close (0066), safety caps (0079), SAME ORDER, enums, events/intents, persistence, DB snapshots (0047), PnL functions |
 | `.claude/rules/grid-db.md` | `shared/db/**` | Multi-tenant DB layer rules, enums, env vars |
 | `.claude/rules/bybit-adapter.md` | `packages/bybit_adapter/**` | REST/WS components, event normalization, V5 API status |

--- a/docs/features/0097_PLAN.md
+++ b/docs/features/0097_PLAN.md
@@ -1,0 +1,153 @@
+# Feature 0097 — Enforce lockfile consistency in CI (Issue #212)
+
+## Context
+
+GitHub issue #212. CI workflows install dependencies with plain `uv sync`,
+which can re-resolve in CI. A PR can change `pyproject.toml` without
+committing a matching `uv.lock` update and still pass — non-deterministic
+builds.
+
+`uv.lock` exists at repo root. The workspace has a root `pyproject.toml`
+plus member manifests under `packages/*`, `shared/*`, and `apps/*` (12
+member `pyproject.toml` files; `bbu_reference/` is vendored and out of
+scope).
+
+**Fix:** use `uv sync --locked` in CI and scheduled workflows; add a
+pre-commit guard via `uv lock --check`; document the lockfile workflow in
+project rules (canonical for agents and humans). Local day-to-day installs
+keep plain `uv sync` (low friction); lockfile discipline is enforced at
+commit time and in CI.
+
+## Files to change
+
+### 1. GitHub workflows — `uv sync` → `uv sync --locked`
+
+| File | Lines | Job / step |
+|---|---|---|
+| `.github/workflows/ci.yml` | 44 | `test` job, "Install dependencies" |
+| `.github/workflows/ci.yml` | 63 | `lint` job, "Install dependencies" |
+| `.github/workflows/risk-tier-monitor.yml` | 24 | `check-tier-drift` job, "Install dependencies" |
+
+Change each `run: uv sync` to `run: uv sync --locked`. No other workflow
+files currently run `uv sync` (`claude.yml`, `claude-code-review.yml` do
+not install Python deps).
+
+### 2. Pre-commit hook (new)
+
+No `.pre-commit-config.yaml` or pre-commit usage exists today.
+
+**Create** `.pre-commit-config.yaml` at repo root with a **local** hook:
+
+- **id:** `uv-lock-check` (or similar)
+- **name:** check uv.lock is up to date
+- **entry:** `uv lock --check`
+- **language:** `system` (runs `uv` from PATH — fine for terminal
+  commits; GUI git clients that don't inherit the shell PATH may not
+  find `uv`, a known pre-commit gotcha, acceptable for this repo's
+  CLI-driven workflow)
+- **pass_filenames:** `false`
+- **files:** trigger when any workspace `pyproject.toml` changes. NOTE:
+  pre-commit `files:` is a **single Python `re` regex**, not a glob —
+  `**` is not glob syntax here and would silently mis-match. Use an
+  explicit anchored regex matching the root manifest plus one-level
+  members, e.g.:
+  `^(pyproject\.toml|(packages|shared|apps)/[^/]+/pyproject\.toml)$`
+  This covers root `pyproject.toml` and each member manifest under
+  `packages/`, `shared/`, `apps/`; `bbu_reference/**` is excluded
+  because it does not live under those three prefixes (no separate
+  `exclude:` needed).
+
+**Add** `pre-commit` to the root `pyproject.toml` `[dependency-groups] dev`
+list so `uv sync` installs the hook runner. After adding, run `uv lock` and
+commit the updated `uv.lock`.
+
+**Rules doc** (below) must tell contributors/agents to run
+`uv run pre-commit install` once per clone (or after pulling this change).
+
+Do **not** add a `make sync` target — `Makefile` has no sync recipe today
+and none is required for this feature.
+
+### 3. Project rules — canonical lockfile workflow
+
+**Edit** `.claude/rules/core-invariants.md`, in or immediately after the
+existing "Continuous Integration" section (~line 68), add a subsection on
+dependency / lockfile discipline covering:
+
+1. **Local install:** plain `uv sync` remains the day-to-day command.
+2. **After editing any workspace `pyproject.toml`** (root or member) or
+   dependency metadata: run `uv lock` at repo root, commit both the manifest
+   change and the updated `uv.lock`.
+3. **CI / scheduled / release workflows:** must use `uv sync --locked` (not
+   plain `uv sync`). Any new workflow that installs deps must follow this.
+4. **Pre-commit:** `uv lock --check` runs via pre-commit; install hooks with
+   `uv run pre-commit install`.
+
+**Edit** `RULES.md` index table: add a one-line pointer in the
+`core-invariants.md` row (or a new "Dependency / lockfile" bullet) so the
+lockfile workflow is discoverable from the index without duplicating full
+text.
+
+Do **not** mass-update scattered install snippets (`README.md` Quick Start,
+`docs/LIVE_BOT_DEBUGGING_GUIDE.md`, app READMEs, runbooks). Optional: a
+single brief sentence in root `README.md` pointing to the rules index for
+lockfile workflow — only if the implementer judges rules alone too invisible
+to humans; prefer rules as canonical.
+
+### 4. Out of scope
+
+- `bbu_reference/**` pyproject files and their separate lockfiles.
+- Changing local docs to recommend `uv sync --locked`.
+- `make sync` Makefile target.
+- Mandatory throwaway remote PR for verification.
+
+## Behavior (how the gates work)
+
+### `uv sync --locked` (CI)
+
+On `uv sync --locked`, uv installs exactly what `uv.lock` specifies. If
+`pyproject.toml` (any workspace member) disagrees with `uv.lock`, the
+command exits non-zero and the workflow job fails at "Install dependencies".
+
+### `uv lock --check` (pre-commit)
+
+On `uv lock --check`, uv resolves the workspace and compares the result to
+the committed `uv.lock` without writing. If they differ, exit non-zero and
+pre-commit blocks the commit with a message to run `uv lock`.
+
+### Developer workflow after this change
+
+1. Edit dependency in any workspace `pyproject.toml`.
+2. Run `uv lock` at repo root.
+3. Commit manifest + `uv.lock` together.
+4. Pre-commit passes; CI `uv sync --locked` passes.
+
+If step 2 is skipped: pre-commit fails on commit; if hooks are bypassed,
+CI still fails on install.
+
+## Verify (local, 1–2 steps)
+
+1. **Pre-commit / lock check:** on a branch, add a dummy dev dependency
+   line to root `pyproject.toml` without running `uv lock`. Run
+   `uv lock --check` — expect non-zero exit. Then exercise the hook —
+   but invoke pre-commit WITHOUT letting `uv run` auto-sync first:
+   plain `uv run pre-commit ...` re-resolves and can rewrite `uv.lock`
+   to match the drifted manifest before the hook fires, so the hook's
+   `uv lock --check` would then pass — a false green. Use
+   `uv run --no-sync pre-commit run uv-lock-check --all-files` (or run
+   `pre-commit` from an already-synced env) — expect failure.
+   Also confirm the `files:` regex actually matches a **member**
+   manifest, not just the root. Do NOT use `--all-files` for this — the
+   root `pyproject.toml` always matches, so the hook runs (and fails)
+   regardless of whether the member branch of the regex works, giving
+   false confidence. Instead offer only a member path:
+   `uv run --no-sync pre-commit run uv-lock-check --files apps/gridbot/pyproject.toml`
+   — expect the hook to run and fail. If the member branch of the regex
+   is wrong, the file list is empty → hook skipped → false green.
+2. **CI install equivalent:** with the same uncommitted manifest drift (or
+   after reverting lock only), run `uv sync --locked` — expect non-zero
+   exit. Confirms the CI "Install dependencies" step would fail without a
+   remote PR.
+
+Keep the dummy manifest drift in place through BOTH steps above (the
+member `--files` check and step 2 all rely on it) — **revert the dummy
+change only at the very end**, after step 2.

--- a/docs/features/0097_REVIEW.md
+++ b/docs/features/0097_REVIEW.md
@@ -1,0 +1,51 @@
+# Feature 0097 — Code Review (Issue #212)
+
+Enforce uv lockfile consistency in CI + pre-commit gate.
+
+## Change surface
+
+- `.github/workflows/ci.yml` — `uv sync` → `uv sync --locked` (test + lint jobs)
+- `.github/workflows/risk-tier-monitor.yml` — `uv sync` → `uv sync --locked`
+- `.pre-commit-config.yaml` (new) — local `uv-lock-check` hook (`uv lock --check`)
+- `pyproject.toml` — `[dependency-groups] dev` += `pre-commit>=3.0`
+- `uv.lock` — `pre-commit` resolved into the lock
+- `.claude/rules/core-invariants.md` — new "Dependency / lockfile discipline" subsection
+- `RULES.md` — index row extended with lockfile pointer
+
+## Local behavioral verification (orchestrator)
+
+| Check | Result |
+|---|---|
+| `uv lock --check` on clean tree | exit 0 |
+| `uv lock --check` on real manifest drift (`tomli` added, no re-lock) | exit 1 |
+| pre-commit `uv-lock-check --files pyproject.toml` on drift | **Failed** (correct message) |
+| `uv sync --locked` on drift (CI equivalent) | exit 1 |
+| post-restore `uv lock --check` | exit 0 |
+| `files:` regex vs 12 members + 2 bbu paths + nested | root & members match; `bbu_reference/**` and nested excluded |
+| `pre-commit` present in `uv.lock` | yes (3 refs) |
+
+## External review trail
+
+- **Engines:** codex + cursor (both, read-only), 1 iteration.
+- **codex:** `NO P1/P2 FINDINGS`; confirmed plan conformance, no P3. (Prior
+  contamination issue — reviewing an unrelated project — resolved by
+  explicit repo anchoring in the prompt.)
+- **cursor:** `NO P1/P2 FINDINGS`; 13-point verification log, all MATCH.
+  One P3: `.pre-commit-config.yaml:11` `files:` omits `uv.lock`, so a
+  lock-only hand-edit commit skips the local hook — **intentional per
+  plan** (CI `uv sync --locked` is the backstop); residual local gap only,
+  not fixed.
+- **Findings:** raised 1 (P3), accepted-as-designed 1, rejected 0, P1/P2 0.
+- **Fixes applied:** none required.
+
+## Result
+
+Zero valid P1/P2. No Python logic changed → no unit tests warranted (gate
+is self-testing via CI + pre-commit hook; plan Verify is manual). Ready to
+commit.
+
+## Reminder on commit
+
+`git add` **all** of: the 6 tracked edits, the new `.pre-commit-config.yaml`,
+and `docs/features/0097_PLAN.md` + this `0097_REVIEW.md`. After pulling this
+change, run `uv run pre-commit install` once per clone to activate the hook.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dev = [
     "pytest-cov>=5.0",
     "pytest-asyncio>=0.23",
     "ruff>=0.1.0",
+    "pre-commit>=3.0",
     "gridbot",
     "pnl-checker",
     "importer",

--- a/uv.lock
+++ b/uv.lock
@@ -78,6 +78,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -273,6 +282,15 @@ toml = [
 ]
 
 [[package]]
+name = "distlib"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/02/bd72be9134d25ed783ecbbc38a539ffaefbf90c78418c7fb7229600dbac7/distlib-0.4.3.tar.gz", hash = "sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed", size = 615141, upload-time = "2026-06-12T08:04:52.847Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl", hash = "sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b", size = 470628, upload-time = "2026-06-12T08:04:50.506Z" },
+]
+
+[[package]]
 name = "event-saver"
 version = "0.1.0"
 source = { editable = "apps/event_saver" }
@@ -287,6 +305,15 @@ requires-dist = [
     { name = "bybit-adapter", editable = "packages/bybit_adapter" },
     { name = "grid-db", editable = "shared/db" },
     { name = "pydantic-settings", specifier = ">=2.0" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.32.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/80/8232b582c4b318b817cf1274ba74976b07b34d35ef439b3eb948f98645a1/filelock-3.32.0.tar.gz", hash = "sha256:7be2ad23a14607ccc71808e68fe30848aeace7058ace17852f68e2a68e310402", size = 213757, upload-time = "2026-07-21T13:17:42.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/79/b4c714bef36bc4ec2beeae1e0c124f0223888cd8c6feb1cdc56038116920/filelock-3.32.0-py3-none-any.whl", hash = "sha256:d396bea984af47333ef05e50eae7eff88c84256de6112aea0ec48a233c064fe3", size = 97732, upload-time = "2026-07-21T13:17:41.55Z" },
 ]
 
 [[package]]
@@ -341,6 +368,7 @@ dev = [
     { name = "gridbot" },
     { name = "importer" },
     { name = "pnl-checker" },
+    { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -354,6 +382,7 @@ dev = [
     { name = "gridbot", editable = "apps/gridbot" },
     { name = "importer", editable = "apps/importer" },
     { name = "pnl-checker", editable = "apps/pnl_checker" },
+    { name = "pre-commit", specifier = ">=3.0" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
     { name = "pytest-cov", specifier = ">=5.0" },
@@ -421,6 +450,15 @@ requires-dist = [
 name = "gridcore"
 version = "0.1.0"
 source = { editable = "packages/gridcore" }
+
+[[package]]
+name = "identify"
+version = "2.6.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
+]
 
 [[package]]
 name = "idna"
@@ -508,12 +546,30 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/9b/560e4be8e26f6fd133a03630a8df0c663b9e8d61b4ade152b72005aec83b/platformdirs-4.11.0.tar.gz", hash = "sha256:0555d18370482847566ffabcaa53ad7c6c1c29f195989ae1ed634a05f76ea1e0", size = 31953, upload-time = "2026-07-21T13:09:36.565Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/68/d8d58938dfb1370b266a1a729e6d77a985be23689a0496498ee17b2cbf90/platformdirs-4.11.0-py3-none-any.whl", hash = "sha256:360ccded2b7fce0af0ff80cc8f5942a1c5d99b0e856033acb030bfc634709e74", size = 23247, upload-time = "2026-07-21T13:09:35.422Z" },
 ]
 
 [[package]]
@@ -544,6 +600,22 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.0" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/3a/ddb78f32a0814e66b18a099377a106a2dcdce92d86a034d69d65df9b256e/pre_commit-4.6.1.tar.gz", hash = "sha256:03e809865c7d178b9979d06c761fcbfe6808fdaded8581a745bb110e52050421", size = 198646, upload-time = "2026-07-21T20:56:58.225Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/49/bc925106abcdac498074f2cbe6137e94e09f418dd2b7775df5b577dc0313/pre_commit-4.6.1-py2.py3-none-any.whl", hash = "sha256:0e3b2942510d1fb34eec167a3ec57331bf8442122f1153a9fb8b58f5c49b2717", size = 226186, upload-time = "2026-07-21T20:56:57.064Z" },
 ]
 
 [[package]]
@@ -827,6 +899,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+]
+
+[[package]]
+name = "python-discovery"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/51/276f964496a5714ab9f320896195639086881c2b39c03b5ad13de84acbb8/python_discovery-1.5.0.tar.gz", hash = "sha256:3e014c6327154d3dda27939a9a0dc9c5c000439f1906d3f303b48f984bd2ecef", size = 72483, upload-time = "2026-07-21T13:14:14.641Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/7b/14882602ddee241d7984a742fcb423cb4a30fb0d6efc546ac3129fba475a/python_discovery-1.5.0-py3-none-any.whl", hash = "sha256:70c4fc61b4e7404e44f01d6fc44a715c4d685ca6cea83d295922f05891877c98", size = 34205, upload-time = "2026-07-21T13:14:13.398Z" },
 ]
 
 [[package]]
@@ -1116,6 +1201,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1e/24/a2a2ed9addd907787d7aa0355ba36a6cadf1768b934c652ea78acbd59dcd/urllib3-2.6.2.tar.gz", hash = "sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797", size = 432930, upload-time = "2025-12-11T15:56:40.252Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6d/b9/4095b668ea3678bf6a0af005527f39de12fb026516fb3df17495a733b7f8/urllib3-2.6.2-py3-none-any.whl", hash = "sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd", size = 131182, upload-time = "2025-12-11T15:56:38.584Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fe/25/e367a7229b0914772ca8d81b41fde012d9feda68523b52644a571bb21ce8/virtualenv-21.7.0.tar.gz", hash = "sha256:7f9519b9432ff11b6e1a3e94061664efc2ff99ea21780e3cf4f6bd0a5da8b37c", size = 5527510, upload-time = "2026-07-21T13:12:14.109Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/7a/ae29312b1e88a22e81f5d21fc11526d2a114089776c2550d2b205b6c2a47/virtualenv-21.7.0-py3-none-any.whl", hash = "sha256:a8370c1c5530fbabf955e40b8fbbc68a431648b10f9433faa587db30a06e51dd", size = 5507078, upload-time = "2026-07-21T13:12:12.136Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- CI + risk-tier-monitor workflows: `uv sync` → `uv sync --locked` (fail install on manifest↔lock drift)
- New local pre-commit hook `uv-lock-check` (`uv lock --check`), gated on workspace `pyproject.toml` changes via anchored regex
- `pre-commit>=3.0` added to `[dependency-groups] dev`; `uv.lock` updated
- Lockfile workflow documented in `core-invariants.md` + `RULES.md` index

## Test plan
- [x] `uv lock --check` exits 0 on clean tree, 1 on real manifest drift
- [x] pre-commit hook Fails on drift (correct message), passes clean
- [x] `uv sync --locked` exits 1 on drift (CI-equivalent)
- [x] `files:` regex matches root + one-level members, excludes `bbu_reference/**` + nested (unit-checked)
- [x] External code review (codex + cursor): NO P1/P2 findings — see `docs/features/0097_REVIEW.md`

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)