### PR TITLE
feat(importer): protocol 1.0 HTTP market-data client (0098)

### DIFF
--- a/.claude/rules/core-invariants.md
+++ b/.claude/rules/core-invariants.md
@@ -1,6 +1,6 @@
 ## Project Overview
 
-Grid trading bot system with pure strategy engine (gridcore), exchange adapter (bybit_adapter), database layer (grid_db), data capture (event_saver), live bot (gridbot), backtest engine, comparator, recorder, replay engine, and PnL checker.
+Grid trading bot system with pure strategy engine (gridcore), exchange adapter (bybit_adapter), database layer (grid_db), data capture (event_saver), live bot (gridbot), backtest engine, comparator, recorder, remote market-data importer, replay engine, and PnL checker.
 
 Successfully extracted pure strategy logic from `bbu2-master` into `packages/gridcore/` with zero exchange dependencies.
 
@@ -58,12 +58,13 @@ uv run pytest apps/backtest/tests -v
 uv run pytest apps/comparator/tests --cov=comparator --cov-report=term-missing -v
 uv run pytest apps/pnl_checker/tests --cov=pnl_checker --cov-report=term-missing -v
 uv run pytest apps/live_check/tests -v
+uv run pytest apps/importer/tests -q
 
 # Integration tests only
 make test-integration
 ```
 
-**`make test` note**: Runs pytest separately per package to avoid `conftest` ImportPathMismatchError. Coverage accumulates across the 11 package runs into one `.coverage`; a trailing `coverage report --fail-under=88` step gates the merged total (real ≈91% as of 2026-07-17). Covers every `pyproject.toml` `testpaths` entry, including `apps/backtest/tests` (added for issue #178 — its prior omission was an oversight with no documented justification).
+**`make test` note**: Runs pytest separately per package to avoid `conftest` ImportPathMismatchError. Coverage accumulates across the 12 package runs into one `.coverage`; a trailing `coverage report --fail-under=88` step gates the merged total (real ≈91% as of 2026-07-17). Covers every `pyproject.toml` `testpaths` entry, including `apps/backtest/tests` (added for issue #178 — its prior omission was an oversight with no documented justification).
 
 ## Continuous Integration (`.github/workflows/ci.yml`)
 
@@ -95,10 +96,10 @@ Maintained code is NOT excluded. When a maintained file has an intentional lint 
 ### Coverage gate (Feature 0092, issue #214)
 
 Two gates in `make test`, both enforced by CI because it runs `make test`:
-- **Total ≥ 88** — trailing `uv run coverage report --fail-under=88` step, evaluated on the merged `.coverage` accumulated by the 11 per-package pytest runs (real total ≈91% as of 2026-07-17).
+- **Total ≥ 88** — trailing `uv run coverage report --fail-under=88` step, evaluated on the merged `.coverage` accumulated by the 12 per-package pytest runs (real total ≈91% as of 2026-07-17).
 - **gridcore ≥ 80** — `--cov-fail-under=80` on gridcore's own pytest invocation. Valid only because that invocation is scoped by `--cov=gridcore` and writes a fresh data file (first in sequence, no `--cov-append`, right after `rm -f .coverage .coverage.*`). It must stay first AND non-append — moved later without adding `--cov-append`, it erases the accumulated data feeding the total gate.
 
-The integration run's `--cov-append`/`--cov-report` flags are inert (no `--cov=` source, so pytest-cov never registers) — the merged total covers the 11 package runs only. Other packages are intentionally ungated; both thresholds sit below real coverage for churn headroom.
+The integration run's `--cov-append`/`--cov-report` flags are inert (no `--cov=` source, so pytest-cov never registers) — the merged total covers the 12 package runs only. Other packages are intentionally ungated; both thresholds sit below real coverage for churn headroom.
 
 ---
 
@@ -192,4 +193,3 @@ All risk config thresholds (`max_margin=8`, `min_total_margin=0.15`) are ratios.
 25. **`runner.py _execute_intents` stale limits snapshot** — `_execute_intents()` must refresh the `limits` snapshot after each successful `_execute_place_intent()` call. Without this, multiple reduce-only intents in the same batch all check against the same stale snapshot, over-covering the position and causing Bybit 110017 reduce-only rejections. Path: `apps/gridbot/src/gridbot/runner.py`. Fixed 2026-04-11.
 26. **Backtest `_should_place_close` must resolve intent qty** — Engine emits `qty=0`; the gate must resolve it via `executor.qty_calculator` before checking `pos_size > (pending + intent_qty)`. Without this, the backtest gate is weaker than live `_is_good_to_place()` and allows over-closing positions. Path: `apps/backtest/src/backtest/runner.py`. Fixed 2026-04-11.
 27. **Backtest `_apply_risk_to_qty` must re-round after multiplier** — Base qty is rounded to `qty_step`, but multiplying by the risk multiplier can produce sub-step values (e.g., 0.001 * 0.5 = 0.0005). Must call `instrument_info.round_qty()` after multiplying, matching live `_resolve_qty`. Path: `apps/backtest/src/backtest/runner.py`. Fixed 2026-04-11.
-

--- a/.claude/rules/importer.md
+++ b/.claude/rules/importer.md
@@ -1,0 +1,21 @@
+---
+paths:
+  - "apps/importer/**"
+---
+
+# Importer invariants
+
+- `MARKET_DATA_API_KEY` is environment-only. Never add a CLI secret or persist,
+  log, describe, or forward the key outside explicit request-level Bearer
+  headers.
+- HTTP requests isolate request-level headers and auth from injected session
+  headers, `session.auth`, netrc, and redirects. `/ticker_data` and `/klines`
+  share the same authenticated session, timeout, retry, and redaction path.
+- Treat pagination cursors as opaque. Decode and validate a complete page,
+  reject cursor repetition/cycles, commit its usable batch transactionally, and
+  only then adopt its `next_cursor`.
+- Keep one transaction per imported batch so crash-resume loses at most the
+  uncommitted batch.
+- HTTP output paths are scoped by full digests of the canonical API base, exact
+  symbol, and optional tag. Exact HTTP symbol spelling is preserved; DB-source
+  symbols retain legacy uppercasing and legacy output filenames.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Monorepo to run, record, and validate a Bybit USDT-perp **grid trading bot** —
 - `packages/gridcore` — grid strategy engine, zero external deps (core logic)
 - `packages/bybit_adapter` — Bybit REST + WS client wrappers
 - `shared/db` — `grid-db`, SQLAlchemy multi-tenant models
-- `apps/*` — runnable CLIs: `gridbot` (live), `backtest`, `recorder`, `replay`, `comparator`, `event_saver`, `pnl_checker`
+- `apps/*` — runnable CLIs: `gridbot` (live), `backtest`, `recorder`, `importer`, `replay`, `comparator`, `event_saver`, `pnl_checker`
 
 **Entry points:** each app at `apps/<name>/src/<name>/main.py`; run via `uv run <name>`.
 
@@ -17,6 +17,7 @@ Monorepo to run, record, and validate a Bybit USDT-perp **grid trading bot** —
 - `make lint` — ruff (line-length 88)
 - `make live-check` — replay-vs-live reconciliation
 - `uv run pytest packages/<name>` — single package; always via `uv run`, never bare `pytest` / `python -m pytest`
+- `uv run pytest apps/importer/tests -q` — importer-only suite
 - `uv run <app>` — run an app (e.g. `uv run gridbot`)
 
 # Coding principles

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ grid-bot-validation/
 │   ├── gridbot/             # Live multi-tenant grid trading bot
 │   ├── backtest/            # Historical backtest engine
 │   ├── recorder/            # Captures live Bybit market + private data to SQLite
+│   ├── importer/            # Imports remote market data into replay SQLite DBs
 │   ├── replay/              # Replays recorded data through the strategy engine
 │   ├── comparator/          # Diffs backtest vs live trade outcomes
 │   ├── event_saver/         # Streaming event persistence used by gridbot
@@ -54,6 +55,11 @@ Holds grid-level math (`greed.py`), the event-driven strategy engine (`strat.py`
 
 **`recorder`** — A standalone process that subscribes to Bybit mainnet WebSocket streams and writes them to SQLite for later replay. Captures L1 ticker snapshots, public trades (optional), and — when API keys are provided — private orders, executions, positions, and wallet snapshots. Tracks gaps and reconciles via REST.
 
+**`importer`** — Reads ticker history from either a read-only database or the
+remote market-data protocol 1.0 API and builds replay-compatible per-symbol
+SQLite databases. HTTP imports are bounded, cursor-paginated, resumable, and
+optionally validate their reconstructed OHLC against the API's 1-minute klines.
+
 **`replay`** — Reads a recorder database for a given `run_id` and time window, then feeds it through the same `gridcore` engine the live bot uses. The point is *shadow validation*: did our strategy, given the exact market it saw live, produce the same orders, fills, and PnL? Hands its output to `comparator`.
 
 **`comparator`** — Compares a replay/backtest run against the corresponding live run from the same database. Surfaces order divergences, fill mismatches, and PnL deltas with configurable price/quantity tolerances.
@@ -88,6 +94,8 @@ Holds grid-level math (`greed.py`), the event-driven strategy engine (`strat.py`
    ┌────┴────────┐
    │ pnl_checker │  (sanity-checks live PnL math vs Bybit)
    └─────────────┘
+
+ remote market API ──▶ importer ──▶ per-symbol SQLite ──▶ replay
 ```
 
 `gridcore` is the strategy engine shared by **gridbot**, **backtest**, and **replay** — that is the entire point of the architecture. The same code that trades live also runs against recorded history and against synthetic backtest data, so divergences are bugs in I/O wrappers or in the data, not in two parallel strategy implementations.
@@ -134,6 +142,18 @@ uv run python -m backtest --config apps/backtest/conf/backtest.yaml
 # Recorder (standalone process — keep running to capture data)
 uv run python -m recorder.main --config apps/recorder/conf/recorder.yaml
 
+# Import a bounded range from the remote market-data API
+IFS= read -rsp 'Market-data API key: ' MARKET_DATA_API_KEY
+printf '\n'
+export MARKET_DATA_API_KEY
+uv run python -m importer.main \
+  --source http \
+  --source-url https://market-api.example.com/deployment \
+  --symbols BTCUSDT \
+  --start 2026-07-01T00:00:00Z \
+  --end 2026-07-02T00:00:00Z
+unset MARKET_DATA_API_KEY
+
 # Replay recorded data through the strategy engine
 uv run python -m replay.main --config apps/replay/conf/replay.yaml
 
@@ -143,6 +163,21 @@ uv run python -m comparator --config apps/replay/conf/replay.yaml
 # Validate live PnL against Bybit
 uv run python -m pnl_checker --config apps/pnl_checker/conf/pnl_checker.yaml
 ```
+
+HTTP importer bounds are mandatory because protocol 1.0 has no MIN/MAX
+endpoint. The API key is read only from `MARKET_DATA_API_KEY`; inject it from a
+secret manager or use a hidden prompt as above, and never commit it or put its
+literal value in a command. `--source-url` is the deployment base URL: it may
+include a base path, but not credentials, a query, or a fragment. Use HTTPS in
+production. Plain HTTP is limited to localhost or a trusted private
+network/tunnel.
+
+Protocol 1.0 HTTP files use a source-scoped `imported_http_<digests>.db`
+namespace derived from the exact symbol, normalized full base URL, and optional
+tag. Draft Feature 0093 HTTP files named
+`imported_<symbol>[_<tag>].db` are intentionally left untouched and are not
+auto-resumed; perform a one-time fresh HTTP import. DB-source filenames and
+their existing resume behavior are unchanged.
 
 ## Configuration Cheat Sheet
 
@@ -178,6 +213,9 @@ make test-integration
 
 # Single package
 uv run pytest packages/gridcore/tests --cov=gridcore -v
+
+# Importer only
+uv run pytest apps/importer/tests -q
 
 # Single file
 uv run pytest apps/backtest/tests/test_runner.py -v

--- a/RULES.md
+++ b/RULES.md
@@ -28,4 +28,5 @@ every ~10 features, sweep the rule files and prune entries that no longer apply.
 | `.claude/rules/replay.md` | `apps/replay/**` | Replay engine, telemetry parity (0034), UTA wallet semantics (0042), fill simulator modes incl. `last_cross` + `event_follower` (0072), test pitfalls |
 | `.claude/rules/pnl-checker.md` | `apps/pnl_checker/**` | Live PnL validation rules |
 | `.claude/rules/live-check.md` | `apps/live_check/**` | Replay-vs-live reconciliation (0088): read-only DB, verdict gates, freshness |
+| `.claude/rules/importer.md` | `apps/importer/**` | Remote importer: environment-only auth, request isolation, opaque cursor commits, source-scoped HTTP outputs |
 | `.claude/rules/risk-tiers.md` | tier-related files (see its `paths:`) | Dynamic risk limit tiers: architecture, consumers, caching, drift monitoring, cache format evolution |

--- a/apps/importer/src/importer/config.py
+++ b/apps/importer/src/importer/config.py
@@ -20,7 +20,7 @@ from urllib.parse import SplitResult, urlsplit, urlunsplit
 import requests
 
 _ASCII_CONTROL_RE = re.compile(r"[\x00-\x1f\x7f]")
-_TOKEN68_RE = re.compile(r"^[A-Za-z0-9\-._~+/]+={0,}$")
+_TOKEN68_RE = re.compile(r"^[A-Za-z0-9\-._~+/]+={0,2}$")
 
 
 class ConfigurationError(ValueError):
@@ -93,8 +93,8 @@ def _safe_hostname(parts: SplitResult) -> tuple[str, int | None]:
     try:
         hostname = parts.hostname
         port = parts.port
-    except ValueError as exc:
-        raise ConfigurationError("--source-url has an invalid host or port") from exc
+    except ValueError:
+        raise ConfigurationError("--source-url has an invalid host or port") from None
     if not hostname:
         raise ConfigurationError("--source-url must include a host")
     try:
@@ -121,8 +121,8 @@ def _safe_hostname(parts: SplitResult) -> tuple[str, int | None]:
                 raise ValueError
             if all(ch.isdigit() or ch == "." for ch in ascii_host):
                 ipaddress.IPv4Address(ascii_host)
-    except (UnicodeError, ValueError) as exc:
-        raise ConfigurationError("--source-url has an invalid host") from exc
+    except (UnicodeError, ValueError):
+        raise ConfigurationError("--source-url has an invalid host") from None
     return hostname, port
 
 
@@ -145,8 +145,8 @@ def preflight_http(source_url: str) -> HttpPreflight:
         raise ConfigurationError("--source-url contains unsafe whitespace or controls")
     try:
         parts = urlsplit(source_url)
-    except ValueError as exc:
-        raise ConfigurationError("--source-url is malformed") from exc
+    except ValueError:
+        raise ConfigurationError("--source-url is malformed") from None
     if parts.scheme.lower() not in {"http", "https"}:
         raise ConfigurationError("--source-url must use http or https")
     if parts.username is not None or parts.password is not None:
@@ -163,8 +163,10 @@ def preflight_http(source_url: str) -> HttpPreflight:
     try:
         prepared = requests.Request("GET", candidate).prepare()
         canonical_with_slash = prepared.url
-    except (requests.RequestException, UnicodeError, ValueError) as exc:
-        raise ConfigurationError("--source-url cannot be prepared as an HTTP URL") from exc
+    except (requests.RequestException, UnicodeError, ValueError):
+        raise ConfigurationError(
+            "--source-url cannot be prepared as an HTTP URL"
+        ) from None
     if canonical_with_slash is None:  # defensive: PreparedRequest.url is optional
         raise ConfigurationError("--source-url cannot be prepared as an HTTP URL")
 
@@ -175,8 +177,10 @@ def preflight_http(source_url: str) -> HttpPreflight:
         endpoint = requests.Request(
             "GET", canonical_base + "/ticker_data"
         ).prepare().url
-    except (requests.RequestException, UnicodeError, ValueError) as exc:
-        raise ConfigurationError("--source-url cannot form protocol endpoints") from exc
+    except (requests.RequestException, UnicodeError, ValueError):
+        raise ConfigurationError(
+            "--source-url cannot form protocol endpoints"
+        ) from None
     if (
         stable != canonical_base + "/"
         or endpoint != canonical_base + "/ticker_data"
@@ -239,10 +243,11 @@ def load_market_data_api_key() -> str | None:
             "https://market-data.invalid/ticker_data",
             headers={"Authorization": f"Bearer {key}"},
         ).prepare()
-    except (UnicodeError, requests.RequestException, ValueError) as exc:
+    except (UnicodeError, requests.RequestException, ValueError):
+        # Drop the cause chain: prepare() may embed the Authorization header.
         raise ConfigurationError(
             "MARKET_DATA_API_KEY cannot be used as an HTTP header"
-        ) from exc
+        ) from None
     if prepared.headers.get("Authorization") != f"Bearer {key}":
         raise ConfigurationError(
             "MARKET_DATA_API_KEY cannot be used as an HTTP header"

--- a/apps/importer/src/importer/config.py
+++ b/apps/importer/src/importer/config.py
@@ -1,4 +1,4 @@
-"""CLI argument parsing and datetime discipline for the importer (feature 0093).
+"""CLI parsing, HTTP preflight, and datetime discipline for the importer.
 
 Every datetime entering the pipeline is normalized to naive UTC (convert to
 UTC, strip tzinfo). SQLite returns naive datetimes, so any aware value that
@@ -9,7 +9,31 @@ the same guard replay applies before comparing timestamps.
 from __future__ import annotations
 
 import argparse
+import hashlib
+import ipaddress
+import os
+import re
+from dataclasses import dataclass
 from datetime import datetime, timezone
+from urllib.parse import SplitResult, urlsplit, urlunsplit
+
+import requests
+
+_ASCII_CONTROL_RE = re.compile(r"[\x00-\x1f\x7f]")
+_TOKEN68_RE = re.compile(r"^[A-Za-z0-9\-._~+/]+={0,}$")
+
+
+class ConfigurationError(ValueError):
+    """A safe-to-display importer configuration error."""
+
+
+@dataclass(frozen=True)
+class HttpPreflight:
+    """Non-secret, locally validated HTTP source identity."""
+
+    canonical_base_url: str
+    origin_label: str
+    source_fingerprint: str
 
 
 def to_naive_utc(dt: datetime) -> datetime:
@@ -57,20 +81,190 @@ def unit_fraction(value: str) -> float:
 
 
 def parse_symbols(value: str) -> list[str]:
-    """Split a comma-separated symbol list; rejects an empty list."""
-    symbols = [s.strip().upper() for s in value.split(",") if s.strip()]
+    """Split a comma-separated symbol list without changing symbol case."""
+    symbols = [s.strip() for s in value.split(",") if s.strip()]
     if not symbols:
         raise argparse.ArgumentTypeError("--symbols must name at least one symbol")
     return symbols
 
 
+def _safe_hostname(parts: SplitResult) -> tuple[str, int | None]:
+    """Return a validated hostname/port without echoing rejected input."""
+    try:
+        hostname = parts.hostname
+        port = parts.port
+    except ValueError as exc:
+        raise ConfigurationError("--source-url has an invalid host or port") from exc
+    if not hostname:
+        raise ConfigurationError("--source-url must include a host")
+    try:
+        if ":" in hostname:
+            ipaddress.IPv6Address(hostname)
+        else:
+            ascii_host = hostname.encode("idna").decode("ascii")
+            labels = (
+                ascii_host[:-1].split(".")
+                if ascii_host.endswith(".")
+                else ascii_host.split(".")
+            )
+            if (
+                len(ascii_host) > 253
+                or any(
+                    not label
+                    or len(label) > 63
+                    or label.startswith("-")
+                    or label.endswith("-")
+                    or not all(ch.isalnum() or ch == "-" for ch in label)
+                    for label in labels
+                )
+            ):
+                raise ValueError
+            if all(ch.isdigit() or ch == "." for ch in ascii_host):
+                ipaddress.IPv4Address(ascii_host)
+    except (UnicodeError, ValueError) as exc:
+        raise ConfigurationError("--source-url has an invalid host") from exc
+    return hostname, port
+
+
+def _without_default_port(url: str) -> str:
+    """Remove only an explicitly prepared default HTTP(S) authority port."""
+    parts = urlsplit(url)
+    hostname, port = _safe_hostname(parts)
+    default = (parts.scheme == "http" and port == 80) or (
+        parts.scheme == "https" and port == 443
+    )
+    if not default:
+        return url
+    rendered_host = f"[{hostname}]" if ":" in hostname else hostname
+    return urlunsplit((parts.scheme, rendered_host, parts.path, "", ""))
+
+
+def preflight_http(source_url: str) -> HttpPreflight:
+    """Validate and canonicalize an HTTP API base URL without network I/O."""
+    if source_url != source_url.strip() or _ASCII_CONTROL_RE.search(source_url):
+        raise ConfigurationError("--source-url contains unsafe whitespace or controls")
+    try:
+        parts = urlsplit(source_url)
+    except ValueError as exc:
+        raise ConfigurationError("--source-url is malformed") from exc
+    if parts.scheme.lower() not in {"http", "https"}:
+        raise ConfigurationError("--source-url must use http or https")
+    if parts.username is not None or parts.password is not None:
+        raise ConfigurationError("--source-url must not contain credentials")
+    if "?" in source_url:
+        raise ConfigurationError("--source-url must not contain a query")
+    if "#" in source_url:
+        raise ConfigurationError("--source-url must not contain a fragment")
+    _safe_hostname(parts)
+
+    # Give requests the exact slash-normalized base spelling that production
+    # calls will use, then make its PreparedRequest URL the canonical authority.
+    candidate = source_url if source_url.endswith("/") else source_url + "/"
+    try:
+        prepared = requests.Request("GET", candidate).prepare()
+        canonical_with_slash = prepared.url
+    except (requests.RequestException, UnicodeError, ValueError) as exc:
+        raise ConfigurationError("--source-url cannot be prepared as an HTTP URL") from exc
+    if canonical_with_slash is None:  # defensive: PreparedRequest.url is optional
+        raise ConfigurationError("--source-url cannot be prepared as an HTTP URL")
+
+    canonical_with_slash = _without_default_port(canonical_with_slash)
+    canonical_base = canonical_with_slash[:-1]
+    try:
+        stable = requests.Request("GET", canonical_base + "/").prepare().url
+        endpoint = requests.Request(
+            "GET", canonical_base + "/ticker_data"
+        ).prepare().url
+    except (requests.RequestException, UnicodeError, ValueError) as exc:
+        raise ConfigurationError("--source-url cannot form protocol endpoints") from exc
+    if (
+        stable != canonical_base + "/"
+        or endpoint != canonical_base + "/ticker_data"
+    ):
+        raise ConfigurationError("--source-url is not stable after normalization")
+
+    canonical_parts = urlsplit(canonical_base)
+    hostname, port = _safe_hostname(canonical_parts)
+    rendered_host = f"[{hostname}]" if ":" in hostname else hostname
+    authority = rendered_host if port is None else f"{rendered_host}:{port}"
+    origin_label = f"http:{canonical_parts.scheme}://{authority}"
+    fingerprint = hashlib.sha256(canonical_base.encode("utf-8")).hexdigest()
+    return HttpPreflight(canonical_base, origin_label, fingerprint)
+
+
+def preflight_args(
+    parser: argparse.ArgumentParser, args: argparse.Namespace
+) -> argparse.Namespace:
+    """Apply source-aware checks before secrets, files, or network are touched."""
+    if args.source == "db":
+        args.symbols = [symbol.upper() for symbol in args.symbols]
+        args.http_base_url = None
+        args.http_origin_label = None
+        args.http_source_fingerprint = None
+        return args
+
+    if args.start is None or args.end is None:
+        parser.error("--source http requires both --start and --end")
+    if args.start > args.end:
+        parser.error("--start must not be after --end for --source http")
+    if args.batch_size > 10000:
+        parser.error("--batch-size for --source http must be in 1..10000")
+    if any(_ASCII_CONTROL_RE.search(symbol) for symbol in args.symbols):
+        parser.error("--symbols contains an unsafe HTTP symbol")
+    try:
+        preflight = preflight_http(args.source_url)
+    except ConfigurationError as exc:
+        parser.error(str(exc))
+    args.http_base_url = preflight.canonical_base_url
+    args.http_origin_label = preflight.origin_label
+    args.http_source_fingerprint = preflight.source_fingerprint
+    return args
+
+
+def load_market_data_api_key() -> str | None:
+    """Read and locally validate ``MARKET_DATA_API_KEY`` exactly once."""
+    key = os.environ.get("MARKET_DATA_API_KEY")
+    if key is None or key == "":
+        return None
+    if (
+        key != key.strip()
+        or _ASCII_CONTROL_RE.search(key)
+        or _TOKEN68_RE.fullmatch(key) is None
+    ):
+        raise ConfigurationError("MARKET_DATA_API_KEY is not a valid Bearer token")
+    try:
+        key.encode("ascii")
+        prepared = requests.Request(
+            "GET",
+            "https://market-data.invalid/ticker_data",
+            headers={"Authorization": f"Bearer {key}"},
+        ).prepare()
+    except (UnicodeError, requests.RequestException, ValueError) as exc:
+        raise ConfigurationError(
+            "MARKET_DATA_API_KEY cannot be used as an HTTP header"
+        ) from exc
+    if prepared.headers.get("Authorization") != f"Bearer {key}":
+        raise ConfigurationError(
+            "MARKET_DATA_API_KEY cannot be used as an HTTP header"
+        )
+    return key
+
+
+class ImporterArgumentParser(argparse.ArgumentParser):
+    """ArgumentParser that completes source-aware, non-secret preflight."""
+
+    def parse_args(self, args=None, namespace=None):
+        parsed = super().parse_args(args, namespace)
+        return preflight_args(self, parsed)
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build the importer CLI parser (invoked via ``python -m importer.main``)."""
-    parser = argparse.ArgumentParser(
+    parser = ImporterArgumentParser(
         prog="python -m importer.main",
         description=(
             "One-way import: trad_save_history ticker_data -> per-symbol "
-            "replay-compatible SQLite DBs (feature 0093). Imported DBs are "
+            "replay-compatible SQLite DBs. Imported DBs are "
             "for counterfactual A/B / relative ranking only."
         ),
     )

--- a/apps/importer/src/importer/fetch_source_http.py
+++ b/apps/importer/src/importer/fetch_source_http.py
@@ -87,6 +87,12 @@ class HttpSource:
         session: Optional[requests.Session] = None,
         api_key: str | None = None,
     ):
+        if batch_size <= 0:
+            raise ValueError(f"batch_size must be positive, got {batch_size}")
+        if batch_size > 10000:
+            raise ValueError(
+                f"batch_size exceeds protocol limit of 10000, got {batch_size}"
+            )
         self._base_url = base_url
         self._batch_size = batch_size
         self._api_key = api_key

--- a/apps/importer/src/importer/fetch_source_http.py
+++ b/apps/importer/src/importer/fetch_source_http.py
@@ -1,145 +1,450 @@
-"""Transport B: HTTP API client for trad_save_history (feature 0093).
-
-Client side of the plan's HTTP contract:
-``GET {base_url}/ticker_data?symbol&start&end&limit&cursor`` returning
-``{"rows": [...], "next_cursor": <opaque or null>}`` in stable
-``(timestamp, id)`` ascending order, both bounds inclusive.
-
-Robustness for long multi-hour pulls: 30 s per-request timeout; retry on
-connection errors / HTTP 429 / 5xx with exponential backoff re-requesting
-the SAME cursor (idempotent GET, so a retried page cannot skip rows); any
-other 4xx aborts with the response body logged.
-"""
+"""Protocol 1.0 HTTP market-data transport."""
 
 from __future__ import annotations
 
+import json
 import logging
+import math
+import random
+import re
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
+from email.utils import parsedate_to_datetime
 from typing import Iterator, Optional
 
 import requests
-
-from importer.config import to_naive_utc
+from requests.auth import AuthBase
 
 logger = logging.getLogger(__name__)
 
-_TIMEOUT_S = 30
+_TIMEOUT = (5, 30)
 _MAX_ATTEMPTS = 5
-_BACKOFF_BASE_S = 1.0
-_BACKOFF_FACTOR = 2.0
 _BACKOFF_CAP_S = 30.0
+_MAX_ERROR_BODY = 1024
+_JSON_MEDIA_TYPE = "application/json"
+_BULK_FIELDS = (
+    "symbol",
+    "timestamp",
+    "last_price",
+    "mark_price",
+    "bid1_price",
+    "ask1_price",
+    "funding_rate",
+)
+_MARKET_FIELDS = _BULK_FIELDS[2:]
 
 
 class HttpSourceError(Exception):
-    """Non-recoverable HTTP source failure (aborts the import)."""
+    """A terminal transport or protocol failure."""
+
+
+class _NoOpAuth(AuthBase):
+    """Truthy request auth that suppresses session auth and netrc lookup."""
+
+    def __call__(self, request):
+        return request
+
+
+_NO_OP_AUTH = _NoOpAuth()
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
 
 
 def iso_utc(dt: datetime) -> str:
-    """Format a naive-UTC datetime as ISO-8601 with the ``Z`` suffix."""
+    """Format a naive-UTC datetime as ISO-8601 with a ``Z`` suffix."""
     return dt.replace(tzinfo=timezone.utc).isoformat().replace("+00:00", "Z")
 
 
+def _parse_z_datetime(value: str) -> datetime:
+    """Parse a protocol UTC datetime and normalize it to naive UTC."""
+    if len(value) < 12 or value[10] != "T" or not value.endswith("Z"):
+        raise ValueError("timestamp must end in Z")
+    parsed = datetime.fromisoformat(value[:-1] + "+00:00")
+    return parsed.astimezone(timezone.utc).replace(tzinfo=None)
+
+
+def _is_json_content_type(value: str) -> bool:
+    return value.split(";", 1)[0].strip().lower() == _JSON_MEDIA_TYPE
+
+
+def _is_finite_number(value: object) -> bool:
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+    )
+
+
 class HttpSource:
-    """Cursor-paginated reader against the trad_save_history HTTP API."""
+    """Authenticated, cursor-paginated protocol 1.0 client."""
 
     def __init__(
         self,
         base_url: str,
         batch_size: int = 10000,
         session: Optional[requests.Session] = None,
+        api_key: str | None = None,
     ):
-        self._base_url = base_url.rstrip("/")
+        self._base_url = base_url
         self._batch_size = batch_size
-        self._session = session or requests.Session()
+        self._api_key = api_key
+        self._owns_session = session is None
+        self._session = requests.Session() if session is None else session
+        self._closed = False
+
+    def close(self) -> None:
+        """Close an owned session exactly once; injected sessions remain open."""
+        if self._owns_session and not self._closed:
+            self._session.close()
+            self._closed = True
+
+    def probe_range(self, symbol: str) -> Optional[tuple[datetime, datetime]]:
+        """Protocol 1.0 exposes no MIN/MAX endpoint."""
+        return None
+
+    def _headers(self) -> dict[str, str | None]:
+        authorization = (
+            f"Bearer {self._api_key}" if self._api_key is not None else None
+        )
+        return {"Accept": _JSON_MEDIA_TYPE, "Authorization": authorization}
+
+    def _redact(self, value: object) -> str:
+        text = str(value)
+        if self._api_key:
+            text = text.replace(self._api_key, "[REDACTED]")
+        return text
+
+    def _safe_body(self, response) -> str:
+        """Read/redact a response body before applying the log-size cap."""
+        content_type = str(getattr(response, "headers", {}).get("Content-Type", ""))
+        if _is_json_content_type(content_type):
+            try:
+                payload = response.json()
+            except Exception:
+                payload = None
+            if isinstance(payload, dict):
+                detail = payload.get("detail")
+                if isinstance(detail, (str, list)):
+                    rendered = (
+                        detail
+                        if isinstance(detail, str)
+                        else json.dumps(detail, ensure_ascii=False)
+                    )
+                    return self._redact(rendered)[:_MAX_ERROR_BODY]
+        try:
+            body = response.text
+        except Exception:
+            body = "<unavailable response body>"
+        return self._redact(body)[:_MAX_ERROR_BODY]
+
+    def _request_failure(self, endpoint: str, kind: str) -> HttpSourceError:
+        return HttpSourceError(f"{endpoint} request failed: {self._redact(kind)}")
+
+    @staticmethod
+    def _retry_after_seconds(response, now: datetime) -> float | None:
+        raw = str(getattr(response, "headers", {}).get("Retry-After", "")).strip()
+        if not raw:
+            return None
+        if re.fullmatch(r"\d+", raw):
+            return float(int(raw))
+        try:
+            parsed = parsedate_to_datetime(raw)
+        except (TypeError, ValueError, OverflowError):
+            return None
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        seconds = (parsed.astimezone(timezone.utc) - now).total_seconds()
+        return seconds if seconds >= 0 else None
+
+    def _request_json(self, endpoint: str, params: dict) -> dict:
+        """Run one shared authenticated JSON request with bounded retries."""
+        url = f"{self._base_url}/{endpoint}"
+        fixed_params = dict(params)
+        for attempt in range(1, _MAX_ATTEMPTS + 1):
+            retry_kind: str | None = None
+            response = None
+            try:
+                response = self._session.get(
+                    url,
+                    params=dict(fixed_params),
+                    headers=self._headers(),
+                    auth=_NO_OP_AUTH,
+                    timeout=_TIMEOUT,
+                    allow_redirects=False,
+                )
+            except (requests.exceptions.SSLError, requests.exceptions.ProxyError):
+                raise self._request_failure(endpoint, "TLS or proxy configuration") from None
+            except (
+                requests.exceptions.ConnectTimeout,
+                requests.exceptions.ReadTimeout,
+            ):
+                retry_kind = "timeout"
+            except requests.exceptions.ChunkedEncodingError:
+                retry_kind = "interrupted response"
+            except requests.exceptions.ConnectionError:
+                retry_kind = "connection error"
+            except (
+                requests.exceptions.InvalidURL,
+                requests.exceptions.MissingSchema,
+                requests.exceptions.InvalidSchema,
+                requests.exceptions.InvalidHeader,
+            ):
+                raise self._request_failure(endpoint, "invalid request configuration") from None
+            except requests.RequestException:
+                raise self._request_failure(endpoint, "terminal request error") from None
+            except Exception as exc:
+                safe = self._redact(exc)
+                raise self._request_failure(endpoint, f"unexpected request error: {safe}") from None
+            else:
+                status = response.status_code
+                if status == 200:
+                    break
+                if status == 429 or 500 <= status <= 599:
+                    retry_kind = f"HTTP {status}"
+                else:
+                    body = self._safe_body(response)
+                    suffix = f": {body}" if body else ""
+                    raise HttpSourceError(
+                        f"{endpoint} returned terminal HTTP {status}{suffix}"
+                    )
+
+            if attempt == _MAX_ATTEMPTS:
+                raise HttpSourceError(
+                    f"{endpoint} failed after {_MAX_ATTEMPTS} attempts "
+                    f"({retry_kind})"
+                )
+
+            ceiling = min(_BACKOFF_CAP_S, 2 ** (attempt - 1))
+            delay = random.uniform(0, ceiling)
+            if response is not None and response.status_code == 429:
+                retry_after = self._retry_after_seconds(response, _utc_now())
+                if retry_after is not None:
+                    if retry_after > _BACKOFF_CAP_S:
+                        raise HttpSourceError(
+                            f"{endpoint} Retry-After exceeds the client retry cap"
+                        )
+                    delay = max(delay, retry_after)
+            logger.warning(
+                "HTTP %s %s (attempt %d/%d); retrying unchanged request",
+                endpoint,
+                retry_kind,
+                attempt,
+                _MAX_ATTEMPTS,
+            )
+            time.sleep(delay)
+        else:  # pragma: no cover - loop either breaks or raises
+            raise HttpSourceError(f"{endpoint} request loop exhausted")
+
+        content_type = str(
+            getattr(response, "headers", {}).get("Content-Type", "")
+        )
+        if not _is_json_content_type(content_type):
+            raise HttpSourceError(
+                f"{endpoint} returned HTTP 200 without application/json"
+            )
+        try:
+            payload = response.json()
+        except Exception:
+            raise HttpSourceError(f"{endpoint} returned invalid JSON") from None
+        if not isinstance(payload, dict):
+            raise HttpSourceError(f"{endpoint} JSON must be a top-level object")
+        return payload
+
+    @staticmethod
+    def _validate_bulk_shape(payload: dict) -> tuple[list, str | None]:
+        if "rows" not in payload or "next_cursor" not in payload:
+            raise HttpSourceError(
+                "ticker_data JSON requires rows and next_cursor"
+            )
+        rows = payload["rows"]
+        cursor = payload["next_cursor"]
+        if not isinstance(rows, list):
+            raise HttpSourceError("ticker_data rows must be a list")
+        if cursor is not None and not isinstance(cursor, str):
+            raise HttpSourceError(
+                "ticker_data next_cursor must be a string or null"
+            )
+        for row in rows:
+            if not isinstance(row, dict):
+                raise HttpSourceError("ticker_data rows must contain objects")
+            if any(field not in row for field in _BULK_FIELDS):
+                raise HttpSourceError(
+                    "ticker_data row is missing a required protocol field"
+                )
+            if row["symbol"] is not None and not isinstance(row["symbol"], str):
+                raise HttpSourceError(
+                    "ticker_data row symbol must be a string or null"
+                )
+            if row["timestamp"] is not None and not isinstance(
+                row["timestamp"], str
+            ):
+                raise HttpSourceError(
+                    "ticker_data row timestamp must be a string or null"
+                )
+            for field in _MARKET_FIELDS:
+                value = row[field]
+                if value is not None and not _is_finite_number(value):
+                    raise HttpSourceError(
+                        f"ticker_data row {field} must be a finite number or null"
+                    )
+        return rows, cursor
 
     def fetch_batches(
         self, symbol: str, start: datetime, end: datetime
     ) -> Iterator[list[dict]]:
-        """Yield batches following ``next_cursor`` to exhaustion."""
-        cursor: Optional[str] = None
-        while True:
-            params: dict = {
+        """Decode complete pages and adopt opaque cursors only after commit."""
+        cursor: str | None = None
+        adopted: set[str] = set()
+        last_timestamp: datetime | None = None
+        filtered = {
+            "null_symbol": 0,
+            "mismatched_symbol": 0,
+            "null_timestamp": 0,
+            "invalid_timestamp": 0,
+        }
+        try:
+            while True:
+                params = {
+                    "symbol": symbol,
+                    "start": iso_utc(start),
+                    "end": iso_utc(end),
+                    "limit": self._batch_size,
+                }
+                if cursor is not None:
+                    params["cursor"] = cursor
+                payload = self._request_json("ticker_data", params)
+                raw_rows, next_cursor = self._validate_bulk_shape(payload)
+                if not raw_rows:
+                    if next_cursor is not None:
+                        raise HttpSourceError(
+                            "ticker_data empty rows cannot advance a cursor"
+                        )
+                    return
+
+                page: list[dict] = []
+                page_last = last_timestamp
+                for raw in raw_rows:
+                    if raw["symbol"] is None:
+                        filtered["null_symbol"] += 1
+                        continue
+                    if raw["symbol"] != symbol:
+                        filtered["mismatched_symbol"] += 1
+                        continue
+                    if raw["timestamp"] is None:
+                        filtered["null_timestamp"] += 1
+                        continue
+                    try:
+                        timestamp = _parse_z_datetime(raw["timestamp"])
+                    except (ValueError, OverflowError):
+                        filtered["invalid_timestamp"] += 1
+                        continue
+                    if not start <= timestamp <= end:
+                        raise HttpSourceError(
+                            "ticker_data returned a timestamp outside the "
+                            "requested inclusive range"
+                        )
+                    if page_last is not None and timestamp < page_last:
+                        raise HttpSourceError(
+                            "ticker_data timestamps decreased; restart into "
+                            "a fresh --tag"
+                        )
+                    page_last = timestamp
+                    page.append(
+                        {
+                            "symbol": symbol,
+                            "timestamp": timestamp,
+                            **{field: raw[field] for field in _MARKET_FIELDS},
+                        }
+                    )
+
+                if next_cursor is not None and (
+                    next_cursor in adopted or next_cursor == cursor
+                ):
+                    raise HttpSourceError(
+                        "ticker_data repeated or cycled next_cursor"
+                    )
+
+                if page:
+                    yield page
+                    last_timestamp = page_last
+
+                if next_cursor is None:
+                    return
+                adopted.add(next_cursor)
+                cursor = next_cursor
+        finally:
+            if any(filtered.values()):
+                logger.warning(
+                    "%s: HTTP damaged-row filters: %s", symbol, filtered
+                )
+
+    def fetch_klines(
+        self, symbol: str, start: datetime, end: datetime
+    ) -> list[dict]:
+        """Fetch and validate a bounded, strictly ordered 1m kline window."""
+        if (
+            start.second
+            or start.microsecond
+            or end.second
+            or end.microsecond
+            or end <= start
+            or end - start > timedelta(hours=24)
+        ):
+            raise HttpSourceError(
+                "klines requires a positive, minute-aligned window of at most 24 hours"
+            )
+        payload = self._request_json(
+            "klines",
+            {
                 "symbol": symbol,
+                "interval": "1m",
                 "start": iso_utc(start),
                 "end": iso_utc(end),
-                "limit": self._batch_size,
-            }
-            if cursor is not None:
-                params["cursor"] = cursor
-            payload = self._get_with_retry(params)
-            rows = payload.get("rows") or []
-            cursor = payload.get("next_cursor")
-            if not rows:
-                # A page with no rows cannot make progress — treat as
-                # exhausted even if the server sent a cursor (a buggy
-                # truthy cursor would otherwise spin forever).
-                if cursor:
-                    logger.warning(
-                        "HTTP source sent next_cursor with an empty rows "
-                        "page — treating as exhausted"
-                    )
-                return
-            yield [self._normalize_row(r) for r in rows]
-            # Contract says null when exhausted; treat any falsy cursor
-            # (e.g. "") as exhausted too — re-sending it would spin forever.
-            if not cursor:
-                return
+            },
+        )
+        if "rows" not in payload or not isinstance(payload["rows"], list):
+            raise HttpSourceError("klines rows must be present and be a list")
 
-    def probe_range(self, symbol: str) -> Optional[tuple[datetime, datetime]]:
-        """The HTTP contract exposes no MIN/MAX probe — always None.
-
-        The caller requires explicit ``--start``/``--end`` for this
-        transport.
-        """
-        return None
-
-    def _get_with_retry(self, params: dict) -> dict:
-        """GET with exponential backoff; retried pages re-request the same cursor."""
-        url = f"{self._base_url}/ticker_data"
-        delay = _BACKOFF_BASE_S
-        for attempt in range(1, _MAX_ATTEMPTS + 1):
-            failure: str
-            try:
-                response = self._session.get(url, params=params, timeout=_TIMEOUT_S)
-            except requests.RequestException as e:
-                failure = f"connection error: {e}"
-            else:
-                if response.status_code == 200:
-                    return response.json()
-                if response.status_code == 429 or response.status_code >= 500:
-                    failure = f"HTTP {response.status_code}"
-                else:
-                    logger.error(
-                        "HTTP source returned %d: %s",
-                        response.status_code,
-                        response.text,
-                    )
+        decoded: list[dict] = []
+        previous: datetime | None = None
+        for row in payload["rows"]:
+            if not isinstance(row, dict):
+                raise HttpSourceError("klines rows must contain objects")
+            fields = ("start_time", "open", "high", "low", "close")
+            if any(field not in row for field in fields):
+                raise HttpSourceError("kline row is missing a required field")
+            if not isinstance(row["start_time"], str):
+                raise HttpSourceError("kline start_time must be a string")
+            for field in fields[1:]:
+                if not _is_finite_number(row[field]):
                     raise HttpSourceError(
-                        f"non-retryable HTTP {response.status_code} from {url}"
+                        f"kline {field} must be a finite non-null number"
                     )
-            if attempt == _MAX_ATTEMPTS:
+            try:
+                start_time = _parse_z_datetime(row["start_time"])
+            except (ValueError, OverflowError):
                 raise HttpSourceError(
-                    f"{failure} after {_MAX_ATTEMPTS} attempts against {url}"
+                    "kline start_time must be an ISO UTC datetime ending in Z"
+                ) from None
+            if start_time.second or start_time.microsecond:
+                raise HttpSourceError(
+                    "kline start_time must be an exact whole UTC minute"
                 )
-            logger.warning(
-                "HTTP source %s (attempt %d/%d), retrying same cursor in %.0fs",
-                failure,
-                attempt,
-                _MAX_ATTEMPTS,
-                delay,
+            if previous is not None and start_time <= previous:
+                raise HttpSourceError(
+                    "kline start_time values must be strictly increasing"
+                )
+            if start_time < start or start_time + timedelta(minutes=1) > end:
+                raise HttpSourceError(
+                    "kline interval lies outside the requested window"
+                )
+            previous = start_time
+            decoded.append(
+                {
+                    "start_time": start_time,
+                    **{field: row[field] for field in fields[1:]},
+                }
             )
-            time.sleep(delay)
-            delay = min(delay * _BACKOFF_FACTOR, _BACKOFF_CAP_S)
-        raise HttpSourceError("unreachable")  # pragma: no cover
-
-    @staticmethod
-    def _normalize_row(row: dict) -> dict:
-        """Parse the ISO-8601 timestamp to naive UTC at the transport boundary."""
-        out = dict(row)
-        ts = out["timestamp"]
-        if isinstance(ts, str):
-            normalized = ts.replace("Z", "+00:00") if ts.endswith("Z") else ts
-            ts = datetime.fromisoformat(normalized)
-        out["timestamp"] = to_naive_utc(ts)
-        return out
+        return decoded

--- a/apps/importer/src/importer/main.py
+++ b/apps/importer/src/importer/main.py
@@ -19,7 +19,7 @@ import sys
 from datetime import datetime
 from typing import Optional
 
-from importer.config import build_parser
+from importer.config import ConfigurationError, build_parser, load_market_data_api_key
 from importer.density import compute_density, log_density_report
 from importer.mapping import FallbackCounters, map_row
 from importer.output_db import (
@@ -33,6 +33,7 @@ from importer.output_db import (
     open_output_db,
     output_db_path,
     release_lock,
+    verify_source_fingerprint,
 )
 from importer.source import SourceTransport, make_source
 from importer.validate import run_validation
@@ -88,11 +89,18 @@ def import_symbol(
     args: argparse.Namespace, source: SourceTransport, symbol: str
 ) -> bool:
     """Import one symbol into its output DB; returns success."""
-    db_path = output_db_path(args.out_dir, symbol, args.tag)
+    db_path = output_db_path(
+        args.out_dir,
+        symbol,
+        args.tag,
+        source_kind=args.source,
+        canonical_base_url=args.http_base_url,
+    )
     lock = acquire_lock(db_path)
     try:
         db = open_output_db(db_path)
         ensure_parents(db, symbol)
+        verify_source_fingerprint(db, args.http_source_fingerprint)
 
         window = _resolve_window(args, source, symbol)
         if window is None:
@@ -148,8 +156,16 @@ def import_symbol(
         if any(fallback_counts.values()):
             logger.warning("%s NULL-fallback/skip counts: %s", symbol, fallback_counts)
 
+        source_desc = (
+            f"db:{args.source_url}"
+            if args.source == "db"
+            else args.http_origin_label
+        )
         run_id = ensure_run_row(
-            db, symbol, source_desc=f"{args.source}:{args.source_url}"
+            db,
+            symbol,
+            source_desc=source_desc,
+            source_fingerprint=args.http_source_fingerprint,
         )
         if run_id is None:
             # Zero-row rule: empty range or every row skipped for NULL
@@ -181,6 +197,7 @@ def import_symbol(
                 bounds,
                 args.ohlc_threshold,
                 args.recorder_db,
+                http_source=source if args.source == "http" else None,
             )
         return True
     finally:
@@ -189,28 +206,42 @@ def import_symbol(
 
 def main(argv: Optional[list[str]] = None) -> int:
     """Entry point; returns non-zero when ANY symbol failed."""
-    args = build_parser().parse_args(argv)
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        api_key = load_market_data_api_key() if args.source == "http" else None
+    except ConfigurationError as exc:
+        parser.error(str(exc))
     setup_logging(debug=args.debug)
 
-    source = make_source(args.source, args.source_url, args.batch_size)
+    source_url = (
+        args.http_base_url if args.source == "http" else args.source_url
+    )
+    source = make_source(
+        args.source, source_url, args.batch_size, api_key=api_key
+    )
 
     failed: list[str] = []
-    for symbol in args.symbols:
-        try:
-            ok = import_symbol(args, source, symbol)
-        except ImportLockHeldError as e:
-            logger.error("%s: %s", symbol, e)
-            ok = False
-        except Exception:
-            logger.error("%s: import failed", symbol, exc_info=True)
-            ok = False
-        if not ok:
-            failed.append(symbol)
+    try:
+        for symbol in args.symbols:
+            try:
+                ok = import_symbol(args, source, symbol)
+            except ImportLockHeldError as e:
+                logger.error("%s: %s", symbol, e)
+                ok = False
+            except Exception:
+                logger.error("%s: import failed", symbol, exc_info=True)
+                ok = False
+            if not ok:
+                failed.append(symbol)
 
-    if failed:
-        logger.error("FAILED symbols: %s", ", ".join(failed))
-        return 1
-    return 0
+        if failed:
+            logger.error("FAILED symbols: %s", ", ".join(failed))
+            return 1
+        return 0
+    finally:
+        if args.source == "http":
+            source.close()
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/apps/importer/src/importer/output_db.py
+++ b/apps/importer/src/importer/output_db.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import logging
 import os
+import hashlib
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Optional
@@ -38,15 +39,41 @@ class ImportLockHeldError(Exception):
     """The ``.importlock`` sidecar is held (or unreadable) — do not write."""
 
 
-def output_db_path(out_dir: str, symbol: str, tag: Optional[str] = None) -> Path:
+class SourceFingerprintMismatchError(Exception):
+    """An HTTP output DB belongs to a different canonical API deployment."""
+
+
+def _sha256(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def output_db_path(
+    out_dir: str,
+    symbol: str,
+    tag: Optional[str] = None,
+    *,
+    source_kind: str = "db",
+    canonical_base_url: str | None = None,
+) -> Path:
     """``{out_dir}/imported_<symbol>[_<tag>].db`` — stable default path.
 
     The filename deliberately does NOT embed start/end: the default
     ``--end`` resolves to a live MAX(timestamp) probe, so a range-encoded
     name would defeat incremental resume.
     """
-    suffix = f"_{tag}" if tag else ""
-    return Path(out_dir) / f"imported_{symbol}{suffix}.db"
+    if source_kind == "db":
+        suffix = f"_{tag}" if tag else ""
+        return Path(out_dir) / f"imported_{symbol}{suffix}.db"
+    if source_kind != "http" or canonical_base_url is None:
+        raise ValueError("HTTP output paths require a canonical base URL")
+    symbol_digest = _sha256(symbol.encode("utf-8"))
+    base_digest = _sha256(canonical_base_url.encode("utf-8"))
+    tag_bytes = b"none" if tag is None else b"value\0" + tag.encode("utf-8")
+    tag_digest = _sha256(tag_bytes)
+    return (
+        Path(out_dir)
+        / f"imported_http_{symbol_digest}_{base_digest}_{tag_digest}.db"
+    )
 
 
 def lock_path(db_path: Path) -> Path:
@@ -195,8 +222,30 @@ def insert_batch(db: DatabaseFactory, snapshots: List[TickerSnapshot]) -> int:
         return TickerSnapshotRepository(session).bulk_insert(snapshots)
 
 
+def verify_source_fingerprint(
+    db: DatabaseFactory, source_fingerprint: str | None
+) -> None:
+    """Reject an existing HTTP run whose stored source identity differs."""
+    if source_fingerprint is None:
+        return
+    with db.get_session() as session:
+        run = RunRepository(session).get_latest_by_type("recording")
+        if run is None:
+            return
+        snapshot = run.config_snapshot or {}
+        stored = snapshot.get("source_fingerprint")
+        if stored is not None and stored != source_fingerprint:
+            raise SourceFingerprintMismatchError(
+                "stored HTTP source fingerprint does not match this output "
+                "path; restart into a fresh --tag"
+            )
+
+
 def ensure_run_row(
-    db: DatabaseFactory, symbol: str, source_desc: str
+    db: DatabaseFactory,
+    symbol: str,
+    source_desc: str,
+    source_fingerprint: str | None = None,
 ) -> Optional[str]:
     """Create-or-update the single synthetic ``recording`` run row.
 
@@ -226,17 +275,20 @@ def ensure_run_row(
         # replay auto-discovery nondeterministic.
         run = RunRepository(session).get_latest_by_type("recording")
         if run is None:
+            config_snapshot = {
+                "note": "imported from trad_save_history",
+                "symbol": symbol,
+                "source": source_desc,
+            }
+            if source_fingerprint is not None:
+                config_snapshot["source_fingerprint"] = source_fingerprint
             run = Run(
                 run_id=str(uuid4()),
                 user_id=IMPORTER_USER_ID,
                 account_id=IMPORTER_ACCOUNT_ID,
                 strategy_id=strategy_id_for(f"{_IMPORTER_NAME}_{symbol.lower()}"),
                 run_type="recording",
-                config_snapshot={
-                    "note": "imported from trad_save_history",
-                    "symbol": symbol,
-                    "source": source_desc,
-                },
+                config_snapshot=config_snapshot,
                 start_ts=min_ts,
                 end_ts=max_ts,
                 status="completed",

--- a/apps/importer/src/importer/source.py
+++ b/apps/importer/src/importer/source.py
@@ -1,4 +1,4 @@
-"""Source transport protocol + factory (feature 0093)."""
+"""Source transport protocols and factory."""
 
 from __future__ import annotations
 
@@ -9,14 +9,11 @@ from typing import Iterator, Optional, Protocol
 class SourceTransport(Protocol):
     """Read-only access to the trad_save_history ``ticker_data`` stream.
 
-    ``fetch_batches`` yields bounded batches of row dicts with keys
-    ``id, symbol, timestamp, last_price, mark_price, bid1_price,
-    ask1_price, funding_rate``. Row ``timestamp`` values are ALREADY naive
-    UTC — normalization happens at the transport boundary because the
-    resume skip compares them against a naive SQLite cursor BEFORE the
-    mapping layer runs. ``start``/``end`` bounds are both inclusive
-    (replay's window filter is inclusive, and the default ``--end``
-    resolves to the source MAX probe).
+    ``fetch_batches`` yields bounded row dicts containing ``symbol``,
+    ``timestamp``, and the five market fields. HTTP rows need no ``id``;
+    market values are nullable and unknown response fields are ignored.
+    Row ``timestamp`` values are already naive UTC. ``start``/``end`` are
+    inclusive.
     """
 
     def fetch_batches(
@@ -35,7 +32,22 @@ class SourceTransport(Protocol):
         ...
 
 
-def make_source(kind: str, url: str, batch_size: int = 10000) -> SourceTransport:
+class HttpKlineSource(Protocol):
+    """Narrow, already-validated HTTP kline contract used by validation."""
+
+    def fetch_klines(
+        self, symbol: str, start: datetime, end: datetime
+    ) -> list[dict]:
+        """Return ordered 1m rows with naive-UTC ``start_time`` values."""
+        ...
+
+
+def make_source(
+    kind: str,
+    url: str,
+    batch_size: int = 10000,
+    api_key: str | None = None,
+) -> SourceTransport:
     """Construct the transport named by ``--source``."""
     if kind == "db":
         from importer.fetch_source_db import DbSource
@@ -44,5 +56,5 @@ def make_source(kind: str, url: str, batch_size: int = 10000) -> SourceTransport
     if kind == "http":
         from importer.fetch_source_http import HttpSource
 
-        return HttpSource(url, batch_size=batch_size)
+        return HttpSource(url, batch_size=batch_size, api_key=api_key)
     raise ValueError(f"unknown source kind: {kind!r}")

--- a/apps/importer/src/importer/validate.py
+++ b/apps/importer/src/importer/validate.py
@@ -59,7 +59,13 @@ _EIGHT_DP = Decimal("0.00000001")
 
 def _epoch_minute(ts: datetime) -> int:
     """Absolute UTC minute key for a naive-UTC timestamp."""
-    return int(ts.replace(tzinfo=timezone.utc).timestamp()) // 60
+    try:
+        epoch = int(ts.replace(tzinfo=timezone.utc).timestamp())
+    except (ValueError, OverflowError):
+        raise ValueError(
+            f"timestamp {ts} cannot be converted to epoch seconds"
+        ) from None
+    return epoch // 60
 
 
 @dataclass
@@ -381,6 +387,7 @@ def smoke_replay(
             [sys.executable, "-m", "replay.main", "--config", str(rendered)],
             capture_output=True,
             text=True,
+            timeout=300,
             env={
                 key: value
                 for key, value in os.environ.copy().items()

--- a/apps/importer/src/importer/validate.py
+++ b/apps/importer/src/importer/validate.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import logging
 import math
+import os
 import re
 import subprocess
 import sys
@@ -37,7 +38,7 @@ from grid_db.settings import DatabaseSettings
 
 from importer.config import to_naive_utc
 from importer.fetch_source_db import aware_utc
-from importer.fetch_source_http import iso_utc
+from importer.source import HttpKlineSource
 
 logger = logging.getLogger(__name__)
 
@@ -211,27 +212,12 @@ def _fetch_klines_db(
 
 
 def _fetch_klines_http(
-    base_url: str, symbol: str, start: datetime, end: datetime
+    source: HttpKlineSource, symbol: str, start: datetime, end: datetime
 ) -> dict[int, OhlcBucket]:
-    """Fetch 1m klines via ``GET {base}/klines?symbol&start&end`` (transport B)."""
-    import requests
-
-    response = requests.get(
-        f"{base_url.rstrip('/')}/klines",
-        params={
-            # Same Z-suffixed ISO format the ticker transport sends.
-            "symbol": symbol,
-            "start": iso_utc(start),
-            "end": iso_utc(end),
-        },
-        timeout=30,
-    )
-    response.raise_for_status()
+    """Convert transport-validated HTTP 1m rows into validation buckets."""
     result: dict[int, OhlcBucket] = {}
-    for row in response.json().get("rows") or []:
-        ts = _coerce_kline_ts(row["start_time"])
-        if not (start <= ts <= end):
-            continue
+    for row in source.fetch_klines(symbol, start, end):
+        ts = row["start_time"]
         result[_epoch_minute(ts)] = OhlcBucket(
             open=Decimal(str(row["open"])).quantize(_EIGHT_DP),
             high=Decimal(str(row["high"])).quantize(_EIGHT_DP),
@@ -290,6 +276,7 @@ def check_ohlc(
     source_url: str,
     bounds: tuple[datetime, datetime],
     threshold: float,
+    http_source: HttpKlineSource | None = None,
 ) -> bool:
     """OHLC cross-check on a sampled day (the middle day of the import)."""
     tick_size = TICK_SIZE.get(symbol)
@@ -319,7 +306,16 @@ def check_ohlc(
         if source_kind == "db":
             klines = _fetch_klines_db(source_url, symbol, day_start, day_end)
         else:
-            klines = _fetch_klines_http(source_url, symbol, day_start, day_end)
+            if http_source is None:
+                raise ValueError(
+                    "HTTP OHLC validation requires the active HTTP source"
+                )
+            klines = _fetch_klines_http(
+                http_source,
+                symbol,
+                day_start,
+                day_start + timedelta(days=1),
+            )
     except Exception as e:
         logger.error("OHLC check: failed to fetch source klines: %s", e)
         return False
@@ -385,6 +381,11 @@ def smoke_replay(
             [sys.executable, "-m", "replay.main", "--config", str(rendered)],
             capture_output=True,
             text=True,
+            env={
+                key: value
+                for key, value in os.environ.copy().items()
+                if key != "MARKET_DATA_API_KEY"
+            },
         )
     if proc.returncode != 0:
         logger.error(
@@ -514,6 +515,7 @@ def run_validation(
     bounds: tuple[datetime, datetime],
     ohlc_threshold: float,
     recorder_db: Optional[str],
+    http_source: HttpKlineSource | None = None,
 ) -> bool:
     """Run the three ``--validate`` checks for one imported symbol.
 
@@ -524,7 +526,13 @@ def run_validation(
         True only when both gating checks pass.
     """
     ohlc_ok = check_ohlc(
-        db, symbol, source_kind, source_url, bounds, ohlc_threshold
+        db,
+        symbol,
+        source_kind,
+        source_url,
+        bounds,
+        ohlc_threshold,
+        http_source=http_source,
     )
     smoke_ok = smoke_replay(db_path, symbol, bounds)
     recorder_overlap_probe(db, symbol, bounds, recorder_db)

--- a/apps/importer/tests/test_config.py
+++ b/apps/importer/tests/test_config.py
@@ -194,6 +194,7 @@ class TestConfig:
         with pytest.raises(ConfigurationError) as caught:
             load_market_data_api_key()
         assert key not in str(caught.value)
+        assert caught.value.__cause__ is None
 
     @pytest.mark.parametrize("value", [None, ""])
     def test_missing_or_empty_bearer_disables_auth(self, value, monkeypatch):
@@ -206,6 +207,13 @@ class TestConfig:
     def test_valid_bearer_is_preserved_exactly(self, monkeypatch):
         monkeypatch.setenv("MARKET_DATA_API_KEY", "opaque-token/+=")
         assert load_market_data_api_key() == "opaque-token/+="
+
+    def test_bearer_rejects_excessive_padding(self, monkeypatch):
+        monkeypatch.setenv("MARKET_DATA_API_KEY", "opaque-token/+===")
+        with pytest.raises(ConfigurationError) as caught:
+            load_market_data_api_key()
+        assert caught.value.__cause__ is None
+        assert "opaque-token" not in str(caught.value)
 
     def test_ohlc_threshold_must_be_unit_fraction(self):
         """--ohlc-threshold outside (0, 1] is rejected."""

--- a/apps/importer/tests/test_config.py
+++ b/apps/importer/tests/test_config.py
@@ -1,14 +1,33 @@
-"""Tests for importer CLI parsing and datetime discipline (feature 0093)."""
+"""Tests for source-aware importer CLI and secret preflight."""
 
 from datetime import datetime
 
 import pytest
 
-from importer.config import build_parser, parse_utc, to_naive_utc
+from importer.config import (
+    ConfigurationError,
+    build_parser,
+    load_market_data_api_key,
+    parse_utc,
+    preflight_http,
+    to_naive_utc,
+)
 
 _BASE_ARGS = [
     "--source", "db",
     "--source-url", "sqlite:///src.db",
+]
+_HTTP_ARGS = [
+    "--source",
+    "http",
+    "--source-url",
+    "https://EXAMPLE.com:443/deploy/",
+    "--symbols",
+    "BtCuSdT",
+    "--start",
+    "2026-07-01T00:00:00+05:00",
+    "--end",
+    "2026-07-02T00:00:00+05:00",
 ]
 
 
@@ -24,6 +43,14 @@ class TestConfig:
             _BASE_ARGS + ["--symbols", "btcusdt, ethusdt"]
         )
         assert args.symbols == ["BTCUSDT", "ETHUSDT"]
+
+    def test_http_symbol_case_and_offset_bounds_are_preserved_normalized(self):
+        args = build_parser().parse_args(_HTTP_ARGS)
+        assert args.symbols == ["BtCuSdT"]
+        assert args.start == datetime(2026, 6, 30, 19)
+        assert args.end == datetime(2026, 7, 1, 19)
+        assert args.http_base_url == "https://example.com/deploy"
+        assert args.http_origin_label == "http:https://example.com"
 
     def test_source_choice_validated(self):
         """--source outside {db,http} is rejected."""
@@ -67,6 +94,118 @@ class TestConfig:
                 build_parser().parse_args(
                     _BASE_ARGS + ["--symbols", "BTCUSDT", "--batch-size", bad]
                 )
+
+    def test_http_batch_is_capped_but_db_is_not(self):
+        with pytest.raises(SystemExit) as caught:
+            build_parser().parse_args(_HTTP_ARGS + ["--batch-size", "10001"])
+        assert caught.value.code == 2
+        db = build_parser().parse_args(
+            _BASE_ARGS
+            + ["--symbols", "btcusdt", "--batch-size", "10001"]
+        )
+        assert db.batch_size == 10001
+
+    @pytest.mark.parametrize(
+        "extra",
+        [
+            [],
+            ["--start", "2026-07-01T00:00:00Z"],
+        ],
+    )
+    def test_http_requires_both_bounds(self, extra):
+        args = [
+            "--source",
+            "http",
+            "--source-url",
+            "https://example.test",
+            "--symbols",
+            "BTCUSDT",
+            *extra,
+        ]
+        with pytest.raises(SystemExit) as caught:
+            build_parser().parse_args(args)
+        assert caught.value.code == 2
+
+    def test_http_reversed_bounds_and_control_symbol_rejected_without_echo(
+        self, capsys
+    ):
+        reversed_args = _HTTP_ARGS.copy()
+        reversed_args[reversed_args.index("--start") + 1] = (
+            "2026-07-03T00:00:00Z"
+        )
+        with pytest.raises(SystemExit):
+            build_parser().parse_args(reversed_args)
+        unsafe = _HTTP_ARGS.copy()
+        unsafe[unsafe.index("--symbols") + 1] = "BTC\nSECRET"
+        with pytest.raises(SystemExit):
+            build_parser().parse_args(unsafe)
+        assert "BTC\nSECRET" not in capsys.readouterr().err
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            " example.test",
+            "ftp://example.test",
+            "https://user:password@example.test",
+            "https://example.test?",
+            "https://example.test#",
+            "https://example.test:99999",
+            "https://[::1",
+            "https://example.test/\npath",
+        ],
+    )
+    def test_invalid_http_urls_are_safe_parser_errors(self, url, capsys):
+        args = _HTTP_ARGS.copy()
+        args[args.index("--source-url") + 1] = url
+        with pytest.raises(SystemExit) as caught:
+            build_parser().parse_args(args)
+        assert caught.value.code == 2
+        assert url not in capsys.readouterr().err
+
+    @pytest.mark.parametrize(
+        "left,right",
+        [
+            ("HTTPS://EXAMPLE.COM:443/api/", "https://example.com/api"),
+            (
+                "https://bücher.example/api",
+                "https://xn--bcher-kva.example/api",
+            ),
+            ("https://example.com/a/../api", "https://example.com/api"),
+            ("https://example.com/api/%7e", "https://example.com/api/~"),
+        ],
+    )
+    def test_canonical_url_equivalence(self, left, right):
+        assert preflight_http(left) == preflight_http(right)
+
+    def test_distinct_base_paths_and_ports_remain_distinct(self):
+        assert preflight_http("https://example.com/a") != preflight_http(
+            "https://example.com/b"
+        )
+        assert preflight_http("https://example.com:444/a") != preflight_http(
+            "https://example.com/a"
+        )
+
+    @pytest.mark.parametrize(
+        "key",
+        [" secret", "secret ", "a\nb", "a:b", "é", "abc=def"],
+    )
+    def test_invalid_bearer_values_never_echo(self, key, monkeypatch):
+        monkeypatch.setenv("MARKET_DATA_API_KEY", key)
+        with pytest.raises(ConfigurationError) as caught:
+            load_market_data_api_key()
+        assert key not in str(caught.value)
+
+    @pytest.mark.parametrize("value", [None, ""])
+    def test_missing_or_empty_bearer_disables_auth(self, value, monkeypatch):
+        if value is None:
+            monkeypatch.delenv("MARKET_DATA_API_KEY", raising=False)
+        else:
+            monkeypatch.setenv("MARKET_DATA_API_KEY", value)
+        assert load_market_data_api_key() is None
+
+    def test_valid_bearer_is_preserved_exactly(self, monkeypatch):
+        monkeypatch.setenv("MARKET_DATA_API_KEY", "opaque-token/+=")
+        assert load_market_data_api_key() == "opaque-token/+="
 
     def test_ohlc_threshold_must_be_unit_fraction(self):
         """--ohlc-threshold outside (0, 1] is rejected."""

--- a/apps/importer/tests/test_fetch_http.py
+++ b/apps/importer/tests/test_fetch_http.py
@@ -178,6 +178,12 @@ class TestRequests:
         source.close()
         assert session.close_calls == 1
 
+    def test_batch_size_bounds_are_enforced(self):
+        with pytest.raises(ValueError, match="positive"):
+            HttpSource("https://example.test", batch_size=0)
+        with pytest.raises(ValueError, match="10000"):
+            HttpSource("https://example.test", batch_size=10001)
+
 
 class TestBulkPages:
     def test_pagination_and_naive_timestamps_without_id(self):

--- a/apps/importer/tests/test_fetch_http.py
+++ b/apps/importer/tests/test_fetch_http.py
@@ -1,180 +1,561 @@
-"""Tests for transport B (HTTP cursor pagination, retry/backoff) — feature 0093."""
+"""Protocol 1.0 HTTP transport tests."""
 
-from datetime import datetime
+from __future__ import annotations
+
+import json
+import logging
+import traceback
+from datetime import datetime, timedelta, timezone
+from email.utils import format_datetime
+from urllib.parse import parse_qs, urlsplit
 
 import pytest
 import requests
 
 from importer.fetch_source_http import HttpSource, HttpSourceError
 
-_T0 = datetime(2026, 7, 1, 0, 0, 0)
-_T1 = datetime(2026, 7, 1, 1, 0, 0)
+_T0 = datetime(2026, 7, 1, 0, 0)
+_T1 = datetime(2026, 7, 1, 1, 0)
 
 
-def _http_row(row_id: int, ts_iso: str, price: float = 100.0) -> dict:
-    return {
-        "id": row_id,
-        "symbol": "BTCUSDT",
-        "timestamp": ts_iso,
-        "last_price": price,
-        "mark_price": price,
-        "bid1_price": price,
-        "ask1_price": price,
-        "funding_rate": 0.0001,
+def _row(ts="2026-07-01T00:00:00Z", symbol="BTCUSDT", **overrides):
+    row = {
+        "symbol": symbol,
+        "timestamp": ts,
+        "last_price": 100.0,
+        "mark_price": 100,
+        "bid1_price": 99.5,
+        "ask1_price": 100.5,
+        "funding_rate": None,
     }
+    row.update(overrides)
+    return row
 
 
-class FakeResponse:
-    def __init__(self, status_code: int, payload: dict | None = None, text: str = ""):
-        self.status_code = status_code
-        self._payload = payload or {}
-        self.text = text
+def _response(
+    status=200,
+    payload=None,
+    *,
+    content_type="application/json; charset=utf-8",
+    headers=None,
+    raw=None,
+):
+    response = requests.Response()
+    response.status_code = status
+    response.headers["Content-Type"] = content_type
+    response.headers.update(headers or {})
+    response._content = (
+        raw
+        if raw is not None
+        else json.dumps(payload if payload is not None else {}).encode()
+    )
+    return response
 
-    def json(self) -> dict:
-        return self._payload
 
+class ScriptedSession(requests.Session):
+    """Real request preparation plus scripted, network-free responses."""
 
-class FakeSession:
-    """Scripted requests.Session stand-in; records every call's params."""
+    def __init__(self, script):
+        super().__init__()
+        self.script = list(script)
+        self.sent = []
+        self.close_calls = 0
 
-    def __init__(self, script: list):
-        self._script = list(script)
-        self.calls: list[dict] = []
-
-    def get(self, url, params=None, timeout=None):
-        self.calls.append(dict(params))
-        item = self._script.pop(0)
+    def send(self, request, **kwargs):
+        self.sent.append((request, kwargs))
+        item = self.script.pop(0)
         if isinstance(item, Exception):
             raise item
+        item.request = request
+        item.url = request.url
         return item
+
+    def close(self):
+        self.close_calls += 1
+        super().close()
 
 
 @pytest.fixture(autouse=True)
-def no_sleep(monkeypatch):
-    """Backoff sleeps are a no-op in tests."""
-    monkeypatch.setattr("importer.fetch_source_http.time.sleep", lambda s: None)
+def deterministic_retry(monkeypatch):
+    monkeypatch.setattr("importer.fetch_source_http.time.sleep", lambda _: None)
+    monkeypatch.setattr(
+        "importer.fetch_source_http.random.uniform", lambda low, high: high
+    )
 
 
-class TestHttpSource:
-    def test_pagination_follows_next_cursor(self):
-        """Batches follow next_cursor to exhaustion."""
-        session = FakeSession(
-            [
-                FakeResponse(
-                    200,
-                    {
-                        "rows": [_http_row(1, "2026-07-01T00:00:00Z")],
-                        "next_cursor": "c1",
-                    },
-                ),
-                FakeResponse(
-                    200,
-                    {
-                        "rows": [_http_row(2, "2026-07-01T00:00:01Z")],
-                        "next_cursor": None,
-                    },
-                ),
-            ]
+def _source(script, **kwargs):
+    session = ScriptedSession(script)
+    return HttpSource("https://example.test/deploy", session=session, **kwargs), session
+
+
+class TestRequests:
+    def test_auth_headers_timeout_redirects_and_base_path(self):
+        source, session = _source(
+            [_response(payload={"rows": [], "next_cursor": None})],
+            api_key="opaque-token==",
         )
-        source = HttpSource("http://src", session=session)
-        batches = list(source.fetch_batches("BTCUSDT", _T0, _T1))
-        assert [r["id"] for b in batches for r in b] == [1, 2]
-        assert "cursor" not in session.calls[0]
-        assert session.calls[1]["cursor"] == "c1"
-
-    def test_timestamps_yielded_naive_utc(self):
-        """ISO-8601 Z timestamps are converted to naive UTC at the boundary."""
-        session = FakeSession(
-            [
-                FakeResponse(
-                    200,
-                    {
-                        "rows": [_http_row(1, "2026-07-01T00:00:00Z")],
-                        "next_cursor": None,
-                    },
-                )
-            ]
+        assert list(source.fetch_batches("BtC/USDT", _T0, _T1)) == []
+        request, kwargs = session.sent[0]
+        assert request.url.startswith(
+            "https://example.test/deploy/ticker_data?"
         )
-        source = HttpSource("http://src", session=session)
-        (batch,) = list(source.fetch_batches("BTCUSDT", _T0, _T1))
-        assert batch[0]["timestamp"] == _T0
-        assert batch[0]["timestamp"].tzinfo is None
+        assert request.headers["Accept"] == "application/json"
+        assert request.headers["Authorization"] == "Bearer opaque-token=="
+        assert kwargs["timeout"] == (5, 30)
+        assert kwargs["allow_redirects"] is False
+        query = parse_qs(urlsplit(request.url).query)
+        assert query["symbol"] == ["BtC/USDT"]
+        assert query["start"] == ["2026-07-01T00:00:00Z"]
 
-    def test_retry_on_429_re_requests_same_cursor(self):
-        """429 retries re-request the identical cursor (no skipped rows)."""
-        ok = FakeResponse(
-            200,
-            {"rows": [_http_row(1, "2026-07-01T00:00:00Z")], "next_cursor": None},
+    def test_no_key_removes_inherited_header_and_session_auth(self):
+        source, session = _source(
+            [_response(payload={"rows": [], "next_cursor": None})]
         )
-        session = FakeSession([FakeResponse(429), ok])
-        source = HttpSource("http://src", session=session)
-        batches = list(source.fetch_batches("BTCUSDT", _T0, _T1))
-        assert len(batches) == 1
-        assert session.calls[0] == session.calls[1]
-
-    def test_retry_on_5xx_and_connection_error(self):
-        """503 and connection errors are retried with the same params."""
-        ok = FakeResponse(200, {"rows": [], "next_cursor": None})
-        session = FakeSession(
-            [FakeResponse(503), requests.ConnectionError("boom"), ok]
-        )
-        source = HttpSource("http://src", session=session)
-        assert list(source.fetch_batches("BTCUSDT", _T0, _T1)) == []
-        assert session.calls[0] == session.calls[1] == session.calls[2]
-
-    def test_non_retryable_4xx_aborts(self):
-        """A 404 aborts immediately with the body logged."""
-        session = FakeSession([FakeResponse(404, text="not found")])
-        source = HttpSource("http://src", session=session)
-        with pytest.raises(HttpSourceError, match="non-retryable HTTP 404"):
-            list(source.fetch_batches("BTCUSDT", _T0, _T1))
-        assert len(session.calls) == 1
-
-    def test_exhausted_retries_abort(self):
-        """Five consecutive retryable failures give up with an error."""
-        session = FakeSession([FakeResponse(500)] * 5)
-        source = HttpSource("http://src", session=session)
-        with pytest.raises(HttpSourceError, match="after 5 attempts"):
-            list(source.fetch_batches("BTCUSDT", _T0, _T1))
-        assert len(session.calls) == 5
-
-    def test_empty_rows_with_truthy_cursor_terminates(self):
-        """An empty rows page ends pagination even with a (buggy) cursor."""
-        session = FakeSession(
-            [FakeResponse(200, {"rows": [], "next_cursor": "c-loop"})]
-        )
-        source = HttpSource("http://src", session=session)
-        assert list(source.fetch_batches("BTCUSDT", _T0, _T1)) == []
-        assert len(session.calls) == 1
-
-    def test_empty_string_cursor_terminates(self):
-        """A falsy (empty-string) next_cursor ends pagination instead of spinning."""
-        session = FakeSession(
-            [
-                FakeResponse(
-                    200,
-                    {
-                        "rows": [_http_row(1, "2026-07-01T00:00:00Z")],
-                        "next_cursor": "",
-                    },
-                )
-            ]
-        )
-        source = HttpSource("http://src", session=session)
-        batches = list(source.fetch_batches("BTCUSDT", _T0, _T1))
-        assert len(batches) == 1
-        assert len(session.calls) == 1
-
-    def test_probe_range_unsupported(self):
-        """The HTTP contract has no MIN/MAX probe."""
-        assert HttpSource("http://src", session=FakeSession([])).probe_range(
-            "BTCUSDT"
-        ) is None
-
-    def test_request_window_is_iso_z(self):
-        """start/end are sent as ISO-8601 UTC with Z suffix."""
-        session = FakeSession([FakeResponse(200, {"rows": [], "next_cursor": None})])
-        source = HttpSource("http://src", session=session)
+        session.headers["Authorization"] = "Bearer inherited"
+        session.auth = ("netrc-user", "netrc-password")
+        original_auth = session.auth
         list(source.fetch_batches("BTCUSDT", _T0, _T1))
-        assert session.calls[0]["start"] == "2026-07-01T00:00:00Z"
-        assert session.calls[0]["end"] == "2026-07-01T01:00:00Z"
+        assert "Authorization" not in session.sent[0][0].headers
+        assert session.headers["Authorization"] == "Bearer inherited"
+        assert session.auth == original_auth
+
+    def test_explicit_key_wins_without_mutating_injected_session(self):
+        source, session = _source(
+            [_response(payload={"rows": [], "next_cursor": None})],
+            api_key="new-token",
+        )
+        session.headers["Authorization"] = "Bearer old-token"
+        session.auth = ("user", "password")
+        list(source.fetch_batches("BTCUSDT", _T0, _T1))
+        assert session.sent[0][0].headers["Authorization"] == "Bearer new-token"
+        assert session.headers["Authorization"] == "Bearer old-token"
+        assert session.auth == ("user", "password")
+
+    def test_truthy_request_auth_suppresses_netrc(self, monkeypatch):
+        called = []
+        monkeypatch.setattr(
+            requests.sessions,
+            "get_netrc_auth",
+            lambda url: called.append(url) or ("user", "password"),
+        )
+        source, session = _source(
+            [_response(payload={"rows": [], "next_cursor": None})]
+        )
+        list(source.fetch_batches("BTCUSDT", _T0, _T1))
+        assert called == []
+        assert "Authorization" not in session.sent[0][0].headers
+
+    def test_cursor_reserved_characters_stay_in_params(self):
+        source, session = _source(
+            [
+                _response(payload={"rows": [_row()], "next_cursor": "a=b&c+d"}),
+                _response(
+                    payload={
+                        "rows": [_row("2026-07-01T00:00:01Z")],
+                        "next_cursor": None,
+                    }
+                ),
+            ]
+        )
+        list(source.fetch_batches("BTCUSDT", _T0, _T1))
+        assert parse_qs(urlsplit(session.sent[1][0].url).query)["cursor"] == [
+            "a=b&c+d"
+        ]
+
+    def test_injected_session_is_never_closed(self):
+        source, session = _source([])
+        source.close()
+        source.close()
+        assert session.close_calls == 0
+
+    def test_owned_session_closes_once(self, monkeypatch):
+        session = ScriptedSession([])
+        monkeypatch.setattr(
+            "importer.fetch_source_http.requests.Session", lambda: session
+        )
+        source = HttpSource("https://example.test")
+        source.close()
+        source.close()
+        assert session.close_calls == 1
+
+
+class TestBulkPages:
+    def test_pagination_and_naive_timestamps_without_id(self):
+        source, _ = _source(
+            [
+                _response(payload={"rows": [_row()], "next_cursor": "c1"}),
+                _response(
+                    payload={
+                        "rows": [_row("2026-07-01T00:00:01Z", extra="ignored")],
+                        "next_cursor": None,
+                    }
+                ),
+            ]
+        )
+        batches = list(source.fetch_batches("BTCUSDT", _T0, _T1))
+        assert [row["timestamp"] for batch in batches for row in batch] == [
+            _T0,
+            _T0 + timedelta(seconds=1),
+        ]
+        assert "extra" not in batches[1][0]
+        assert "id" not in batches[0][0]
+
+    @pytest.mark.parametrize(
+        "payload,match",
+        [
+            ({"rows": []}, "rows and next_cursor"),
+            ({"rows": {}, "next_cursor": None}, "rows must be a list"),
+            ({"rows": [], "next_cursor": 1}, "string or null"),
+            ({"rows": [1], "next_cursor": None}, "contain objects"),
+            (
+                {"rows": [{"symbol": "BTCUSDT"}], "next_cursor": None},
+                "missing a required",
+            ),
+            (
+                {"rows": [_row(symbol=1)], "next_cursor": None},
+                "symbol must be",
+            ),
+            (
+                {"rows": [_row(last_price=True)], "next_cursor": None},
+                "finite number",
+            ),
+            (
+                {"rows": [_row(last_price=float("nan"))], "next_cursor": None},
+                "finite number",
+            ),
+        ],
+    )
+    def test_schema_errors(self, payload, match):
+        source, _ = _source([_response(payload=payload)])
+        with pytest.raises(HttpSourceError, match=match):
+            list(source.fetch_batches("BTCUSDT", _T0, _T1))
+
+    def test_damaged_rows_filter_and_continue(self, caplog):
+        source, _ = _source(
+            [
+                _response(
+                    payload={
+                        "rows": [
+                            _row(symbol=None),
+                            _row(symbol="ETHUSDT"),
+                            _row(ts=None),
+                            _row(ts="not-a-time"),
+                        ],
+                        "next_cursor": "next",
+                    }
+                ),
+                _response(
+                    payload={
+                        "rows": [_row("2026-07-01T00:00:01Z")],
+                        "next_cursor": None,
+                    }
+                ),
+            ]
+        )
+        with caplog.at_level(logging.WARNING):
+            batches = list(source.fetch_batches("BTCUSDT", _T0, _T1))
+        assert len(batches) == 1
+        records = [r for r in caplog.records if "damaged-row filters" in r.message]
+        assert len(records) == 1
+        assert all(f"'{'null_symbol'}': 1" not in r.message for r in [])
+        assert "'null_symbol': 1" in records[0].message
+
+    @pytest.mark.parametrize(
+        "timestamp",
+        ["2026-06-30T23:59:59Z", "2026-07-01T01:00:01Z"],
+    )
+    def test_out_of_window_rejected(self, timestamp):
+        source, _ = _source(
+            [_response(payload={"rows": [_row(timestamp)], "next_cursor": None})]
+        )
+        with pytest.raises(HttpSourceError, match="outside"):
+            list(source.fetch_batches("BTCUSDT", _T0, _T1))
+
+    def test_decreasing_inside_or_across_pages_rejected(self):
+        inside, _ = _source(
+            [
+                _response(
+                    payload={
+                        "rows": [
+                            _row("2026-07-01T00:00:02Z"),
+                            _row("2026-07-01T00:00:01Z"),
+                        ],
+                        "next_cursor": None,
+                    }
+                )
+            ]
+        )
+        with pytest.raises(HttpSourceError, match="decreased"):
+            list(inside.fetch_batches("BTCUSDT", _T0, _T1))
+
+        across, _ = _source(
+            [
+                _response(
+                    payload={
+                        "rows": [_row("2026-07-01T00:00:02Z")],
+                        "next_cursor": "c1",
+                    }
+                ),
+                _response(
+                    payload={
+                        "rows": [_row("2026-07-01T00:00:01Z")],
+                        "next_cursor": None,
+                    }
+                ),
+            ]
+        )
+        with pytest.raises(HttpSourceError, match="decreased"):
+            list(across.fetch_batches("BTCUSDT", _T0, _T1))
+
+    def test_cursor_progress_rules(self):
+        empty, _ = _source(
+            [_response(payload={"rows": [], "next_cursor": "bad"})]
+        )
+        with pytest.raises(HttpSourceError, match="empty rows"):
+            list(empty.fetch_batches("BTCUSDT", _T0, _T1))
+
+        repeated, _ = _source(
+            [
+                _response(payload={"rows": [_row()], "next_cursor": "c1"}),
+                _response(
+                    payload={
+                        "rows": [_row("2026-07-01T00:00:01Z")],
+                        "next_cursor": "c1",
+                    }
+                ),
+            ]
+        )
+        yielded = repeated.fetch_batches("BTCUSDT", _T0, _T1)
+        next(yielded)
+        with pytest.raises(HttpSourceError, match="cycled"):
+            next(yielded)
+
+    def test_empty_string_is_opaque_cursor(self):
+        source, session = _source(
+            [
+                _response(payload={"rows": [_row()], "next_cursor": ""}),
+                _response(
+                    payload={
+                        "rows": [_row("2026-07-01T00:00:01Z")],
+                        "next_cursor": None,
+                    }
+                ),
+            ]
+        )
+        assert len(list(source.fetch_batches("BTCUSDT", _T0, _T1))) == 2
+        assert parse_qs(
+            urlsplit(session.sent[1][0].url).query, keep_blank_values=True
+        )["cursor"] == [""]
+
+
+class TestErrorsAndRetries:
+    @pytest.mark.parametrize("status", [401, 404, 422, 302, 204, 418])
+    def test_terminal_statuses(self, status):
+        source, session = _source([_response(status=status, raw=b"failure")])
+        with pytest.raises(HttpSourceError, match=str(status)):
+            list(source.fetch_batches("BTCUSDT", _T0, _T1))
+        assert len(session.sent) == 1
+
+    @pytest.mark.parametrize("status", [429, 500, 599])
+    def test_retryable_statuses_reuse_parameters(self, status):
+        source, session = _source(
+            [
+                _response(status=status),
+                _response(payload={"rows": [], "next_cursor": None}),
+            ]
+        )
+        assert list(source.fetch_batches("BTCUSDT", _T0, _T1)) == []
+        assert session.sent[0][0].url == session.sent[1][0].url
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            requests.ConnectTimeout("x"),
+            requests.ReadTimeout("x"),
+            requests.ConnectionError("x"),
+            requests.exceptions.ChunkedEncodingError("x"),
+        ],
+    )
+    def test_retryable_request_exceptions(self, exc):
+        source, session = _source(
+            [exc, _response(payload={"rows": [], "next_cursor": None})]
+        )
+        assert list(source.fetch_batches("BTCUSDT", _T0, _T1)) == []
+        assert len(session.sent) == 2
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            requests.exceptions.SSLError("x"),
+            requests.exceptions.ProxyError("x"),
+            requests.exceptions.InvalidURL("x"),
+            requests.exceptions.MissingSchema("x"),
+            requests.exceptions.InvalidSchema("x"),
+            requests.exceptions.InvalidHeader("x"),
+            requests.RequestException("x"),
+        ],
+    )
+    def test_terminal_request_exceptions(self, exc):
+        source, session = _source([exc])
+        with pytest.raises(HttpSourceError):
+            list(source.fetch_batches("BTCUSDT", _T0, _T1))
+        assert len(session.sent) == 1
+
+    def test_retry_after_delta_date_and_over_cap(self, monkeypatch):
+        sleeps = []
+        monkeypatch.setattr(
+            "importer.fetch_source_http.time.sleep", sleeps.append
+        )
+        source, _ = _source(
+            [
+                _response(status=429, headers={"Retry-After": "3"}),
+                _response(payload={"rows": [], "next_cursor": None}),
+            ]
+        )
+        list(source.fetch_batches("BTCUSDT", _T0, _T1))
+        assert sleeps == [3]
+
+        now = datetime(2026, 7, 1, tzinfo=timezone.utc)
+        monkeypatch.setattr("importer.fetch_source_http._utc_now", lambda: now)
+        source, _ = _source(
+            [
+                _response(
+                    status=429,
+                    headers={
+                        "Retry-After": format_datetime(
+                            now + timedelta(seconds=4), usegmt=True
+                        )
+                    },
+                ),
+                _response(payload={"rows": [], "next_cursor": None}),
+            ]
+        )
+        list(source.fetch_batches("BTCUSDT", _T0, _T1))
+        assert sleeps[-1] == 4
+
+        source, _ = _source(
+            [_response(status=429, headers={"Retry-After": "31"})]
+        )
+        with pytest.raises(HttpSourceError, match="exceeds"):
+            list(source.fetch_batches("BTCUSDT", _T0, _T1))
+
+    @pytest.mark.parametrize(
+        "response,match",
+        [
+            (
+                _response(
+                    payload={"rows": [], "next_cursor": None},
+                    content_type="text/plain",
+                ),
+                "application/json",
+            ),
+            (
+                _response(raw=b"{", content_type="application/json"),
+                "invalid JSON",
+            ),
+            (_response(payload=[]), "top-level object"),
+        ],
+    )
+    def test_terminal_200_protocol_errors_are_not_retried(self, response, match):
+        source, session = _source([response])
+        with pytest.raises(HttpSourceError, match=match):
+            list(source.fetch_batches("BTCUSDT", _T0, _T1))
+        assert len(session.sent) == 1
+
+    def test_secret_redacted_from_body_exception_and_traceback(self):
+        secret = "very-secret-token"
+        source, _ = _source(
+            [
+                _response(
+                    status=401,
+                    payload={"detail": ["prefix", secret, "suffix"]},
+                )
+            ],
+            api_key=secret,
+        )
+        with pytest.raises(HttpSourceError) as caught:
+            list(source.fetch_batches("BTCUSDT", _T0, _T1))
+        rendered = "".join(traceback.format_exception(caught.value))
+        assert secret not in str(caught.value)
+        assert secret not in rendered
+
+        source, _ = _source([RuntimeError(f"boom {secret}")], api_key=secret)
+        with pytest.raises(HttpSourceError) as caught:
+            list(source.fetch_batches("BTCUSDT", _T0, _T1))
+        assert secret not in "".join(traceback.format_exception(caught.value))
+
+
+class TestKlines:
+    def _kline(self, ts="2026-07-01T00:00:00Z", **overrides):
+        row = {
+            "start_time": ts,
+            "open": 1,
+            "high": 2.0,
+            "low": 0.5,
+            "close": 1.5,
+        }
+        row.update(overrides)
+        return row
+
+    def test_authenticated_shared_transport_and_gaps(self):
+        source, session = _source(
+            [
+                _response(
+                    payload={
+                        "rows": [
+                            self._kline(),
+                            self._kline("2026-07-01T00:02:00Z"),
+                        ]
+                    }
+                )
+            ],
+            api_key="token",
+        )
+        rows = source.fetch_klines("BTCUSDT", _T0, _T0 + timedelta(days=1))
+        assert [row["start_time"] for row in rows] == [
+            _T0,
+            _T0 + timedelta(minutes=2),
+        ]
+        request, kwargs = session.sent[0]
+        assert "/deploy/klines?" in request.url
+        assert parse_qs(urlsplit(request.url).query)["interval"] == ["1m"]
+        assert request.headers["Authorization"] == "Bearer token"
+        assert kwargs["timeout"] == (5, 30)
+
+    @pytest.mark.parametrize(
+        "payload,match",
+        [
+            ({}, "rows"),
+            ({"rows": {}}, "rows"),
+            ({"rows": [1]}, "objects"),
+            ({"rows": [{"start_time": "x"}]}, "missing"),
+            (
+                {"rows": [{"start_time": "x", "open": True, "high": 1, "low": 1, "close": 1}]},
+                "finite",
+            ),
+            (
+                {"rows": [{"start_time": "x", "open": 1, "high": 1, "low": 1, "close": 1}]},
+                "ending in Z",
+            ),
+        ],
+    )
+    def test_kline_schema(self, payload, match):
+        source, _ = _source([_response(payload=payload)])
+        with pytest.raises(HttpSourceError, match=match):
+            source.fetch_klines("BTCUSDT", _T0, _T0 + timedelta(days=1))
+
+    def test_minute_order_and_window_rules(self):
+        for rows, match in [
+            ([self._kline("2026-07-01T00:00:01Z")], "whole UTC minute"),
+            ([self._kline(), self._kline()], "strictly increasing"),
+            ([self._kline("2026-07-02T00:00:00Z")], "outside"),
+        ]:
+            source, _ = _source([_response(payload={"rows": rows})])
+            with pytest.raises(HttpSourceError, match=match):
+                source.fetch_klines("BTCUSDT", _T0, _T0 + timedelta(days=1))
+
+        source, _ = _source([])
+        with pytest.raises(HttpSourceError, match="at most 24 hours"):
+            source.fetch_klines(
+                "BTCUSDT", _T0, _T0 + timedelta(days=1, minutes=1)
+            )

--- a/apps/importer/tests/test_output_db.py
+++ b/apps/importer/tests/test_output_db.py
@@ -20,6 +20,8 @@ from importer.output_db import (
     open_output_db,
     output_db_path,
     release_lock,
+    SourceFingerprintMismatchError,
+    verify_source_fingerprint,
 )
 
 _T0 = datetime(2026, 7, 1, 0, 0, 0)
@@ -47,6 +49,42 @@ class TestOutputDbPath:
             output_db_path(str(tmp_path), "BTCUSDT", "fresh").name
             == "imported_BTCUSDT_fresh.db"
         )
+
+    def test_http_paths_hash_exact_symbol_base_and_tag(self, tmp_path):
+        def path(symbol, base, tag=None):
+            return output_db_path(
+                str(tmp_path),
+                symbol,
+                tag,
+                source_kind="http",
+                canonical_base_url=base,
+            )
+
+        baseline = path("BtC", "https://example.test/api", "tag")
+        assert baseline == path("BtC", "https://example.test/api", "tag")
+        assert baseline != path("btc", "https://example.test/api", "tag")
+        assert baseline != path("BtC", "https://example.test/other", "tag")
+        assert baseline != path("BtC", "https://example.test/api", "TAG")
+        assert baseline.name.startswith("imported_http_")
+        assert all(
+            raw not in baseline.name
+            for raw in ("BtC", "example", "api", "tag")
+        )
+
+    def test_http_unicode_normalization_remains_distinct(self, tmp_path):
+        composed = output_db_path(
+            str(tmp_path),
+            "É",
+            source_kind="http",
+            canonical_base_url="https://example.test",
+        )
+        decomposed = output_db_path(
+            str(tmp_path),
+            "E\u0301",
+            source_kind="http",
+            canonical_base_url="https://example.test",
+        )
+        assert composed != decomposed
 
 
 class TestOutputDb:
@@ -95,6 +133,24 @@ class TestOutputDb:
             assert len(runs) == 1
             assert runs[0].start_ts == _T0  # unchanged on append
             assert runs[0].end_ts == _T0 + timedelta(hours=1)
+
+    def test_http_run_metadata_and_fingerprint_guard(self, tmp_path):
+        db = open_output_db(tmp_path / "out.db")
+        ensure_parents(db, "BtC")
+        insert_batch(db, [_snapshot(_T0, symbol="BtC")])
+        ensure_run_row(
+            db,
+            "BtC",
+            "http:https://example.test",
+            source_fingerprint="a" * 64,
+        )
+        verify_source_fingerprint(db, "a" * 64)
+        with pytest.raises(SourceFingerprintMismatchError, match="fresh --tag"):
+            verify_source_fingerprint(db, "b" * 64)
+        with db.get_session() as session:
+            run = RunRepository(session).get_latest_by_type("recording")
+            assert run.config_snapshot["source"] == "http:https://example.test"
+            assert run.config_snapshot["source_fingerprint"] == "a" * 64
 
     def test_parents_idempotent(self, tmp_path):
         """ensure_parents reruns session.get the same pinned rows."""

--- a/apps/importer/tests/test_resume.py
+++ b/apps/importer/tests/test_resume.py
@@ -2,11 +2,13 @@
 
 from datetime import datetime, timedelta
 
+import pytest
 from sqlalchemy import create_engine, text
 
 from grid_db.models import Run, TickerSnapshot
 
 import importer.main as importer_main
+from importer.config import preflight_http
 from importer.output_db import open_output_db, output_db_path
 
 _T0 = datetime(2026, 7, 1, 0, 0, 0)
@@ -180,15 +182,18 @@ class TestResume:
         assert str(by_ts[dup_ts]) == "101.00000000"  # first by id survived
 
     def test_http_source_requires_explicit_bounds(self, tmp_path, capsys):
-        """--source http without --start/--end fails per symbol (no probe)."""
+        """HTTP bounds fail globally before output paths are created."""
         argv = [
             "--source", "http",
             "--source-url", "http://unreachable.invalid",
             "--symbols", "BTCUSDT",
             "--out-dir", str(tmp_path / "out"),
         ]
-        assert importer_main.main(argv) == 1  # fails before any HTTP call
-        assert "pass explicit bounds" in capsys.readouterr().out
+        with pytest.raises(SystemExit) as caught:
+            importer_main.main(argv)
+        assert caught.value.code == 2
+        assert "requires both" in capsys.readouterr().err
+        assert not (tmp_path / "out").exists()
 
     def test_tagged_import_is_isolated(self, tmp_path, seed_source_db, src_row):
         """--tag writes a distinct file, leaving the default DB untouched."""
@@ -208,3 +213,201 @@ class TestResume:
             ).scalar()
         engine.dispose()
         assert count == 1
+
+
+class FakeHttpSource:
+    def __init__(self, rows, batch_size=2, failure=None):
+        self.rows = rows
+        self.batch_size = batch_size
+        self.failure = failure
+        self.close_calls = 0
+        self.fetch_calls = []
+
+    def probe_range(self, symbol):
+        return None
+
+    def fetch_batches(self, symbol, start, end):
+        self.fetch_calls.append((symbol, start, end))
+        if self.failure is not None:
+            raise self.failure
+        eligible = [
+            row
+            for row in self.rows
+            if row["symbol"] == symbol and start <= row["timestamp"] <= end
+        ]
+        for offset in range(0, len(eligible), self.batch_size):
+            yield eligible[offset : offset + self.batch_size]
+
+    def close(self):
+        self.close_calls += 1
+
+
+def _http_rows(symbol="BtC", count=5):
+    return [
+        {
+            "symbol": symbol,
+            "timestamp": _T0 + timedelta(minutes=index),
+            "last_price": 100 + index,
+            "mark_price": 100 + index,
+            "bid1_price": 99 + index,
+            "ask1_price": 101 + index,
+            "funding_rate": 0.001,
+        }
+        for index in range(count)
+    ]
+
+
+def _http_argv(out_dir, extra=None):
+    return [
+        "--source",
+        "http",
+        "--source-url",
+        "HTTPS://EXAMPLE.test:443/deploy/",
+        "--symbols",
+        "BtC",
+        "--start",
+        _T0.isoformat() + "Z",
+        "--end",
+        (_T0 + timedelta(minutes=4)).isoformat() + "Z",
+        "--batch-size",
+        "2",
+        "--out-dir",
+        str(out_dir),
+        "--tag",
+        "CaseTag",
+        *(extra or []),
+    ]
+
+
+class TestHttpMain:
+    def test_secret_source_validation_and_close_share_one_instance(
+        self, tmp_path, monkeypatch
+    ):
+        source = FakeHttpSource(_http_rows())
+        calls = {"load": 0}
+        made = {}
+        validated = {}
+
+        def load_key():
+            calls["load"] += 1
+            return "opaque-token"
+
+        def make_source(kind, url, batch_size, api_key=None):
+            made.update(
+                kind=kind, url=url, batch_size=batch_size, api_key=api_key
+            )
+            return source
+
+        def validate(*args, http_source=None, **kwargs):
+            validated["source"] = http_source
+            return True
+
+        monkeypatch.setattr(importer_main, "load_market_data_api_key", load_key)
+        monkeypatch.setattr(importer_main, "make_source", make_source)
+        monkeypatch.setattr(importer_main, "run_validation", validate)
+        assert importer_main.main(_http_argv(tmp_path, ["--validate"])) == 0
+        assert calls["load"] == 1
+        assert made == {
+            "kind": "http",
+            "url": "https://example.test/deploy",
+            "batch_size": 2,
+            "api_key": "opaque-token",
+        }
+        assert validated["source"] is source
+        assert source.close_calls == 1
+
+        identity = preflight_http("https://example.test/deploy")
+        path = output_db_path(
+            str(tmp_path),
+            "BtC",
+            "CaseTag",
+            source_kind="http",
+            canonical_base_url=identity.canonical_base_url,
+        )
+        db = open_output_db(path)
+        with db.get_session() as session:
+            run = session.query(Run).filter(Run.run_type == "recording").one()
+            snapshot = run.config_snapshot
+            assert snapshot["source"] == "http:https://example.test"
+            assert snapshot["source_fingerprint"] == identity.source_fingerprint
+            rendered = str(snapshot)
+            assert "opaque-token" not in rendered
+            assert "/deploy" not in rendered
+
+    @pytest.mark.parametrize(
+        "failure,expected_exception",
+        [(RuntimeError("boom"), None), (KeyboardInterrupt(), KeyboardInterrupt)],
+    )
+    def test_session_closed_on_symbol_failure_and_interruption(
+        self, tmp_path, monkeypatch, failure, expected_exception
+    ):
+        source = FakeHttpSource([], failure=failure)
+        monkeypatch.setattr(importer_main, "make_source", lambda *a, **k: source)
+        monkeypatch.setattr(
+            importer_main, "load_market_data_api_key", lambda: None
+        )
+        if expected_exception is None:
+            assert importer_main.main(_http_argv(tmp_path)) == 1
+        else:
+            with pytest.raises(expected_exception):
+                importer_main.main(_http_argv(tmp_path))
+        assert source.close_calls == 1
+
+    def test_http_crash_resume_reuses_path_and_heals_metadata(
+        self, tmp_path, monkeypatch
+    ):
+        rows = _http_rows()
+        sources = []
+
+        def factory(kind, url, batch_size, api_key=None):
+            source = FakeHttpSource(rows, batch_size=batch_size)
+            sources.append(source)
+            return source
+
+        monkeypatch.setattr(importer_main, "make_source", factory)
+        monkeypatch.setattr(
+            importer_main, "load_market_data_api_key", lambda: None
+        )
+        real_insert = importer_main.insert_batch
+        insert_calls = {"count": 0}
+
+        def crash_after_first_commit(db, snapshots):
+            insert_calls["count"] += 1
+            if insert_calls["count"] == 2:
+                raise RuntimeError("crash before run metadata")
+            return real_insert(db, snapshots)
+
+        monkeypatch.setattr(importer_main, "insert_batch", crash_after_first_commit)
+        assert importer_main.main(_http_argv(tmp_path)) == 1
+        monkeypatch.setattr(importer_main, "insert_batch", real_insert)
+
+        identity = preflight_http("https://example.test/deploy")
+        path = output_db_path(
+            str(tmp_path),
+            "BtC",
+            "CaseTag",
+            source_kind="http",
+            canonical_base_url=identity.canonical_base_url,
+        )
+        db = open_output_db(path)
+        with db.get_session() as session:
+            assert session.query(TickerSnapshot).count() == 2
+            assert session.query(Run).count() == 0
+
+        assert importer_main.main(_http_argv(tmp_path)) == 0
+        with db.get_session() as session:
+            ticks = (
+                session.query(TickerSnapshot)
+                .filter(TickerSnapshot.symbol == "BtC")
+                .order_by(TickerSnapshot.exchange_ts)
+                .all()
+            )
+            run = session.query(Run).filter(Run.run_type == "recording").one()
+            assert len(ticks) == 5
+            assert len({tick.exchange_ts for tick in ticks}) == 5
+            assert (
+                run.config_snapshot["source_fingerprint"]
+                == identity.source_fingerprint
+            )
+        assert sources[1].fetch_calls[0][1] == _T0 + timedelta(minutes=1)
+        assert [source.close_calls for source in sources] == [1, 1]

--- a/apps/importer/tests/test_validate_ohlc.py
+++ b/apps/importer/tests/test_validate_ohlc.py
@@ -296,9 +296,10 @@ class TestSmokeReplayMocked:
     def _fake_run(captured, returncode=0, stdout="Net PnL:    1.23"):
         import yaml
 
-        def fake_run(cmd, capture_output, text, env):
+        def fake_run(cmd, capture_output, text, env, timeout=None):
             captured["cmd"] = cmd
             captured["env"] = env
+            captured["timeout"] = timeout
             with open(cmd[-1]) as f:
                 captured["config"] = yaml.safe_load(f)
             return SimpleNamespace(
@@ -327,6 +328,7 @@ class TestSmokeReplayMocked:
         assert config["start_ts"] == (_T0 + timedelta(hours=2)).isoformat()
         assert config["end_ts"] == (_T0 + timedelta(hours=6)).isoformat()
         assert captured["cmd"][1:3] == ["-m", "replay.main"]
+        assert captured["timeout"] == 300
 
     def test_market_api_key_removed_only_from_child_env(
         self, tmp_path, monkeypatch

--- a/apps/importer/tests/test_validate_ohlc.py
+++ b/apps/importer/tests/test_validate_ohlc.py
@@ -231,6 +231,56 @@ class TestCheckOhlc:
             db, "BTCUSDT", "db", f"sqlite:///{source}", bounds, 0.99
         )
 
+    def test_http_uses_active_source_and_exact_24_hour_window(self, tmp_path):
+        ticks = _ticks_two_minutes()
+        db, _ = _seed_output_ticks(tmp_path, ticks)
+        buckets = rebuild_ohlc(ticks)
+
+        class FakeHttpSource:
+            def __init__(self):
+                self.call = None
+
+            def fetch_klines(self, symbol, start, end):
+                self.call = (symbol, start, end)
+                return [
+                    {
+                        "start_time": datetime.fromtimestamp(
+                            key * 60, tz=timezone.utc
+                        ).replace(tzinfo=None),
+                        "open": float(bucket.open),
+                        "high": float(bucket.high),
+                        "low": float(bucket.low),
+                        "close": float(bucket.close),
+                    }
+                    for key, bucket in buckets.items()
+                ]
+
+        source = FakeHttpSource()
+        assert check_ohlc(
+            db,
+            "BTCUSDT",
+            "http",
+            "must-not-be-used",
+            (ticks[0][0], ticks[-1][0]),
+            0.99,
+            http_source=source,
+        )
+        _, start, end = source.call
+        assert start == datetime(2026, 7, 1)
+        assert end == datetime(2026, 7, 2)
+
+    def test_http_without_active_source_fails_closed(self, tmp_path):
+        ticks = _ticks_two_minutes()
+        db, _ = _seed_output_ticks(tmp_path, ticks)
+        assert not check_ohlc(
+            db,
+            "BTCUSDT",
+            "http",
+            "https://example.test",
+            (ticks[0][0], ticks[-1][0]),
+            0.99,
+        )
+
 
 class TestSmokeReplayGuards:
     def test_unknown_symbol_fails_without_subprocess(self, tmp_path):
@@ -246,8 +296,9 @@ class TestSmokeReplayMocked:
     def _fake_run(captured, returncode=0, stdout="Net PnL:    1.23"):
         import yaml
 
-        def fake_run(cmd, capture_output, text):
+        def fake_run(cmd, capture_output, text, env):
             captured["cmd"] = cmd
+            captured["env"] = env
             with open(cmd[-1]) as f:
                 captured["config"] = yaml.safe_load(f)
             return SimpleNamespace(
@@ -276,6 +327,21 @@ class TestSmokeReplayMocked:
         assert config["start_ts"] == (_T0 + timedelta(hours=2)).isoformat()
         assert config["end_ts"] == (_T0 + timedelta(hours=6)).isoformat()
         assert captured["cmd"][1:3] == ["-m", "replay.main"]
+
+    def test_market_api_key_removed_only_from_child_env(
+        self, tmp_path, monkeypatch
+    ):
+        captured = {}
+        monkeypatch.setenv("MARKET_DATA_API_KEY", "secret")
+        monkeypatch.setenv("IMPORTER_TEST_KEEP", "yes")
+        monkeypatch.setattr(
+            "importer.validate.subprocess.run", self._fake_run(captured)
+        )
+        bounds = (_T0, _T0 + timedelta(hours=6))
+        assert smoke_replay(tmp_path / "x.db", "BTCUSDT", bounds)
+        assert "MARKET_DATA_API_KEY" not in captured["env"]
+        assert captured["env"]["IMPORTER_TEST_KEEP"] == "yes"
+        assert __import__("os").environ["MARKET_DATA_API_KEY"] == "secret"
 
     def test_nan_metric_fails(self, tmp_path, monkeypatch):
         """A NaN in the replay summary fails the smoke check."""

--- a/docs/CLIENT.md
+++ b/docs/CLIENT.md
@@ -1,0 +1,567 @@
+# Bybit Market Data Read API — client protocol
+
+Protocol document version: **1.0**
+
+Last updated: **2026-07-26**
+
+Read-only HTTP API over collected Bybit linear ticker snapshots. The intended
+production consumer is another backend service.
+
+- **Production base URL:** provided separately by the API operator; use
+  `https://<API_HOST>`.
+- **Documented API responses:** successful and handled-error responses use
+  `Content-Type: application/json`.
+- **Request header:** `Accept: application/json`.
+- All endpoints are `GET` and do not accept a request body.
+
+Production clients MUST use HTTPS. Plain HTTP is acceptable only on localhost
+or inside a trusted private network/tunnel.
+
+Protocol version `1.0` is the compatibility boundary for the currently
+unversioned paths. While a `1.0` consumer remains active, the operator MUST NOT
+deploy a breaking change without first publishing a new protocol version and
+coordinating the consumer's migration.
+
+Compatible changes include adding an endpoint, adding an optional request
+parameter, or adding a response field. Breaking changes include removing or
+renaming a field or endpoint; changing a field's type, nullability, meaning, or
+required status; changing ordering, time-bound, pagination, authentication, or
+error-status semantics. Clients MUST ignore unknown response fields so
+compatible fields can be added.
+
+---
+
+## Authentication
+
+When production authentication is enabled, every endpoint except `/health`
+requires:
+
+```http
+Authorization: Bearer <API_KEY>
+```
+
+The API operator provides the key separately through a secure channel. Do not
+commit it to source control or include it in URLs, logs, exception messages, or
+support screenshots.
+
+This shared-secret scheme is intended for server-to-server use. A key embedded
+in browser, desktop, or mobile code cannot be kept secret; such clients require
+a separate user-facing authentication design.
+
+Wrong, missing, or malformed credentials return:
+
+```http
+HTTP/1.1 401 Unauthorized
+Content-Type: application/json
+```
+
+```json
+{"detail":"Invalid or missing API key"}
+```
+
+The Bearer scheme is case-insensitive. When authentication is enabled,
+interactive documentation (`/docs`, `/redoc`, `/openapi.json`) is disabled.
+
+An operator may disable authentication for local development or a protected
+private network. Clients must not assume that production endpoints are open.
+
+---
+
+## Timestamps and URL encoding
+
+- Clients SHOULD send query timestamps in UTC with a trailing `Z`, for example
+  `2026-07-20T10:15:00Z`.
+- The server also accepts ISO-8601 timestamps with an explicit offset and
+  converts them to UTC. Naive timestamps are accepted for compatibility and are
+  treated as UTC, but clients should avoid them.
+- Response timestamps are UTC ISO-8601 strings with a trailing `Z`.
+  Microseconds are preserved when present:
+  `2026-07-20T10:15:00.123456Z`.
+- All documented time bounds are inclusive.
+
+Always construct query strings with the HTTP library's query-parameter encoder.
+Do not concatenate raw values. This is particularly important for:
+
+- offsets such as `+05:00`, where `+` must be encoded as `%2B`;
+- opaque cursors, which may contain `=` or other characters that require
+  encoding.
+
+`timestamp` is the collector's observation time, not Bybit's exchange-event
+timestamp. `created_at` is the database insertion time and can be later because
+the collector writes rows in batches.
+
+---
+
+## Common conventions
+
+- Symbols are matched exactly. Use a value returned by `/symbols`; do not add
+  whitespace or change its case.
+- Empty collections return `200` with an empty collection field (`symbols`,
+  `items`, or `rows`), not `404`.
+- Numeric fields in `TickerRow` and bulk-export rows are JSON numbers backed by
+  floating-point storage and may be `null`. They must not be used as exact
+  decimal accounting values. Returned kline OHLC fields are non-null.
+- `funding_rate` is a fraction, not a displayed percentage:
+  `0.0001` means `0.01%`.
+- Price, quantity, open-interest, volume, and turnover values retain the units
+  supplied by Bybit for the instrument. `volume_24h` is rolling traded quantity;
+  `turnover_24h` is rolling traded value. Consumers that convert units should
+  use instrument metadata rather than infer units from the JSON field name.
+- Clients SHOULD ignore unknown response fields for forward compatibility, but
+  must not assume that a documented required field will always be non-null when
+  its type explicitly permits `null`.
+
+The market fields originate from Bybit's linear ticker stream. See the
+[Bybit ticker field definitions](https://bybit-exchange.github.io/docs/v5/websocket/public/ticker).
+
+### Data availability and freshness
+
+- This API exposes observations that the collector successfully stored. It does
+  not guarantee complete coverage of every Bybit update or every time interval.
+  Missing rows or candles must not be interpreted as zero trading activity.
+- The collector stores change-gated ticker observations. The age of the newest
+  `timestamp` is a useful freshness signal, but by itself is not proof that the
+  collector is healthy or unhealthy.
+- Protocol `1.0` does not define a freshness SLA or minimum history-retention
+  period. A production consumer that needs either guarantee must obtain the
+  agreed threshold or retention window from the operator as deployment
+  configuration.
+- `/health` proves only that the HTTP process is alive. Until a separate
+  readiness/freshness endpoint is provided, clients should monitor successful
+  data queries and apply their configured maximum observation age.
+- Historical rows can be removed by operator maintenance or a configured
+  retention job. Clients must not rely on indefinite server-side history.
+
+---
+
+## Endpoints
+
+| Method and path | Authentication | Purpose | Order / pagination |
+|---|---|---|---|
+| `GET /health` | no | HTTP process liveness | — |
+| `GET /symbols` | yes | Symbols with stored rows | ascending symbols |
+| `GET /ticker/{symbol}/latest` | yes | Newest timestamped row | one row |
+| `GET /ticker/{symbol}/history` | yes | Recent rows | descending, limited |
+| `GET /ticker_data` | yes | Paginated range export | ascending, cursor |
+| `GET /klines` | yes | Derived 1-minute OHLC | ascending minutes |
+
+“yes” means authentication is required when production authentication is
+enabled as described above.
+
+### `GET /health` — no authentication
+
+Process liveness check:
+
+```json
+{"status":"ok"}
+```
+
+This endpoint does not query the database and is not a database-readiness or
+data-freshness check. Do not send the API key to `/health`.
+
+---
+
+### `GET /symbols`
+
+Returns the distinct symbols for which stored data exists, sorted ascending:
+
+```json
+{"symbols":["BTCUSDT","ETHUSDT","LTCUSDT","SOLUSDT"]}
+```
+
+When no symbols are available:
+
+```json
+{"symbols":[]}
+```
+
+Presence in this list does not guarantee that `/latest` can return a row:
+legacy rows for a symbol may all have unusable `null` timestamps.
+
+---
+
+### `TickerRow`
+
+`/ticker/{symbol}/latest` and `/ticker/{symbol}/history` return this row shape.
+
+| Field | JSON type | Nullable | Meaning |
+|---|---|---:|---|
+| `id` | integer | no | Row identifier; stable while the row remains in the current database |
+| `timestamp` | string (date-time) | no | Collector observation time in UTC |
+| `symbol` | string | no | Exact Bybit instrument symbol |
+| `last_price` | number | yes | Latest traded price reported by the ticker |
+| `mark_price` | number | yes | Mark price |
+| `index_price` | number | yes | Index price |
+| `bid1_price` | number | yes | Best bid price |
+| `bid1_size` | number | yes | Quantity available at the best bid |
+| `ask1_price` | number | yes | Best ask price |
+| `ask1_size` | number | yes | Quantity available at the best ask |
+| `funding_rate` | number | yes | Funding rate as a fraction |
+| `open_interest` | number | yes | Bybit open-interest size, both sides |
+| `volume_24h` | number | yes | Rolling 24-hour traded quantity |
+| `turnover_24h` | number | yes | Rolling 24-hour traded value |
+| `created_at` | string (date-time) | yes | Database insertion time in UTC |
+
+Example:
+
+```json
+{
+  "id": 42,
+  "timestamp": "2026-07-20T10:15:00.123456Z",
+  "symbol": "BTCUSDT",
+  "last_price": 118000.5,
+  "mark_price": 118001.0,
+  "index_price": 117999.0,
+  "bid1_price": 118000.0,
+  "bid1_size": 1.2,
+  "ask1_price": 118000.5,
+  "ask1_size": 0.8,
+  "funding_rate": 0.0001,
+  "open_interest": 12345.0,
+  "volume_24h": 1200000000.0,
+  "turnover_24h": 98000000000.0,
+  "created_at": "2026-07-20T10:15:00.200000Z"
+}
+```
+
+Treat `id` as opaque. It is useful only as a deterministic tie-breaker within
+the current database; it is not a global identifier and may change after data
+reimport, migration, or restore.
+
+---
+
+### `GET /ticker/{symbol}/latest`
+
+Returns the newest row with a non-null `timestamp` for the exact symbol, ordered
+by `timestamp DESC, id DESC`. Market fields, including `last_price`, can still
+be `null`.
+
+If no row with a usable timestamp exists:
+
+```http
+HTTP/1.1 404 Not Found
+Content-Type: application/json
+```
+
+```json
+{"detail":"Ticker data not found for symbol NOPEUSDT"}
+```
+
+---
+
+### `GET /ticker/{symbol}/history`
+
+Returns recent rows, newest first (`timestamp DESC, id DESC`).
+
+| Query parameter | Type | Default | Rules |
+|---|---|---:|---|
+| `limit` | integer | `100` | `1…1000` |
+| `from` | date-time | — | Optional inclusive lower bound |
+| `to` | date-time | — | Optional inclusive upper bound |
+
+Example:
+
+```json
+{
+  "symbol": "BTCUSDT",
+  "count": 1,
+  "items": [
+    {
+      "id": 42,
+      "timestamp": "2026-07-20T10:15:00.123456Z",
+      "symbol": "BTCUSDT",
+      "last_price": 118000.5,
+      "mark_price": 118001.0,
+      "index_price": 117999.0,
+      "bid1_price": 118000.0,
+      "bid1_size": 1.2,
+      "ask1_price": 118000.5,
+      "ask1_size": 0.8,
+      "funding_rate": 0.0001,
+      "open_interest": 12345.0,
+      "volume_24h": 1200000000.0,
+      "turnover_24h": 98000000000.0,
+      "created_at": "2026-07-20T10:15:00.200000Z"
+    }
+  ]
+}
+```
+
+`count` is the number of elements in this response's `items`, not the total
+number of matching database rows.
+
+- Unknown symbol: `200` with `count: 0` and `items: []`.
+- `from > to`: `422`.
+- This endpoint has no cursor or offset pagination. It returns at most the
+  newest `limit` matching rows. Use `/ticker_data` for a complete range export.
+
+---
+
+### `GET /ticker_data` — paginated bulk export
+
+| Query parameter | Type | Required | Rules |
+|---|---|---:|---|
+| `symbol` | string | yes | Exact value returned by `/symbols` |
+| `start` | date-time | yes | Inclusive |
+| `end` | date-time | yes | Inclusive; `start <= end` |
+| `limit` | integer | no | Default `10000`; range `1…10000` |
+| `cursor` | string | no | Opaque `next_cursor` from the preceding page |
+
+Rows are returned in stable ascending order:
+`timestamp ASC, id ASC`.
+
+Each bulk row contains:
+
+| Field | JSON type | Nullable |
+|---|---|---:|
+| `symbol` | string | yes |
+| `timestamp` | string (date-time) | yes |
+| `last_price` | number | yes |
+| `mark_price` | number | yes |
+| `bid1_price` | number | yes |
+| `ask1_price` | number | yes |
+| `funding_rate` | number | yes |
+
+The schema is deliberately nullable so one legacy or damaged row does not make
+an entire export fail. Under normal operation, returned rows have non-null
+`symbol`, `timestamp`, and `last_price`; clients must still define their own
+handling for unexpected null market values.
+
+Example response for a page that has more rows:
+
+```json
+{
+  "rows": [
+    {
+      "symbol": "BTCUSDT",
+      "timestamp": "2026-07-20T10:00:00Z",
+      "last_price": 118000.5,
+      "mark_price": 118001.0,
+      "bid1_price": 118000.0,
+      "ask1_price": 118000.5,
+      "funding_rate": 0.0001
+    }
+  ],
+  "next_cursor": "<opaque-cursor>"
+}
+```
+
+An empty or exhausted range returns:
+
+```json
+{"rows":[],"next_cursor":null}
+```
+
+#### Pagination protocol
+
+1. Make the first request without `cursor`.
+2. Process `rows` in the returned order.
+3. If `next_cursor` is not `null`, repeat the request with exactly the same
+   `symbol`, `start`, `end`, and `limit`, passing `cursor=next_cursor`.
+4. Stop when `next_cursor` is `null`.
+5. Treat the cursor as opaque. Store and replay it verbatim; never decode,
+   modify, or construct one.
+6. Pass the cursor through the HTTP library's query-parameter encoder.
+7. Persist a complete page and its `next_cursor` atomically when possible. Do
+   not advance the checkpoint after processing only part of a page.
+
+A cursor rejected by the server normally returns:
+
+```http
+HTTP/1.1 422 Unprocessable Entity
+```
+
+```json
+{"detail":"invalid cursor"}
+```
+
+A cursor is valid only for the active export walk and the original `symbol`,
+`start`, `end`, and `limit`. Do not use it as a durable checkpoint for a later
+export or replay it with different parameters.
+
+Pagination is keyset-based but does not create a database snapshot. Rows added
+or removed while an export is in progress can affect later pages. For a
+repeatable historical export, choose an `end` time that is no longer being
+written and avoid running retention cleanup during the walk.
+
+Consequently, retrying the same cursor is safe with respect to server state but
+is not guaranteed to return a byte-for-byte identical page while data is being
+inserted or removed. A row inserted late behind the current cursor can be
+missed. Clients should consume only fully decoded response bodies and make page
+storage idempotent or transactional. If page storage and cursor advancement
+cannot be atomic, processing has at-least-once delivery semantics and may need
+client-specific duplicate handling.
+
+---
+
+### `GET /klines` — derived 1-minute OHLC
+
+| Query parameter | Type | Required | Rules |
+|---|---|---:|---|
+| `symbol` | string | yes | Exact value returned by `/symbols` |
+| `start` | date-time | yes | Inclusive |
+| `end` | date-time | yes | Inclusive; `start <= end` |
+| `interval` | string | no | Only `"1m"`; default `"1m"` |
+
+Rows are ordered by `start_time ASC`.
+
+```json
+{
+  "rows": [
+    {
+      "start_time": "2026-07-20T10:00:00Z",
+      "open": 100.0,
+      "high": 105.0,
+      "low": 99.0,
+      "close": 103.0
+    }
+  ]
+}
+```
+
+All five fields in a returned kline row are non-null.
+
+#### Semantics and limitations
+
+- Candles are calculated from collected `last_price` ticker updates grouped
+  into whole UTC minutes. They are not built from trades or Bybit's kline feed.
+- Every returned `start_time` is the exact start of a whole UTC minute
+  (`second=0`, no fractional seconds). Each minute appears at most once, so the
+  documented ascending order is strict. Missing minutes remain valid gaps.
+- OHLC values are a best-effort approximation and will not exactly match
+  Bybit's official 1-minute trade candles.
+- The collector stores change-gated ticker observations. A returned candle
+  means at least one usable observation existed in that minute; it does not
+  prove continuous market-data coverage for the whole minute.
+- A minute `m` is emitted only when its entire `[m, m+1 minute)` window lies
+  inside the requested `[start, end]` range. Partially covered edge minutes are
+  omitted. Clients should use minute-aligned bounds.
+- Minutes without a non-null `last_price` observation are omitted. The API does
+  not create empty candles or forward-fill gaps.
+- Unknown symbols and ranges with no complete usable minutes return
+  `200 {"rows":[]}`.
+- The maximum request window is currently `1440` minutes (24 hours). A larger
+  window returns `422 {"detail":"range too large"}`. Split longer ranges into
+  minute-aligned requests of at most 24 hours.
+
+---
+
+## Errors
+
+| Status | Meaning | Client action |
+|---:|---|---|
+| `401` | Missing or invalid Bearer token | Do not retry unchanged credentials |
+| `404` | No latest row, or unknown route | Treat as terminal for that request |
+| `405` | HTTP method is not supported | Correct the client request |
+| `422` | Missing/invalid query, bounds, limit, interval, range, or cursor | Correct the request; do not retry unchanged |
+| `429` | Infrastructure rate limit, if configured | Honor `Retry-After`, then retry with backoff |
+| `500–599` | Server or infrastructure failure | Retry with bounded exponential backoff and jitter |
+
+Handled application errors use a string `detail`:
+
+```json
+{"detail":"start must be <= end"}
+```
+
+Framework-level validation errors use an array:
+
+```json
+{
+  "detail": [
+    {
+      "type": "missing",
+      "loc": ["query", "symbol"],
+      "msg": "Field required",
+      "input": null
+    }
+  ]
+}
+```
+
+Clients must support both forms. Responses generated by a reverse proxy or
+other infrastructure are not guaranteed to have a JSON body, including `429`,
+`502`, `503`, and `504`. Error handling must therefore check status and
+`Content-Type` before attempting to parse JSON.
+
+Authentication is evaluated independently of endpoint validation. A protected
+malformed request without valid credentials can return `401` before any query
+error is reported.
+
+---
+
+## Timeouts, retries, and concurrency
+
+- Set explicit connection and response timeouts; do not rely on an HTTP
+  library's unlimited default.
+- Retry connection failures, `429`, and `5xx` using bounded exponential backoff
+  with jitter.
+- Do not automatically retry `401`, `404`, or `422` without changing the
+  request.
+- Reuse the same bulk cursor and all original query parameters when retrying a
+  page.
+- GET requests do not mutate server state, but live market responses can change
+  between attempts.
+- No application-level rate limit is currently advertised. Clients should still
+  avoid unbounded parallel requests because bulk and kline queries read the
+  shared market database.
+
+Browser cross-origin access is not part of this contract. A browser client
+requires an explicitly configured CORS policy and must not contain the shared
+API key.
+
+---
+
+## Minimal Bash examples
+
+Replace the example host with the value supplied by the API operator and enter
+the supplied key at the prompt. Quoting is required; literal `<...>`
+placeholders are not valid shell values.
+
+```bash
+BASE='https://market-api.example.com'
+# Read without echoing the key or storing it in shell history.
+IFS= read -rsp 'API key: ' KEY
+printf '\n'
+
+# Liveness is public; do not send the key.
+curl --fail-with-body --silent --show-error \
+  -H 'Accept: application/json' \
+  "$BASE/health"
+
+curl --fail-with-body --silent --show-error \
+  -H 'Accept: application/json' \
+  -H "Authorization: Bearer $KEY" \
+  "$BASE/symbols"
+
+curl --fail-with-body --silent --show-error \
+  -H 'Accept: application/json' \
+  -H "Authorization: Bearer $KEY" \
+  "$BASE/ticker/BTCUSDT/latest"
+
+curl --fail-with-body --silent --show-error --get \
+  -H 'Accept: application/json' \
+  -H "Authorization: Bearer $KEY" \
+  --data-urlencode 'limit=100' \
+  --data-urlencode 'from=2026-07-20T10:00:00Z' \
+  --data-urlencode 'to=2026-07-20T11:00:00Z' \
+  "$BASE/ticker/BTCUSDT/history"
+
+# Bulk first page. Repeat with cursor=<next_cursor> until it is null.
+curl --fail-with-body --silent --show-error --get \
+  -H 'Accept: application/json' \
+  -H "Authorization: Bearer $KEY" \
+  --data-urlencode 'symbol=BTCUSDT' \
+  --data-urlencode 'start=2026-07-20T10:00:00Z' \
+  --data-urlencode 'end=2026-07-20T11:00:00Z' \
+  --data-urlencode 'limit=10000' \
+  "$BASE/ticker_data"
+
+curl --fail-with-body --silent --show-error --get \
+  -H 'Accept: application/json' \
+  -H "Authorization: Bearer $KEY" \
+  --data-urlencode 'symbol=BTCUSDT' \
+  --data-urlencode 'start=2026-07-20T10:00:00Z' \
+  --data-urlencode 'end=2026-07-20T11:00:00Z' \
+  --data-urlencode 'interval=1m' \
+  "$BASE/klines"
+```

--- a/docs/features/0098_PLAN.md
+++ b/docs/features/0098_PLAN.md
@@ -1,0 +1,514 @@
+# Feature 0098 — remote market-data API client protocol 1.0
+
+## Context
+
+The request is to “реализовать app которая будет читать из удаленной базы
+данных” according to `docs/CLIENT.md`.
+
+The repository already has the appropriate app: `apps/importer` reads a remote
+market-data source and converts ticker rows into replay-compatible per-symbol
+SQLite databases. Its HTTP transport already walks `/ticker_data`, but it was
+implemented against the earlier Feature 0093 draft contract. It currently has
+no Bearer authentication, does not share its retry policy with `/klines`, and
+does not fully enforce the published protocol 1.0 response and nullability
+rules.
+
+Extend `apps/importer` rather than create a duplicate app. Keep `DbSource` and
+the observable `--source db` behavior unchanged: DB symbols retain the legacy
+uppercasing and DB batch sizes remain any positive integer. Protocol-only
+constraints are applied only to `--source http`. For an HTTP source, the import
+continues to use `GET /ticker_data`; `GET /klines` is used only by the existing
+`--validate` OHLC check. `/health`, `/symbols`,
+`/ticker/{symbol}/latest`, and `/ticker/{symbol}/history` are not needed by this
+workflow.
+
+## Acceptance criteria
+
+- Existing DB imports keep their current parsing, probe, pagination, resume,
+  validation, and side-effect behavior.
+- Protocol 1.0 HTTP outputs are deterministically namespaced by the exact symbol
+  and normalized full API base URL, so two case/Unicode-distinct symbols or two
+  deployments on one origin cannot share an output DB.
+- Invalid HTTP CLI arguments fail before reading the secret; an invalid secret
+  then fails before source construction, output path/lock/DB side effects, or
+  network I/O.
+- The API key is read once, is sent only as a Bearer request header, never leaks
+  through inherited `requests` authentication, redirects, persisted source
+  metadata, errors, tracebacks, or logs, and the owned session is always closed.
+- `/ticker_data` accepts exactly the protocol 1.0 nullable schema, commits only
+  completely decoded pages whose usable rows remain inside the requested
+  inclusive range, makes only valid forward progress, and preserves the
+  existing per-batch transactional resume behavior.
+- HTTP OHLC validation uses the same authenticated transport and enforces the
+  protocol's schema, ordering, minute, and 24-hour window rules before values
+  reach `validate.py`.
+- Importer tests, workspace lint/tests, documentation, task tracking, and the
+  path-scoped importer rules all pass or are updated in the same change.
+
+## Files and changes
+
+### `apps/importer/src/importer/config.py`
+
+- Add one secret loader for `MARKET_DATA_API_KEY`. After parsing and completing
+  the source-aware CLI preflight, `main()` calls it exactly once for HTTP and
+  does not inspect it for DB. Do not add a CLI argument for the secret:
+  command-line values are visible in process lists and shell history. Treat an
+  unset or empty value as “authentication disabled”; preserve a non-empty key
+  exactly because it is opaque. Before source construction, verify without I/O
+  that `Bearer <key>` is a valid single HTTP header value: reject CR/LF, other
+  control characters, leading/trailing whitespace, non-encodable values, and
+  anything outside the RFC Bearer `token68` syntax. Prepare a representative
+  authenticated `requests.Request` locally as a second guard. Report a clean
+  configuration error that never echoes the key or emits a traceback. A
+  protected deployment without a key will fail with the server's terminal
+  `401`.
+- Make comma parsing return each trimmed `--symbols` value without changing its
+  case. After `--source` is known, preserve those values exactly for HTTP
+  protocol 1.0, but uppercase them for DB imports to preserve Feature 0093
+  behavior.
+- Keep the parser's existing positive-integer check for `--batch-size`. Add a
+  source-aware preflight that restricts HTTP batch sizes to `1..10000` while
+  leaving DB batch sizes unchanged.
+- Run one global HTTP preflight before loading the secret, constructing the
+  source, acquiring an import lock, creating an output directory/DB, or making a
+  remote request. It requires both `--start` and `--end`, rejects `start > end`,
+  and enforces `1..10000` for `--batch-size`. Parse `--source-url` as an
+  absolute URL: require an `http` or `https` scheme and a host, allow an
+  optional base path, and reject userinfo, query, and fragment components.
+  Credentials belong only in `MARKET_DATA_API_KEY`; query/fragment components
+  would also make endpoint joining ambiguous. Reject surrounding whitespace,
+  ASCII control characters, malformed IPv6/IDNA hosts, and invalid or
+  out-of-range ports; force local `requests` preparation of a representative
+  endpoint URL during preflight so every URL-shape failure is found before the
+  secret is read, without making a request. Normalize only the trailing base
+  slash needed for deterministic endpoint construction; retain an optional
+  base path.
+- Define one canonical base used by both requests and hashing. After structural
+  validation, locally prepare the unauthenticated base URL with `requests` and
+  take the resulting `PreparedRequest.url` as the authority: this captures the
+  library's actual scheme/IDNA-host, dot-segment, Unicode, and percent-encoding
+  normalization without network I/O. Because `requests` preserves an explicitly
+  written default port, remove `:80` for HTTP and `:443` for HTTPS from the
+  prepared authority, then prepare that result once more and require it to be
+  stable. Remove only its final deployment trailing slash, then append endpoint
+  path segments. Hash exactly that final canonical base and also use it for the
+  real requests; never hash a spelling that the eventual request will rewrite.
+- Because the exact HTTP symbol enters log and generated-config context, reject
+  NUL and other ASCII control characters in the same preflight. Do not otherwise
+  canonicalize, uppercase, or restrict protocol symbols. The raw symbol is not
+  used in the HTTP output filename.
+- Return/derive a non-secret HTTP provenance label from the validated origin
+  only, in the form `http:<scheme>://<host>[:port]`. It excludes userinfo,
+  base path, endpoint, query parameters, and the key. Separately compute a full
+  SHA-256 source fingerprint over the canonical normalized base URL, including
+  its base path but excluding userinfo/query/fragment/key. This fingerprint is
+  the stable non-secret source identity used for output names and metadata.
+  Configuration errors are routed through `ArgumentParser.error()` with
+  messages that describe the invalid field but never echo a rejected URL,
+  unsafe symbol, or key, producing the standard exit code `2` without a
+  traceback. DB imports and bounds that require a DB probe keep the existing
+  per-symbol validation and side-effect order.
+
+### `apps/importer/src/importer/source.py`
+
+- Extend `make_source()` with the optional API key and pass it only to
+  `HttpSource`; `DbSource` remains read-only and credentialed through its
+  SQLAlchemy URL as before. The factory must not retain or describe the key.
+- Update `SourceTransport` documentation to match the published bulk-row
+  contract: HTTP rows do not require an `id`, the market fields are nullable,
+  and unknown response fields are ignored.
+- Define a narrow `HttpKlineSource` protocol with `fetch_klines()` for
+  validation typing. Do not add `/klines` to `SourceTransport`, because
+  `DbSource` validates against its existing SQL path.
+- Make that narrow contract explicit:
+  `fetch_klines(symbol, start, end) -> list[dict]`. Returned rows have already
+  passed HTTP/schema/window/order validation, and `start_time` is normalized to
+  naive UTC; the four numeric JSON values remain `int | float` so
+  `validate.py` remains the single place that converts them through
+  `Decimal(str(value))`. Do not reference `validate.OhlcBucket` from
+  `source.py`, which would create a transport/validation dependency cycle.
+- Do not add session lifecycle methods to `SourceTransport` or `DbSource`.
+  `HttpSource.close()` is an HTTP-only operation; it closes its session exactly
+  once only when the instance created that session, and is a no-op for an
+  injected session. `main.py` calls it through the concrete HTTP instance in
+  its outer `finally`.
+
+### `apps/importer/src/importer/fetch_source_http.py`
+
+- Make `HttpSource` reuse one `requests.Session`, but do not mutate an externally
+  injected session's persistent headers or auth state. Build explicit
+  request-level headers for every call: `Accept: application/json` plus exactly
+  one `Authorization: Bearer <key>` when `MARKET_DATA_API_KEY` is present; in
+  the no-key case pass request-level `Authorization: None` (the `requests`
+  header-removal mechanism) so an inherited session header is absent from the
+  prepared request. Headers
+  alone are insufficient: `session.auth` or netrc credentials can add or
+  overwrite `Authorization` during request preparation. Every request therefore
+  also uses an explicit truthy no-op request-level `AuthBase` (or an equivalently
+  tested mechanism) that suppresses both inherited `session.auth` and netrc
+  authentication while leaving the explicit Bearer header intact. Never put the
+  key in query parameters, exception text, source descriptions, or logs.
+  Centralize secret redaction for every upstream-controlled string (HTTP
+  `detail`/body and request exception) before it reaches an exception or log,
+  and limit logged error bodies to 1024 characters after redaction. Prefer
+  classifying request failures by exception type and endpoint rather than
+  carrying raw exception/request/response objects. When wrapping an upstream
+  exception, do not attach the raw exception as an explicit cause or custom
+  exception attribute; use suppressed chaining (`raise ... from None`) or raise
+  the sanitized error outside the handler so `main()`'s `exc_info=True`
+  traceback cannot reveal the key. Disable redirects so an authenticated request
+  is never forwarded outside the exact protocol request; any `3xx` is terminal.
+- Track session ownership with `session is None`, not truthiness, and make
+  `close()` idempotent. Do not add the API key to `__repr__`, an exception
+  attribute, or any object description.
+- Build endpoint URLs by appending `ticker_data` or `klines` to the validated
+  normalized base URL without `urljoin()` path-reset semantics, so an optional
+  deployment base path is retained. Never interpolate query parameters into
+  that URL.
+- Keep URL query construction in `requests` through `params`; this preserves
+  correct encoding for offsets such as `+05:00` and opaque cursors containing
+  `=` or other reserved characters.
+- Use an explicit `(5s connect, 30s read)` timeout tuple. Production examples
+  and documentation must use HTTPS; retain HTTP support for localhost and
+  trusted private network/tunnel use as permitted by `CLIENT.md`.
+- Extract one internal JSON request path on `HttpSource`, shared by
+  `/ticker_data` and the HTTP `/klines` validation fetch:
+  1. Send the request with a fixed copy of the current query parameters.
+  2. Retry transient connection/read failures, `429`, or statuses in the exact
+     `500..599` range for at most five total attempts. Invalid URL/schema, TLS
+     certificate, and other unchanged local configuration failures are
+     terminal. Classify the concrete `requests` exception subclasses
+     deliberately and in this order: terminal `SSLError` and `ProxyError`
+     before their broad `ConnectionError` parent; retry
+     `ConnectTimeout`/`ReadTimeout`, `ChunkedEncodingError` (an interrupted
+     response-body read), and remaining `ConnectionError`; terminal
+     `InvalidURL`, `MissingSchema`, `InvalidSchema`, `InvalidHeader`, and every
+     other `RequestException`. Treat proxy selection/configuration as unchanged
+     local state; HTTP errors returned by a proxy still follow their status
+     codes. Limit the exception handler to request execution: JSON/content-type/
+     schema failures are parsed outside it and can never be mistaken for
+     retryable transport failures.
+     An unexpected ordinary exception raised by request execution is also
+     terminal and sanitized before wrapping; do not catch process-control
+     `BaseException` subclasses such as `KeyboardInterrupt`.
+  3. Use full-jitter exponential backoff
+     `uniform(0, min(30s, 1s * 2**(attempt-1)))`. For `429`, parse both standard
+     `Retry-After` forms: non-negative delta-seconds and an HTTP-date relative
+     to an injectable UTC clock. Invalid, negative, or past values fall back to
+     calculated backoff. Sleep for at least a valid `Retry-After`; if it exceeds
+     the 30-second client cap, fail instead of retrying earlier than the server
+     allowed. Patch sleep, randomness, and clock in tests.
+  4. Every retry of a bulk page must reuse the same `symbol`, `start`, `end`,
+     `limit`, and opaque `cursor`.
+  5. Treat `401`, `404`, `405`, `422`, and other non-`429` `4xx` responses as
+     terminal. Parse either a string or array `detail` only when the response
+     is JSON; handle proxy-generated non-JSON bodies without masking the HTTP
+     status.
+  6. Treat every other status, including `1xx`, `3xx`, `204`, and other
+     non-`200` `2xx`, as terminal. On `200`, require `Content-Type:
+     application/json` (case-insensitive, optional media-type parameters), valid
+     JSON, and a top-level object. Invalid JSON/content type/shape is a terminal
+     protocol error and must not advance pagination.
+- Validate `/ticker_data` pages without rejecting unknown fields:
+  - both `rows` and `next_cursor` keys are required;
+  - `rows` must be a list and `next_cursor` a string or `null`;
+  - every row must be an object containing all seven documented bulk fields;
+  - present `symbol` and `timestamp` values must be strings or `null`;
+  - every market value must be a finite JSON number or `null`; booleans,
+    strings, `NaN`, and infinities are protocol errors.
+- Decode and validate the entire raw page before yielding anything. A
+  non-null timestamp must be an ISO date-time with the protocol-required
+  trailing `Z`; normalize it to naive UTC at the transport boundary. A present
+  string that cannot be parsed as such a timestamp, a null timestamp, a null
+  symbol, or a symbol different from the requested exact value is a damaged
+  row: skip it and increment a per-`fetch_batches()` counter. Missing required
+  fields and wrong JSON types are page-level protocol errors, not nullable
+  values. Let valid nullable numeric fields continue into the existing
+  `map_row()` fallback/skip policy.
+- Every usable normalized timestamp must also satisfy the original inclusive
+  `start <= timestamp <= end` request. A valid timestamp outside that range is
+  a page-level protocol error, not a damaged-row skip: accepting it would write
+  data the operator explicitly excluded and can corrupt append-only resume.
+- Verify that usable timestamps never decrease within or across pages. The HTTP
+  payload omits `id`, so equal timestamps are allowed and the server-owned
+  cursor remains the opaque tie-breaker. A regression is a terminal protocol
+  error; the error tells the operator to restart into a fresh `--tag`, because
+  append-only resume cannot repair an already committed out-of-order page.
+- Before yielding a page, validate its candidate `next_cursor` against the
+  per-walk set of previously adopted cursors; a repeat or cycle is a protocol
+  error and the page must not be committed. For a new candidate, yield the fully
+  decoded non-empty normalized page first and add/adopt that cursor only when
+  iteration resumes after the caller's batch commit. An empty string is still
+  an opaque non-null cursor and must be replayed verbatim. Stop normally only
+  when `next_cursor` is `null`.
+- Treat `rows=[]` with a non-null cursor as a protocol error. In contrast, when
+  the raw page is non-empty but every row is filtered as damaged, do not yield
+  an empty batch (because `main.import_symbol()` reads `batch[-1]`); adopt the
+  validated new cursor and continue. This distinction prevents both silent
+  truncation and false progress failures.
+- Keep filter counters local to one `fetch_batches(symbol, ...)` generator and
+  log the non-zero totals once in a `finally`, including on a later page error.
+  Never store them on the shared `HttpSource`, so counts cannot bleed between
+  symbols.
+- Implement `HttpSource.fetch_klines()` on the same instance and therefore the
+  same authenticated session, timeout, JSON/error handling, and retry policy.
+  Send `interval=1m`. Require top-level `rows` and require it to be a list, then
+  require every kline row to be an object with `start_time` plus finite,
+  non-null numeric `open/high/low/close`; ignore unknown fields. Require
+  `start_time` to be an ISO date-time with a trailing `Z` and an exact whole UTC
+  minute (`second == microsecond == 0`), normalize it to naive UTC, and require
+  strict increase (`current > previous`) so duplicate minutes cannot silently
+  overwrite one another. Gaps remain valid. Accept a candle only when its full
+  `[start_time, start_time + 1 minute)` interval lies within the requested
+  inclusive `[start, end]` range. For the minute-aligned validation-day request
+  this is equivalent to `start <= start_time < end`; reject every other row.
+
+### `apps/importer/src/importer/main.py`
+
+- After parsing the source kind, load `MARKET_DATA_API_KEY` once for HTTP and
+  pass it, together with the preflight-normalized base URL, through the source
+  factory. Do not read it for DB imports. Never log its value.
+- Preserve only the preflight-produced non-secret HTTP origin label in the
+  synthetic run's `config_snapshot`, together with the full-base source
+  fingerprint; do not pass the key, base path, endpoint, or raw request URL into
+  `source_desc`. DB source metadata remains unchanged in this feature.
+- Pass the actual `HttpSource` instance into HTTP validation through the narrow
+  `HttpKlineSource` interface. Do not pass the credential separately or create
+  a second `Session`; this guarantees `/ticker_data` and `/klines` share the
+  same authentication, timeout, retry, redaction, and connection pool.
+- Close the owned HTTP session once after all symbols finish, without closing an
+  externally injected session. Put this in an outer
+  `try/finally` around the complete multi-symbol run so the owned session is also
+  closed on an unexpected exception or interruption.
+- Keep the current per-symbol failure isolation, atomic per-batch database
+  commits, idempotent resume, and aggregate non-zero exit behavior.
+
+### `apps/importer/src/importer/output_db.py`
+
+- Keep the existing `output_db_path()` behavior byte-for-byte for DB imports.
+  For HTTP, derive the filename only from full SHA-256 digests of the UTF-8
+  exact symbol, canonical full base URL, and optional tag, using fixed
+  separators and a distinct `imported_http_...db` namespace. Raw symbol, base
+  path, and tag never enter the filename. This makes paths stable across reruns
+  yet distinct across exact-case/Unicode symbols, base paths on the same origin,
+  and tags even on case-insensitive or Unicode-normalizing filesystems.
+- Store the sanitized origin label and full-base source fingerprint in a new
+  HTTP run's `config_snapshot`. On an existing protocol-1.0 HTTP output, verify
+  any stored fingerprint matches the path-derived current fingerprint before
+  inserting a batch; a mismatch is a terminal current-symbol error with a
+  fresh-`--tag` hint. The fingerprinted path remains the source-of-identity
+  fallback after a crash that committed batches before creating the run row.
+- Feature 0093 draft HTTP databases used the unscoped
+  `imported_<symbol>[_<tag>].db` name. Do not auto-adopt, rename, or append to
+  them: protocol 1.0 starts in the new source-scoped namespace. Leave those
+  files untouched and document the one-time fresh HTTP import. DB-source files
+  continue using the legacy name and resume behavior.
+- Keep start/end refresh, the single-run invariant, parent creation, locking,
+  and per-batch transaction behavior unchanged.
+
+### `apps/importer/src/importer/validate.py`
+
+- Remove the standalone unauthenticated `requests.get()` in
+  `_fetch_klines_http()`. `run_validation()` and `check_ohlc()` receive the
+  optional `HttpKlineSource` instance and call its already-decoded
+  `fetch_klines()` result only for an HTTP source; the DB validation path and
+  SQLAlchemy URL remain unchanged. Fail closed with a clean validation error if
+  the source kind is HTTP but no `HttpKlineSource` was supplied; do not fall
+  back to a standalone request.
+- Request a minute-aligned UTC day with a window no larger than the protocol's
+  1440-minute maximum: HTTP `start` is sampled-day `00:00:00Z` and HTTP `end`
+  is the following day's `00:00:00Z`. The latter fully encloses the sampled
+  day's `23:59` minute under protocol semantics without exceeding 1440 minutes.
+  Local imported ticks remain restricted through
+  `23:59:59.999999` of the sampled UTC calendar day, and a broken server row at
+  the following midnight is rejected by the helper rather than compared. Kline
+  results are already schema/time/window/order validated by `HttpSource`;
+  validation code only converts the decoded rows into `OhlcBucket` values.
+- Continue parsing kline prices through `Decimal(str(value))`; returned OHLC
+  values are non-null under protocol 1.0.
+- `smoke_replay()` must pass an explicit copy of the current environment with
+  `MARKET_DATA_API_KEY` removed to `subprocess.run()`. The replay subprocess
+  does not need the market API credential and must not inherit it. Do not delete
+  or modify the parent process's environment.
+
+### Tests
+
+Update `apps/importer/tests/test_config.py`,
+`apps/importer/tests/test_fetch_http.py`,
+`apps/importer/tests/test_output_db.py`,
+`apps/importer/tests/test_resume.py`, and
+`apps/importer/tests/test_validate_ohlc.py`:
+
+- assert HTTP symbols retain exact case and reject batch sizes outside
+  `1..10000`, while DB symbols retain legacy uppercasing and DB batch sizes
+  greater than `10000` remain valid;
+- assert missing either HTTP bound, reversed HTTP bounds, an oversized HTTP
+  batch, a control-bearing HTTP symbol, a malformed/credential-bearing HTTP base
+  URL (including invalid host/port/control-character forms), or an invalid
+  Bearer token fails before secret access where applicable, source construction,
+  output-directory/lock/DB creation, and network I/O; the same DB cases retain
+  their existing per-symbol side-effect order; rejected credential-bearing URLs,
+  symbols, and keys do not appear in stderr;
+- assert HTTP output paths differ for exact symbols that vary only by case or
+  Unicode normalization, for base paths on the same origin, and for tags that
+  differ only by case; assert rerunning the identical tuple produces the same
+  path, raw values are absent from the filename, and DB-source path behavior is
+  unchanged;
+- parameterize canonical-URL equivalence: scheme/host case, Unicode versus IDNA
+  host, explicit default port, and one trailing slash produce the same request
+  base, source fingerprint, endpoint, and HTTP output path. Include equivalent
+  dot-segment and percent-escape spellings that `PreparedRequest` rewrites.
+  Conversely, non-default ports and semantically distinct prepared base paths
+  must remain distinct;
+- assert `Accept` is always sent, Bearer auth is sent when configured, and no
+  `Authorization` header is sent when the key is absent, including when an
+  injected session started with one; assert the injected session's persistent
+  header/auth configuration is unchanged after requests;
+- inspect prepared requests from sessions carrying both a pre-existing
+  `Authorization` header and `session.auth`; prove the API key still produces
+  exactly one Bearer header and the no-key case produces no authorization.
+  Exercise/suppress a netrc credential path as well;
+- assert both endpoints use the `(5, 30)` timeout tuple and disable redirects;
+- assert both endpoints retain an optional deployment base path while request
+  query values stay exclusively in `params`;
+- assert unset/empty keys disable auth and CR/LF, whitespace, control,
+  non-encodable, and non-`token68` keys fail before source construction without
+  echoing the value;
+- inject the API key into a JSON `detail`, a non-JSON body, and a request
+  exception under debug logging; assert it never appears in captured logs,
+  raised exception text, exception cause/context rendered by a traceback, or
+  the full stdout/stderr emitted by `main()` with `exc_info=True`. Assert body
+  truncation happens only after redaction;
+- assert all request values are passed through `params`, inspect a prepared
+  request to prove reserved cursor characters are encoded, and separately
+  assert offset CLI bounds normalize to Z-suffixed UTC;
+- cover string and array `detail`, non-JSON infrastructure errors, malformed
+  `200` JSON/content type, missing required top-level/row fields, non-object
+  rows, wrong field types, non-finite/bool numerics, and unknown response
+  fields;
+- cover terminal `401`/`404`/`422`, retryable connection/`429`/`5xx`, valid
+  delta-seconds and HTTP-date `Retry-After`, invalid/past/over-cap values,
+  bounded attempts, deterministic jitter, terminal redirects/other statuses,
+  and identical parameters on page retries;
+- separately cover retryable `ConnectTimeout`/`ReadTimeout` and remaining
+  `ConnectionError`; terminal `SSLError`/`ProxyError`/`InvalidURL`/
+  `MissingSchema`/`InvalidSchema`/`InvalidHeader` plus a generic non-connection
+  `RequestException` and unexpected ordinary exception; guard the subclass
+  ordering, prove invalid JSON is not retried as a request failure, and prove
+  unexpected exception text is redacted;
+- cover `ChunkedEncodingError` as retryable and prove the retry reuses identical
+  endpoint parameters;
+- use protocol-accurate bulk rows without `id`;
+- cover null/mismatched symbol and null/invalid timestamp filtering, including
+  a fully unusable page followed by a valid cursor page; reject otherwise-valid
+  ticker timestamps before `start` or after `end` before yield/commit;
+- cover `rows=[]` with a non-null cursor, an empty-string opaque cursor,
+  immediately repeated cursor, a multi-cursor cycle, and decreasing timestamps
+  inside and across pages; prove a page whose candidate cursor repeats/cycles is
+  rejected before its rows can be yielded or committed;
+- assert filter counters are per-symbol, logged once, and retained when a later
+  page fails;
+- assert `main()` loads the environment credential once and passes the same
+  `HttpSource`/fake session to import and HTTP validation without making real
+  network calls; assert the created run metadata contains only the sanitized
+  HTTP origin label plus source fingerprint and neither the key, base path, nor
+  raw request URL; assert a stored fingerprint mismatch fails before batch
+  insertion and existing DB-source metadata is not refreshed;
+- add an end-to-end HTTP crash-resume case that fails after at least one
+  committed batch but before `ensure_run_row()`, then reruns with the identical
+  source/symbol/tag tuple. Prove the fingerprinted path is reused, committed
+  rows survive without duplication or loss, pagination resumes, and the
+  sanitized fingerprinted run metadata is healed;
+- assert an owned session is closed exactly once on success, aggregate symbol
+  failure, and unexpected exit, while an injected session is never closed;
+- assert the smoke-replay subprocess environment excludes
+  `MARKET_DATA_API_KEY` while the parent environment remains unchanged;
+- cover authenticated `/klines`, `interval=1m`, minute-aligned 24-hour bounds,
+  retry/error handling reuse, non-list `rows`, row-level response validation,
+  non-minute-aligned timestamps, duplicate/decreasing minutes, gaps, and
+  out-of-window rejection.
+
+All HTTP tests remain hermetic with injected fake sessions and patched
+sleep/jitter/clock; they must not contact the production API.
+
+### Documentation
+
+- Add `docs/CLIENT.md` protocol 1.0 to the same committed change as the client
+  plan/implementation; it is the versioned compatibility source referenced by
+  this feature and must not remain an untracked local dependency.
+- State explicitly in `docs/CLIENT.md` that every kline `start_time` is a unique
+  whole UTC minute and rows are therefore strictly increasing, while missing
+  minutes remain valid gaps.
+- Update `README.md` to list `importer` among runnable apps and add one remote
+  HTTP example using `MARKET_DATA_API_KEY`, explicit UTC `--start`/`--end`, and
+  an HTTPS base URL. Acquire the key with a hidden shell prompt or documented
+  secret-manager injection; never place a literal secret in the command or
+  shell history, and unset the interactive variable after the run.
+- State that HTTP imports require explicit bounds because protocol 1.0 has no
+  MIN/MAX endpoint, that the key must not be committed, and that plain HTTP is
+  limited to localhost or a trusted private network/tunnel. Document that
+  `--source-url` is a base URL and must not contain credentials, a query, or a
+  fragment.
+- Document the protocol-1.0 source-scoped HTTP filename namespace and that draft
+  Feature 0093 HTTP files are intentionally left untouched rather than
+  auto-resumed; DB-source filenames do not change.
+- Extend README's data-flow diagram with
+  `remote market API -> importer -> per-symbol SQLite -> replay`.
+- Update the existing app inventories in `CLAUDE.md` and
+  `.claude/rules/core-invariants.md` to include `importer`; add its focused
+  pytest command and correct the stale package-run count there. These are
+  Feature 0093 documentation omissions exposed by this work, not protocol
+  duplication.
+
+### Project rules and task tracking
+
+- Split the implementation into the five checkable phases recorded in
+  `tasks/todo.md`: config/auth lifecycle, shared request/retry path, bulk
+  pagination/schema, kline validation integration, and docs/full verification.
+- Add a short path-scoped `.claude/rules/importer.md` with
+  `paths: ["apps/importer/**"]` for the durable importer invariants introduced
+  here (environment-only secret, request-level auth isolation, opaque cursor
+  handling after complete-page decode, per-batch commits, source/symbol-scoped
+  HTTP output paths, exact HTTP symbols versus legacy DB uppercasing), and add
+  it to the `RULES.md` index. Do not duplicate the full protocol document there.
+
+## Import and retry algorithm
+
+1. Parse symbols and inclusive UTC bounds; apply exact symbol case, log safety,
+   and the `1..10000` limit only to HTTP, preserve legacy DB normalization, and
+   reject invalid explicit HTTP input before reading the key or performing
+   output-DB or remote I/O.
+2. Validate the Bearer value locally, derive the source/symbol/tag-scoped HTTP
+   output path, then build a protected `/ticker_data` request without a cursor.
+3. Decode and validate the entire page and its required row schema. Filter only
+   permitted-but-unusable identity/time rows; reject usable timestamps outside
+   the requested range; retain valid nullable market values for the existing
+   mapping policy.
+4. Yield the normalized non-empty batch. The importer maps it to
+   `TickerSnapshot` objects and commits the batch transaction.
+5. If `next_cursor` is non-null, repeat with the exact original parameters and
+   that opaque cursor. Validate that it is previously unseen before yielding
+   the current page, then adopt it only after the yielded page has returned
+   control following its batch commit. A retry repeats the same page; it never
+   advances the cursor.
+6. A non-empty raw page filtered to zero usable rows advances to its unseen
+   non-null cursor without yielding, or stops if its cursor is null. An empty
+   raw page with a cursor, repeated/cyclic cursor, or timestamp regression is a
+   protocol error.
+7. Stop normally only on `next_cursor=null`. Any terminal HTTP/protocol error
+   fails only the current symbol, and the existing main loop continues with the
+   remaining symbols.
+
+## Verification
+
+1. Run `uv run pytest apps/importer/tests -q`.
+2. Run `make lint`.
+3. Run `make test` to verify the importer signature changes do not break replay,
+   shared DB, or workspace coverage gates.
+4. Run `git diff --check` plus `git status --short`; the latter is required
+   because `git diff` does not show untracked files.
+5. Before commit, stage the intended change and run `git diff --cached --check`
+   plus `git diff --cached --name-only`. Confirm `docs/CLIENT.md`,
+   `docs/features/0098_PLAN.md`, `tasks/todo.md`, the importer rule and
+   `RULES.md`, the small `CLAUDE.md`/core-invariants inventory corrections,
+   implementation, tests, and README are all present.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -33,8 +33,8 @@ Plan: docs/features/0093_PLAN.md  |  Branch: feature/0093-importer
 
 Plan: docs/features/0098_PLAN.md
 
-- [ ] Phase 1: source-aware config preflight, secret loading, auth/session lifecycle
-- [ ] Phase 2: shared JSON request path, retries, Retry-After, redaction
-- [ ] Phase 3: bulk-page schema, damaged-row filtering, cursor/order invariants
-- [ ] Phase 4: authenticated kline fetch, strict minute/window validation
-- [ ] Phase 5: tests, CLIENT/README/rules updates, full verification
+- [x] Phase 1: source-aware config preflight, secret loading, auth/session lifecycle
+- [x] Phase 2: shared JSON request path, retries, Retry-After, redaction
+- [x] Phase 3: bulk-page schema, damaged-row filtering, cursor/order invariants
+- [x] Phase 4: authenticated kline fetch, strict minute/window validation
+- [x] Phase 5: tests, CLIENT/README/rules updates, full verification

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -46,3 +46,8 @@ Plan: docs/features/0098_PLAN.md
   large cursor pagination memory bounds (cycle set stays unbounded by design).
 - 0098 review P3: consumer-side MARKET_DATA_API_KEY handling notes belong in
   importer README/ops docs, not the protocol `docs/CLIENT.md` contract.
+- 0098 review round-2 P1/P2 deferred: `_safe_hostname` split refactor; hot-path
+  timestamp filter micro-opts; live HTTP integration server test; cached
+  `_headers()` dict; truncated output digests; preflight redirect note;
+  `_validate_bulk_shape` module-level move; extra preflight_http comments;
+  CLIENT.md ops rate-limit section.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -38,3 +38,11 @@ Plan: docs/features/0098_PLAN.md
 - [x] Phase 3: bulk-page schema, damaged-row filtering, cursor/order invariants
 - [x] Phase 4: authenticated kline fetch, strict minute/window validation
 - [x] Phase 5: tests, CLIENT/README/rules updates, full verification
+
+## Follow-ups
+- 0098 review P2: optional charset warning in `_is_json_content_type` (warn on
+  non-utf-8 charset parameters without rejecting otherwise-valid JSON).
+- 0098 review P2: extra stress tests for concurrent lock acquisition and very
+  large cursor pagination memory bounds (cycle set stays unbounded by design).
+- 0098 review P3: consumer-side MARKET_DATA_API_KEY handling notes belong in
+  importer README/ops docs, not the protocol `docs/CLIENT.md` contract.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -28,3 +28,13 @@ Plan: docs/features/0093_PLAN.md  |  Branch: feature/0093-importer
   Missing kline minutes are legitimate source sparsity.
 
 ## Not committed — awaiting user review/approval before any commit.
+
+# Feature 0098 — remote market-data API client protocol 1.0
+
+Plan: docs/features/0098_PLAN.md
+
+- [ ] Phase 1: source-aware config preflight, secret loading, auth/session lifecycle
+- [ ] Phase 2: shared JSON request path, retries, Retry-After, redaction
+- [ ] Phase 3: bulk-page schema, damaged-row filtering, cursor/order invariants
+- [ ] Phase 4: authenticated kline fetch, strict minute/window validation
+- [ ] Phase 5: tests, CLIENT/README/rules updates, full verification


### PR DESCRIPTION
## Summary
- Align `apps/importer` HTTP transport with published market-data client protocol 1.0 (Bearer auth, shared retry/redaction, strict ticker/kline schema).
- Namespace HTTP output DBs by canonical API base + exact symbol; keep DB-source behavior unchanged.
- Add `docs/CLIENT.md`, Feature 0098 plan, and path-scoped importer rules.

## Test plan
- [ ] `uv run pytest apps/importer`
- [ ] `make lint`
- [ ] `make test` (or at least importer + lockfile gate)
- [ ] Smoke HTTP import against a protocol-compatible source with/without `MARKET_DATA_API_KEY`
- [ ] Confirm DB `--source db` path still works unchanged


Made with [Cursor](https://cursor.com)